### PR TITLE
Updated readme with information about approval_prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,8 @@ URL:
       scope: 'https://www.googleapis.com/auth/plus.me'
     });
 
+In order to get a refresh token for offline use, supply `approval_prompt: 'force'` to `generateAuthUrl`.
+
 #### Retrieving Tokens
 Once user has given permissions on the consent page, Google will redirect
 the page to the redirect url you have provided with a code query parameter.


### PR DESCRIPTION
So, I'm a little confused about the `approval_prompt` parameter for oauth. I thought I'd receive a refresh token regardless of this parameter, however, when testing and authenticating my user account, it seems that I only receive the `refresh_token` when I include `approval_prompt: 'force'`. Anyways, I figured I'd document it.
