### PR TITLE
Tighten up readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,9 +151,9 @@ access_token and replays the request.
 
 Following sample retrieves Google+ profile of the authenticated user.
 
-    oauth2Client.tokens = {
-      access_token = 'ACCESS TOKEN HERE',
-      refresh_token = 'REFRESH TOKEN HERE'
+    oauth2Client.credentials = {
+      access_token: 'ACCESS TOKEN HERE',
+      refresh_token: 'REFRESH TOKEN HERE'
     };
 
     client


### PR DESCRIPTION
I fixed what would be syntax errors in readme. Though, I also think `oauth2Client.credentials` was intended in this example. If these aren't set, an error will be thrown [here](https://github.com/google/google-api-nodejs-client/blob/master/lib/auth/oauth2client.js#L158.).
