### PR TITLE
Make error objects be made with 'new'

### DIFF
--- a/lib/auth/authclient.js
+++ b/lib/auth/authclient.js
@@ -24,7 +24,7 @@ function AuthClient() {
  * implementations with auth credentials.
  */
 AuthClient.prototype.request = function() {
-  throw Error('Not implemented yet.');
+  throw new Error('Not implemented yet.');
 };
 
 /**

--- a/lib/auth/oauth2client.js
+++ b/lib/auth/oauth2client.js
@@ -157,7 +157,7 @@ OAuth2Client.prototype.request =
   var credentials = this.credentials;
 
   if (!credentials.access_token) {
-    throw Error('No access token is set.');
+    throw new Error('No access token is set.');
   }
 
   opts.uri += querystring.stringify({


### PR DESCRIPTION
Invoking `Error` without `new` will add a new line `at Error (unknown source)` which is unnecessary and to some annoying.

```
alfred-nsh@google-api-nodejs-client:~/439948 (master) $ node -pe "throw Error('stuff')"                                                                                                                                                            

[eval]:1                                                                                                                                                                                                                                           
throw Error('stuff')                                                                                                                                                                                                                               
      ^                                                                                                                                                                                                                                            
Error: stuff                                                                                                                                                                                                                                       
    at Error (unknown source)                                                                                                                                                                                                                      
    at [eval]:1:7                                                                                                                                                                                                                                  
    at Object.<anonymous> ([eval]-wrapper:6:22)                                                                                                                                                                                                    
    at Module._compile (module.js:449:26)                                                                                                                                                                                                          
    at evalScript (node.js:282:25)                                                                                                                                                                                                                 
    at startup (node.js:76:7)                                                                                                                                                                                                                      
    at node.js:627:3                                                                                                                                                                                                                               
alfred-nsh@google-api-nodejs-client:~/439948 (master) $ node -pe "throw new Error('stuff')"                                                                                                                                                        

[eval]:1                                                                                                                                                                                                                                           
throw new Error('stuff')                                                                                                                                                                                                                           
      ^                                                                                                                                                                                                                                            
Error: stuff                                                                                                                                                                                                                                       
    at [eval]:1:7                                                                                                                                                                                                                                  
    at Object.<anonymous> ([eval]-wrapper:6:22)                                                                                                                                                                                                    
    at Module._compile (module.js:449:26)                                                                                                                                                                                                          
    at evalScript (node.js:282:25)                                                                                                                                                                                                                 
    at startup (node.js:76:7)                                                                                                                                                                                                                      
    at node.js:627:3
```
