### PR TITLE
Error is truncated to first character

### DIFF
--- a/lib/requests.js
+++ b/lib/requests.js
@@ -170,16 +170,9 @@ Request.prototype.generatePayload = function() {
  * @return {Function} Wraps response callback and returns.
  */
 Request.prototype.handleResponse = function(opt_fn) {
-  return function(errors, results, res) {
-
-    var result = null;
-    if (results) {
-      result = results[0].result;
-    }
-    var err = null;
-    if (errors) {
-      err = errors[0];
-    }
+  return function(err, results, res) {
+    var result = results && results[0] && results[0].result;
+    err = err && util.isArray(err) ? err[0] : err;
     opt_fn && opt_fn(err, result, res);
   };
 };

--- a/tests/data/res_invalidgrant.json
+++ b/tests/data/res_invalidgrant.json
@@ -1,0 +1,1 @@
+{ "error": "invalid_grant" }

--- a/tests/test.requests.js
+++ b/tests/test.requests.js
@@ -67,6 +67,22 @@ describe('Requests', function() {
     });
   });
 
+  it('should handle non-RPC errors for single requests without ' +
+      'assuming the errors should be an array', function(done) {
+    var invalidGrantMockTransporter =
+        new MockTransporter(__dirname + '/data/res_invalidgrant.json');
+    var gapis = new googleapis.GoogleApis();
+    var callback = function(err, client) {
+      var req = client.urlshortener.url.list();
+      req.transporter = invalidGrantMockTransporter;
+      req.execute(function (err, res) {
+        assert.equal(err, 'invalid_grant');
+        done();
+      });
+    };
+    gapis.discover('urlshortener', 'v1').execute(callback);
+  });
+
   it('should generate a valid JSON-RPC payload if any params are given',
       function(done) {
     var gapis = new googleapis.GoogleApis();


### PR DESCRIPTION
I've only tested this with `latitude.location.list`, but can reproduce every time:
1. Okay on the consent page for a client and logged in user as per [here](https://github.com/google/google-api-nodejs-client#consent-page-url).
2. Make an authenticated request for `latitude.location.list` as per [here](https://github.com/google/google-api-nodejs-client#making-authenticated-requests).
3. See that the `callback` function is called with a `null` `err` argument, and data in the second argument.
4. Go to the **Authorized Access to your Google Account page**, here:
   https://accounts.google.com/b/0/IssuedAuthSubTokens
   
   Hit _Revoke Access_ for your client.
5. Make a second authenticated request for `latitude.location.list`.
- What's expected: the `callback` function's `err` argument contains a description of the error. In this case: `"invalid_auth"`.
- What's observed: the `callback` functions `err` argument is set to `"i"`.

---

The problem originates in `Request.prototype.handleResponse` [here](https://github.com/dukedave/google-api-nodejs-client/blob/0af005d034aedd051ff221c6a15a7dd21e35f870/lib/requests.js#L181), where it assumed that `errors` is an array and `errors[0]` is used.
In this case `errors` is actually a string and it strips `"invalid_grant"` down to just `"i"`.

It can be fixed by checking `util.isArray(errors)`, I'll submit a pull request in a moment.
