### PR TITLE
There should be a public method to retrieve a new access token from refresh token

### DIFF
--- a/lib/auth/oauth2client.js
+++ b/lib/auth/oauth2client.js
@@ -131,7 +131,7 @@ OAuth2Client.prototype.refreshToken_ =
  * Retrieves access token using refresh token
  * @param {function=} callback callback
  */
-OAuth2Client.prototype.getAccessToken =
+OAuth2Client.prototype.refreshAccessToken =
   function(callback) {
     var that = this;
     


### PR DESCRIPTION
I'm querying an API using auth for many different users in succession, I need to be able to cache access tokens so I'm not constantly sending refresh requests. I'm not sure if this is optimal at all, maybe refreshToken_ should just be changed into a public method, but this was my quick solution. 
