### PR TITLE
Allow any Google cloud endpoint to be used

### DIFF
--- a/lib/requests.js
+++ b/lib/requests.js
@@ -183,7 +183,7 @@ Request.prototype.generatePayload = function(rootUrl) {
 Request.prototype.generateBody = function(rootUrl) {
   var path = this.generatePath(this.params);
   return {
-    uri: rootUrl + path,
+    uri: (rootUrl || BaseRequest.BASE_URL) + path,
     path: path,
     method: this.methodMeta.httpMethod,
     json: this.body
@@ -202,7 +202,7 @@ Request.prototype.generateUploadBody = function(rootUrl) {
     params.uploadType = 'media';
 
     return {
-      uri: rootUrl + '/upload' + this.generatePath(params),
+      uri: (rootUrl || BaseRequest.BASE_URL) + '/upload' + this.generatePath(params),
       method: this.methodMeta.httpMethod,
       headers: {
         'Content-Type': this.media.mimeType,
@@ -215,7 +215,7 @@ Request.prototype.generateUploadBody = function(rootUrl) {
   params.uploadType = 'multipart';
 
   return {
-    uri: rootUrl + '/upload' + this.generatePath(params),
+    uri: (rootUrl || BaseRequest.BASE_URL) + '/upload' + this.generatePath(params),
     method: this.methodMeta.httpMethod,
     multipart: [{
       'Content-Type': 'application/json',


### PR DESCRIPTION
The code allow you to load discovery documents from your own Google cloud endpoint.
There was a bug in the code that always assumed that the base url is https://www.googleapis.com and not the one that you used to create the discovery document. 
