### PR TITLE
0.4.0 ignores query params

### DIFF
--- a/lib/requests.js
+++ b/lib/requests.js
@@ -48,11 +48,14 @@ BaseRequest.prototype.withApiKey = function(apiKey) {
 };
 
 /**
- * Returns true if request requires a parameter.
+ * Returns true if given params contains a query parameter key.
  * If no metadata is known about the request's method, true is returned.
+ *
+ * @param {object} params The parameters object.
  * @return {boolean} Returns whether a parameter is required or not.
  */
-BaseRequest.prototype.doesRequireParams = function() {
+BaseRequest.prototype.containsQueryParams = function(params) {
+  params = params || {};
   if (!this.methodMeta) {
     // we dont know much about the method, dont speculate
     // and require parameters
@@ -60,7 +63,8 @@ BaseRequest.prototype.doesRequireParams = function() {
   }
   var parameters = this.methodMeta.parameters || {};
   for (var paramName in parameters) {
-    if (parameters[paramName].required) {
+    if (parameters[paramName].location == 'query' &&
+        params[paramName]) {
       return true;
     }
   }
@@ -124,7 +128,8 @@ function Request(
   this.apiMeta = apiMeta;
   this.methodMeta = methodMeta;
 
-  if (!this.doesRequireParams() && !opt_body) {
+  // move params to 
+  if (!this.containsQueryParams(opt_params) && !opt_body) {
     this.params = {};
     this.body = opt_params;
   } else {

--- a/tests/test.requests.js
+++ b/tests/test.requests.js
@@ -164,13 +164,13 @@ describe('Requests', function() {
       var requests = client.newBatchRequest();
       requests.add(client.urlshortener.url.list());
       requests.add(client.urlshortener.url.get());
-      requests.add(client.urlshortener.url.get({ id: 'http://goo.gl/mR2d' }));
+      requests.add(client.urlshortener.url.get({ shortUrl: 'http://goo.gl/mR2d' }));
 
       // should construct the payload in the given order.
       var payload = requests.generatePayload();
       assert.equal(payload.multipart[0].body, 'GET /urlshortener/v1/url/history\r\n');
       assert.equal(payload.multipart[1].body, 'GET /urlshortener/v1/url\r\n');
-      assert.equal(payload.multipart[2].body, 'GET /urlshortener/v1/url?id=http%3A%2F%2Fgoo.gl%2FmR2d\r\n');
+      assert.equal(payload.multipart[2].body, 'GET /urlshortener/v1/url?shortUrl=http%3A%2F%2Fgoo.gl%2FmR2d\r\n');
       done();
     });
   });
@@ -191,7 +191,7 @@ describe('Requests', function() {
 
   it('should generate a valid multipart upload payload if media and metadata '
       + 'are set both', function(done) {
-    googleapis.discover('drive', 'v2').execute(function(err, client){
+    googleapis.discover('drive', 'v2').execute(function(err, client) {
       var req = client.drive.files
           .insert({ title: 'title' })
           .withMedia('text/plain', 'hey');
@@ -204,6 +204,18 @@ describe('Requests', function() {
       assert.equal(payload.multipart[1]['Content-Type'], 'text/plain');
       assert.equal(payload.multipart[1].body, 'hey');
       assert.equal(payload.body, null);
+      done();
+    });
+  });
+
+  it('should differentiate query params and body object', function(done) {
+    googleapis.discover('drive', 'v2').execute(function(err, client) {
+      var req1 = client.drive.files.insert({ title: 'Hello' });
+      var req2 = client.drive.files.list({ q: 'title contains "H"' });
+
+      assert.equal(req1.params.title, null);
+      assert.equal(req1.body.title, 'Hello');
+      assert.equal(req2.params.q, 'title contains "H"');
       done();
     });
   });


### PR DESCRIPTION
``` js
var params = {
  q: "'root' in parents and mimeType = 'application/vnd.google-apps.folder'"
};

client.drive.files.list(params).execute();
```

responses with HTTP 400.
