### PR TITLE
Force decode responses

### DIFF
--- a/lib/transporters.js
+++ b/lib/transporters.js
@@ -63,20 +63,17 @@ DefaultTransporter.prototype.wrapCallback_ = function(opt_callback) {
     if (err || !body) {
       return opt_callback && opt_callback(err, body, res);
     }
-
-    // decode application/json responses.
-    if (res.headers && res.headers['content-type'] &&
-        res.headers['content-type'].indexOf('application/json') >= 0 &&
-        typeof body == 'string') {
-      try {
-        body = JSON.parse(body);
-      } finally { /* no op */ }
-    }
+    // Only and only application/json responses should
+    // be decoded back to JSON, but there are cases API back-ends
+    // responds without proper content-type.
+    try {
+      body = JSON.parse(body);
+    } catch (err) { /* no op */ }
 
     if (body && body.error) {
       // handle single request errors
       err = body.error;
-      delete body.error;
+      body = null;
     }
     opt_callback && opt_callback(err, body, res);
   };


### PR DESCRIPTION
Assuming some APIs dont respond with valid `content-type` header although they response with JSON.
