### PR TITLE
Cache#isExpired is always false with default EXPIRES_IN_.

### DIFF
--- a/lib/cache.js
+++ b/lib/cache.js
@@ -93,7 +93,7 @@ Cache.prototype.write = function(api, data) {
  */
 Cache.prototype.isExpired = function(path) {
   var expiresIn = this.opts.expiresIn || Cache.EXPIRES_IN_;
-  return new Date(fs.statSync(path).mtime).getTime() - expiresIn < 0;
+  return Date.now() - new Date(fs.statSync(path).mtime).getTime() > expiresIn;
 };
 
 /**


### PR DESCRIPTION
https://github.com/google/google-api-nodejs-client/blob/3d40484947a45b6eca73ef68f3c5a9e545aa250f/lib/cache.js#L94

`new Date(fs.statSync(path).mtime).getTime()` will return a number on the order of 1377737486000 (taken from a recently modified file on my filesystem). `Cache.EXPIRES_IN_` is, by default, 300000. Thus, only files that were modified within 299999 milliseconds of the epoch will ever be considered expired. The correct logic is as follows:

``` coffeescript
Cache.prototype.isExpired = function(path) {
  var expiresIn = this.opts.expiresIn || Cache.EXPIRES_IN_;
  return Date.now() - new Date(fs.statSync(path).mtime).getTime() > expiresIn;
};
```

Not sure about test practices, etc, but I've attached some code with this in place.
