### PR TITLE
change to make youtube video insertion work

### DIFF
--- a/lib/requests.js
+++ b/lib/requests.js
@@ -190,7 +190,7 @@ Request.prototype.generateBody = function(rootUrl) {
  */
 Request.prototype.generateUploadBody = function(rootUrl) {
   var params = this.params || {};
-  if (rootUrl.slice(-1) === "/") rootUrl = rootUrl.slice(0, -1);
+  rootUrl.replace(/\/+$/, ''); // Remove any trailing slashes.
 
   if (!this.body) {
     params.uploadType = 'media';


### PR DESCRIPTION
The API discovery gives a rootUrl for youtube video insertion with a trailing slash. Appending "/upload" to that in Request.prototype.generateUploadBody results in a request that gets rejected by YouTube. I'm not sure if "/upload" should be "upload" or if the rootUrl returned by discovery should not have a trailing slash. In either case, this non-destructive change resolves the symptom.
