### PR TITLE
Fix multipart bodies vanishing

### DIFF
--- a/lib/auth/oauth2client.js
+++ b/lib/auth/oauth2client.js
@@ -135,7 +135,7 @@ OAuth2Client.prototype.refreshAccessToken =
   function(callback) {
     var that = this;
 
-    if (! this.credentials.refresh_token){
+    if (! this.credentials.refresh_token) {
       throw new Error('No refresh token is set');
     }
 
@@ -188,12 +188,12 @@ OAuth2Client.prototype.request =
   opts.headers = opts.headers || {};
   opts.headers['Authorization']
       = credentials.token_type + ' ' + credentials.access_token;
-      
+
   // Make a reference copy of the multipart bodies
   var bodies = [];
-  if( opts.multipart ){
-    opts.multipart.forEach(function(part){
-      bodies.push( part.body );
+  if (opts.multipart) {
+    opts.multipart.forEach(function(part) {
+      bodies.push(part.body);
     });
   }
 
@@ -211,12 +211,12 @@ OAuth2Client.prototype.request =
           var tokens = result;
           tokens.refresh_token = credentials.refresh_token;
           that.credentials = tokens;
-          
+
           // Refresh the bodies
-          bodies.forEach( function(body,i){
+          bodies.forEach(function(body, i) {
             opts.multipart[i].body = body;
           });
-          
+
           that.request(opts, opt_callback, true);
         }
       });


### PR DESCRIPTION
If a command is created withMedia() and that command fails because the authentication has expired, the retry (after the auth has been fetched) does not seem to have the bodies associated with the multiparts. This patch is a bit of a kludge, since it simply makes a copy of the multipart bodies and sets them back as part of the request after the auth succeeds.
