### PR TITLE
Add error handling if there is no response object

### DIFF
--- a/lib/auth/oauth2client.js
+++ b/lib/auth/oauth2client.js
@@ -190,8 +190,11 @@ OAuth2Client.prototype.request =
       = credentials.token_type + ' ' + credentials.access_token;
 
   this.transporter.request(opts, function(err, body, res) {
+    if (err || !res) {
+      return opt_callback && opt_callback(err, body, res);
+    }
     // TODO: Check if it's not userRateLimitExceeded
-    var hasAuthError = !res || res.statusCode == 401 || res.statusCode == 403;
+    var hasAuthError = res.statusCode == 401 || res.statusCode == 403;
     // if there is an auth error, refresh the token
     // and make the request again
     if (!opt_dontForceRefresh && hasAuthError && credentials.refresh_token) {


### PR DESCRIPTION
Had my server error out. This line needs an additional error check.

/home/user/node_modules/googleapis/lib/auth/oauth2client.js:194 
      var hasAuthError = res.statusCode == 401 || res.statusCode == 403; 
  ^ 
  TypeError: Cannot read property 'statusCode' of undefined 
          at OAuth2Client.request (/home/user/node_modules/googleapis/lib/auth/oauth2client.js:194:27) 
          at Request.DefaultTransporter.wrapCallback_ [as _callback](/home/user/node_modules/googleapis/lib/transporters.js:64:30) 
          at Request.init.self.callback (/home/user/node_modules/googleapis/node_modules/request/index.js:148:22) 
          at Request.EventEmitter.emit (events.js:88:17) 
          at ClientRequest.Request.init.self.clientErrorHandler (/home/user/node_modules/googleapis/node_modules/request/index.js:257:10) 
          at ClientRequest.EventEmitter.emit (events.js:88:17) 
          at CleartextStream.socketErrorListener (http.js:1320:9) 
          at CleartextStream.EventEmitter.emit (events.js:88:17) 
          at SecurePair.exports.connect.cleartext._controlReleased (tls.js:1166:15) 
          at SecurePair.EventEmitter.emit (events.js:88:17) 
          at SecurePair.error (tls.js:822:10) 
          at EncryptedStream.CryptoStream._done (tls.js:296:17) 
          at EncryptedStream.CryptoStream._pull (tls.js:447:12) 
          at SecurePair.cycle (tls.js:736:20) 
          at EncryptedStream.CryptoStream.end (tls.js:269:13) 
          at Socket.onend (stream.js:66:10) 
          at Socket.EventEmitter.emit (events.js:115:20) 
          at TCP.onread (net.js:418:51) 
