### PR TITLE
fixed deletion of a key from an object passed by reference

### DIFF
--- a/lib/requests.js
+++ b/lib/requests.js
@@ -113,15 +113,23 @@ BaseRequest.prototype.handleResponse = function(opt_fn) {
  *                              to replace inline path parameters e.g. {param}
  * @return {string} A URL.
  */
-var buildUri = function(root, paths, queryParams) {
+var buildUri = function(root, paths, params) {
   // create a path is starts with a slash and ends without it.
   // Preventing double slashes along the way
   var path = '/' + paths.join('/').split('/').filter(function(p) {
           return !!p;
       }).join('/'),
       fullPath = url.resolve(root, path);
+	
+	// duplicate params so as not to mangle an object passed by reference
+	var queryParams = {};
+	if (params) {
+		var keys = Object.keys(params)
+		keys.forEach( function(key) {
+			queryParams[key] = params[key];
+		});
+	}
 
-  queryParams = queryParams || {};
   // replace path query parameters, if there are on the path
   for (var paramName in queryParams) {
     var param = '{' + paramName + '}';


### PR DESCRIPTION
Request.buildUri() was mangling the param object, which is passed by
reference from application code.  Duplicated the params object before
mangling to solve the problem.
