### PR TITLE
Don't crash on undefined response

### DIFF
--- a/lib/auth/oauth2client.js
+++ b/lib/auth/oauth2client.js
@@ -191,7 +191,7 @@ OAuth2Client.prototype.request =
 
   this.transporter.request(opts, function(err, body, res) {
     // TODO: Check if it's not userRateLimitExceeded
-    var hasAuthError = res.statusCode == 401 || res.statusCode == 403;
+    var hasAuthError = res && (res.statusCode == 401 || res.statusCode == 403);
     // if there is an auth error, refresh the token
     // and make the request again
     if (!opt_dontForceRefresh && hasAuthError && credentials.refresh_token) {


### PR DESCRIPTION
When the underlaying socket crashes (EMFILE for example) the request callback is called without a res parameter (it is undefined) is such case the code will crash without letting the upper layer have a chance to know about it.
