### PR TITLE
Update JWT auth client with impersonation support

### DIFF
--- a/examples/jwt.js
+++ b/examples/jwt.js
@@ -16,11 +16,29 @@
 
 var googleapis = require('../lib/googleapis.js');
 
+/**
+ * The JWT authorization is ideal for performing server-to-server communication without
+ * asking for user consent.
+ *
+ * Suggested reading for Admin SDK users using service accounts:
+ * https://developers.google.com/admin-sdk/directory/v1/guides/delegation
+ *
+ * Note on the private_key.pem:
+ * Node.js currently does not support direct access to the keys stored within PKCS12 file
+ * (see issue comment https://github.com/joyent/node/issues/4050#issuecomment-8816304)
+ * so the private key must be extracted and converted to a passphrase-less RSA key:
+ * Convert the .p12 file to .pem: openssl pkcs12 -in key.p12 -out key.pem -nocerts
+ * Remove the passphrase from the .pem file: openssl rsa -in key.pem -out key.pem
+ */
 var authClient = googleapis.auth.JWT(
     'service-account-email@developer.gserviceaccount.com',
-    'path to private_key.pem',
-    'keyphrase',
-    ['https://www.googleapis.com/auth/drive.readonly']);
+    'path/to/private_key.pem',
+    // Contents of private_key.pem if you want to load the pem file yourself
+    // (do not use the path parameter above if using this param)
+    'key',
+    ['https://www.googleapis.com/auth/drive.readonly'],
+    // User to impersonate (leave empty if no impersonation needed)
+    'subject-account-email@example.com');
 
 authClient.authorize(function(err, tokens) {
   if (err) {

--- a/lib/auth/jwtclient.js
+++ b/lib/auth/jwtclient.js
@@ -27,11 +27,13 @@ var GAPI = require('gapitoken');
  * @param {string=} email service account email address.
  * @param {string=} keyFile path to private key file.
  * @param {array=} scopes list of requested scopes.
+ * @param {string=} subject impersonated account's email address.
  *
  */
-function JWT(email, keyFile, key, scopes) {
+function JWT(email, keyFile, key, scopes, subject) {
   JWT.super_.call(this);
   this.email = email;
+  this.subject = subject;
   this.keyFile = keyFile;
   this.key = key;
   this.scopes = scopes;
@@ -51,6 +53,7 @@ JWT.prototype.authorize = function(opt_callback) {
   var that = this;
   that.gapi = new that.GAPI({
     iss: that.email,
+    sub: that.subject,
     scope: that.scopes.join(' '),
     keyFile: that.keyFile,
     key : that.key

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "dependencies" : {
     "request": "~2.25.0",
     "async": "0.2.6",
-    "gapitoken": "0.1.0"
+    "gapitoken": "~0.1.2"
   },
   "devDependencies" : {
     "mocha": "1.8.1",

--- a/test/test.jwt.js
+++ b/test/test.jwt.js
@@ -24,11 +24,13 @@ describe('JWT auth client', function() {
         'foo@serviceaccount.com',
         '/path/to/key.pem',
         null,
-        ['http://bar', 'http://foo']);
+        ['http://bar', 'http://foo'],
+        'bar@subjectaccount.com');
     jwt.GAPI = function(opts, callback) {
       assert.equal('foo@serviceaccount.com', opts.iss);
       assert.equal('/path/to/key.pem', opts.keyFile);
       assert.equal('http://bar http://foo', opts.scope);
+      assert.equal('bar@subjectaccount.com', opts.sub);
       setTimeout(function() {
         callback(null);
       }, 0);
@@ -48,7 +50,8 @@ describe('JWT auth client', function() {
     var jwt = new googleapis.auth.JWT(
         'foo@serviceaccount.com',
         '/path/to/key.pem',
-        ['http://bar', 'http://foo']);
+        ['http://bar', 'http://foo'],
+        'bar@subjectaccount.com');
     jwt.credentials = {
       access_token: 'initial-access-token',
       refresh_token: 'jwt-placeholder'


### PR DESCRIPTION
This patch upgrades the **gapitoken** library to newest version which adds support for the "sub" attribute in JWT authorisation header which is necessary to perform impersonation.

**Notes:**
- I have relaxed the package requirement to allow patch updates on the **gapitoken** library (`~0.1.2`)
- I have expanded the jwt example substantially to provide more details about its usage

I hope I have not forgotten anything. Let me know if any updates are necessary before merge.
