### PR TITLE
Allow Oauth2 scopes to be passed as arrays

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ var scopes = [
 
 var url = oauth2Client.generateAuthUrl({
   access_type: 'offline', // 'online' (default) or 'offline' (gets refresh_token)
-  scope: scopes.join(' ') // space delimited string of scopes
+  scope: scopes // If you only need one scope you can pass it as string
 });
 ```
 

--- a/examples/oauth2.js
+++ b/examples/oauth2.js
@@ -37,7 +37,7 @@ function getAccessToken(oauth2Client, callback) {
   // generate consent page url
   var url = oauth2Client.generateAuthUrl({
     access_type: 'offline', // will return a refresh token
-    scope: 'https://www.googleapis.com/auth/plus.me'
+    scope: 'https://www.googleapis.com/auth/plus.me' // can be a space-delimited string or an array of scopes
   });
 
   console.log('Visit the url: ', url);

--- a/lib/auth/oauth2client.js
+++ b/lib/auth/oauth2client.js
@@ -103,6 +103,10 @@ OAuth2Client.prototype.generateAuthUrl = function(opt_opts) {
   opts.response_type = opts.response_type || 'code';
   opts.client_id = this.clientId_;
   opts.redirect_uri = this.redirectUri_;
+  // Allow scopes to be passed either as array or a string
+  if (opts.scope instanceof Array) {
+    opts.scope = opts.scope.join(' ');
+  }
 
   var rootUrl = this.opts.authBaseUrl ||
     OAuth2Client.GOOGLE_OAUTH2_AUTH_BASE_URL_;

--- a/test/test.oauth2.js
+++ b/test/test.oauth2.js
@@ -33,6 +33,7 @@ describe('OAuth2 client', function() {
   var REDIRECT_URI = 'REDIRECT';
   var ACCESS_TYPE = 'offline';
   var SCOPE = 'scopex';
+  var SCOPE_ARRAY = ['scopex', 'scopey'];
 
   var PUBLIC_KEY = '';
   var PRIVATE_KEY = '';
@@ -55,6 +56,23 @@ describe('OAuth2 client', function() {
     assert.equal(query.scope, SCOPE);
     assert.equal(query.client_id, CLIENT_ID);
     assert.equal(query.redirect_uri, REDIRECT_URI);
+    done();
+  });
+
+  it('should allow scopes to be specified as array', function(done) {
+    var opts = {
+      access_type: ACCESS_TYPE,
+      scope: SCOPE_ARRAY,
+      response_type: 'code token'
+    };
+
+    var oauth2client =
+        new googleapis.auth.OAuth2(CLIENT_ID, CLIENT_SECRET, REDIRECT_URI);
+    var generated = oauth2client.generateAuthUrl(opts);
+    var parsed = url.parse(generated);
+    var query = qs.parse(parsed.query);
+
+    assert.equal(query.scope, SCOPE_ARRAY.join(' '));
     done();
   });
 


### PR DESCRIPTION
The scopes should be provided as space-delimited string but we can join them together ourselves if we need.

This patch allows the scopes to be passed either as a string (single scope), space-delimited string or an array of strings (multiple scopes).

Comments/suggestions are welcome, thanks for merging.:)
