### PR TITLE
Removed body from GET and DELETE requests

### DIFF
--- a/lib/apirequest.js
+++ b/lib/apirequest.js
@@ -32,6 +32,7 @@ var transporter = new DefaultTransporter();
  */
 function createAPIRequest(context, params, options, isMedia, callback) {
   var req;
+  var method = options.method;
   var media = params.media;
   var resource = params.resource;
   var authClient = params.auth || context._options.auth || context.google._options.auth;
@@ -87,7 +88,7 @@ function createAPIRequest(context, params, options, isMedia, callback) {
     });
   }
   else {
-    options.json = resource || {};
+    options.json = resource || ((method === 'GET' || method === 'DELETE') ? true : {});
   }
 
   options.qs = params;

--- a/test/test.transporters.js
+++ b/test/test.transporters.js
@@ -40,10 +40,30 @@ describe('Transporters', function() {
     assert(re.test(opts.headers['User-Agent']));
   });
 
-  it('should automatically add content-type', function() {
+  it('should automatically add content-type for POST requests', function() {
+    var google = require('../lib/googleapis');
+    var drive = google.drive('v2');
+    var req = drive.comments.insert({
+        fileId: 'a'
+    });
+    assert.equal(req.headers['content-type'], 'application/json');
+  });
+
+  it('should not add body for GET requests', function() {
     var google = require('../lib/googleapis');
     var drive = google.drive('v2');
     var req = drive.files.list();
-    assert.equal(req.headers['content-type'], 'application/json');
+    assert.equal(req.headers['content-type'], null);
+    assert.equal(req.body, null);
+  });
+
+  it('should not add body for DELETE requests', function() {
+    var google = require('../lib/googleapis');
+    var drive = google.drive('v2');
+    var req = drive.files.delete({
+        fileId: 'test'
+    });
+    assert.equal(req.headers['content-type'], null);
+    assert.equal(req.body, null);
   });
 });


### PR DESCRIPTION
`GET` and `DELETE` requests should not have a body, and their `Content-Type` header should be blank.

The example from the readme:

``` javascript
var google = require('googleapis');
var urlshortener = google.urlshortener('v1');

var params = { shortUrl: 'http://goo.gl/xKbRu3' };

urlshortener.url.get(params, function (err, response) {
    console.log(response);
});
```

Currently gets a `400 Bad Request`:

```
<!DOCTYPE html>
<html lang=en>
  <meta charset=utf-8>
  <meta name=viewport content="initial-scale=1, minimum-scale=1, width=device-width">
  <title>Error 400 (Bad Request)!!1</title>
  <style>
    *{margin:0;padding:0}html,code{font:15px/22px arial,sans-serif}html{background:#fff;color:#222;padding:15px}body{margin:7% auto 0;max-width:390px;min-height:180px;padding:30px 0 15px}* > body{background:url(//www.google.com/images/errors/robot.png) 100% 5px no-repeat;padding-right:205px}p{margin:11px 0 22px;overflow:hidden}ins{color:#777;text-decoration:none}a img{border:0}@media screen and (max-width:772px){body{background:none;margin-top:0;max-width:none;padding-right:0}}#logo{background:url(//www.google.com/images/errors/logo_sm_2.png) no-repeat}@media only screen and (min-resolution:192dpi){#logo{background:url(//www.google.com/images/errors/logo_sm_2_hr.png) no-repeat 0% 0%/100% 100%;-moz-border-image:url(//www.google.com/images/errors/logo_sm_2_hr.png) 0}}@media only screen and (-webkit-min-device-pixel-ratio:2){#logo{background:url(//www.google.com/images/errors/logo_sm_2_hr.png) no-repeat;-webkit-background-size:100% 100%}}#logo{display:inline-block;height:55px;width:150px}
  </style>
  <a href=//www.google.com/><span id=logo aria-label=Google></span></a>
  <p><b>400.</b> <ins>That’s an error.</ins>
  <p>Your client has issued a malformed or illegal request.  <ins>That’s all we know.</ins>
```

Setting `json: true` instead of `json: {}` for `GET` and `DELETE` requests in the parameters to `request` fixes the problem.
