### PR TITLE
auth.JWT should support string scope

### DIFF
--- a/examples/jwt.js
+++ b/examples/jwt.js
@@ -37,6 +37,7 @@ var authClient = new google.auth.JWT(
     // Contents of private_key.pem if you want to load the pem file yourself
     // (do not use the path parameter above if using this param)
     'key',
+    // Scopes can be specified either as an array or as a single, space-delimited string
     ['https://www.googleapis.com/auth/drive.readonly'],
     // User to impersonate (leave empty if no impersonation needed)
     'subject-account-email@example.com');

--- a/lib/auth/jwtclient.js
+++ b/lib/auth/jwtclient.js
@@ -28,7 +28,7 @@ var GAPI = require('gapitoken');
  * @param {string=} email service account email address.
  * @param {string=} keyFile path to private key file.
  * @param {string=} key value of key
- * @param {array=} scopes list of requested scopes.
+ * @param {(string|array)=} scopes list of requested scopes or a single scope.
  * @param {string=} subject impersonated account's email address.
  * @constructor
  */
@@ -56,7 +56,7 @@ JWT.prototype.authorize = function(opt_callback) {
   that.gapi = new that.GAPI({
     iss: that.email,
     sub: that.subject,
-    scope: that.scopes.join(' '),
+    scope: that.scopes instanceof Array ? that.scopes.join(' ') : that.scopes,
     keyFile: that.keyFile,
     key: that.key
   }, function(err) {

--- a/test/test.jwt.js
+++ b/test/test.jwt.js
@@ -48,6 +48,23 @@ describe('JWT auth client', function() {
       done();
     });
   });
+
+  it('should accept scope as string', function (done) {
+    var jwt = new googleapis.auth.JWT(
+        'foo@serviceaccount.com',
+        '/path/to/key.pem',
+        null,
+        'http://foo',
+        'bar@subjectaccount.com');
+
+    jwt.GAPI = function(opts, callback) {
+      assert.equal('http://foo', opts.scope);
+      done();
+    }
+
+    jwt.authorize();
+  });
+
   it('should refresh token when request fails', function(done) {
     var jwt = new googleapis.auth.JWT(
         'foo@serviceaccount.com',


### PR DESCRIPTION
This is mainly a follow-up of my previous PR #209. The OAuth client now supports both string and array as input for scopes, but the JWT only supports array. This PR levels up the JWT client to support both.

Comments are welcome - thanks for merging!
(rebased on current master, as proposed in #214)
