### PR TITLE
Add jscoverage support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules/*
 .idea
 docs/
 npm-debug.log
+coverage

--- a/.npmignore
+++ b/.npmignore
@@ -2,3 +2,4 @@ test
 examples
 docs
 node_modules
+coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,3 +4,5 @@ node_js:
 script:
   - npm test
   - npm run lint
+after_success:
+  - npm run coveralls

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Google APIs Node.js Client [![Build Status][travisimg]][travis]
+# Google APIs Node.js Client [![Build Status][travisimg]][travis] [![Code Coverage][coverallsimg]][coveralls]
 
 Google's officially supported [node.js][node] client library for using
 Google APIs. It also supports authorization and authentication with OAuth 2.0.
@@ -353,3 +353,5 @@ See [CONTRIBUTING][contributing].
 [options]: https://github.com/google/google-api-nodejs-client/tree/master#options
 [gcloud]: https://github.com/GoogleCloudPlatform/gcloud-node
 [cloudplatform]: https://developers.google.com/cloud/
+[coveralls]: https://coveralls.io/r/google/google-api-nodejs-client?branch=master
+[coverallsimg]: https://coveralls.io/repos/google/google-api-nodejs-client/badge.png?branch=master

--- a/package.json
+++ b/package.json
@@ -39,6 +39,8 @@
     "request": "2.37.0"
   },
   "devDependencies": {
+    "coveralls": "^2.11.1",
+    "istanbul": "~0.3.2",
     "js-beautify": "1.5.1",
     "jsdoc": "3.3.0-alpha9",
     "jshint": "^2.5.5",
@@ -55,7 +57,9 @@
     "test": "mocha --reporter spec --timeout 4000",
     "generate-apis": "node scripts/generate",
     "generate-docs": "jsdoc -c jsdoc-conf.json ./README.md",
-    "prepare": "npm run generate-apis && npm test && npm run lint && npm version patch"
+    "prepare": "npm run generate-apis && npm test && npm run lint && npm version patch",
+    "coverage": "istanbul cover -x 'apis/**' _mocha -- --reporter spec --timeout 4000",
+    "coveralls": "istanbul cover -x 'apis/**' _mocha --report lcovonly -- --reporter spec --timeout 4000 && cat coverage/lcov.info | coveralls"
   },
   "license": "Apache-2.0"
 }


### PR DESCRIPTION
To generate coverage html report:
`$ npm run coverage`
This will generate _coverage.html_ in the project root. We can also reconfigure it to generate json coverage data and send it to something like [Coveralls](https://coveralls.io).

Closes #30.
