### PR TITLE
Compute proper JWT expiry date.

### DIFF
--- a/lib/auth/jwtclient.js
+++ b/lib/auth/jwtclient.js
@@ -86,7 +86,7 @@ JWT.prototype.refreshToken_ = function(ignored_, opt_callback) {
     opt_callback && opt_callback(err, {
       access_token: token,
       token_type: 'Bearer',
-      expiry_date: ((new Date()).getTime() + (that.gapi.token_expires * 1000))
+      expiry_date: that.gapi.token_expires
     });
   });
 };


### PR DESCRIPTION
The current version produces an expiry_date which is:

now + token_expires + 1

This fixes it to use the already computed expiry date in token_expires.
