### PR TITLE
added try catch around verifySignedJwtWithCerts in verifyIdToken

### DIFF
--- a/lib/auth/oauth2client.js
+++ b/lib/auth/oauth2client.js
@@ -297,11 +297,15 @@ OAuth2Client.prototype.verifyIdToken = function(idToken, audience, callback) {
     if (err) {
       callback(err, null);
     }
-    var login = this.verifySignedJwtWithCerts(idToken, certs, audience,
+    var login;
+    try {
+      login = this.verifySignedJwtWithCerts(idToken, certs, audience,
         OAuth2Client.ISSUER_);
-    if (!login) {
-      callback('Unable to verify the ID Token', null);
+    } catch (err) {
+      callback(err);
+      return;
     }
+
     callback(null, login);
   }.bind(this));
 };


### PR DESCRIPTION
verifyIdToken is not throw safe because verifySignedJwtWithCerts throws. 

but we can't simply wrap the verifyIdToken call in try catch because the call to verifySignedJwtWithCerts is async. 

also returning the error seems more helpful than just a generic error string.
