### PR TITLE
Throw better 'version not found' error

### DIFF
--- a/apis/index.js
+++ b/apis/index.js
@@ -37,7 +37,7 @@ function requireAPI(filename) {
       throw new Error('Argument error: Accepts only string or object');
     }
     try {
-      var Endpoint = require(__dirname + '/' + filename + '/' + path.basename(version));
+      var Endpoint = require(path.join(__dirname, filename, path.basename(version)));
       var ep = new Endpoint(options);
       ep.google = this; // for drive.google.transporter
       return Object.freeze(ep); // create new & freeze

--- a/templates/api-index.js
+++ b/templates/api-index.js
@@ -37,7 +37,7 @@ function requireAPI(filename) {
       throw new Error('Argument error: Accepts only string or object');
     }
     try {
-      var Endpoint = require(__dirname + '/' + filename + '/' + path.basename(version));
+      var Endpoint = require(path.join(__dirname, filename, path.basename(version)));
       var ep = new Endpoint(options);
       ep.google = this; // for drive.google.transporter
       return Object.freeze(ep); // create new & freeze


### PR DESCRIPTION
From the code:

``` js
try {
  var Endpoint = require(__dirname + '/' + filename + '/' + path.basename(version));
  var ep = new Endpoint(options);
  ep.google = this; // for drive.google.transporter
  return Object.freeze(ep); // create new & freeze
} catch (e) {
  console.log(e);
  throw new Error('Error: Version \"' + version + '\" not found.');
}
```

We should not console.log(e) here, we should be returning its value in the new Error that is thrown.

My proposal:

``` js
throw new Error('Version \"' + version + '\" not found: ' + e.message);
```

This will produce something like:

```
'Error: Version "bad_version" not found: Cannot find module '/Users/ryanseys/google-api-nodejs-client/apis/drive/bad_version'
```

Also use `path.join` instead of `+ '/' +` because this won't work on Windows.
