### PR TITLE
Add custom discovery and base urls through args

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,7 +26,7 @@ Submit a pull request. The repo owner will review your request. If it is
 approved, the change will be merged. If it needs additional work, the repo
 owner will respond with useful comments.
 
-## Generating APIs and Documentation
+## Generating APIs
 
 If you're a developer interested in contributing to this library, the following
 section will be useful for you. Each of the files in `apis/` is generated from
@@ -36,6 +36,20 @@ the following command:
 ``` sh
 npm run generate-apis
 ```
+
+You can pass in a custom Discovery URL:
+
+``` sh
+node scripts/generate --discovery-url "http://discoveryurl.example.com"
+```
+
+Or a custom Base URL:
+
+``` sh
+node scripts/generate --base-url "http://baseurl.example.com"
+```
+
+## Generating Documentation
 
 You can generate the documentation for the APIs by running:
 

--- a/lib/generator.js
+++ b/lib/generator.js
@@ -22,12 +22,14 @@ var beautify = require('js-beautify').js_beautify;
 var path = require('path');
 var mkdirp = require('mkdirp');
 var fs = require('fs');
+var argv = require('minimist')(process.argv.slice(2));
 
-var BASE_URL = 'https://www.googleapis.com';
+var BASE_URL = argv['base-url'] || 'https://www.googleapis.com';
+var DISCOVERY_URL = argv['discovery-url'] || 'https://www.googleapis.com/discovery/v1/apis/';
+
 var API_INDEX = './apis/index.js';
 var API_INDEX_TEMPLATE = './templates/api-index.js';
 var API_TEMPLATE = './templates/api-endpoint.js';
-var DISCOVERY_URL = 'https://www.googleapis.com/discovery/v1/apis/';
 var BEAUTIFY_OPTIONS = {
   'indent_size': 2,
   'indent_char': ' ',

--- a/package.json
+++ b/package.json
@@ -43,7 +43,8 @@
     "nock": "0.42.1",
     "rimraf": "2.2.8",
     "swig": "1.3.2",
-    "url": "0.7.9"
+    "url": "0.7.9",
+    "minimist": "1.1.0"
   },
   "scripts": {
     "test": "mocha --reporter spec --timeout 4000",


### PR DESCRIPTION
You can now pass in a custom Discovery URL:

``` sh
node scripts/generate --discovery-url "http://discoveryurl.example.com"
```

Or a custom Base URL:

``` sh
node scripts/generate --base-url "http://baseurl.example.com"
```

**Note:** Adds devDependency: https://github.com/substack/minimist

Fixes #264.
