### PR TITLE
Use platform-independent absolute paths

### DIFF
--- a/apis/index.js
+++ b/apis/index.js
@@ -37,7 +37,7 @@ function requireAPI(filename) {
       throw new Error('Argument error: Accepts only string or object');
     }
     try {
-      var Endpoint = require(__dirname + '/' + filename + '/' + path.basename(version));
+      var Endpoint = require(path.join(__dirname, filename, path.basename(version)));
       var ep = new Endpoint(options);
       ep.google = this; // for drive.google.transporter
       return Object.freeze(ep); // create new & freeze

--- a/lib/generator.js
+++ b/lib/generator.js
@@ -110,7 +110,7 @@ swig.setFilter('buildurl', buildurl);
 swig.setFilter('getAPIs', getAPIs);
 swig.setFilter('oneLine', oneLine);
 swig.setFilter('getPathParams', getPathParams);
-swig.setDefaults({ loader: swig.loaders.fs(__dirname + '/../templates')});
+swig.setDefaults({ loader: swig.loaders.fs(path.join(__dirname, '..', 'templates'))});
 
 /**
  * Handle error object with callback
@@ -190,7 +190,7 @@ Generator.prototype.generateAPI = function(apiDiscoveryUrl, callback) {
       return handleError(err, callback);
     }
     var contents = beautify(swig.render(templateContents, { locals: resp }), BEAUTIFY_OPTIONS);
-    var exportFilename = './apis/' + resp.name + '/' + resp.version + '.js';
+    var exportFilename = path.join('apis', resp.name, resp.version + '.js'); // e.g. apis/drive/v2.js
     mkdirp(path.dirname(exportFilename), function(err) {
       if (err) {
         return handleError(err, callback);

--- a/scripts/generate.js
+++ b/scripts/generate.js
@@ -18,12 +18,13 @@
 
 var Generator = require('../lib/generator');
 var rimraf = require('rimraf');
+var path = require('path')
 var debug = false;
 // constructors
 var gen = new Generator({ debug: debug, includePrivate: false });
 
 console.log('Removing old APIs...');
-rimraf(__dirname + '/../apis', function(err) {
+rimraf(path.join(__dirname, '..', 'apis'), function(err) {
   if (err) {
     throw err;
   }

--- a/templates/api-index.js
+++ b/templates/api-index.js
@@ -37,7 +37,7 @@ function requireAPI(filename) {
       throw new Error('Argument error: Accepts only string or object');
     }
     try {
-      var Endpoint = require(__dirname + '/' + filename + '/' + path.basename(version));
+      var Endpoint = require(path.join(__dirname, filename, path.basename(version)));
       var ep = new Endpoint(options);
       ep.google = this; // for drive.google.transporter
       return Object.freeze(ep); // create new & freeze


### PR DESCRIPTION
This resolves issues caused by having a path with both forward and backslashes (especially on Win32 as the hardcoded paths were for *nix).

I believe this was the cause of the following [SO question](http://stackoverflow.com/questions/25579734/nodejs-google-api-module-version-v2-not-found), however, being fully Mac-centric, I currently have no means to test this (at least on OS X everything still works :-) ).

I have regenerated the apis/index.js file so hopefully a new patch release will do the trick.
