### PR TITLE
Update dependencies and relax version restrictions

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,24 +33,24 @@
     "client library"
   ],
   "dependencies": {
-    "async": "0.2.10",
-    "gapitoken": "0.1.2",
-    "multipart-stream": "1.0.0",
-    "request": "2.37.0"
+    "async": "~0.9.0",
+    "gapitoken": "~0.1.2",
+    "multipart-stream": "~1.0.0",
+    "request": "~2.40.0"
   },
   "devDependencies": {
     "coveralls": "^2.11.1",
     "istanbul": "~0.3.2",
-    "js-beautify": "1.5.1",
-    "jsdoc": "3.3.0-alpha9",
+    "js-beautify": "^1.5.1",
     "jshint": "^2.5.5",
-    "mkdirp": "0.5.0",
-    "mocha": "1.8.1",
-    "nock": "0.42.1",
-    "rimraf": "2.2.8",
-    "swig": "1.3.2",
-    "url": "0.7.9",
-    "minimist": "1.1.0"
+    "jsdoc": "~3.3.0-alpha9",
+    "mkdirp": "~0.5.0",
+    "mocha": "^1.8.1",
+    "nock": "~0.46.0",
+    "rimraf": "^2.2.8",
+    "swig": "^1.4.2",
+    "url": "~0.10.1",
+    "minimist": "^1.1.0"
   },
   "scripts": {
     "lint": "jshint lib test scripts apis",


### PR DESCRIPTION
Relaxed version requirements to allow for patches released by 3rd parties to be installed without needing of a new version. _devDependencies_ above v1 now also allow minor release updates (^).
