### PR TITLE
Warn if installing on older Node.js version than supported

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,9 @@
       "email": "monsur@google.com"
     }
   ],
+  "engines": {
+    "node": ">=0.10"
+  },
   "main": "./lib/googleapis",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This will produce a warning when this library is installed on a system with node.js version below 0.10. See [NPM#Engines](https://www.npmjs.org/doc/files/package.json.html#engines).

This is yet another PR based on the discussion and issue described on [this SO question](http://stackoverflow.com/questions/25579734/nodejs-google-api-module-typeerror-cannot-read-property-prototype-of-und/25584308?noredirect=1#comment39984308_25584308) (and your comment).
