### PR TITLE
Add --save to installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ This library is distributed on `npm`. In order to add it as a dependency,
 run the following command:
 
 ``` sh
-$ npm install googleapis
+$ npm install googleapis --save
 ```
 
 ## Usage


### PR DESCRIPTION
Hey. Just reading through the README I noticed that you specify that you can install the module as a dependency with the command `npm install googleapis`. This is not strictly true. It will not be added as a dependecy unless you also add --save.

If that was a misreading from me, then please feel free to close this.

Other than that, thanks so much for making this available and have a great weekend!
