### PR TITLE
urlencode all path params

### DIFF
--- a/lib/apirequest.js
+++ b/lib/apirequest.js
@@ -21,6 +21,7 @@ var utils = require('./utils.js');
 var DefaultTransporter = require('./transporters.js');
 var transporter = new DefaultTransporter();
 var stream = require('stream');
+var parseString = require('string-template');
 
 function isReadableStream(obj) {
   return obj instanceof stream.Stream && typeof obj._read === 'function' &&
@@ -48,6 +49,30 @@ function isValidParams(params, keys, callback) {
 }
 
 /**
+ * Take a url path template and replace placeholders with data from params,
+ * i.e. parsePath('/my/{value}', { value: 'something' }); // /my/something
+ * @param  {String} path   String with template placeholders in curly braces
+ * @param  {object} params Properties to be placed into the placeholders
+ * @return {String}        Templated string with actual values
+ */
+function parsePath(path, params) {
+
+  if (! path) {
+    return path;
+  }
+
+  // escape path params
+  var escapedParams = {};
+
+  Object.keys(params).forEach(function(value) {
+    escapedParams[value] = encodeURIComponent(params[value]);
+  });
+
+  // process the url template and return parsed url
+  return parseString(path, escapedParams);
+}
+
+/**
  * Create and send request to Google API
  * @param  {object}   parameters Parameters used to form request
  * @param  {Function} callback   Callback when request finished or error found
@@ -55,7 +80,6 @@ function isValidParams(params, keys, callback) {
  */
 function createAPIRequest(parameters, callback) {
   var req, body;
-  var mediaUrl = parameters.mediaUrl;
   var context = parameters.context;
   var params = parameters.params;
   var options = parameters.options || {};
@@ -89,6 +113,10 @@ function createAPIRequest(parameters, callback) {
   delete params.resource;
   delete params.auth;
 
+  // Parse urls and urlescape path params
+  options.url = parsePath(options.url, params);
+  parameters.mediaUrl = parsePath(parameters.mediaUrl, params);
+
   // delete required parameters
   for (var i = 0, len = pathParams.length; i < len; i++) {
     delete params[pathParams[i]];
@@ -100,8 +128,8 @@ function createAPIRequest(parameters, callback) {
     authClient = null;
   }
 
-  if (mediaUrl && media && media.body) {
-    options.url = mediaUrl;
+  if (parameters.mediaUrl && media && media.body) {
+    options.url = parameters.mediaUrl;
     if (resource) {
       // Create a boundary identifier and multipart read stream
       var boundary = Math.random().toString(36).slice(2);

--- a/lib/generator.js
+++ b/lib/generator.js
@@ -60,13 +60,8 @@ var transporter = new DefaultTransporter();
  */
 function buildurl(input) {
   return ('\'' + BASE_URL + input + '\'')
-    .replace(/{\+/g, '\' + params.')
-    .replace(/{\//g, '\' + params.')
-    .replace(/{/g, '\' + params.')
-    .replace(/\*}\'$/g, '')
-    .replace(/\*}/g, ' + \'')
-    .replace(new RegExp('}\'$', 'g'), '')
-    .replace(new RegExp('}', 'g'), ' + \'');
+    .replace(/\*/g, '')
+    .replace(/\{\//g, '/{');
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "async": "~0.9.0",
     "gapitoken": "~0.1.2",
     "multipart-stream": "~1.0.0",
-    "request": "~2.40.0"
+    "request": "~2.40.0",
+    "string-template": "~0.2.0"
   },
   "devDependencies": {
     "coveralls": "^2.11.1",

--- a/test/test.path.js
+++ b/test/test.path.js
@@ -81,6 +81,11 @@ describe('Path params', function() {
     assert.equal(req.uri.pathname, '/drive/v2/files/123abc');
   });
 
+  it('should be urlencoded', function () {
+    var req = drive.files.get({ fileId: 'p@ram' }, noop);
+    assert.equal(req.uri.path.split('/').pop(), 'p%40ram');
+  });
+
   it('should keep query params null if only path params', function() {
     var req = drive.files.get({ fileId: '123abc' }, noop);
     assert.equal(req.uri.query, null);


### PR DESCRIPTION
Tests and docblock included. Requires rebuilding of all apis.

It runs all the endpoint urls through `parsePath`, a new function defined in `lib/apirequest.js` - it handlers the string parsing ('my {param}' -> 'my value') as well as urlencoding the individual path components.

Closes #275.
