### PR TITLE
[requires api-rebuild] Refactor apirequest.js

### DIFF
--- a/lib/apirequest.js
+++ b/lib/apirequest.js
@@ -19,34 +19,38 @@
 var Multipart = require('multipart-stream');
 var utils = require('./utils.js');
 var DefaultTransporter = require('./transporters.js');
-var transporter = new DefaultTransporter();
 var stream = require('stream');
 var parseString = require('string-template');
 var querystring = require('querystring');
 
 function isReadableStream(obj) {
-  return obj instanceof stream.Stream && typeof obj._read === 'function' &&
-      typeof obj._readableState === 'object';
+  return obj instanceof stream.Stream &&
+    typeof obj._read === 'function' &&
+    typeof obj._readableState === 'object';
 }
 
-function logErrorOnly(err) {
+function logError(err) {
   if (err) {
     console.error(err);
   }
 }
 
 function createCallback(callback) {
-  return typeof callback === 'function' ? callback : logErrorOnly;
+  return typeof callback === 'function' ? callback : logError;
 }
 
-function isValidParams(params, keys, callback) {
-  for (var i = 0, len = keys.length; i < len; i++) {
-    if (!params[keys[i]]) {
-      callback(new Error('Missing required parameter: ' + keys[i]), null);
-      return false;
+function getMissingParams(params, required) {
+  var missing = [];
+
+  required.forEach(function(param) {
+    // Is the required param in the params object?
+    if (! params[param]) {
+      missing.push(param);
     }
-  }
-  return true;
+  });
+
+  // If there are any required params missing, return their names in array, otherwise return null
+  return missing.length > 0 ? missing : null;
 }
 
 /**
@@ -80,35 +84,41 @@ function parsePath(path, params) {
  * @return {Request}             Returns Request object or null
  */
 function createAPIRequest(parameters, callback) {
-  var req, body;
-  var context = parameters.context;
+  var req, body, missingParams;
   var params = parameters.params;
-  var options = parameters.options || {};
-  var requiredParams = parameters.requiredParams || [];
-  var pathParams = parameters.pathParams || [];
+  var options = utils.extend({}, parameters.options);
 
   /**
    * If the params are not present, and callback was passed instead,
    * use params as the callback and create empty params.
    */
-  if (typeof(params) === 'function') {
+  if (typeof params === 'function') {
     callback = params;
     params = {};
   } else {
+    // Create a new params object so it can no longer be modified from outside code
     params = utils.extend({}, params);
   }
 
-  // Redefining callback var
+  // Normalize callback
   callback = createCallback(callback);
 
-  if (!isValidParams(params, requiredParams, callback)) {
+  // Check for missing required parameters in the API request
+  missingParams = getMissingParams(params, parameters.requiredParams);
+  if (missingParams) {
+    // Some params are missing - stop further operations and inform the developer which required
+    // params are not included in the request
+    callback(new Error('Missing required parameters: ', missingParams.join(', ')));
+
     return null;
   }
 
-  var method = options.method;
   var media = params.media || {};
   var resource = params.resource;
-  var authClient = params.auth || context._options.auth || context.google._options.auth;
+  var authClient = params.auth ||
+    parameters.context._options.auth ||
+    parameters.context.google._options.auth;
+
   var defaultMime = typeof media.body === 'string' ? 'text/plain' : 'application/octet-stream';
   delete params.media;
   delete params.resource;
@@ -118,10 +128,10 @@ function createAPIRequest(parameters, callback) {
   options.url = parsePath(options.url, params);
   parameters.mediaUrl = parsePath(parameters.mediaUrl, params);
 
-  // delete required parameters
-  for (var i = 0, len = pathParams.length; i < len; i++) {
-    delete params[pathParams[i]];
-  }
+  // delete path parameters from the params object so they do not end up in query
+  parameters.pathParams.forEach(function(param) {
+    delete params[param];
+  });
 
   // if authClient is actually a string, use it as an API KEY
   if (typeof authClient === 'string') {
@@ -129,18 +139,17 @@ function createAPIRequest(parameters, callback) {
     authClient = null;
   }
 
-  if (parameters.mediaUrl && media && media.body) {
+  if (parameters.mediaUrl && media.body) {
     options.url = parameters.mediaUrl;
     if (resource) {
       // Create a boundary identifier and multipart read stream
-      var boundary = Math.random().toString(36).slice(2);
-      body = new Multipart(boundary);
+      body = new Multipart();
 
       // Use multipart upload
       params.uploadType = 'multipart';
 
       options.headers = {
-        'Content-Type': 'multipart/related; boundary="' + boundary + '"'
+        'Content-Type': 'multipart/related; boundary="' + body.boundary + '"'
       };
 
       // Add parts to multipart request
@@ -170,21 +179,27 @@ function createAPIRequest(parameters, callback) {
       }
     }
   } else {
-    options.json = resource || ((method === 'GET' || method === 'DELETE') ? true : {});
+    options.json = resource || (
+      (options.method === 'GET' || options.method === 'DELETE') ? true : {}
+    );
   }
 
   if(Object.keys(params).length) {
     options.url += '?' + querystring.stringify(params);
   }
 
-  options = utils.extend({}, context.google._options, context._options, options);
+  options = utils.extend({},
+    parameters.context.google._options,
+    parameters.context._options,
+    options
+  );
   delete options.auth; // is overridden by our auth code
 
   // create request (using authClient or otherwise and return request obj)
   if (authClient) {
     req = authClient.request(options, callback);
   } else {
-    req = transporter.request(options, callback);
+    req = new DefaultTransporter().request(options, callback);
   }
 
   if (body) {
@@ -194,9 +209,7 @@ function createAPIRequest(parameters, callback) {
 }
 
 /**
- * Exports helper functionsj
- * @type {object}
+ * Exports createAPIRequest
+ * @type {Function}
  */
-module.exports = {
-  createAPIRequest: createAPIRequest
-};
+module.exports = createAPIRequest;

--- a/templates/api-endpoint.js
+++ b/templates/api-endpoint.js
@@ -18,8 +18,7 @@
 
 'use strict';
 
-var apirequest = require('../../lib/apirequest');
-var createAPIRequest = apirequest.createAPIRequest;
+var createAPIRequest = require('../../lib/apirequest');
 
 {% set Name = name|capitalize %}
 {% set Version = version|replace('\.', '_')|capitalize %}

--- a/templates/method-partial.js
+++ b/templates/method-partial.js
@@ -34,8 +34,8 @@
     },
     params: params,
     {%- if m.mediaUpload.protocols.simple.path -%}mediaUrl: {{ m.mediaUpload.protocols.simple.path|buildurl }},{%- endif -%}
-    {%- if m.parameterOrder.length -%}requiredParams: ['{{ m.parameterOrder|join("', '")|safe }}'],{%- endif -%}
-    {%- if pathParams.length -%}pathParams: ['{{ pathParams|join("', '")|safe }}'],{%- endif -%}
+    requiredParams: [{%- if m.parameterOrder.length -%}'{{ m.parameterOrder|join("', '")|safe }}'{%- endif -%}],
+    pathParams: [{%- if pathParams.length -%}'{{ pathParams|join("', '")|safe }}'{%- endif -%}],
     context: self
   };
 


### PR DESCRIPTION
While studying the apirequest.js code, I frequently found myself jumping up and down the code to see where a variable is declared and what it holds etc. and some parts were not very clear what they are supposed to do. So I decided to do a little bit of cleanup in hopes that it will help me as well as other devs to better understand the code and make it more readable and maintainable.

I could not help but add a single big commit. Below is the summary of changes.
- reduce the amount of `var` declarations as much as possible
- for readability, replace `for` loops with `Array.prototype.forEach` where suitable (I know that `forEach` is less performant than `for` loop but we will be mostly waiting for the remote endpoint to respond, and compared to that, the performace hit is negligible)
- add more comments to better describe what a particular code block is supposed to do
- When required params are missing from an API call, list them all at once in the Error message
- define `pathParams` and `requiredParams` on API methods even if there are none (reduces clutter by not needing to check for their presence first in apirequest)

I am open for further discussion or improvements. Let me know if there is anything you would like to change.

Tests are passing after regenerating the clients, `npm run lint`-free.
