### PR TITLE
Handle 5xx as errors

### DIFF
--- a/lib/transporters.js
+++ b/lib/transporters.js
@@ -78,6 +78,14 @@ DefaultTransporter.prototype.wrapCallback_ = function(opt_callback) {
       err = body.error;
       body = null;
     }
+
+    // there is no err and is a body and no body.error
+    // but server still returns error code
+    if (res.statusCode >= 500) {
+      err = { code: res.statusCode, message: body };
+      body = null;
+    }
+
     if (opt_callback) {
       opt_callback(err, body, res);
     }


### PR DESCRIPTION
Fixes #293. @Alaneor, want to take an extra look?

mikeal/request does not return an err object on 5xx errors because they are not errors related to the socket. So instead, I check the response.statusCode of each response and return an error object if it's a 5xx. I also set the body of the message to null.
