### PR TITLE
Handle 4xx as errors?

### DIFF
--- a/lib/transporters.js
+++ b/lib/transporters.js
@@ -79,10 +79,17 @@ DefaultTransporter.prototype.wrapCallback_ = function(opt_callback) {
       body = null;
     }
 
-    // there is no err and is a body and no body.error
-    // but server still returns error code
+    // For 4xx errors, set the err.code to HTTP status code but do not set body to null for
+    // backwards-compatibility
+    if (res.statusCode >= 400 && res.statusCode < 500) {
+      err = new Error(body);
+      err.code = res.statusCode;
+    }
+
+    // For 5xx errors, set the err.code to HTTP status code and set body to null
     if (res.statusCode >= 500) {
-      err = { code: res.statusCode, message: body };
+      err = new Error(body);
+      err.code = res.statusCode;
       body = null;
     }
 


### PR DESCRIPTION
I was off the grid since Friday so could not join the discussion around #293 on #304 but here are my suggestions that might improve on that. Comments are very welcome!
- Also handle client (4xx) HTTP errors (just in case, you never know...)
- Return actual instance or `Error` when an HTTP error occurs

PS. Not sure if we should also have a test case for a successful HTTP response...?
