### PR TITLE
Fix missing params not being shown in Error message

### DIFF
--- a/lib/apirequest.js
+++ b/lib/apirequest.js
@@ -108,7 +108,7 @@ function createAPIRequest(parameters, callback) {
   if (missingParams) {
     // Some params are missing - stop further operations and inform the developer which required
     // params are not included in the request
-    callback(new Error('Missing required parameters: ', missingParams.join(', ')));
+    callback(new Error('Missing required parameters: ' + missingParams.join(', ')));
 
     return null;
   }

--- a/test/test.path.js
+++ b/test/test.path.js
@@ -43,6 +43,13 @@ describe('Path params', function() {
     });
   });
 
+  it('should be mentioned in err.message when missing', function (done) {
+    drive.files.get({}, function(err) {
+      assert.notEqual(err.message.indexOf('fileId'), -1, 'Missing param not mentioned in error');
+      done();
+    });
+  });
+
   it('should return null response object if not included and required', function(done) {
     drive.files.get({}, function(err, resp) {
       assert.equal(resp, null);


### PR DESCRIPTION
Bug introduced in 4d920bf. I added test for this feature to prevent similar issues in the future...
