### PR TITLE
Update request to 2.48 and use built-in querystring support

### DIFF
--- a/lib/apirequest.js
+++ b/lib/apirequest.js
@@ -21,7 +21,6 @@ var utils = require('./utils.js');
 var DefaultTransporter = require('./transporters.js');
 var stream = require('stream');
 var parseString = require('string-template');
-var querystring = require('querystring');
 
 function isReadableStream(obj) {
   return obj instanceof stream.Stream &&
@@ -188,9 +187,8 @@ function createAPIRequest(parameters, callback) {
     );
   }
 
-  if(Object.keys(params).length) {
-    options.url += '?' + querystring.stringify(params);
-  }
+  options.qs = params;
+  options.useQuerystring = true;
 
   options = utils.extend({},
     parameters.context.google._options,

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "async": "~0.9.0",
     "gapitoken": "~0.1.2",
     "multipart-stream": "~1.0.0",
-    "request": "~2.40.0",
+    "request": "~2.48.0",
     "string-template": "~0.2.0"
   },
   "devDependencies": {


### PR DESCRIPTION
No need to do the heavy lifting ourselves anymore - Request now has **querystring** parsing built-in since 2.46.
