### PR TITLE
Better streams

### DIFF
--- a/lib/apirequest.js
+++ b/lib/apirequest.js
@@ -16,7 +16,6 @@
 
 'use strict';
 
-var Multipart = require('multipart-stream');
 var utils = require('./utils.js');
 var DefaultTransporter = require('./transporters.js');
 var stream = require('stream');
@@ -145,30 +144,17 @@ function createAPIRequest(parameters, callback) {
   if (parameters.mediaUrl && media.body) {
     options.url = parameters.mediaUrl;
     if (resource) {
-      // Create a boundary identifier and multipart read stream
-      body = new Multipart();
-
-      // Use multipart upload
       params.uploadType = 'multipart';
-
-      options.headers = {
-        'Content-Type': 'multipart/related; boundary="' + body.boundary + '"'
-      };
-
-      // Add parts to multipart request
-      body.addPart({
-        headers: {
-          'Content-Type': 'application/json'
+      options.multipart = [
+        {
+          'Content-Type': 'application/json',
+          body: JSON.stringify(resource)
         },
-        body: JSON.stringify(resource)
-      });
-
-      body.addPart({
-        headers: {
-          'Content-Type': media.mimeType || resource && resource.mimeType || defaultMime
-        },
-        body: media.body // can be a readable stream or raw string!
-      });
+        {
+          'Content-Type': media.mimeType || resource && resource.mimeType || defaultMime,
+          body: media.body // can be a readable stream or raw string!
+        }
+      ];
     } else {
       params.uploadType = 'media';
       options.headers = {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
   "dependencies": {
     "async": "~0.9.0",
     "gapitoken": "~0.1.2",
-    "multipart-stream": "~1.0.0",
     "request": "~2.48.0",
     "string-template": "~0.2.0"
   },

--- a/test/test.media.js
+++ b/test/test.media.js
@@ -92,8 +92,8 @@ describe('Media', function() {
           req.uri.href,
           'https://www.googleapis.com/upload/drive/v2/files?uploadType=multipart'
         );
-        assert.equal(req.headers['Content-Type'].indexOf('multipart/related;'), 0);
-        var boundary = req.src.boundary;
+        assert.equal(req.headers['content-type'].indexOf('multipart/related;'), 0);
+        var boundary = req.boundary;
         expectedResp = expectedResp
             .replace(/\n/g, '\r\n')
             .replace(/\$boundary/g, boundary)
@@ -136,8 +136,8 @@ describe('Media', function() {
         req.uri.href,
         'https://www.googleapis.com/upload/drive/v2/files?uploadType=multipart'
       );
-      assert.equal(req.headers['Content-Type'].indexOf('multipart/related;'), 0);
-      var boundary = req.src.boundary;
+      assert.equal(req.headers['content-type'].indexOf('multipart/related;'), 0);
+      var boundary = req.boundary;
       expectedResp = expectedResp
           .replace(/\n/g, '\r\n')
           .replace(/\$boundary/g, boundary)
@@ -213,7 +213,7 @@ describe('Media', function() {
       resource: resource,
       media: media
     }, function(err, resp) {
-      var boundary = req.src.boundary;
+      var boundary = req.boundary;
       expectedBody = expectedBody
           .replace(/\n/g, '\r\n')
           .replace(/\$boundary/g, boundary)


### PR DESCRIPTION
This removes the buggy `multipart-stream` library and uses the new `request` library capabilities to upload streams. Uploading a 3GB file on old implementation would cause node to immediately allocate 3GB of memory. Now Node consumes memory as it uses it. In my tests with the 3GB file, the memory usage did not exceed 100MB.

Fixes #327 
Fixes #236 

@rakyll can you review?

Edit: Please :)
