### PR TITLE
Remove reference docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,9 +103,6 @@ runSample().catch(console.error);
 ### Samples
 There are a lot of [samples](https://github.com/google/google-api-nodejs-client/tree/master/samples) 🤗  If you're trying to figure out how to use an API ... look there first! If there's a sample you need missing, feel free to file an [issue][bugs].
 
-### Reference API
-This library provides generated [Reference API documentation](http://google.github.io/google-api-nodejs-client/).
-
 ## Authentication and authorization
 The are three primary ways to authenticate to Google APIs. Some service support all authentication methods, other may only support one or two.
 
@@ -196,7 +193,7 @@ oauth2client.setCredentials({
 });
 ```
 
-Once the client has a refresh token, access tokens will be acquired and refreshed automatically in the next call to the API. 
+Once the client has a refresh token, access tokens will be acquired and refreshed automatically in the next call to the API.
 
 ### Using API keys
 You may need to send an API key with the request you are going to make. The following uses an API key to make a request to the Google+ API service to retrieve a person's profile given a userId:

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "pretest": "npm run compile",
     "prepare": "npm run compile",
     "test": "nyc mocha build/test",
-    "docs": "echo no docs 👻 # typedoc --out docs src && touch docs/.nojekyll",
+    "docs": "echo no docs 👻",
     "system-test": "echo no system tests 👻",
     "samples-test": "cd samples && npm link ../ && pwd && npm test",
     "lint": "gts check && semistandard 'samples/**/*.js'",
@@ -79,8 +79,7 @@
     "fix": "semistandard --fix 'samples/**/*.js' && gts fix",
     "pregenerate": "npm run build-tools",
     "generate": "node build/src/generator/generate.js",
-    "postgenerate": "npm run fix",
-    "publish-docs": "gh-pages --dotfiles --dist docs --remote upstream"
+    "postgenerate": "npm run fix"
   },
   "author": "Google Inc.",
   "keywords": [
@@ -119,7 +118,6 @@
     "codecov": "^3.0.2",
     "copyfiles": "^2.0.0",
     "express": "^4.16.3",
-    "gh-pages": "^1.1.0",
     "gts": "^0.8.0",
     "hard-rejection": "^1.0.0",
     "intelli-espower-loader": "^1.0.1",
@@ -141,7 +139,6 @@
     "server-destroy": "^1.0.1",
     "source-map-support": "^0.5.5",
     "tmp": "^0.0.33",
-    "typedoc": "^0.12.0",
     "typescript": "~3.0.0",
     "uuid": "^3.2.1"
   }

--- a/samples/README.md
+++ b/samples/README.md
@@ -9,8 +9,9 @@ The following samples show basic usage of various APIs. Throughout these samples
 
 View and manage your Google Analytics data.
 
-Documentation for the Google Analytics API in
-[JSDoc](http://google.github.io/google-api-nodejs-client/classes/_apis_analytics_v3_.analytics.html).
+<!--Documentation for the Google Analytics API in
+[JSDoc](http://google.github.io/google-api-nodejs-client/classes/_apis_analytics_v3_.analytics.html).-->
+
 
 <table>
   <tr>
@@ -23,8 +24,8 @@ Documentation for the Google Analytics API in
 
 View and manage Blogger data.
 
-Documentation for the Blogger API in
-[JSDoc](http://google.github.io/google-api-nodejs-client/classes/_apis_blogger_v3_.blogger.html).
+<!--Documentation for the Blogger API in
+[JSDoc](http://google.github.io/google-api-nodejs-client/classes/_apis_blogger_v3_.blogger.html).-->
 
 <table>
   <tr>
@@ -37,8 +38,8 @@ Documentation for the Blogger API in
 
 Lets you set key/value pairs using the GCE metadata service.
 
-Documentation for the Google Compute Engine Metadata API in
-[JSDoc](http://google.github.io/google-api-nodejs-client/classes/_apis_compute_v1_.compute.html).
+<!--Documentation for the Google Compute Engine Metadata API in
+[JSDoc](http://google.github.io/google-api-nodejs-client/classes/_apis_compute_v1_.compute.html).-->
 
 <table>
   <tr>
@@ -51,8 +52,8 @@ Documentation for the Google Compute Engine Metadata API in
 
 Lets you search over a website or collection of websites.
 
-Documentation for the CustomSearch API in
-[JSDoc](http://google.github.io/google-api-nodejs-client/classes/_apis_customsearch_v1_.customsearch.html).
+<!--Documentation for the CustomSearch API in
+[JSDoc](http://google.github.io/google-api-nodejs-client/classes/_apis_customsearch_v1_.customsearch.html).-->
 
 <table>
   <tr>
@@ -66,8 +67,8 @@ Documentation for the CustomSearch API in
 
 The Google Mirror API allows you to build web-based services that interact with Google Glass. It provides this functionality over a cloud-based API and does not require running code on Glass.
 
-Documentation for the Glass Mirror API in
-[JSDoc](http://google.github.io/google-api-nodejs-client/classes/_apis_mirror_v1_.mirror.html).
+<!--Documentation for the Glass Mirror API in
+[JSDoc](http://google.github.io/google-api-nodejs-client/classes/_apis_mirror_v1_.mirror.html).-->
 
 <table>
   <tr>
@@ -80,8 +81,8 @@ Documentation for the Glass Mirror API in
 
 With the YouTube Data API, you can add a variety of YouTube features to your application. Use the API to upload videos, manage playlists and subscriptions, update channel settings, and more.
 
-Documentation for the YouTube Data API in
-[JSDoc](http://google.github.io/google-api-nodejs-client/classes/_apis_youtube_v3_.youtube.html).
+<!--Documentation for the YouTube Data API in
+[JSDoc](http://google.github.io/google-api-nodejs-client/classes/_apis_youtube_v3_.youtube.html).-->
 
 <table>
   <tr>


### PR DESCRIPTION
Generating docs with TypeDoc is currently busted.  Having out of date docs is worse than no API reference docs, so I want to take them down while we work out another solution. 