### PR TITLE
refactor: add dev dependencies to APIs

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,15 +29,14 @@
     "system-test": "mocha build/system-test",
     "samples-test": "cd samples && npm link ../ && pwd && npm test",
     "lint": "gts check && eslint 'samples/**/*.js'",
-    "compile": "tsc -v && tsc -p . && copyfiles src/apis/**/README.md src/apis/**/package.json build",
+    "compile": "tsc -p .",
     "build-tools": "tsc -p tsconfig.tools.json",
     "clean": "gts clean",
     "codecov": "nyc report && codecov -f .coverage/*.json",
-    "fix": "eslint --fix 'samples/**/*.js' && prettier --write samples/**/*.js && gts fix",
+    "fix": "eslint --fix '**/*.js' && gts fix",
     "pregenerate": "npm run build-tools",
     "generate": "node build/src/generator/generate.js",
-    "postgenerate": "npm run fix",
-    "prettier": "prettier --write samples/**/*.js"
+    "postgenerate": "npm run fix"
   },
   "author": "Google Inc.",
   "keywords": [
@@ -72,7 +71,6 @@
     "assert-rejects": "^1.0.0",
     "axios": "^0.18.0",
     "codecov": "^3.0.2",
-    "copyfiles": "^2.0.0",
     "eslint": "^5.6.0",
     "eslint-config-prettier": "^3.0.1",
     "eslint-plugin-node": "^8.0.0",

--- a/src/apis/abusiveexperiencereport/package.json
+++ b/src/apis/abusiveexperiencereport/package.json
@@ -2,8 +2,8 @@
   "name": "@google/abusiveexperiencereport",
   "version": "0.1.0",
   "description": "abusiveexperiencereport",
-  "main": "index.js",
-  "types": "index.d.ts",
+  "main": "build/index.js",
+  "types": "build/index.d.ts",
   "keywords": ["google"],
   "author": "Google LLC",
   "license": "Apache-2.0",
@@ -18,7 +18,19 @@
   "engines": {
     "node": ">=6.0.0"
   },
+  "scripts": {
+    "fix": "gts fix",
+    "lint": "gts check",
+    "compile": "tsc -p .",
+    "prepare": "npm run compile",
+    "docs": "typedoc --out docs/"
+  },
   "dependencies": {
     "googleapis-common": "^0.4.0"
+  },
+  "devDependencies": {
+    "gts": "^0.9.0",
+    "typescript": "~3.2.0",
+    "typedoc": "^0.13.0"
   }
 }

--- a/src/apis/abusiveexperiencereport/tsconfig.json
+++ b/src/apis/abusiveexperiencereport/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./node_modules/gts/tsconfig-google.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "build"
+  },
+  "include": [
+    "*.ts",
+  ]
+}

--- a/src/apis/acceleratedmobilepageurl/package.json
+++ b/src/apis/acceleratedmobilepageurl/package.json
@@ -2,8 +2,8 @@
   "name": "@google/acceleratedmobilepageurl",
   "version": "0.1.0",
   "description": "acceleratedmobilepageurl",
-  "main": "index.js",
-  "types": "index.d.ts",
+  "main": "build/index.js",
+  "types": "build/index.d.ts",
   "keywords": ["google"],
   "author": "Google LLC",
   "license": "Apache-2.0",
@@ -18,7 +18,19 @@
   "engines": {
     "node": ">=6.0.0"
   },
+  "scripts": {
+    "fix": "gts fix",
+    "lint": "gts check",
+    "compile": "tsc -p .",
+    "prepare": "npm run compile",
+    "docs": "typedoc --out docs/"
+  },
   "dependencies": {
     "googleapis-common": "^0.4.0"
+  },
+  "devDependencies": {
+    "gts": "^0.9.0",
+    "typescript": "~3.2.0",
+    "typedoc": "^0.13.0"
   }
 }

--- a/src/apis/acceleratedmobilepageurl/tsconfig.json
+++ b/src/apis/acceleratedmobilepageurl/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./node_modules/gts/tsconfig-google.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "build"
+  },
+  "include": [
+    "*.ts",
+  ]
+}

--- a/src/apis/accesscontextmanager/package.json
+++ b/src/apis/accesscontextmanager/package.json
@@ -2,8 +2,8 @@
   "name": "@google/accesscontextmanager",
   "version": "0.1.0",
   "description": "accesscontextmanager",
-  "main": "index.js",
-  "types": "index.d.ts",
+  "main": "build/index.js",
+  "types": "build/index.d.ts",
   "keywords": ["google"],
   "author": "Google LLC",
   "license": "Apache-2.0",
@@ -18,7 +18,19 @@
   "engines": {
     "node": ">=6.0.0"
   },
+  "scripts": {
+    "fix": "gts fix",
+    "lint": "gts check",
+    "compile": "tsc -p .",
+    "prepare": "npm run compile",
+    "docs": "typedoc --out docs/"
+  },
   "dependencies": {
     "googleapis-common": "^0.4.0"
+  },
+  "devDependencies": {
+    "gts": "^0.9.0",
+    "typescript": "~3.2.0",
+    "typedoc": "^0.13.0"
   }
 }

--- a/src/apis/accesscontextmanager/tsconfig.json
+++ b/src/apis/accesscontextmanager/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./node_modules/gts/tsconfig-google.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "build"
+  },
+  "include": [
+    "*.ts",
+  ]
+}

--- a/src/apis/adexchangebuyer/package.json
+++ b/src/apis/adexchangebuyer/package.json
@@ -2,8 +2,8 @@
   "name": "@google/adexchangebuyer",
   "version": "0.1.0",
   "description": "adexchangebuyer",
-  "main": "index.js",
-  "types": "index.d.ts",
+  "main": "build/index.js",
+  "types": "build/index.d.ts",
   "keywords": ["google"],
   "author": "Google LLC",
   "license": "Apache-2.0",
@@ -18,7 +18,19 @@
   "engines": {
     "node": ">=6.0.0"
   },
+  "scripts": {
+    "fix": "gts fix",
+    "lint": "gts check",
+    "compile": "tsc -p .",
+    "prepare": "npm run compile",
+    "docs": "typedoc --out docs/"
+  },
   "dependencies": {
     "googleapis-common": "^0.4.0"
+  },
+  "devDependencies": {
+    "gts": "^0.9.0",
+    "typescript": "~3.2.0",
+    "typedoc": "^0.13.0"
   }
 }

--- a/src/apis/adexchangebuyer/tsconfig.json
+++ b/src/apis/adexchangebuyer/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./node_modules/gts/tsconfig-google.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "build"
+  },
+  "include": [
+    "*.ts",
+  ]
+}

--- a/src/apis/adexchangebuyer2/package.json
+++ b/src/apis/adexchangebuyer2/package.json
@@ -2,8 +2,8 @@
   "name": "@google/adexchangebuyer2",
   "version": "0.1.0",
   "description": "adexchangebuyer2",
-  "main": "index.js",
-  "types": "index.d.ts",
+  "main": "build/index.js",
+  "types": "build/index.d.ts",
   "keywords": ["google"],
   "author": "Google LLC",
   "license": "Apache-2.0",
@@ -18,7 +18,19 @@
   "engines": {
     "node": ">=6.0.0"
   },
+  "scripts": {
+    "fix": "gts fix",
+    "lint": "gts check",
+    "compile": "tsc -p .",
+    "prepare": "npm run compile",
+    "docs": "typedoc --out docs/"
+  },
   "dependencies": {
     "googleapis-common": "^0.4.0"
+  },
+  "devDependencies": {
+    "gts": "^0.9.0",
+    "typescript": "~3.2.0",
+    "typedoc": "^0.13.0"
   }
 }

--- a/src/apis/adexchangebuyer2/tsconfig.json
+++ b/src/apis/adexchangebuyer2/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./node_modules/gts/tsconfig-google.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "build"
+  },
+  "include": [
+    "*.ts",
+  ]
+}

--- a/src/apis/adexperiencereport/package.json
+++ b/src/apis/adexperiencereport/package.json
@@ -2,8 +2,8 @@
   "name": "@google/adexperiencereport",
   "version": "0.1.0",
   "description": "adexperiencereport",
-  "main": "index.js",
-  "types": "index.d.ts",
+  "main": "build/index.js",
+  "types": "build/index.d.ts",
   "keywords": ["google"],
   "author": "Google LLC",
   "license": "Apache-2.0",
@@ -18,7 +18,19 @@
   "engines": {
     "node": ">=6.0.0"
   },
+  "scripts": {
+    "fix": "gts fix",
+    "lint": "gts check",
+    "compile": "tsc -p .",
+    "prepare": "npm run compile",
+    "docs": "typedoc --out docs/"
+  },
   "dependencies": {
     "googleapis-common": "^0.4.0"
+  },
+  "devDependencies": {
+    "gts": "^0.9.0",
+    "typescript": "~3.2.0",
+    "typedoc": "^0.13.0"
   }
 }

--- a/src/apis/adexperiencereport/tsconfig.json
+++ b/src/apis/adexperiencereport/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./node_modules/gts/tsconfig-google.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "build"
+  },
+  "include": [
+    "*.ts",
+  ]
+}

--- a/src/apis/admin/package.json
+++ b/src/apis/admin/package.json
@@ -2,8 +2,8 @@
   "name": "@google/admin",
   "version": "0.1.0",
   "description": "admin",
-  "main": "index.js",
-  "types": "index.d.ts",
+  "main": "build/index.js",
+  "types": "build/index.d.ts",
   "keywords": ["google"],
   "author": "Google LLC",
   "license": "Apache-2.0",
@@ -18,7 +18,19 @@
   "engines": {
     "node": ">=6.0.0"
   },
+  "scripts": {
+    "fix": "gts fix",
+    "lint": "gts check",
+    "compile": "tsc -p .",
+    "prepare": "npm run compile",
+    "docs": "typedoc --out docs/"
+  },
   "dependencies": {
     "googleapis-common": "^0.4.0"
+  },
+  "devDependencies": {
+    "gts": "^0.9.0",
+    "typescript": "~3.2.0",
+    "typedoc": "^0.13.0"
   }
 }

--- a/src/apis/admin/tsconfig.json
+++ b/src/apis/admin/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./node_modules/gts/tsconfig-google.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "build"
+  },
+  "include": [
+    "*.ts",
+  ]
+}

--- a/src/apis/adsense/package.json
+++ b/src/apis/adsense/package.json
@@ -2,8 +2,8 @@
   "name": "@google/adsense",
   "version": "0.1.0",
   "description": "adsense",
-  "main": "index.js",
-  "types": "index.d.ts",
+  "main": "build/index.js",
+  "types": "build/index.d.ts",
   "keywords": ["google"],
   "author": "Google LLC",
   "license": "Apache-2.0",
@@ -18,7 +18,19 @@
   "engines": {
     "node": ">=6.0.0"
   },
+  "scripts": {
+    "fix": "gts fix",
+    "lint": "gts check",
+    "compile": "tsc -p .",
+    "prepare": "npm run compile",
+    "docs": "typedoc --out docs/"
+  },
   "dependencies": {
     "googleapis-common": "^0.4.0"
+  },
+  "devDependencies": {
+    "gts": "^0.9.0",
+    "typescript": "~3.2.0",
+    "typedoc": "^0.13.0"
   }
 }

--- a/src/apis/adsense/tsconfig.json
+++ b/src/apis/adsense/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./node_modules/gts/tsconfig-google.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "build"
+  },
+  "include": [
+    "*.ts",
+  ]
+}

--- a/src/apis/adsensehost/package.json
+++ b/src/apis/adsensehost/package.json
@@ -2,8 +2,8 @@
   "name": "@google/adsensehost",
   "version": "0.1.0",
   "description": "adsensehost",
-  "main": "index.js",
-  "types": "index.d.ts",
+  "main": "build/index.js",
+  "types": "build/index.d.ts",
   "keywords": ["google"],
   "author": "Google LLC",
   "license": "Apache-2.0",
@@ -18,7 +18,19 @@
   "engines": {
     "node": ">=6.0.0"
   },
+  "scripts": {
+    "fix": "gts fix",
+    "lint": "gts check",
+    "compile": "tsc -p .",
+    "prepare": "npm run compile",
+    "docs": "typedoc --out docs/"
+  },
   "dependencies": {
     "googleapis-common": "^0.4.0"
+  },
+  "devDependencies": {
+    "gts": "^0.9.0",
+    "typescript": "~3.2.0",
+    "typedoc": "^0.13.0"
   }
 }

--- a/src/apis/adsensehost/tsconfig.json
+++ b/src/apis/adsensehost/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./node_modules/gts/tsconfig-google.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "build"
+  },
+  "include": [
+    "*.ts",
+  ]
+}

--- a/src/apis/alertcenter/package.json
+++ b/src/apis/alertcenter/package.json
@@ -2,8 +2,8 @@
   "name": "@google/alertcenter",
   "version": "0.1.0",
   "description": "alertcenter",
-  "main": "index.js",
-  "types": "index.d.ts",
+  "main": "build/index.js",
+  "types": "build/index.d.ts",
   "keywords": ["google"],
   "author": "Google LLC",
   "license": "Apache-2.0",
@@ -18,7 +18,19 @@
   "engines": {
     "node": ">=6.0.0"
   },
+  "scripts": {
+    "fix": "gts fix",
+    "lint": "gts check",
+    "compile": "tsc -p .",
+    "prepare": "npm run compile",
+    "docs": "typedoc --out docs/"
+  },
   "dependencies": {
     "googleapis-common": "^0.4.0"
+  },
+  "devDependencies": {
+    "gts": "^0.9.0",
+    "typescript": "~3.2.0",
+    "typedoc": "^0.13.0"
   }
 }

--- a/src/apis/alertcenter/tsconfig.json
+++ b/src/apis/alertcenter/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./node_modules/gts/tsconfig-google.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "build"
+  },
+  "include": [
+    "*.ts",
+  ]
+}

--- a/src/apis/analytics/package.json
+++ b/src/apis/analytics/package.json
@@ -2,8 +2,8 @@
   "name": "@google/analytics",
   "version": "0.1.0",
   "description": "analytics",
-  "main": "index.js",
-  "types": "index.d.ts",
+  "main": "build/index.js",
+  "types": "build/index.d.ts",
   "keywords": ["google"],
   "author": "Google LLC",
   "license": "Apache-2.0",
@@ -18,7 +18,19 @@
   "engines": {
     "node": ">=6.0.0"
   },
+  "scripts": {
+    "fix": "gts fix",
+    "lint": "gts check",
+    "compile": "tsc -p .",
+    "prepare": "npm run compile",
+    "docs": "typedoc --out docs/"
+  },
   "dependencies": {
     "googleapis-common": "^0.4.0"
+  },
+  "devDependencies": {
+    "gts": "^0.9.0",
+    "typescript": "~3.2.0",
+    "typedoc": "^0.13.0"
   }
 }

--- a/src/apis/analytics/tsconfig.json
+++ b/src/apis/analytics/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./node_modules/gts/tsconfig-google.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "build"
+  },
+  "include": [
+    "*.ts",
+  ]
+}

--- a/src/apis/analyticsreporting/package.json
+++ b/src/apis/analyticsreporting/package.json
@@ -2,8 +2,8 @@
   "name": "@google/analyticsreporting",
   "version": "0.1.0",
   "description": "analyticsreporting",
-  "main": "index.js",
-  "types": "index.d.ts",
+  "main": "build/index.js",
+  "types": "build/index.d.ts",
   "keywords": ["google"],
   "author": "Google LLC",
   "license": "Apache-2.0",
@@ -18,7 +18,19 @@
   "engines": {
     "node": ">=6.0.0"
   },
+  "scripts": {
+    "fix": "gts fix",
+    "lint": "gts check",
+    "compile": "tsc -p .",
+    "prepare": "npm run compile",
+    "docs": "typedoc --out docs/"
+  },
   "dependencies": {
     "googleapis-common": "^0.4.0"
+  },
+  "devDependencies": {
+    "gts": "^0.9.0",
+    "typescript": "~3.2.0",
+    "typedoc": "^0.13.0"
   }
 }

--- a/src/apis/analyticsreporting/tsconfig.json
+++ b/src/apis/analyticsreporting/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./node_modules/gts/tsconfig-google.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "build"
+  },
+  "include": [
+    "*.ts",
+  ]
+}

--- a/src/apis/androiddeviceprovisioning/package.json
+++ b/src/apis/androiddeviceprovisioning/package.json
@@ -2,8 +2,8 @@
   "name": "@google/androiddeviceprovisioning",
   "version": "0.1.0",
   "description": "androiddeviceprovisioning",
-  "main": "index.js",
-  "types": "index.d.ts",
+  "main": "build/index.js",
+  "types": "build/index.d.ts",
   "keywords": ["google"],
   "author": "Google LLC",
   "license": "Apache-2.0",
@@ -18,7 +18,19 @@
   "engines": {
     "node": ">=6.0.0"
   },
+  "scripts": {
+    "fix": "gts fix",
+    "lint": "gts check",
+    "compile": "tsc -p .",
+    "prepare": "npm run compile",
+    "docs": "typedoc --out docs/"
+  },
   "dependencies": {
     "googleapis-common": "^0.4.0"
+  },
+  "devDependencies": {
+    "gts": "^0.9.0",
+    "typescript": "~3.2.0",
+    "typedoc": "^0.13.0"
   }
 }

--- a/src/apis/androiddeviceprovisioning/tsconfig.json
+++ b/src/apis/androiddeviceprovisioning/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./node_modules/gts/tsconfig-google.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "build"
+  },
+  "include": [
+    "*.ts",
+  ]
+}

--- a/src/apis/androidenterprise/package.json
+++ b/src/apis/androidenterprise/package.json
@@ -2,8 +2,8 @@
   "name": "@google/androidenterprise",
   "version": "0.1.0",
   "description": "androidenterprise",
-  "main": "index.js",
-  "types": "index.d.ts",
+  "main": "build/index.js",
+  "types": "build/index.d.ts",
   "keywords": ["google"],
   "author": "Google LLC",
   "license": "Apache-2.0",
@@ -18,7 +18,19 @@
   "engines": {
     "node": ">=6.0.0"
   },
+  "scripts": {
+    "fix": "gts fix",
+    "lint": "gts check",
+    "compile": "tsc -p .",
+    "prepare": "npm run compile",
+    "docs": "typedoc --out docs/"
+  },
   "dependencies": {
     "googleapis-common": "^0.4.0"
+  },
+  "devDependencies": {
+    "gts": "^0.9.0",
+    "typescript": "~3.2.0",
+    "typedoc": "^0.13.0"
   }
 }

--- a/src/apis/androidenterprise/tsconfig.json
+++ b/src/apis/androidenterprise/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./node_modules/gts/tsconfig-google.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "build"
+  },
+  "include": [
+    "*.ts",
+  ]
+}

--- a/src/apis/androidmanagement/package.json
+++ b/src/apis/androidmanagement/package.json
@@ -2,8 +2,8 @@
   "name": "@google/androidmanagement",
   "version": "0.1.0",
   "description": "androidmanagement",
-  "main": "index.js",
-  "types": "index.d.ts",
+  "main": "build/index.js",
+  "types": "build/index.d.ts",
   "keywords": ["google"],
   "author": "Google LLC",
   "license": "Apache-2.0",
@@ -18,7 +18,19 @@
   "engines": {
     "node": ">=6.0.0"
   },
+  "scripts": {
+    "fix": "gts fix",
+    "lint": "gts check",
+    "compile": "tsc -p .",
+    "prepare": "npm run compile",
+    "docs": "typedoc --out docs/"
+  },
   "dependencies": {
     "googleapis-common": "^0.4.0"
+  },
+  "devDependencies": {
+    "gts": "^0.9.0",
+    "typescript": "~3.2.0",
+    "typedoc": "^0.13.0"
   }
 }

--- a/src/apis/androidmanagement/tsconfig.json
+++ b/src/apis/androidmanagement/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./node_modules/gts/tsconfig-google.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "build"
+  },
+  "include": [
+    "*.ts",
+  ]
+}

--- a/src/apis/androidpublisher/package.json
+++ b/src/apis/androidpublisher/package.json
@@ -2,8 +2,8 @@
   "name": "@google/androidpublisher",
   "version": "0.1.0",
   "description": "androidpublisher",
-  "main": "index.js",
-  "types": "index.d.ts",
+  "main": "build/index.js",
+  "types": "build/index.d.ts",
   "keywords": ["google"],
   "author": "Google LLC",
   "license": "Apache-2.0",
@@ -18,7 +18,19 @@
   "engines": {
     "node": ">=6.0.0"
   },
+  "scripts": {
+    "fix": "gts fix",
+    "lint": "gts check",
+    "compile": "tsc -p .",
+    "prepare": "npm run compile",
+    "docs": "typedoc --out docs/"
+  },
   "dependencies": {
     "googleapis-common": "^0.4.0"
+  },
+  "devDependencies": {
+    "gts": "^0.9.0",
+    "typescript": "~3.2.0",
+    "typedoc": "^0.13.0"
   }
 }

--- a/src/apis/androidpublisher/tsconfig.json
+++ b/src/apis/androidpublisher/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./node_modules/gts/tsconfig-google.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "build"
+  },
+  "include": [
+    "*.ts",
+  ]
+}

--- a/src/apis/appengine/package.json
+++ b/src/apis/appengine/package.json
@@ -2,8 +2,8 @@
   "name": "@google/appengine",
   "version": "0.1.0",
   "description": "appengine",
-  "main": "index.js",
-  "types": "index.d.ts",
+  "main": "build/index.js",
+  "types": "build/index.d.ts",
   "keywords": ["google"],
   "author": "Google LLC",
   "license": "Apache-2.0",
@@ -18,7 +18,19 @@
   "engines": {
     "node": ">=6.0.0"
   },
+  "scripts": {
+    "fix": "gts fix",
+    "lint": "gts check",
+    "compile": "tsc -p .",
+    "prepare": "npm run compile",
+    "docs": "typedoc --out docs/"
+  },
   "dependencies": {
     "googleapis-common": "^0.4.0"
+  },
+  "devDependencies": {
+    "gts": "^0.9.0",
+    "typescript": "~3.2.0",
+    "typedoc": "^0.13.0"
   }
 }

--- a/src/apis/appengine/tsconfig.json
+++ b/src/apis/appengine/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./node_modules/gts/tsconfig-google.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "build"
+  },
+  "include": [
+    "*.ts",
+  ]
+}

--- a/src/apis/appsactivity/package.json
+++ b/src/apis/appsactivity/package.json
@@ -2,8 +2,8 @@
   "name": "@google/appsactivity",
   "version": "0.1.0",
   "description": "appsactivity",
-  "main": "index.js",
-  "types": "index.d.ts",
+  "main": "build/index.js",
+  "types": "build/index.d.ts",
   "keywords": ["google"],
   "author": "Google LLC",
   "license": "Apache-2.0",
@@ -18,7 +18,19 @@
   "engines": {
     "node": ">=6.0.0"
   },
+  "scripts": {
+    "fix": "gts fix",
+    "lint": "gts check",
+    "compile": "tsc -p .",
+    "prepare": "npm run compile",
+    "docs": "typedoc --out docs/"
+  },
   "dependencies": {
     "googleapis-common": "^0.4.0"
+  },
+  "devDependencies": {
+    "gts": "^0.9.0",
+    "typescript": "~3.2.0",
+    "typedoc": "^0.13.0"
   }
 }

--- a/src/apis/appsactivity/tsconfig.json
+++ b/src/apis/appsactivity/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./node_modules/gts/tsconfig-google.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "build"
+  },
+  "include": [
+    "*.ts",
+  ]
+}

--- a/src/apis/appstate/package.json
+++ b/src/apis/appstate/package.json
@@ -2,8 +2,8 @@
   "name": "@google/appstate",
   "version": "0.1.0",
   "description": "appstate",
-  "main": "index.js",
-  "types": "index.d.ts",
+  "main": "build/index.js",
+  "types": "build/index.d.ts",
   "keywords": ["google"],
   "author": "Google LLC",
   "license": "Apache-2.0",
@@ -18,7 +18,19 @@
   "engines": {
     "node": ">=6.0.0"
   },
+  "scripts": {
+    "fix": "gts fix",
+    "lint": "gts check",
+    "compile": "tsc -p .",
+    "prepare": "npm run compile",
+    "docs": "typedoc --out docs/"
+  },
   "dependencies": {
     "googleapis-common": "^0.4.0"
+  },
+  "devDependencies": {
+    "gts": "^0.9.0",
+    "typescript": "~3.2.0",
+    "typedoc": "^0.13.0"
   }
 }

--- a/src/apis/appstate/tsconfig.json
+++ b/src/apis/appstate/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./node_modules/gts/tsconfig-google.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "build"
+  },
+  "include": [
+    "*.ts",
+  ]
+}

--- a/src/apis/bigquery/package.json
+++ b/src/apis/bigquery/package.json
@@ -2,8 +2,8 @@
   "name": "@google/bigquery",
   "version": "0.1.0",
   "description": "bigquery",
-  "main": "index.js",
-  "types": "index.d.ts",
+  "main": "build/index.js",
+  "types": "build/index.d.ts",
   "keywords": ["google"],
   "author": "Google LLC",
   "license": "Apache-2.0",
@@ -18,7 +18,19 @@
   "engines": {
     "node": ">=6.0.0"
   },
+  "scripts": {
+    "fix": "gts fix",
+    "lint": "gts check",
+    "compile": "tsc -p .",
+    "prepare": "npm run compile",
+    "docs": "typedoc --out docs/"
+  },
   "dependencies": {
     "googleapis-common": "^0.4.0"
+  },
+  "devDependencies": {
+    "gts": "^0.9.0",
+    "typescript": "~3.2.0",
+    "typedoc": "^0.13.0"
   }
 }

--- a/src/apis/bigquery/tsconfig.json
+++ b/src/apis/bigquery/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./node_modules/gts/tsconfig-google.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "build"
+  },
+  "include": [
+    "*.ts",
+  ]
+}

--- a/src/apis/bigquerydatatransfer/package.json
+++ b/src/apis/bigquerydatatransfer/package.json
@@ -2,8 +2,8 @@
   "name": "@google/bigquerydatatransfer",
   "version": "0.1.0",
   "description": "bigquerydatatransfer",
-  "main": "index.js",
-  "types": "index.d.ts",
+  "main": "build/index.js",
+  "types": "build/index.d.ts",
   "keywords": ["google"],
   "author": "Google LLC",
   "license": "Apache-2.0",
@@ -18,7 +18,19 @@
   "engines": {
     "node": ">=6.0.0"
   },
+  "scripts": {
+    "fix": "gts fix",
+    "lint": "gts check",
+    "compile": "tsc -p .",
+    "prepare": "npm run compile",
+    "docs": "typedoc --out docs/"
+  },
   "dependencies": {
     "googleapis-common": "^0.4.0"
+  },
+  "devDependencies": {
+    "gts": "^0.9.0",
+    "typescript": "~3.2.0",
+    "typedoc": "^0.13.0"
   }
 }

--- a/src/apis/bigquerydatatransfer/tsconfig.json
+++ b/src/apis/bigquerydatatransfer/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./node_modules/gts/tsconfig-google.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "build"
+  },
+  "include": [
+    "*.ts",
+  ]
+}

--- a/src/apis/binaryauthorization/package.json
+++ b/src/apis/binaryauthorization/package.json
@@ -2,8 +2,8 @@
   "name": "@google/binaryauthorization",
   "version": "0.1.0",
   "description": "binaryauthorization",
-  "main": "index.js",
-  "types": "index.d.ts",
+  "main": "build/index.js",
+  "types": "build/index.d.ts",
   "keywords": ["google"],
   "author": "Google LLC",
   "license": "Apache-2.0",
@@ -18,7 +18,19 @@
   "engines": {
     "node": ">=6.0.0"
   },
+  "scripts": {
+    "fix": "gts fix",
+    "lint": "gts check",
+    "compile": "tsc -p .",
+    "prepare": "npm run compile",
+    "docs": "typedoc --out docs/"
+  },
   "dependencies": {
     "googleapis-common": "^0.4.0"
+  },
+  "devDependencies": {
+    "gts": "^0.9.0",
+    "typescript": "~3.2.0",
+    "typedoc": "^0.13.0"
   }
 }

--- a/src/apis/binaryauthorization/tsconfig.json
+++ b/src/apis/binaryauthorization/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./node_modules/gts/tsconfig-google.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "build"
+  },
+  "include": [
+    "*.ts",
+  ]
+}

--- a/src/apis/blogger/package.json
+++ b/src/apis/blogger/package.json
@@ -2,8 +2,8 @@
   "name": "@google/blogger",
   "version": "0.1.0",
   "description": "blogger",
-  "main": "index.js",
-  "types": "index.d.ts",
+  "main": "build/index.js",
+  "types": "build/index.d.ts",
   "keywords": ["google"],
   "author": "Google LLC",
   "license": "Apache-2.0",
@@ -18,7 +18,19 @@
   "engines": {
     "node": ">=6.0.0"
   },
+  "scripts": {
+    "fix": "gts fix",
+    "lint": "gts check",
+    "compile": "tsc -p .",
+    "prepare": "npm run compile",
+    "docs": "typedoc --out docs/"
+  },
   "dependencies": {
     "googleapis-common": "^0.4.0"
+  },
+  "devDependencies": {
+    "gts": "^0.9.0",
+    "typescript": "~3.2.0",
+    "typedoc": "^0.13.0"
   }
 }

--- a/src/apis/blogger/tsconfig.json
+++ b/src/apis/blogger/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./node_modules/gts/tsconfig-google.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "build"
+  },
+  "include": [
+    "*.ts",
+  ]
+}

--- a/src/apis/books/package.json
+++ b/src/apis/books/package.json
@@ -2,8 +2,8 @@
   "name": "@google/books",
   "version": "0.1.0",
   "description": "books",
-  "main": "index.js",
-  "types": "index.d.ts",
+  "main": "build/index.js",
+  "types": "build/index.d.ts",
   "keywords": ["google"],
   "author": "Google LLC",
   "license": "Apache-2.0",
@@ -18,7 +18,19 @@
   "engines": {
     "node": ">=6.0.0"
   },
+  "scripts": {
+    "fix": "gts fix",
+    "lint": "gts check",
+    "compile": "tsc -p .",
+    "prepare": "npm run compile",
+    "docs": "typedoc --out docs/"
+  },
   "dependencies": {
     "googleapis-common": "^0.4.0"
+  },
+  "devDependencies": {
+    "gts": "^0.9.0",
+    "typescript": "~3.2.0",
+    "typedoc": "^0.13.0"
   }
 }

--- a/src/apis/books/tsconfig.json
+++ b/src/apis/books/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./node_modules/gts/tsconfig-google.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "build"
+  },
+  "include": [
+    "*.ts",
+  ]
+}

--- a/src/apis/calendar/package.json
+++ b/src/apis/calendar/package.json
@@ -2,8 +2,8 @@
   "name": "@google/calendar",
   "version": "0.1.0",
   "description": "calendar",
-  "main": "index.js",
-  "types": "index.d.ts",
+  "main": "build/index.js",
+  "types": "build/index.d.ts",
   "keywords": ["google"],
   "author": "Google LLC",
   "license": "Apache-2.0",
@@ -18,7 +18,19 @@
   "engines": {
     "node": ">=6.0.0"
   },
+  "scripts": {
+    "fix": "gts fix",
+    "lint": "gts check",
+    "compile": "tsc -p .",
+    "prepare": "npm run compile",
+    "docs": "typedoc --out docs/"
+  },
   "dependencies": {
     "googleapis-common": "^0.4.0"
+  },
+  "devDependencies": {
+    "gts": "^0.9.0",
+    "typescript": "~3.2.0",
+    "typedoc": "^0.13.0"
   }
 }

--- a/src/apis/calendar/tsconfig.json
+++ b/src/apis/calendar/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./node_modules/gts/tsconfig-google.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "build"
+  },
+  "include": [
+    "*.ts",
+  ]
+}

--- a/src/apis/chat/package.json
+++ b/src/apis/chat/package.json
@@ -2,8 +2,8 @@
   "name": "@google/chat",
   "version": "0.1.0",
   "description": "chat",
-  "main": "index.js",
-  "types": "index.d.ts",
+  "main": "build/index.js",
+  "types": "build/index.d.ts",
   "keywords": ["google"],
   "author": "Google LLC",
   "license": "Apache-2.0",
@@ -18,7 +18,19 @@
   "engines": {
     "node": ">=6.0.0"
   },
+  "scripts": {
+    "fix": "gts fix",
+    "lint": "gts check",
+    "compile": "tsc -p .",
+    "prepare": "npm run compile",
+    "docs": "typedoc --out docs/"
+  },
   "dependencies": {
     "googleapis-common": "^0.4.0"
+  },
+  "devDependencies": {
+    "gts": "^0.9.0",
+    "typescript": "~3.2.0",
+    "typedoc": "^0.13.0"
   }
 }

--- a/src/apis/chat/tsconfig.json
+++ b/src/apis/chat/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./node_modules/gts/tsconfig-google.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "build"
+  },
+  "include": [
+    "*.ts",
+  ]
+}

--- a/src/apis/civicinfo/package.json
+++ b/src/apis/civicinfo/package.json
@@ -2,8 +2,8 @@
   "name": "@google/civicinfo",
   "version": "0.1.0",
   "description": "civicinfo",
-  "main": "index.js",
-  "types": "index.d.ts",
+  "main": "build/index.js",
+  "types": "build/index.d.ts",
   "keywords": ["google"],
   "author": "Google LLC",
   "license": "Apache-2.0",
@@ -18,7 +18,19 @@
   "engines": {
     "node": ">=6.0.0"
   },
+  "scripts": {
+    "fix": "gts fix",
+    "lint": "gts check",
+    "compile": "tsc -p .",
+    "prepare": "npm run compile",
+    "docs": "typedoc --out docs/"
+  },
   "dependencies": {
     "googleapis-common": "^0.4.0"
+  },
+  "devDependencies": {
+    "gts": "^0.9.0",
+    "typescript": "~3.2.0",
+    "typedoc": "^0.13.0"
   }
 }

--- a/src/apis/civicinfo/tsconfig.json
+++ b/src/apis/civicinfo/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./node_modules/gts/tsconfig-google.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "build"
+  },
+  "include": [
+    "*.ts",
+  ]
+}

--- a/src/apis/classroom/package.json
+++ b/src/apis/classroom/package.json
@@ -2,8 +2,8 @@
   "name": "@google/classroom",
   "version": "0.1.0",
   "description": "classroom",
-  "main": "index.js",
-  "types": "index.d.ts",
+  "main": "build/index.js",
+  "types": "build/index.d.ts",
   "keywords": ["google"],
   "author": "Google LLC",
   "license": "Apache-2.0",
@@ -18,7 +18,19 @@
   "engines": {
     "node": ">=6.0.0"
   },
+  "scripts": {
+    "fix": "gts fix",
+    "lint": "gts check",
+    "compile": "tsc -p .",
+    "prepare": "npm run compile",
+    "docs": "typedoc --out docs/"
+  },
   "dependencies": {
     "googleapis-common": "^0.4.0"
+  },
+  "devDependencies": {
+    "gts": "^0.9.0",
+    "typescript": "~3.2.0",
+    "typedoc": "^0.13.0"
   }
 }

--- a/src/apis/classroom/tsconfig.json
+++ b/src/apis/classroom/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./node_modules/gts/tsconfig-google.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "build"
+  },
+  "include": [
+    "*.ts",
+  ]
+}

--- a/src/apis/cloudasset/package.json
+++ b/src/apis/cloudasset/package.json
@@ -2,8 +2,8 @@
   "name": "@google/cloudasset",
   "version": "0.1.0",
   "description": "cloudasset",
-  "main": "index.js",
-  "types": "index.d.ts",
+  "main": "build/index.js",
+  "types": "build/index.d.ts",
   "keywords": ["google"],
   "author": "Google LLC",
   "license": "Apache-2.0",
@@ -18,7 +18,19 @@
   "engines": {
     "node": ">=6.0.0"
   },
+  "scripts": {
+    "fix": "gts fix",
+    "lint": "gts check",
+    "compile": "tsc -p .",
+    "prepare": "npm run compile",
+    "docs": "typedoc --out docs/"
+  },
   "dependencies": {
     "googleapis-common": "^0.4.0"
+  },
+  "devDependencies": {
+    "gts": "^0.9.0",
+    "typescript": "~3.2.0",
+    "typedoc": "^0.13.0"
   }
 }

--- a/src/apis/cloudasset/tsconfig.json
+++ b/src/apis/cloudasset/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./node_modules/gts/tsconfig-google.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "build"
+  },
+  "include": [
+    "*.ts",
+  ]
+}

--- a/src/apis/cloudbilling/package.json
+++ b/src/apis/cloudbilling/package.json
@@ -2,8 +2,8 @@
   "name": "@google/cloudbilling",
   "version": "0.1.0",
   "description": "cloudbilling",
-  "main": "index.js",
-  "types": "index.d.ts",
+  "main": "build/index.js",
+  "types": "build/index.d.ts",
   "keywords": ["google"],
   "author": "Google LLC",
   "license": "Apache-2.0",
@@ -18,7 +18,19 @@
   "engines": {
     "node": ">=6.0.0"
   },
+  "scripts": {
+    "fix": "gts fix",
+    "lint": "gts check",
+    "compile": "tsc -p .",
+    "prepare": "npm run compile",
+    "docs": "typedoc --out docs/"
+  },
   "dependencies": {
     "googleapis-common": "^0.4.0"
+  },
+  "devDependencies": {
+    "gts": "^0.9.0",
+    "typescript": "~3.2.0",
+    "typedoc": "^0.13.0"
   }
 }

--- a/src/apis/cloudbilling/tsconfig.json
+++ b/src/apis/cloudbilling/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./node_modules/gts/tsconfig-google.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "build"
+  },
+  "include": [
+    "*.ts",
+  ]
+}

--- a/src/apis/cloudbuild/package.json
+++ b/src/apis/cloudbuild/package.json
@@ -2,8 +2,8 @@
   "name": "@google/cloudbuild",
   "version": "0.1.0",
   "description": "cloudbuild",
-  "main": "index.js",
-  "types": "index.d.ts",
+  "main": "build/index.js",
+  "types": "build/index.d.ts",
   "keywords": ["google"],
   "author": "Google LLC",
   "license": "Apache-2.0",
@@ -18,7 +18,19 @@
   "engines": {
     "node": ">=6.0.0"
   },
+  "scripts": {
+    "fix": "gts fix",
+    "lint": "gts check",
+    "compile": "tsc -p .",
+    "prepare": "npm run compile",
+    "docs": "typedoc --out docs/"
+  },
   "dependencies": {
     "googleapis-common": "^0.4.0"
+  },
+  "devDependencies": {
+    "gts": "^0.9.0",
+    "typescript": "~3.2.0",
+    "typedoc": "^0.13.0"
   }
 }

--- a/src/apis/cloudbuild/tsconfig.json
+++ b/src/apis/cloudbuild/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./node_modules/gts/tsconfig-google.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "build"
+  },
+  "include": [
+    "*.ts",
+  ]
+}

--- a/src/apis/clouddebugger/package.json
+++ b/src/apis/clouddebugger/package.json
@@ -2,8 +2,8 @@
   "name": "@google/clouddebugger",
   "version": "0.1.0",
   "description": "clouddebugger",
-  "main": "index.js",
-  "types": "index.d.ts",
+  "main": "build/index.js",
+  "types": "build/index.d.ts",
   "keywords": ["google"],
   "author": "Google LLC",
   "license": "Apache-2.0",
@@ -18,7 +18,19 @@
   "engines": {
     "node": ">=6.0.0"
   },
+  "scripts": {
+    "fix": "gts fix",
+    "lint": "gts check",
+    "compile": "tsc -p .",
+    "prepare": "npm run compile",
+    "docs": "typedoc --out docs/"
+  },
   "dependencies": {
     "googleapis-common": "^0.4.0"
+  },
+  "devDependencies": {
+    "gts": "^0.9.0",
+    "typescript": "~3.2.0",
+    "typedoc": "^0.13.0"
   }
 }

--- a/src/apis/clouddebugger/tsconfig.json
+++ b/src/apis/clouddebugger/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./node_modules/gts/tsconfig-google.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "build"
+  },
+  "include": [
+    "*.ts",
+  ]
+}

--- a/src/apis/clouderrorreporting/package.json
+++ b/src/apis/clouderrorreporting/package.json
@@ -2,8 +2,8 @@
   "name": "@google/clouderrorreporting",
   "version": "0.1.0",
   "description": "clouderrorreporting",
-  "main": "index.js",
-  "types": "index.d.ts",
+  "main": "build/index.js",
+  "types": "build/index.d.ts",
   "keywords": ["google"],
   "author": "Google LLC",
   "license": "Apache-2.0",
@@ -18,7 +18,19 @@
   "engines": {
     "node": ">=6.0.0"
   },
+  "scripts": {
+    "fix": "gts fix",
+    "lint": "gts check",
+    "compile": "tsc -p .",
+    "prepare": "npm run compile",
+    "docs": "typedoc --out docs/"
+  },
   "dependencies": {
     "googleapis-common": "^0.4.0"
+  },
+  "devDependencies": {
+    "gts": "^0.9.0",
+    "typescript": "~3.2.0",
+    "typedoc": "^0.13.0"
   }
 }

--- a/src/apis/clouderrorreporting/tsconfig.json
+++ b/src/apis/clouderrorreporting/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./node_modules/gts/tsconfig-google.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "build"
+  },
+  "include": [
+    "*.ts",
+  ]
+}

--- a/src/apis/cloudfunctions/package.json
+++ b/src/apis/cloudfunctions/package.json
@@ -2,8 +2,8 @@
   "name": "@google/cloudfunctions",
   "version": "0.1.0",
   "description": "cloudfunctions",
-  "main": "index.js",
-  "types": "index.d.ts",
+  "main": "build/index.js",
+  "types": "build/index.d.ts",
   "keywords": ["google"],
   "author": "Google LLC",
   "license": "Apache-2.0",
@@ -18,7 +18,19 @@
   "engines": {
     "node": ">=6.0.0"
   },
+  "scripts": {
+    "fix": "gts fix",
+    "lint": "gts check",
+    "compile": "tsc -p .",
+    "prepare": "npm run compile",
+    "docs": "typedoc --out docs/"
+  },
   "dependencies": {
     "googleapis-common": "^0.4.0"
+  },
+  "devDependencies": {
+    "gts": "^0.9.0",
+    "typescript": "~3.2.0",
+    "typedoc": "^0.13.0"
   }
 }

--- a/src/apis/cloudfunctions/tsconfig.json
+++ b/src/apis/cloudfunctions/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./node_modules/gts/tsconfig-google.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "build"
+  },
+  "include": [
+    "*.ts",
+  ]
+}

--- a/src/apis/cloudiot/package.json
+++ b/src/apis/cloudiot/package.json
@@ -2,8 +2,8 @@
   "name": "@google/cloudiot",
   "version": "0.1.0",
   "description": "cloudiot",
-  "main": "index.js",
-  "types": "index.d.ts",
+  "main": "build/index.js",
+  "types": "build/index.d.ts",
   "keywords": ["google"],
   "author": "Google LLC",
   "license": "Apache-2.0",
@@ -18,7 +18,19 @@
   "engines": {
     "node": ">=6.0.0"
   },
+  "scripts": {
+    "fix": "gts fix",
+    "lint": "gts check",
+    "compile": "tsc -p .",
+    "prepare": "npm run compile",
+    "docs": "typedoc --out docs/"
+  },
   "dependencies": {
     "googleapis-common": "^0.4.0"
+  },
+  "devDependencies": {
+    "gts": "^0.9.0",
+    "typescript": "~3.2.0",
+    "typedoc": "^0.13.0"
   }
 }

--- a/src/apis/cloudiot/tsconfig.json
+++ b/src/apis/cloudiot/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./node_modules/gts/tsconfig-google.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "build"
+  },
+  "include": [
+    "*.ts",
+  ]
+}

--- a/src/apis/cloudkms/package.json
+++ b/src/apis/cloudkms/package.json
@@ -2,8 +2,8 @@
   "name": "@google/cloudkms",
   "version": "0.1.0",
   "description": "cloudkms",
-  "main": "index.js",
-  "types": "index.d.ts",
+  "main": "build/index.js",
+  "types": "build/index.d.ts",
   "keywords": ["google"],
   "author": "Google LLC",
   "license": "Apache-2.0",
@@ -18,7 +18,19 @@
   "engines": {
     "node": ">=6.0.0"
   },
+  "scripts": {
+    "fix": "gts fix",
+    "lint": "gts check",
+    "compile": "tsc -p .",
+    "prepare": "npm run compile",
+    "docs": "typedoc --out docs/"
+  },
   "dependencies": {
     "googleapis-common": "^0.4.0"
+  },
+  "devDependencies": {
+    "gts": "^0.9.0",
+    "typescript": "~3.2.0",
+    "typedoc": "^0.13.0"
   }
 }

--- a/src/apis/cloudkms/tsconfig.json
+++ b/src/apis/cloudkms/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./node_modules/gts/tsconfig-google.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "build"
+  },
+  "include": [
+    "*.ts",
+  ]
+}

--- a/src/apis/cloudprofiler/package.json
+++ b/src/apis/cloudprofiler/package.json
@@ -2,8 +2,8 @@
   "name": "@google/cloudprofiler",
   "version": "0.1.0",
   "description": "cloudprofiler",
-  "main": "index.js",
-  "types": "index.d.ts",
+  "main": "build/index.js",
+  "types": "build/index.d.ts",
   "keywords": ["google"],
   "author": "Google LLC",
   "license": "Apache-2.0",
@@ -18,7 +18,19 @@
   "engines": {
     "node": ">=6.0.0"
   },
+  "scripts": {
+    "fix": "gts fix",
+    "lint": "gts check",
+    "compile": "tsc -p .",
+    "prepare": "npm run compile",
+    "docs": "typedoc --out docs/"
+  },
   "dependencies": {
     "googleapis-common": "^0.4.0"
+  },
+  "devDependencies": {
+    "gts": "^0.9.0",
+    "typescript": "~3.2.0",
+    "typedoc": "^0.13.0"
   }
 }

--- a/src/apis/cloudprofiler/tsconfig.json
+++ b/src/apis/cloudprofiler/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./node_modules/gts/tsconfig-google.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "build"
+  },
+  "include": [
+    "*.ts",
+  ]
+}

--- a/src/apis/cloudresourcemanager/package.json
+++ b/src/apis/cloudresourcemanager/package.json
@@ -2,8 +2,8 @@
   "name": "@google/cloudresourcemanager",
   "version": "0.1.0",
   "description": "cloudresourcemanager",
-  "main": "index.js",
-  "types": "index.d.ts",
+  "main": "build/index.js",
+  "types": "build/index.d.ts",
   "keywords": ["google"],
   "author": "Google LLC",
   "license": "Apache-2.0",
@@ -18,7 +18,19 @@
   "engines": {
     "node": ">=6.0.0"
   },
+  "scripts": {
+    "fix": "gts fix",
+    "lint": "gts check",
+    "compile": "tsc -p .",
+    "prepare": "npm run compile",
+    "docs": "typedoc --out docs/"
+  },
   "dependencies": {
     "googleapis-common": "^0.4.0"
+  },
+  "devDependencies": {
+    "gts": "^0.9.0",
+    "typescript": "~3.2.0",
+    "typedoc": "^0.13.0"
   }
 }

--- a/src/apis/cloudresourcemanager/tsconfig.json
+++ b/src/apis/cloudresourcemanager/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./node_modules/gts/tsconfig-google.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "build"
+  },
+  "include": [
+    "*.ts",
+  ]
+}

--- a/src/apis/cloudscheduler/package.json
+++ b/src/apis/cloudscheduler/package.json
@@ -2,8 +2,8 @@
   "name": "@google/cloudscheduler",
   "version": "0.1.0",
   "description": "cloudscheduler",
-  "main": "index.js",
-  "types": "index.d.ts",
+  "main": "build/index.js",
+  "types": "build/index.d.ts",
   "keywords": ["google"],
   "author": "Google LLC",
   "license": "Apache-2.0",
@@ -18,7 +18,19 @@
   "engines": {
     "node": ">=6.0.0"
   },
+  "scripts": {
+    "fix": "gts fix",
+    "lint": "gts check",
+    "compile": "tsc -p .",
+    "prepare": "npm run compile",
+    "docs": "typedoc --out docs/"
+  },
   "dependencies": {
     "googleapis-common": "^0.4.0"
+  },
+  "devDependencies": {
+    "gts": "^0.9.0",
+    "typescript": "~3.2.0",
+    "typedoc": "^0.13.0"
   }
 }

--- a/src/apis/cloudscheduler/tsconfig.json
+++ b/src/apis/cloudscheduler/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./node_modules/gts/tsconfig-google.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "build"
+  },
+  "include": [
+    "*.ts",
+  ]
+}

--- a/src/apis/cloudsearch/package.json
+++ b/src/apis/cloudsearch/package.json
@@ -2,8 +2,8 @@
   "name": "@google/cloudsearch",
   "version": "0.1.0",
   "description": "cloudsearch",
-  "main": "index.js",
-  "types": "index.d.ts",
+  "main": "build/index.js",
+  "types": "build/index.d.ts",
   "keywords": ["google"],
   "author": "Google LLC",
   "license": "Apache-2.0",
@@ -18,7 +18,19 @@
   "engines": {
     "node": ">=6.0.0"
   },
+  "scripts": {
+    "fix": "gts fix",
+    "lint": "gts check",
+    "compile": "tsc -p .",
+    "prepare": "npm run compile",
+    "docs": "typedoc --out docs/"
+  },
   "dependencies": {
     "googleapis-common": "^0.4.0"
+  },
+  "devDependencies": {
+    "gts": "^0.9.0",
+    "typescript": "~3.2.0",
+    "typedoc": "^0.13.0"
   }
 }

--- a/src/apis/cloudsearch/tsconfig.json
+++ b/src/apis/cloudsearch/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./node_modules/gts/tsconfig-google.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "build"
+  },
+  "include": [
+    "*.ts",
+  ]
+}

--- a/src/apis/cloudshell/package.json
+++ b/src/apis/cloudshell/package.json
@@ -2,8 +2,8 @@
   "name": "@google/cloudshell",
   "version": "0.1.0",
   "description": "cloudshell",
-  "main": "index.js",
-  "types": "index.d.ts",
+  "main": "build/index.js",
+  "types": "build/index.d.ts",
   "keywords": ["google"],
   "author": "Google LLC",
   "license": "Apache-2.0",
@@ -18,7 +18,19 @@
   "engines": {
     "node": ">=6.0.0"
   },
+  "scripts": {
+    "fix": "gts fix",
+    "lint": "gts check",
+    "compile": "tsc -p .",
+    "prepare": "npm run compile",
+    "docs": "typedoc --out docs/"
+  },
   "dependencies": {
     "googleapis-common": "^0.4.0"
+  },
+  "devDependencies": {
+    "gts": "^0.9.0",
+    "typescript": "~3.2.0",
+    "typedoc": "^0.13.0"
   }
 }

--- a/src/apis/cloudshell/tsconfig.json
+++ b/src/apis/cloudshell/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./node_modules/gts/tsconfig-google.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "build"
+  },
+  "include": [
+    "*.ts",
+  ]
+}

--- a/src/apis/cloudtasks/package.json
+++ b/src/apis/cloudtasks/package.json
@@ -2,8 +2,8 @@
   "name": "@google/cloudtasks",
   "version": "0.1.0",
   "description": "cloudtasks",
-  "main": "index.js",
-  "types": "index.d.ts",
+  "main": "build/index.js",
+  "types": "build/index.d.ts",
   "keywords": ["google"],
   "author": "Google LLC",
   "license": "Apache-2.0",
@@ -18,7 +18,19 @@
   "engines": {
     "node": ">=6.0.0"
   },
+  "scripts": {
+    "fix": "gts fix",
+    "lint": "gts check",
+    "compile": "tsc -p .",
+    "prepare": "npm run compile",
+    "docs": "typedoc --out docs/"
+  },
   "dependencies": {
     "googleapis-common": "^0.4.0"
+  },
+  "devDependencies": {
+    "gts": "^0.9.0",
+    "typescript": "~3.2.0",
+    "typedoc": "^0.13.0"
   }
 }

--- a/src/apis/cloudtasks/tsconfig.json
+++ b/src/apis/cloudtasks/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./node_modules/gts/tsconfig-google.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "build"
+  },
+  "include": [
+    "*.ts",
+  ]
+}

--- a/src/apis/cloudtrace/package.json
+++ b/src/apis/cloudtrace/package.json
@@ -2,8 +2,8 @@
   "name": "@google/cloudtrace",
   "version": "0.1.0",
   "description": "cloudtrace",
-  "main": "index.js",
-  "types": "index.d.ts",
+  "main": "build/index.js",
+  "types": "build/index.d.ts",
   "keywords": ["google"],
   "author": "Google LLC",
   "license": "Apache-2.0",
@@ -18,7 +18,19 @@
   "engines": {
     "node": ">=6.0.0"
   },
+  "scripts": {
+    "fix": "gts fix",
+    "lint": "gts check",
+    "compile": "tsc -p .",
+    "prepare": "npm run compile",
+    "docs": "typedoc --out docs/"
+  },
   "dependencies": {
     "googleapis-common": "^0.4.0"
+  },
+  "devDependencies": {
+    "gts": "^0.9.0",
+    "typescript": "~3.2.0",
+    "typedoc": "^0.13.0"
   }
 }

--- a/src/apis/cloudtrace/tsconfig.json
+++ b/src/apis/cloudtrace/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./node_modules/gts/tsconfig-google.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "build"
+  },
+  "include": [
+    "*.ts",
+  ]
+}

--- a/src/apis/composer/package.json
+++ b/src/apis/composer/package.json
@@ -2,8 +2,8 @@
   "name": "@google/composer",
   "version": "0.1.0",
   "description": "composer",
-  "main": "index.js",
-  "types": "index.d.ts",
+  "main": "build/index.js",
+  "types": "build/index.d.ts",
   "keywords": ["google"],
   "author": "Google LLC",
   "license": "Apache-2.0",
@@ -18,7 +18,19 @@
   "engines": {
     "node": ">=6.0.0"
   },
+  "scripts": {
+    "fix": "gts fix",
+    "lint": "gts check",
+    "compile": "tsc -p .",
+    "prepare": "npm run compile",
+    "docs": "typedoc --out docs/"
+  },
   "dependencies": {
     "googleapis-common": "^0.4.0"
+  },
+  "devDependencies": {
+    "gts": "^0.9.0",
+    "typescript": "~3.2.0",
+    "typedoc": "^0.13.0"
   }
 }

--- a/src/apis/composer/tsconfig.json
+++ b/src/apis/composer/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./node_modules/gts/tsconfig-google.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "build"
+  },
+  "include": [
+    "*.ts",
+  ]
+}

--- a/src/apis/compute/package.json
+++ b/src/apis/compute/package.json
@@ -2,8 +2,8 @@
   "name": "@google/compute",
   "version": "0.1.0",
   "description": "compute",
-  "main": "index.js",
-  "types": "index.d.ts",
+  "main": "build/index.js",
+  "types": "build/index.d.ts",
   "keywords": ["google"],
   "author": "Google LLC",
   "license": "Apache-2.0",
@@ -18,7 +18,19 @@
   "engines": {
     "node": ">=6.0.0"
   },
+  "scripts": {
+    "fix": "gts fix",
+    "lint": "gts check",
+    "compile": "tsc -p .",
+    "prepare": "npm run compile",
+    "docs": "typedoc --out docs/"
+  },
   "dependencies": {
     "googleapis-common": "^0.4.0"
+  },
+  "devDependencies": {
+    "gts": "^0.9.0",
+    "typescript": "~3.2.0",
+    "typedoc": "^0.13.0"
   }
 }

--- a/src/apis/compute/tsconfig.json
+++ b/src/apis/compute/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./node_modules/gts/tsconfig-google.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "build"
+  },
+  "include": [
+    "*.ts",
+  ]
+}

--- a/src/apis/container/package.json
+++ b/src/apis/container/package.json
@@ -2,8 +2,8 @@
   "name": "@google/container",
   "version": "0.1.0",
   "description": "container",
-  "main": "index.js",
-  "types": "index.d.ts",
+  "main": "build/index.js",
+  "types": "build/index.d.ts",
   "keywords": ["google"],
   "author": "Google LLC",
   "license": "Apache-2.0",
@@ -18,7 +18,19 @@
   "engines": {
     "node": ">=6.0.0"
   },
+  "scripts": {
+    "fix": "gts fix",
+    "lint": "gts check",
+    "compile": "tsc -p .",
+    "prepare": "npm run compile",
+    "docs": "typedoc --out docs/"
+  },
   "dependencies": {
     "googleapis-common": "^0.4.0"
+  },
+  "devDependencies": {
+    "gts": "^0.9.0",
+    "typescript": "~3.2.0",
+    "typedoc": "^0.13.0"
   }
 }

--- a/src/apis/container/tsconfig.json
+++ b/src/apis/container/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./node_modules/gts/tsconfig-google.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "build"
+  },
+  "include": [
+    "*.ts",
+  ]
+}

--- a/src/apis/content/package.json
+++ b/src/apis/content/package.json
@@ -2,8 +2,8 @@
   "name": "@google/content",
   "version": "0.1.0",
   "description": "content",
-  "main": "index.js",
-  "types": "index.d.ts",
+  "main": "build/index.js",
+  "types": "build/index.d.ts",
   "keywords": ["google"],
   "author": "Google LLC",
   "license": "Apache-2.0",
@@ -18,7 +18,19 @@
   "engines": {
     "node": ">=6.0.0"
   },
+  "scripts": {
+    "fix": "gts fix",
+    "lint": "gts check",
+    "compile": "tsc -p .",
+    "prepare": "npm run compile",
+    "docs": "typedoc --out docs/"
+  },
   "dependencies": {
     "googleapis-common": "^0.4.0"
+  },
+  "devDependencies": {
+    "gts": "^0.9.0",
+    "typescript": "~3.2.0",
+    "typedoc": "^0.13.0"
   }
 }

--- a/src/apis/content/tsconfig.json
+++ b/src/apis/content/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./node_modules/gts/tsconfig-google.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "build"
+  },
+  "include": [
+    "*.ts",
+  ]
+}

--- a/src/apis/customsearch/package.json
+++ b/src/apis/customsearch/package.json
@@ -2,8 +2,8 @@
   "name": "@google/customsearch",
   "version": "0.1.0",
   "description": "customsearch",
-  "main": "index.js",
-  "types": "index.d.ts",
+  "main": "build/index.js",
+  "types": "build/index.d.ts",
   "keywords": ["google"],
   "author": "Google LLC",
   "license": "Apache-2.0",
@@ -18,7 +18,19 @@
   "engines": {
     "node": ">=6.0.0"
   },
+  "scripts": {
+    "fix": "gts fix",
+    "lint": "gts check",
+    "compile": "tsc -p .",
+    "prepare": "npm run compile",
+    "docs": "typedoc --out docs/"
+  },
   "dependencies": {
     "googleapis-common": "^0.4.0"
+  },
+  "devDependencies": {
+    "gts": "^0.9.0",
+    "typescript": "~3.2.0",
+    "typedoc": "^0.13.0"
   }
 }

--- a/src/apis/customsearch/tsconfig.json
+++ b/src/apis/customsearch/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./node_modules/gts/tsconfig-google.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "build"
+  },
+  "include": [
+    "*.ts",
+  ]
+}

--- a/src/apis/dataflow/package.json
+++ b/src/apis/dataflow/package.json
@@ -2,8 +2,8 @@
   "name": "@google/dataflow",
   "version": "0.1.0",
   "description": "dataflow",
-  "main": "index.js",
-  "types": "index.d.ts",
+  "main": "build/index.js",
+  "types": "build/index.d.ts",
   "keywords": ["google"],
   "author": "Google LLC",
   "license": "Apache-2.0",
@@ -18,7 +18,19 @@
   "engines": {
     "node": ">=6.0.0"
   },
+  "scripts": {
+    "fix": "gts fix",
+    "lint": "gts check",
+    "compile": "tsc -p .",
+    "prepare": "npm run compile",
+    "docs": "typedoc --out docs/"
+  },
   "dependencies": {
     "googleapis-common": "^0.4.0"
+  },
+  "devDependencies": {
+    "gts": "^0.9.0",
+    "typescript": "~3.2.0",
+    "typedoc": "^0.13.0"
   }
 }

--- a/src/apis/dataflow/tsconfig.json
+++ b/src/apis/dataflow/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./node_modules/gts/tsconfig-google.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "build"
+  },
+  "include": [
+    "*.ts",
+  ]
+}

--- a/src/apis/dataproc/package.json
+++ b/src/apis/dataproc/package.json
@@ -2,8 +2,8 @@
   "name": "@google/dataproc",
   "version": "0.1.0",
   "description": "dataproc",
-  "main": "index.js",
-  "types": "index.d.ts",
+  "main": "build/index.js",
+  "types": "build/index.d.ts",
   "keywords": ["google"],
   "author": "Google LLC",
   "license": "Apache-2.0",
@@ -18,7 +18,19 @@
   "engines": {
     "node": ">=6.0.0"
   },
+  "scripts": {
+    "fix": "gts fix",
+    "lint": "gts check",
+    "compile": "tsc -p .",
+    "prepare": "npm run compile",
+    "docs": "typedoc --out docs/"
+  },
   "dependencies": {
     "googleapis-common": "^0.4.0"
+  },
+  "devDependencies": {
+    "gts": "^0.9.0",
+    "typescript": "~3.2.0",
+    "typedoc": "^0.13.0"
   }
 }

--- a/src/apis/dataproc/tsconfig.json
+++ b/src/apis/dataproc/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./node_modules/gts/tsconfig-google.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "build"
+  },
+  "include": [
+    "*.ts",
+  ]
+}

--- a/src/apis/datastore/package.json
+++ b/src/apis/datastore/package.json
@@ -2,8 +2,8 @@
   "name": "@google/datastore",
   "version": "0.1.0",
   "description": "datastore",
-  "main": "index.js",
-  "types": "index.d.ts",
+  "main": "build/index.js",
+  "types": "build/index.d.ts",
   "keywords": ["google"],
   "author": "Google LLC",
   "license": "Apache-2.0",
@@ -18,7 +18,19 @@
   "engines": {
     "node": ">=6.0.0"
   },
+  "scripts": {
+    "fix": "gts fix",
+    "lint": "gts check",
+    "compile": "tsc -p .",
+    "prepare": "npm run compile",
+    "docs": "typedoc --out docs/"
+  },
   "dependencies": {
     "googleapis-common": "^0.4.0"
+  },
+  "devDependencies": {
+    "gts": "^0.9.0",
+    "typescript": "~3.2.0",
+    "typedoc": "^0.13.0"
   }
 }

--- a/src/apis/datastore/tsconfig.json
+++ b/src/apis/datastore/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./node_modules/gts/tsconfig-google.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "build"
+  },
+  "include": [
+    "*.ts",
+  ]
+}

--- a/src/apis/deploymentmanager/package.json
+++ b/src/apis/deploymentmanager/package.json
@@ -2,8 +2,8 @@
   "name": "@google/deploymentmanager",
   "version": "0.1.0",
   "description": "deploymentmanager",
-  "main": "index.js",
-  "types": "index.d.ts",
+  "main": "build/index.js",
+  "types": "build/index.d.ts",
   "keywords": ["google"],
   "author": "Google LLC",
   "license": "Apache-2.0",
@@ -18,7 +18,19 @@
   "engines": {
     "node": ">=6.0.0"
   },
+  "scripts": {
+    "fix": "gts fix",
+    "lint": "gts check",
+    "compile": "tsc -p .",
+    "prepare": "npm run compile",
+    "docs": "typedoc --out docs/"
+  },
   "dependencies": {
     "googleapis-common": "^0.4.0"
+  },
+  "devDependencies": {
+    "gts": "^0.9.0",
+    "typescript": "~3.2.0",
+    "typedoc": "^0.13.0"
   }
 }

--- a/src/apis/deploymentmanager/tsconfig.json
+++ b/src/apis/deploymentmanager/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./node_modules/gts/tsconfig-google.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "build"
+  },
+  "include": [
+    "*.ts",
+  ]
+}

--- a/src/apis/dfareporting/package.json
+++ b/src/apis/dfareporting/package.json
@@ -2,8 +2,8 @@
   "name": "@google/dfareporting",
   "version": "0.1.0",
   "description": "dfareporting",
-  "main": "index.js",
-  "types": "index.d.ts",
+  "main": "build/index.js",
+  "types": "build/index.d.ts",
   "keywords": ["google"],
   "author": "Google LLC",
   "license": "Apache-2.0",
@@ -18,7 +18,19 @@
   "engines": {
     "node": ">=6.0.0"
   },
+  "scripts": {
+    "fix": "gts fix",
+    "lint": "gts check",
+    "compile": "tsc -p .",
+    "prepare": "npm run compile",
+    "docs": "typedoc --out docs/"
+  },
   "dependencies": {
     "googleapis-common": "^0.4.0"
+  },
+  "devDependencies": {
+    "gts": "^0.9.0",
+    "typescript": "~3.2.0",
+    "typedoc": "^0.13.0"
   }
 }

--- a/src/apis/dfareporting/tsconfig.json
+++ b/src/apis/dfareporting/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./node_modules/gts/tsconfig-google.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "build"
+  },
+  "include": [
+    "*.ts",
+  ]
+}

--- a/src/apis/dialogflow/package.json
+++ b/src/apis/dialogflow/package.json
@@ -2,8 +2,8 @@
   "name": "@google/dialogflow",
   "version": "0.1.0",
   "description": "dialogflow",
-  "main": "index.js",
-  "types": "index.d.ts",
+  "main": "build/index.js",
+  "types": "build/index.d.ts",
   "keywords": ["google"],
   "author": "Google LLC",
   "license": "Apache-2.0",
@@ -18,7 +18,19 @@
   "engines": {
     "node": ">=6.0.0"
   },
+  "scripts": {
+    "fix": "gts fix",
+    "lint": "gts check",
+    "compile": "tsc -p .",
+    "prepare": "npm run compile",
+    "docs": "typedoc --out docs/"
+  },
   "dependencies": {
     "googleapis-common": "^0.4.0"
+  },
+  "devDependencies": {
+    "gts": "^0.9.0",
+    "typescript": "~3.2.0",
+    "typedoc": "^0.13.0"
   }
 }

--- a/src/apis/dialogflow/tsconfig.json
+++ b/src/apis/dialogflow/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./node_modules/gts/tsconfig-google.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "build"
+  },
+  "include": [
+    "*.ts",
+  ]
+}

--- a/src/apis/digitalassetlinks/package.json
+++ b/src/apis/digitalassetlinks/package.json
@@ -2,8 +2,8 @@
   "name": "@google/digitalassetlinks",
   "version": "0.1.0",
   "description": "digitalassetlinks",
-  "main": "index.js",
-  "types": "index.d.ts",
+  "main": "build/index.js",
+  "types": "build/index.d.ts",
   "keywords": ["google"],
   "author": "Google LLC",
   "license": "Apache-2.0",
@@ -18,7 +18,19 @@
   "engines": {
     "node": ">=6.0.0"
   },
+  "scripts": {
+    "fix": "gts fix",
+    "lint": "gts check",
+    "compile": "tsc -p .",
+    "prepare": "npm run compile",
+    "docs": "typedoc --out docs/"
+  },
   "dependencies": {
     "googleapis-common": "^0.4.0"
+  },
+  "devDependencies": {
+    "gts": "^0.9.0",
+    "typescript": "~3.2.0",
+    "typedoc": "^0.13.0"
   }
 }

--- a/src/apis/digitalassetlinks/tsconfig.json
+++ b/src/apis/digitalassetlinks/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./node_modules/gts/tsconfig-google.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "build"
+  },
+  "include": [
+    "*.ts",
+  ]
+}

--- a/src/apis/discovery/package.json
+++ b/src/apis/discovery/package.json
@@ -2,8 +2,8 @@
   "name": "@google/discovery",
   "version": "0.1.0",
   "description": "discovery",
-  "main": "index.js",
-  "types": "index.d.ts",
+  "main": "build/index.js",
+  "types": "build/index.d.ts",
   "keywords": ["google"],
   "author": "Google LLC",
   "license": "Apache-2.0",
@@ -18,7 +18,19 @@
   "engines": {
     "node": ">=6.0.0"
   },
+  "scripts": {
+    "fix": "gts fix",
+    "lint": "gts check",
+    "compile": "tsc -p .",
+    "prepare": "npm run compile",
+    "docs": "typedoc --out docs/"
+  },
   "dependencies": {
     "googleapis-common": "^0.4.0"
+  },
+  "devDependencies": {
+    "gts": "^0.9.0",
+    "typescript": "~3.2.0",
+    "typedoc": "^0.13.0"
   }
 }

--- a/src/apis/discovery/tsconfig.json
+++ b/src/apis/discovery/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./node_modules/gts/tsconfig-google.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "build"
+  },
+  "include": [
+    "*.ts",
+  ]
+}

--- a/src/apis/dlp/package.json
+++ b/src/apis/dlp/package.json
@@ -2,8 +2,8 @@
   "name": "@google/dlp",
   "version": "0.1.0",
   "description": "dlp",
-  "main": "index.js",
-  "types": "index.d.ts",
+  "main": "build/index.js",
+  "types": "build/index.d.ts",
   "keywords": ["google"],
   "author": "Google LLC",
   "license": "Apache-2.0",
@@ -18,7 +18,19 @@
   "engines": {
     "node": ">=6.0.0"
   },
+  "scripts": {
+    "fix": "gts fix",
+    "lint": "gts check",
+    "compile": "tsc -p .",
+    "prepare": "npm run compile",
+    "docs": "typedoc --out docs/"
+  },
   "dependencies": {
     "googleapis-common": "^0.4.0"
+  },
+  "devDependencies": {
+    "gts": "^0.9.0",
+    "typescript": "~3.2.0",
+    "typedoc": "^0.13.0"
   }
 }

--- a/src/apis/dlp/tsconfig.json
+++ b/src/apis/dlp/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./node_modules/gts/tsconfig-google.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "build"
+  },
+  "include": [
+    "*.ts",
+  ]
+}

--- a/src/apis/dns/package.json
+++ b/src/apis/dns/package.json
@@ -2,8 +2,8 @@
   "name": "@google/dns",
   "version": "0.1.0",
   "description": "dns",
-  "main": "index.js",
-  "types": "index.d.ts",
+  "main": "build/index.js",
+  "types": "build/index.d.ts",
   "keywords": ["google"],
   "author": "Google LLC",
   "license": "Apache-2.0",
@@ -18,7 +18,19 @@
   "engines": {
     "node": ">=6.0.0"
   },
+  "scripts": {
+    "fix": "gts fix",
+    "lint": "gts check",
+    "compile": "tsc -p .",
+    "prepare": "npm run compile",
+    "docs": "typedoc --out docs/"
+  },
   "dependencies": {
     "googleapis-common": "^0.4.0"
+  },
+  "devDependencies": {
+    "gts": "^0.9.0",
+    "typescript": "~3.2.0",
+    "typedoc": "^0.13.0"
   }
 }

--- a/src/apis/dns/tsconfig.json
+++ b/src/apis/dns/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./node_modules/gts/tsconfig-google.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "build"
+  },
+  "include": [
+    "*.ts",
+  ]
+}

--- a/src/apis/doubleclickbidmanager/package.json
+++ b/src/apis/doubleclickbidmanager/package.json
@@ -2,8 +2,8 @@
   "name": "@google/doubleclickbidmanager",
   "version": "0.1.0",
   "description": "doubleclickbidmanager",
-  "main": "index.js",
-  "types": "index.d.ts",
+  "main": "build/index.js",
+  "types": "build/index.d.ts",
   "keywords": ["google"],
   "author": "Google LLC",
   "license": "Apache-2.0",
@@ -18,7 +18,19 @@
   "engines": {
     "node": ">=6.0.0"
   },
+  "scripts": {
+    "fix": "gts fix",
+    "lint": "gts check",
+    "compile": "tsc -p .",
+    "prepare": "npm run compile",
+    "docs": "typedoc --out docs/"
+  },
   "dependencies": {
     "googleapis-common": "^0.4.0"
+  },
+  "devDependencies": {
+    "gts": "^0.9.0",
+    "typescript": "~3.2.0",
+    "typedoc": "^0.13.0"
   }
 }

--- a/src/apis/doubleclickbidmanager/tsconfig.json
+++ b/src/apis/doubleclickbidmanager/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./node_modules/gts/tsconfig-google.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "build"
+  },
+  "include": [
+    "*.ts",
+  ]
+}

--- a/src/apis/doubleclicksearch/package.json
+++ b/src/apis/doubleclicksearch/package.json
@@ -2,8 +2,8 @@
   "name": "@google/doubleclicksearch",
   "version": "0.1.0",
   "description": "doubleclicksearch",
-  "main": "index.js",
-  "types": "index.d.ts",
+  "main": "build/index.js",
+  "types": "build/index.d.ts",
   "keywords": ["google"],
   "author": "Google LLC",
   "license": "Apache-2.0",
@@ -18,7 +18,19 @@
   "engines": {
     "node": ">=6.0.0"
   },
+  "scripts": {
+    "fix": "gts fix",
+    "lint": "gts check",
+    "compile": "tsc -p .",
+    "prepare": "npm run compile",
+    "docs": "typedoc --out docs/"
+  },
   "dependencies": {
     "googleapis-common": "^0.4.0"
+  },
+  "devDependencies": {
+    "gts": "^0.9.0",
+    "typescript": "~3.2.0",
+    "typedoc": "^0.13.0"
   }
 }

--- a/src/apis/doubleclicksearch/tsconfig.json
+++ b/src/apis/doubleclicksearch/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./node_modules/gts/tsconfig-google.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "build"
+  },
+  "include": [
+    "*.ts",
+  ]
+}

--- a/src/apis/drive/package.json
+++ b/src/apis/drive/package.json
@@ -2,8 +2,8 @@
   "name": "@google/drive",
   "version": "0.1.0",
   "description": "drive",
-  "main": "index.js",
-  "types": "index.d.ts",
+  "main": "build/index.js",
+  "types": "build/index.d.ts",
   "keywords": ["google"],
   "author": "Google LLC",
   "license": "Apache-2.0",
@@ -18,7 +18,19 @@
   "engines": {
     "node": ">=6.0.0"
   },
+  "scripts": {
+    "fix": "gts fix",
+    "lint": "gts check",
+    "compile": "tsc -p .",
+    "prepare": "npm run compile",
+    "docs": "typedoc --out docs/"
+  },
   "dependencies": {
     "googleapis-common": "^0.4.0"
+  },
+  "devDependencies": {
+    "gts": "^0.9.0",
+    "typescript": "~3.2.0",
+    "typedoc": "^0.13.0"
   }
 }

--- a/src/apis/drive/tsconfig.json
+++ b/src/apis/drive/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./node_modules/gts/tsconfig-google.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "build"
+  },
+  "include": [
+    "*.ts",
+  ]
+}

--- a/src/apis/driveactivity/package.json
+++ b/src/apis/driveactivity/package.json
@@ -2,8 +2,8 @@
   "name": "@google/driveactivity",
   "version": "0.1.0",
   "description": "driveactivity",
-  "main": "index.js",
-  "types": "index.d.ts",
+  "main": "build/index.js",
+  "types": "build/index.d.ts",
   "keywords": ["google"],
   "author": "Google LLC",
   "license": "Apache-2.0",
@@ -18,7 +18,19 @@
   "engines": {
     "node": ">=6.0.0"
   },
+  "scripts": {
+    "fix": "gts fix",
+    "lint": "gts check",
+    "compile": "tsc -p .",
+    "prepare": "npm run compile",
+    "docs": "typedoc --out docs/"
+  },
   "dependencies": {
     "googleapis-common": "^0.4.0"
+  },
+  "devDependencies": {
+    "gts": "^0.9.0",
+    "typescript": "~3.2.0",
+    "typedoc": "^0.13.0"
   }
 }

--- a/src/apis/driveactivity/tsconfig.json
+++ b/src/apis/driveactivity/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./node_modules/gts/tsconfig-google.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "build"
+  },
+  "include": [
+    "*.ts",
+  ]
+}

--- a/src/apis/file/package.json
+++ b/src/apis/file/package.json
@@ -2,8 +2,8 @@
   "name": "@google/file",
   "version": "0.1.0",
   "description": "file",
-  "main": "index.js",
-  "types": "index.d.ts",
+  "main": "build/index.js",
+  "types": "build/index.d.ts",
   "keywords": ["google"],
   "author": "Google LLC",
   "license": "Apache-2.0",
@@ -18,7 +18,19 @@
   "engines": {
     "node": ">=6.0.0"
   },
+  "scripts": {
+    "fix": "gts fix",
+    "lint": "gts check",
+    "compile": "tsc -p .",
+    "prepare": "npm run compile",
+    "docs": "typedoc --out docs/"
+  },
   "dependencies": {
     "googleapis-common": "^0.4.0"
+  },
+  "devDependencies": {
+    "gts": "^0.9.0",
+    "typescript": "~3.2.0",
+    "typedoc": "^0.13.0"
   }
 }

--- a/src/apis/file/tsconfig.json
+++ b/src/apis/file/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./node_modules/gts/tsconfig-google.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "build"
+  },
+  "include": [
+    "*.ts",
+  ]
+}

--- a/src/apis/firebasedynamiclinks/package.json
+++ b/src/apis/firebasedynamiclinks/package.json
@@ -2,8 +2,8 @@
   "name": "@google/firebasedynamiclinks",
   "version": "0.1.0",
   "description": "firebasedynamiclinks",
-  "main": "index.js",
-  "types": "index.d.ts",
+  "main": "build/index.js",
+  "types": "build/index.d.ts",
   "keywords": ["google"],
   "author": "Google LLC",
   "license": "Apache-2.0",
@@ -18,7 +18,19 @@
   "engines": {
     "node": ">=6.0.0"
   },
+  "scripts": {
+    "fix": "gts fix",
+    "lint": "gts check",
+    "compile": "tsc -p .",
+    "prepare": "npm run compile",
+    "docs": "typedoc --out docs/"
+  },
   "dependencies": {
     "googleapis-common": "^0.4.0"
+  },
+  "devDependencies": {
+    "gts": "^0.9.0",
+    "typescript": "~3.2.0",
+    "typedoc": "^0.13.0"
   }
 }

--- a/src/apis/firebasedynamiclinks/tsconfig.json
+++ b/src/apis/firebasedynamiclinks/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./node_modules/gts/tsconfig-google.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "build"
+  },
+  "include": [
+    "*.ts",
+  ]
+}

--- a/src/apis/firebasehosting/package.json
+++ b/src/apis/firebasehosting/package.json
@@ -2,8 +2,8 @@
   "name": "@google/firebasehosting",
   "version": "0.1.0",
   "description": "firebasehosting",
-  "main": "index.js",
-  "types": "index.d.ts",
+  "main": "build/index.js",
+  "types": "build/index.d.ts",
   "keywords": ["google"],
   "author": "Google LLC",
   "license": "Apache-2.0",
@@ -18,7 +18,19 @@
   "engines": {
     "node": ">=6.0.0"
   },
+  "scripts": {
+    "fix": "gts fix",
+    "lint": "gts check",
+    "compile": "tsc -p .",
+    "prepare": "npm run compile",
+    "docs": "typedoc --out docs/"
+  },
   "dependencies": {
     "googleapis-common": "^0.4.0"
+  },
+  "devDependencies": {
+    "gts": "^0.9.0",
+    "typescript": "~3.2.0",
+    "typedoc": "^0.13.0"
   }
 }

--- a/src/apis/firebasehosting/tsconfig.json
+++ b/src/apis/firebasehosting/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./node_modules/gts/tsconfig-google.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "build"
+  },
+  "include": [
+    "*.ts",
+  ]
+}

--- a/src/apis/firebaserules/package.json
+++ b/src/apis/firebaserules/package.json
@@ -2,8 +2,8 @@
   "name": "@google/firebaserules",
   "version": "0.1.0",
   "description": "firebaserules",
-  "main": "index.js",
-  "types": "index.d.ts",
+  "main": "build/index.js",
+  "types": "build/index.d.ts",
   "keywords": ["google"],
   "author": "Google LLC",
   "license": "Apache-2.0",
@@ -18,7 +18,19 @@
   "engines": {
     "node": ">=6.0.0"
   },
+  "scripts": {
+    "fix": "gts fix",
+    "lint": "gts check",
+    "compile": "tsc -p .",
+    "prepare": "npm run compile",
+    "docs": "typedoc --out docs/"
+  },
   "dependencies": {
     "googleapis-common": "^0.4.0"
+  },
+  "devDependencies": {
+    "gts": "^0.9.0",
+    "typescript": "~3.2.0",
+    "typedoc": "^0.13.0"
   }
 }

--- a/src/apis/firebaserules/tsconfig.json
+++ b/src/apis/firebaserules/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./node_modules/gts/tsconfig-google.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "build"
+  },
+  "include": [
+    "*.ts",
+  ]
+}

--- a/src/apis/firestore/package.json
+++ b/src/apis/firestore/package.json
@@ -2,8 +2,8 @@
   "name": "@google/firestore",
   "version": "0.1.0",
   "description": "firestore",
-  "main": "index.js",
-  "types": "index.d.ts",
+  "main": "build/index.js",
+  "types": "build/index.d.ts",
   "keywords": ["google"],
   "author": "Google LLC",
   "license": "Apache-2.0",
@@ -18,7 +18,19 @@
   "engines": {
     "node": ">=6.0.0"
   },
+  "scripts": {
+    "fix": "gts fix",
+    "lint": "gts check",
+    "compile": "tsc -p .",
+    "prepare": "npm run compile",
+    "docs": "typedoc --out docs/"
+  },
   "dependencies": {
     "googleapis-common": "^0.4.0"
+  },
+  "devDependencies": {
+    "gts": "^0.9.0",
+    "typescript": "~3.2.0",
+    "typedoc": "^0.13.0"
   }
 }

--- a/src/apis/firestore/tsconfig.json
+++ b/src/apis/firestore/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./node_modules/gts/tsconfig-google.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "build"
+  },
+  "include": [
+    "*.ts",
+  ]
+}

--- a/src/apis/fitness/package.json
+++ b/src/apis/fitness/package.json
@@ -2,8 +2,8 @@
   "name": "@google/fitness",
   "version": "0.1.0",
   "description": "fitness",
-  "main": "index.js",
-  "types": "index.d.ts",
+  "main": "build/index.js",
+  "types": "build/index.d.ts",
   "keywords": ["google"],
   "author": "Google LLC",
   "license": "Apache-2.0",
@@ -18,7 +18,19 @@
   "engines": {
     "node": ">=6.0.0"
   },
+  "scripts": {
+    "fix": "gts fix",
+    "lint": "gts check",
+    "compile": "tsc -p .",
+    "prepare": "npm run compile",
+    "docs": "typedoc --out docs/"
+  },
   "dependencies": {
     "googleapis-common": "^0.4.0"
+  },
+  "devDependencies": {
+    "gts": "^0.9.0",
+    "typescript": "~3.2.0",
+    "typedoc": "^0.13.0"
   }
 }

--- a/src/apis/fitness/tsconfig.json
+++ b/src/apis/fitness/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./node_modules/gts/tsconfig-google.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "build"
+  },
+  "include": [
+    "*.ts",
+  ]
+}

--- a/src/apis/fusiontables/package.json
+++ b/src/apis/fusiontables/package.json
@@ -2,8 +2,8 @@
   "name": "@google/fusiontables",
   "version": "0.1.0",
   "description": "fusiontables",
-  "main": "index.js",
-  "types": "index.d.ts",
+  "main": "build/index.js",
+  "types": "build/index.d.ts",
   "keywords": ["google"],
   "author": "Google LLC",
   "license": "Apache-2.0",
@@ -18,7 +18,19 @@
   "engines": {
     "node": ">=6.0.0"
   },
+  "scripts": {
+    "fix": "gts fix",
+    "lint": "gts check",
+    "compile": "tsc -p .",
+    "prepare": "npm run compile",
+    "docs": "typedoc --out docs/"
+  },
   "dependencies": {
     "googleapis-common": "^0.4.0"
+  },
+  "devDependencies": {
+    "gts": "^0.9.0",
+    "typescript": "~3.2.0",
+    "typedoc": "^0.13.0"
   }
 }

--- a/src/apis/fusiontables/tsconfig.json
+++ b/src/apis/fusiontables/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./node_modules/gts/tsconfig-google.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "build"
+  },
+  "include": [
+    "*.ts",
+  ]
+}

--- a/src/apis/games/package.json
+++ b/src/apis/games/package.json
@@ -2,8 +2,8 @@
   "name": "@google/games",
   "version": "0.1.0",
   "description": "games",
-  "main": "index.js",
-  "types": "index.d.ts",
+  "main": "build/index.js",
+  "types": "build/index.d.ts",
   "keywords": ["google"],
   "author": "Google LLC",
   "license": "Apache-2.0",
@@ -18,7 +18,19 @@
   "engines": {
     "node": ">=6.0.0"
   },
+  "scripts": {
+    "fix": "gts fix",
+    "lint": "gts check",
+    "compile": "tsc -p .",
+    "prepare": "npm run compile",
+    "docs": "typedoc --out docs/"
+  },
   "dependencies": {
     "googleapis-common": "^0.4.0"
+  },
+  "devDependencies": {
+    "gts": "^0.9.0",
+    "typescript": "~3.2.0",
+    "typedoc": "^0.13.0"
   }
 }

--- a/src/apis/games/tsconfig.json
+++ b/src/apis/games/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./node_modules/gts/tsconfig-google.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "build"
+  },
+  "include": [
+    "*.ts",
+  ]
+}

--- a/src/apis/gamesConfiguration/package.json
+++ b/src/apis/gamesConfiguration/package.json
@@ -2,8 +2,8 @@
   "name": "@google/gamesConfiguration",
   "version": "0.1.0",
   "description": "gamesConfiguration",
-  "main": "index.js",
-  "types": "index.d.ts",
+  "main": "build/index.js",
+  "types": "build/index.d.ts",
   "keywords": ["google"],
   "author": "Google LLC",
   "license": "Apache-2.0",
@@ -18,7 +18,19 @@
   "engines": {
     "node": ">=6.0.0"
   },
+  "scripts": {
+    "fix": "gts fix",
+    "lint": "gts check",
+    "compile": "tsc -p .",
+    "prepare": "npm run compile",
+    "docs": "typedoc --out docs/"
+  },
   "dependencies": {
     "googleapis-common": "^0.4.0"
+  },
+  "devDependencies": {
+    "gts": "^0.9.0",
+    "typescript": "~3.2.0",
+    "typedoc": "^0.13.0"
   }
 }

--- a/src/apis/gamesConfiguration/tsconfig.json
+++ b/src/apis/gamesConfiguration/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./node_modules/gts/tsconfig-google.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "build"
+  },
+  "include": [
+    "*.ts",
+  ]
+}

--- a/src/apis/gamesManagement/package.json
+++ b/src/apis/gamesManagement/package.json
@@ -2,8 +2,8 @@
   "name": "@google/gamesManagement",
   "version": "0.1.0",
   "description": "gamesManagement",
-  "main": "index.js",
-  "types": "index.d.ts",
+  "main": "build/index.js",
+  "types": "build/index.d.ts",
   "keywords": ["google"],
   "author": "Google LLC",
   "license": "Apache-2.0",
@@ -18,7 +18,19 @@
   "engines": {
     "node": ">=6.0.0"
   },
+  "scripts": {
+    "fix": "gts fix",
+    "lint": "gts check",
+    "compile": "tsc -p .",
+    "prepare": "npm run compile",
+    "docs": "typedoc --out docs/"
+  },
   "dependencies": {
     "googleapis-common": "^0.4.0"
+  },
+  "devDependencies": {
+    "gts": "^0.9.0",
+    "typescript": "~3.2.0",
+    "typedoc": "^0.13.0"
   }
 }

--- a/src/apis/gamesManagement/tsconfig.json
+++ b/src/apis/gamesManagement/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./node_modules/gts/tsconfig-google.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "build"
+  },
+  "include": [
+    "*.ts",
+  ]
+}

--- a/src/apis/genomics/package.json
+++ b/src/apis/genomics/package.json
@@ -2,8 +2,8 @@
   "name": "@google/genomics",
   "version": "0.1.0",
   "description": "genomics",
-  "main": "index.js",
-  "types": "index.d.ts",
+  "main": "build/index.js",
+  "types": "build/index.d.ts",
   "keywords": ["google"],
   "author": "Google LLC",
   "license": "Apache-2.0",
@@ -18,7 +18,19 @@
   "engines": {
     "node": ">=6.0.0"
   },
+  "scripts": {
+    "fix": "gts fix",
+    "lint": "gts check",
+    "compile": "tsc -p .",
+    "prepare": "npm run compile",
+    "docs": "typedoc --out docs/"
+  },
   "dependencies": {
     "googleapis-common": "^0.4.0"
+  },
+  "devDependencies": {
+    "gts": "^0.9.0",
+    "typescript": "~3.2.0",
+    "typedoc": "^0.13.0"
   }
 }

--- a/src/apis/genomics/tsconfig.json
+++ b/src/apis/genomics/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./node_modules/gts/tsconfig-google.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "build"
+  },
+  "include": [
+    "*.ts",
+  ]
+}

--- a/src/apis/gmail/package.json
+++ b/src/apis/gmail/package.json
@@ -2,8 +2,8 @@
   "name": "@google/gmail",
   "version": "0.1.0",
   "description": "gmail",
-  "main": "index.js",
-  "types": "index.d.ts",
+  "main": "build/index.js",
+  "types": "build/index.d.ts",
   "keywords": ["google"],
   "author": "Google LLC",
   "license": "Apache-2.0",
@@ -18,7 +18,19 @@
   "engines": {
     "node": ">=6.0.0"
   },
+  "scripts": {
+    "fix": "gts fix",
+    "lint": "gts check",
+    "compile": "tsc -p .",
+    "prepare": "npm run compile",
+    "docs": "typedoc --out docs/"
+  },
   "dependencies": {
     "googleapis-common": "^0.4.0"
+  },
+  "devDependencies": {
+    "gts": "^0.9.0",
+    "typescript": "~3.2.0",
+    "typedoc": "^0.13.0"
   }
 }

--- a/src/apis/gmail/tsconfig.json
+++ b/src/apis/gmail/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./node_modules/gts/tsconfig-google.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "build"
+  },
+  "include": [
+    "*.ts",
+  ]
+}

--- a/src/apis/groupsmigration/package.json
+++ b/src/apis/groupsmigration/package.json
@@ -2,8 +2,8 @@
   "name": "@google/groupsmigration",
   "version": "0.1.0",
   "description": "groupsmigration",
-  "main": "index.js",
-  "types": "index.d.ts",
+  "main": "build/index.js",
+  "types": "build/index.d.ts",
   "keywords": ["google"],
   "author": "Google LLC",
   "license": "Apache-2.0",
@@ -18,7 +18,19 @@
   "engines": {
     "node": ">=6.0.0"
   },
+  "scripts": {
+    "fix": "gts fix",
+    "lint": "gts check",
+    "compile": "tsc -p .",
+    "prepare": "npm run compile",
+    "docs": "typedoc --out docs/"
+  },
   "dependencies": {
     "googleapis-common": "^0.4.0"
+  },
+  "devDependencies": {
+    "gts": "^0.9.0",
+    "typescript": "~3.2.0",
+    "typedoc": "^0.13.0"
   }
 }

--- a/src/apis/groupsmigration/tsconfig.json
+++ b/src/apis/groupsmigration/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./node_modules/gts/tsconfig-google.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "build"
+  },
+  "include": [
+    "*.ts",
+  ]
+}

--- a/src/apis/groupssettings/package.json
+++ b/src/apis/groupssettings/package.json
@@ -2,8 +2,8 @@
   "name": "@google/groupssettings",
   "version": "0.1.0",
   "description": "groupssettings",
-  "main": "index.js",
-  "types": "index.d.ts",
+  "main": "build/index.js",
+  "types": "build/index.d.ts",
   "keywords": ["google"],
   "author": "Google LLC",
   "license": "Apache-2.0",
@@ -18,7 +18,19 @@
   "engines": {
     "node": ">=6.0.0"
   },
+  "scripts": {
+    "fix": "gts fix",
+    "lint": "gts check",
+    "compile": "tsc -p .",
+    "prepare": "npm run compile",
+    "docs": "typedoc --out docs/"
+  },
   "dependencies": {
     "googleapis-common": "^0.4.0"
+  },
+  "devDependencies": {
+    "gts": "^0.9.0",
+    "typescript": "~3.2.0",
+    "typedoc": "^0.13.0"
   }
 }

--- a/src/apis/groupssettings/tsconfig.json
+++ b/src/apis/groupssettings/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./node_modules/gts/tsconfig-google.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "build"
+  },
+  "include": [
+    "*.ts",
+  ]
+}

--- a/src/apis/iam/package.json
+++ b/src/apis/iam/package.json
@@ -2,8 +2,8 @@
   "name": "@google/iam",
   "version": "0.1.0",
   "description": "iam",
-  "main": "index.js",
-  "types": "index.d.ts",
+  "main": "build/index.js",
+  "types": "build/index.d.ts",
   "keywords": ["google"],
   "author": "Google LLC",
   "license": "Apache-2.0",
@@ -18,7 +18,19 @@
   "engines": {
     "node": ">=6.0.0"
   },
+  "scripts": {
+    "fix": "gts fix",
+    "lint": "gts check",
+    "compile": "tsc -p .",
+    "prepare": "npm run compile",
+    "docs": "typedoc --out docs/"
+  },
   "dependencies": {
     "googleapis-common": "^0.4.0"
+  },
+  "devDependencies": {
+    "gts": "^0.9.0",
+    "typescript": "~3.2.0",
+    "typedoc": "^0.13.0"
   }
 }

--- a/src/apis/iam/tsconfig.json
+++ b/src/apis/iam/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./node_modules/gts/tsconfig-google.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "build"
+  },
+  "include": [
+    "*.ts",
+  ]
+}

--- a/src/apis/iamcredentials/package.json
+++ b/src/apis/iamcredentials/package.json
@@ -2,8 +2,8 @@
   "name": "@google/iamcredentials",
   "version": "0.1.0",
   "description": "iamcredentials",
-  "main": "index.js",
-  "types": "index.d.ts",
+  "main": "build/index.js",
+  "types": "build/index.d.ts",
   "keywords": ["google"],
   "author": "Google LLC",
   "license": "Apache-2.0",
@@ -18,7 +18,19 @@
   "engines": {
     "node": ">=6.0.0"
   },
+  "scripts": {
+    "fix": "gts fix",
+    "lint": "gts check",
+    "compile": "tsc -p .",
+    "prepare": "npm run compile",
+    "docs": "typedoc --out docs/"
+  },
   "dependencies": {
     "googleapis-common": "^0.4.0"
+  },
+  "devDependencies": {
+    "gts": "^0.9.0",
+    "typescript": "~3.2.0",
+    "typedoc": "^0.13.0"
   }
 }

--- a/src/apis/iamcredentials/tsconfig.json
+++ b/src/apis/iamcredentials/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./node_modules/gts/tsconfig-google.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "build"
+  },
+  "include": [
+    "*.ts",
+  ]
+}

--- a/src/apis/iap/package.json
+++ b/src/apis/iap/package.json
@@ -2,8 +2,8 @@
   "name": "@google/iap",
   "version": "0.1.0",
   "description": "iap",
-  "main": "index.js",
-  "types": "index.d.ts",
+  "main": "build/index.js",
+  "types": "build/index.d.ts",
   "keywords": ["google"],
   "author": "Google LLC",
   "license": "Apache-2.0",
@@ -18,7 +18,19 @@
   "engines": {
     "node": ">=6.0.0"
   },
+  "scripts": {
+    "fix": "gts fix",
+    "lint": "gts check",
+    "compile": "tsc -p .",
+    "prepare": "npm run compile",
+    "docs": "typedoc --out docs/"
+  },
   "dependencies": {
     "googleapis-common": "^0.4.0"
+  },
+  "devDependencies": {
+    "gts": "^0.9.0",
+    "typescript": "~3.2.0",
+    "typedoc": "^0.13.0"
   }
 }

--- a/src/apis/iap/tsconfig.json
+++ b/src/apis/iap/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./node_modules/gts/tsconfig-google.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "build"
+  },
+  "include": [
+    "*.ts",
+  ]
+}

--- a/src/apis/identitytoolkit/package.json
+++ b/src/apis/identitytoolkit/package.json
@@ -2,8 +2,8 @@
   "name": "@google/identitytoolkit",
   "version": "0.1.0",
   "description": "identitytoolkit",
-  "main": "index.js",
-  "types": "index.d.ts",
+  "main": "build/index.js",
+  "types": "build/index.d.ts",
   "keywords": ["google"],
   "author": "Google LLC",
   "license": "Apache-2.0",
@@ -18,7 +18,19 @@
   "engines": {
     "node": ">=6.0.0"
   },
+  "scripts": {
+    "fix": "gts fix",
+    "lint": "gts check",
+    "compile": "tsc -p .",
+    "prepare": "npm run compile",
+    "docs": "typedoc --out docs/"
+  },
   "dependencies": {
     "googleapis-common": "^0.4.0"
+  },
+  "devDependencies": {
+    "gts": "^0.9.0",
+    "typescript": "~3.2.0",
+    "typedoc": "^0.13.0"
   }
 }

--- a/src/apis/identitytoolkit/tsconfig.json
+++ b/src/apis/identitytoolkit/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./node_modules/gts/tsconfig-google.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "build"
+  },
+  "include": [
+    "*.ts",
+  ]
+}

--- a/src/apis/indexing/package.json
+++ b/src/apis/indexing/package.json
@@ -2,8 +2,8 @@
   "name": "@google/indexing",
   "version": "0.1.0",
   "description": "indexing",
-  "main": "index.js",
-  "types": "index.d.ts",
+  "main": "build/index.js",
+  "types": "build/index.d.ts",
   "keywords": ["google"],
   "author": "Google LLC",
   "license": "Apache-2.0",
@@ -18,7 +18,19 @@
   "engines": {
     "node": ">=6.0.0"
   },
+  "scripts": {
+    "fix": "gts fix",
+    "lint": "gts check",
+    "compile": "tsc -p .",
+    "prepare": "npm run compile",
+    "docs": "typedoc --out docs/"
+  },
   "dependencies": {
     "googleapis-common": "^0.4.0"
+  },
+  "devDependencies": {
+    "gts": "^0.9.0",
+    "typescript": "~3.2.0",
+    "typedoc": "^0.13.0"
   }
 }

--- a/src/apis/indexing/tsconfig.json
+++ b/src/apis/indexing/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./node_modules/gts/tsconfig-google.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "build"
+  },
+  "include": [
+    "*.ts",
+  ]
+}

--- a/src/apis/jobs/package.json
+++ b/src/apis/jobs/package.json
@@ -2,8 +2,8 @@
   "name": "@google/jobs",
   "version": "0.1.0",
   "description": "jobs",
-  "main": "index.js",
-  "types": "index.d.ts",
+  "main": "build/index.js",
+  "types": "build/index.d.ts",
   "keywords": ["google"],
   "author": "Google LLC",
   "license": "Apache-2.0",
@@ -18,7 +18,19 @@
   "engines": {
     "node": ">=6.0.0"
   },
+  "scripts": {
+    "fix": "gts fix",
+    "lint": "gts check",
+    "compile": "tsc -p .",
+    "prepare": "npm run compile",
+    "docs": "typedoc --out docs/"
+  },
   "dependencies": {
     "googleapis-common": "^0.4.0"
+  },
+  "devDependencies": {
+    "gts": "^0.9.0",
+    "typescript": "~3.2.0",
+    "typedoc": "^0.13.0"
   }
 }

--- a/src/apis/jobs/tsconfig.json
+++ b/src/apis/jobs/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./node_modules/gts/tsconfig-google.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "build"
+  },
+  "include": [
+    "*.ts",
+  ]
+}

--- a/src/apis/kgsearch/package.json
+++ b/src/apis/kgsearch/package.json
@@ -2,8 +2,8 @@
   "name": "@google/kgsearch",
   "version": "0.1.0",
   "description": "kgsearch",
-  "main": "index.js",
-  "types": "index.d.ts",
+  "main": "build/index.js",
+  "types": "build/index.d.ts",
   "keywords": ["google"],
   "author": "Google LLC",
   "license": "Apache-2.0",
@@ -18,7 +18,19 @@
   "engines": {
     "node": ">=6.0.0"
   },
+  "scripts": {
+    "fix": "gts fix",
+    "lint": "gts check",
+    "compile": "tsc -p .",
+    "prepare": "npm run compile",
+    "docs": "typedoc --out docs/"
+  },
   "dependencies": {
     "googleapis-common": "^0.4.0"
+  },
+  "devDependencies": {
+    "gts": "^0.9.0",
+    "typescript": "~3.2.0",
+    "typedoc": "^0.13.0"
   }
 }

--- a/src/apis/kgsearch/tsconfig.json
+++ b/src/apis/kgsearch/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./node_modules/gts/tsconfig-google.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "build"
+  },
+  "include": [
+    "*.ts",
+  ]
+}

--- a/src/apis/language/package.json
+++ b/src/apis/language/package.json
@@ -2,8 +2,8 @@
   "name": "@google/language",
   "version": "0.1.0",
   "description": "language",
-  "main": "index.js",
-  "types": "index.d.ts",
+  "main": "build/index.js",
+  "types": "build/index.d.ts",
   "keywords": ["google"],
   "author": "Google LLC",
   "license": "Apache-2.0",
@@ -18,7 +18,19 @@
   "engines": {
     "node": ">=6.0.0"
   },
+  "scripts": {
+    "fix": "gts fix",
+    "lint": "gts check",
+    "compile": "tsc -p .",
+    "prepare": "npm run compile",
+    "docs": "typedoc --out docs/"
+  },
   "dependencies": {
     "googleapis-common": "^0.4.0"
+  },
+  "devDependencies": {
+    "gts": "^0.9.0",
+    "typescript": "~3.2.0",
+    "typedoc": "^0.13.0"
   }
 }

--- a/src/apis/language/tsconfig.json
+++ b/src/apis/language/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./node_modules/gts/tsconfig-google.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "build"
+  },
+  "include": [
+    "*.ts",
+  ]
+}

--- a/src/apis/licensing/package.json
+++ b/src/apis/licensing/package.json
@@ -2,8 +2,8 @@
   "name": "@google/licensing",
   "version": "0.1.0",
   "description": "licensing",
-  "main": "index.js",
-  "types": "index.d.ts",
+  "main": "build/index.js",
+  "types": "build/index.d.ts",
   "keywords": ["google"],
   "author": "Google LLC",
   "license": "Apache-2.0",
@@ -18,7 +18,19 @@
   "engines": {
     "node": ">=6.0.0"
   },
+  "scripts": {
+    "fix": "gts fix",
+    "lint": "gts check",
+    "compile": "tsc -p .",
+    "prepare": "npm run compile",
+    "docs": "typedoc --out docs/"
+  },
   "dependencies": {
     "googleapis-common": "^0.4.0"
+  },
+  "devDependencies": {
+    "gts": "^0.9.0",
+    "typescript": "~3.2.0",
+    "typedoc": "^0.13.0"
   }
 }

--- a/src/apis/licensing/tsconfig.json
+++ b/src/apis/licensing/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./node_modules/gts/tsconfig-google.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "build"
+  },
+  "include": [
+    "*.ts",
+  ]
+}

--- a/src/apis/logging/package.json
+++ b/src/apis/logging/package.json
@@ -2,8 +2,8 @@
   "name": "@google/logging",
   "version": "0.1.0",
   "description": "logging",
-  "main": "index.js",
-  "types": "index.d.ts",
+  "main": "build/index.js",
+  "types": "build/index.d.ts",
   "keywords": ["google"],
   "author": "Google LLC",
   "license": "Apache-2.0",
@@ -18,7 +18,19 @@
   "engines": {
     "node": ">=6.0.0"
   },
+  "scripts": {
+    "fix": "gts fix",
+    "lint": "gts check",
+    "compile": "tsc -p .",
+    "prepare": "npm run compile",
+    "docs": "typedoc --out docs/"
+  },
   "dependencies": {
     "googleapis-common": "^0.4.0"
+  },
+  "devDependencies": {
+    "gts": "^0.9.0",
+    "typescript": "~3.2.0",
+    "typedoc": "^0.13.0"
   }
 }

--- a/src/apis/logging/tsconfig.json
+++ b/src/apis/logging/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./node_modules/gts/tsconfig-google.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "build"
+  },
+  "include": [
+    "*.ts",
+  ]
+}

--- a/src/apis/manufacturers/package.json
+++ b/src/apis/manufacturers/package.json
@@ -2,8 +2,8 @@
   "name": "@google/manufacturers",
   "version": "0.1.0",
   "description": "manufacturers",
-  "main": "index.js",
-  "types": "index.d.ts",
+  "main": "build/index.js",
+  "types": "build/index.d.ts",
   "keywords": ["google"],
   "author": "Google LLC",
   "license": "Apache-2.0",
@@ -18,7 +18,19 @@
   "engines": {
     "node": ">=6.0.0"
   },
+  "scripts": {
+    "fix": "gts fix",
+    "lint": "gts check",
+    "compile": "tsc -p .",
+    "prepare": "npm run compile",
+    "docs": "typedoc --out docs/"
+  },
   "dependencies": {
     "googleapis-common": "^0.4.0"
+  },
+  "devDependencies": {
+    "gts": "^0.9.0",
+    "typescript": "~3.2.0",
+    "typedoc": "^0.13.0"
   }
 }

--- a/src/apis/manufacturers/tsconfig.json
+++ b/src/apis/manufacturers/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./node_modules/gts/tsconfig-google.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "build"
+  },
+  "include": [
+    "*.ts",
+  ]
+}

--- a/src/apis/mirror/package.json
+++ b/src/apis/mirror/package.json
@@ -2,8 +2,8 @@
   "name": "@google/mirror",
   "version": "0.1.0",
   "description": "mirror",
-  "main": "index.js",
-  "types": "index.d.ts",
+  "main": "build/index.js",
+  "types": "build/index.d.ts",
   "keywords": ["google"],
   "author": "Google LLC",
   "license": "Apache-2.0",
@@ -18,7 +18,19 @@
   "engines": {
     "node": ">=6.0.0"
   },
+  "scripts": {
+    "fix": "gts fix",
+    "lint": "gts check",
+    "compile": "tsc -p .",
+    "prepare": "npm run compile",
+    "docs": "typedoc --out docs/"
+  },
   "dependencies": {
     "googleapis-common": "^0.4.0"
+  },
+  "devDependencies": {
+    "gts": "^0.9.0",
+    "typescript": "~3.2.0",
+    "typedoc": "^0.13.0"
   }
 }

--- a/src/apis/mirror/tsconfig.json
+++ b/src/apis/mirror/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./node_modules/gts/tsconfig-google.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "build"
+  },
+  "include": [
+    "*.ts",
+  ]
+}

--- a/src/apis/ml/package.json
+++ b/src/apis/ml/package.json
@@ -2,8 +2,8 @@
   "name": "@google/ml",
   "version": "0.1.0",
   "description": "ml",
-  "main": "index.js",
-  "types": "index.d.ts",
+  "main": "build/index.js",
+  "types": "build/index.d.ts",
   "keywords": ["google"],
   "author": "Google LLC",
   "license": "Apache-2.0",
@@ -18,7 +18,19 @@
   "engines": {
     "node": ">=6.0.0"
   },
+  "scripts": {
+    "fix": "gts fix",
+    "lint": "gts check",
+    "compile": "tsc -p .",
+    "prepare": "npm run compile",
+    "docs": "typedoc --out docs/"
+  },
   "dependencies": {
     "googleapis-common": "^0.4.0"
+  },
+  "devDependencies": {
+    "gts": "^0.9.0",
+    "typescript": "~3.2.0",
+    "typedoc": "^0.13.0"
   }
 }

--- a/src/apis/ml/tsconfig.json
+++ b/src/apis/ml/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./node_modules/gts/tsconfig-google.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "build"
+  },
+  "include": [
+    "*.ts",
+  ]
+}

--- a/src/apis/monitoring/package.json
+++ b/src/apis/monitoring/package.json
@@ -2,8 +2,8 @@
   "name": "@google/monitoring",
   "version": "0.1.0",
   "description": "monitoring",
-  "main": "index.js",
-  "types": "index.d.ts",
+  "main": "build/index.js",
+  "types": "build/index.d.ts",
   "keywords": ["google"],
   "author": "Google LLC",
   "license": "Apache-2.0",
@@ -18,7 +18,19 @@
   "engines": {
     "node": ">=6.0.0"
   },
+  "scripts": {
+    "fix": "gts fix",
+    "lint": "gts check",
+    "compile": "tsc -p .",
+    "prepare": "npm run compile",
+    "docs": "typedoc --out docs/"
+  },
   "dependencies": {
     "googleapis-common": "^0.4.0"
+  },
+  "devDependencies": {
+    "gts": "^0.9.0",
+    "typescript": "~3.2.0",
+    "typedoc": "^0.13.0"
   }
 }

--- a/src/apis/monitoring/tsconfig.json
+++ b/src/apis/monitoring/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./node_modules/gts/tsconfig-google.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "build"
+  },
+  "include": [
+    "*.ts",
+  ]
+}

--- a/src/apis/oauth2/package.json
+++ b/src/apis/oauth2/package.json
@@ -2,8 +2,8 @@
   "name": "@google/oauth2",
   "version": "0.1.0",
   "description": "oauth2",
-  "main": "index.js",
-  "types": "index.d.ts",
+  "main": "build/index.js",
+  "types": "build/index.d.ts",
   "keywords": ["google"],
   "author": "Google LLC",
   "license": "Apache-2.0",
@@ -18,7 +18,19 @@
   "engines": {
     "node": ">=6.0.0"
   },
+  "scripts": {
+    "fix": "gts fix",
+    "lint": "gts check",
+    "compile": "tsc -p .",
+    "prepare": "npm run compile",
+    "docs": "typedoc --out docs/"
+  },
   "dependencies": {
     "googleapis-common": "^0.4.0"
+  },
+  "devDependencies": {
+    "gts": "^0.9.0",
+    "typescript": "~3.2.0",
+    "typedoc": "^0.13.0"
   }
 }

--- a/src/apis/oauth2/tsconfig.json
+++ b/src/apis/oauth2/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./node_modules/gts/tsconfig-google.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "build"
+  },
+  "include": [
+    "*.ts",
+  ]
+}

--- a/src/apis/oslogin/package.json
+++ b/src/apis/oslogin/package.json
@@ -2,8 +2,8 @@
   "name": "@google/oslogin",
   "version": "0.1.0",
   "description": "oslogin",
-  "main": "index.js",
-  "types": "index.d.ts",
+  "main": "build/index.js",
+  "types": "build/index.d.ts",
   "keywords": ["google"],
   "author": "Google LLC",
   "license": "Apache-2.0",
@@ -18,7 +18,19 @@
   "engines": {
     "node": ">=6.0.0"
   },
+  "scripts": {
+    "fix": "gts fix",
+    "lint": "gts check",
+    "compile": "tsc -p .",
+    "prepare": "npm run compile",
+    "docs": "typedoc --out docs/"
+  },
   "dependencies": {
     "googleapis-common": "^0.4.0"
+  },
+  "devDependencies": {
+    "gts": "^0.9.0",
+    "typescript": "~3.2.0",
+    "typedoc": "^0.13.0"
   }
 }

--- a/src/apis/oslogin/tsconfig.json
+++ b/src/apis/oslogin/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./node_modules/gts/tsconfig-google.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "build"
+  },
+  "include": [
+    "*.ts",
+  ]
+}

--- a/src/apis/pagespeedonline/package.json
+++ b/src/apis/pagespeedonline/package.json
@@ -2,8 +2,8 @@
   "name": "@google/pagespeedonline",
   "version": "0.1.0",
   "description": "pagespeedonline",
-  "main": "index.js",
-  "types": "index.d.ts",
+  "main": "build/index.js",
+  "types": "build/index.d.ts",
   "keywords": ["google"],
   "author": "Google LLC",
   "license": "Apache-2.0",
@@ -18,7 +18,19 @@
   "engines": {
     "node": ">=6.0.0"
   },
+  "scripts": {
+    "fix": "gts fix",
+    "lint": "gts check",
+    "compile": "tsc -p .",
+    "prepare": "npm run compile",
+    "docs": "typedoc --out docs/"
+  },
   "dependencies": {
     "googleapis-common": "^0.4.0"
+  },
+  "devDependencies": {
+    "gts": "^0.9.0",
+    "typescript": "~3.2.0",
+    "typedoc": "^0.13.0"
   }
 }

--- a/src/apis/pagespeedonline/tsconfig.json
+++ b/src/apis/pagespeedonline/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./node_modules/gts/tsconfig-google.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "build"
+  },
+  "include": [
+    "*.ts",
+  ]
+}

--- a/src/apis/people/package.json
+++ b/src/apis/people/package.json
@@ -2,8 +2,8 @@
   "name": "@google/people",
   "version": "0.1.0",
   "description": "people",
-  "main": "index.js",
-  "types": "index.d.ts",
+  "main": "build/index.js",
+  "types": "build/index.d.ts",
   "keywords": ["google"],
   "author": "Google LLC",
   "license": "Apache-2.0",
@@ -18,7 +18,19 @@
   "engines": {
     "node": ">=6.0.0"
   },
+  "scripts": {
+    "fix": "gts fix",
+    "lint": "gts check",
+    "compile": "tsc -p .",
+    "prepare": "npm run compile",
+    "docs": "typedoc --out docs/"
+  },
   "dependencies": {
     "googleapis-common": "^0.4.0"
+  },
+  "devDependencies": {
+    "gts": "^0.9.0",
+    "typescript": "~3.2.0",
+    "typedoc": "^0.13.0"
   }
 }

--- a/src/apis/people/tsconfig.json
+++ b/src/apis/people/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./node_modules/gts/tsconfig-google.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "build"
+  },
+  "include": [
+    "*.ts",
+  ]
+}

--- a/src/apis/playcustomapp/package.json
+++ b/src/apis/playcustomapp/package.json
@@ -2,8 +2,8 @@
   "name": "@google/playcustomapp",
   "version": "0.1.0",
   "description": "playcustomapp",
-  "main": "index.js",
-  "types": "index.d.ts",
+  "main": "build/index.js",
+  "types": "build/index.d.ts",
   "keywords": ["google"],
   "author": "Google LLC",
   "license": "Apache-2.0",
@@ -18,7 +18,19 @@
   "engines": {
     "node": ">=6.0.0"
   },
+  "scripts": {
+    "fix": "gts fix",
+    "lint": "gts check",
+    "compile": "tsc -p .",
+    "prepare": "npm run compile",
+    "docs": "typedoc --out docs/"
+  },
   "dependencies": {
     "googleapis-common": "^0.4.0"
+  },
+  "devDependencies": {
+    "gts": "^0.9.0",
+    "typescript": "~3.2.0",
+    "typedoc": "^0.13.0"
   }
 }

--- a/src/apis/playcustomapp/tsconfig.json
+++ b/src/apis/playcustomapp/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./node_modules/gts/tsconfig-google.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "build"
+  },
+  "include": [
+    "*.ts",
+  ]
+}

--- a/src/apis/plus/package.json
+++ b/src/apis/plus/package.json
@@ -2,8 +2,8 @@
   "name": "@google/plus",
   "version": "0.1.0",
   "description": "plus",
-  "main": "index.js",
-  "types": "index.d.ts",
+  "main": "build/index.js",
+  "types": "build/index.d.ts",
   "keywords": ["google"],
   "author": "Google LLC",
   "license": "Apache-2.0",
@@ -18,7 +18,19 @@
   "engines": {
     "node": ">=6.0.0"
   },
+  "scripts": {
+    "fix": "gts fix",
+    "lint": "gts check",
+    "compile": "tsc -p .",
+    "prepare": "npm run compile",
+    "docs": "typedoc --out docs/"
+  },
   "dependencies": {
     "googleapis-common": "^0.4.0"
+  },
+  "devDependencies": {
+    "gts": "^0.9.0",
+    "typescript": "~3.2.0",
+    "typedoc": "^0.13.0"
   }
 }

--- a/src/apis/plus/tsconfig.json
+++ b/src/apis/plus/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./node_modules/gts/tsconfig-google.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "build"
+  },
+  "include": [
+    "*.ts",
+  ]
+}

--- a/src/apis/plusDomains/package.json
+++ b/src/apis/plusDomains/package.json
@@ -2,8 +2,8 @@
   "name": "@google/plusDomains",
   "version": "0.1.0",
   "description": "plusDomains",
-  "main": "index.js",
-  "types": "index.d.ts",
+  "main": "build/index.js",
+  "types": "build/index.d.ts",
   "keywords": ["google"],
   "author": "Google LLC",
   "license": "Apache-2.0",
@@ -18,7 +18,19 @@
   "engines": {
     "node": ">=6.0.0"
   },
+  "scripts": {
+    "fix": "gts fix",
+    "lint": "gts check",
+    "compile": "tsc -p .",
+    "prepare": "npm run compile",
+    "docs": "typedoc --out docs/"
+  },
   "dependencies": {
     "googleapis-common": "^0.4.0"
+  },
+  "devDependencies": {
+    "gts": "^0.9.0",
+    "typescript": "~3.2.0",
+    "typedoc": "^0.13.0"
   }
 }

--- a/src/apis/plusDomains/tsconfig.json
+++ b/src/apis/plusDomains/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./node_modules/gts/tsconfig-google.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "build"
+  },
+  "include": [
+    "*.ts",
+  ]
+}

--- a/src/apis/poly/package.json
+++ b/src/apis/poly/package.json
@@ -2,8 +2,8 @@
   "name": "@google/poly",
   "version": "0.1.0",
   "description": "poly",
-  "main": "index.js",
-  "types": "index.d.ts",
+  "main": "build/index.js",
+  "types": "build/index.d.ts",
   "keywords": ["google"],
   "author": "Google LLC",
   "license": "Apache-2.0",
@@ -18,7 +18,19 @@
   "engines": {
     "node": ">=6.0.0"
   },
+  "scripts": {
+    "fix": "gts fix",
+    "lint": "gts check",
+    "compile": "tsc -p .",
+    "prepare": "npm run compile",
+    "docs": "typedoc --out docs/"
+  },
   "dependencies": {
     "googleapis-common": "^0.4.0"
+  },
+  "devDependencies": {
+    "gts": "^0.9.0",
+    "typescript": "~3.2.0",
+    "typedoc": "^0.13.0"
   }
 }

--- a/src/apis/poly/tsconfig.json
+++ b/src/apis/poly/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./node_modules/gts/tsconfig-google.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "build"
+  },
+  "include": [
+    "*.ts",
+  ]
+}

--- a/src/apis/proximitybeacon/package.json
+++ b/src/apis/proximitybeacon/package.json
@@ -2,8 +2,8 @@
   "name": "@google/proximitybeacon",
   "version": "0.1.0",
   "description": "proximitybeacon",
-  "main": "index.js",
-  "types": "index.d.ts",
+  "main": "build/index.js",
+  "types": "build/index.d.ts",
   "keywords": ["google"],
   "author": "Google LLC",
   "license": "Apache-2.0",
@@ -18,7 +18,19 @@
   "engines": {
     "node": ">=6.0.0"
   },
+  "scripts": {
+    "fix": "gts fix",
+    "lint": "gts check",
+    "compile": "tsc -p .",
+    "prepare": "npm run compile",
+    "docs": "typedoc --out docs/"
+  },
   "dependencies": {
     "googleapis-common": "^0.4.0"
+  },
+  "devDependencies": {
+    "gts": "^0.9.0",
+    "typescript": "~3.2.0",
+    "typedoc": "^0.13.0"
   }
 }

--- a/src/apis/proximitybeacon/tsconfig.json
+++ b/src/apis/proximitybeacon/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./node_modules/gts/tsconfig-google.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "build"
+  },
+  "include": [
+    "*.ts",
+  ]
+}

--- a/src/apis/pubsub/package.json
+++ b/src/apis/pubsub/package.json
@@ -2,8 +2,8 @@
   "name": "@google/pubsub",
   "version": "0.1.0",
   "description": "pubsub",
-  "main": "index.js",
-  "types": "index.d.ts",
+  "main": "build/index.js",
+  "types": "build/index.d.ts",
   "keywords": ["google"],
   "author": "Google LLC",
   "license": "Apache-2.0",
@@ -18,7 +18,19 @@
   "engines": {
     "node": ">=6.0.0"
   },
+  "scripts": {
+    "fix": "gts fix",
+    "lint": "gts check",
+    "compile": "tsc -p .",
+    "prepare": "npm run compile",
+    "docs": "typedoc --out docs/"
+  },
   "dependencies": {
     "googleapis-common": "^0.4.0"
+  },
+  "devDependencies": {
+    "gts": "^0.9.0",
+    "typescript": "~3.2.0",
+    "typedoc": "^0.13.0"
   }
 }

--- a/src/apis/pubsub/tsconfig.json
+++ b/src/apis/pubsub/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./node_modules/gts/tsconfig-google.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "build"
+  },
+  "include": [
+    "*.ts",
+  ]
+}

--- a/src/apis/redis/package.json
+++ b/src/apis/redis/package.json
@@ -2,8 +2,8 @@
   "name": "@google/redis",
   "version": "0.1.0",
   "description": "redis",
-  "main": "index.js",
-  "types": "index.d.ts",
+  "main": "build/index.js",
+  "types": "build/index.d.ts",
   "keywords": ["google"],
   "author": "Google LLC",
   "license": "Apache-2.0",
@@ -18,7 +18,19 @@
   "engines": {
     "node": ">=6.0.0"
   },
+  "scripts": {
+    "fix": "gts fix",
+    "lint": "gts check",
+    "compile": "tsc -p .",
+    "prepare": "npm run compile",
+    "docs": "typedoc --out docs/"
+  },
   "dependencies": {
     "googleapis-common": "^0.4.0"
+  },
+  "devDependencies": {
+    "gts": "^0.9.0",
+    "typescript": "~3.2.0",
+    "typedoc": "^0.13.0"
   }
 }

--- a/src/apis/redis/tsconfig.json
+++ b/src/apis/redis/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./node_modules/gts/tsconfig-google.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "build"
+  },
+  "include": [
+    "*.ts",
+  ]
+}

--- a/src/apis/replicapool/package.json
+++ b/src/apis/replicapool/package.json
@@ -2,8 +2,8 @@
   "name": "@google/replicapool",
   "version": "0.1.0",
   "description": "replicapool",
-  "main": "index.js",
-  "types": "index.d.ts",
+  "main": "build/index.js",
+  "types": "build/index.d.ts",
   "keywords": ["google"],
   "author": "Google LLC",
   "license": "Apache-2.0",
@@ -18,7 +18,19 @@
   "engines": {
     "node": ">=6.0.0"
   },
+  "scripts": {
+    "fix": "gts fix",
+    "lint": "gts check",
+    "compile": "tsc -p .",
+    "prepare": "npm run compile",
+    "docs": "typedoc --out docs/"
+  },
   "dependencies": {
     "googleapis-common": "^0.4.0"
+  },
+  "devDependencies": {
+    "gts": "^0.9.0",
+    "typescript": "~3.2.0",
+    "typedoc": "^0.13.0"
   }
 }

--- a/src/apis/replicapool/tsconfig.json
+++ b/src/apis/replicapool/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./node_modules/gts/tsconfig-google.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "build"
+  },
+  "include": [
+    "*.ts",
+  ]
+}

--- a/src/apis/replicapoolupdater/package.json
+++ b/src/apis/replicapoolupdater/package.json
@@ -2,8 +2,8 @@
   "name": "@google/replicapoolupdater",
   "version": "0.1.0",
   "description": "replicapoolupdater",
-  "main": "index.js",
-  "types": "index.d.ts",
+  "main": "build/index.js",
+  "types": "build/index.d.ts",
   "keywords": ["google"],
   "author": "Google LLC",
   "license": "Apache-2.0",
@@ -18,7 +18,19 @@
   "engines": {
     "node": ">=6.0.0"
   },
+  "scripts": {
+    "fix": "gts fix",
+    "lint": "gts check",
+    "compile": "tsc -p .",
+    "prepare": "npm run compile",
+    "docs": "typedoc --out docs/"
+  },
   "dependencies": {
     "googleapis-common": "^0.4.0"
+  },
+  "devDependencies": {
+    "gts": "^0.9.0",
+    "typescript": "~3.2.0",
+    "typedoc": "^0.13.0"
   }
 }

--- a/src/apis/replicapoolupdater/tsconfig.json
+++ b/src/apis/replicapoolupdater/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./node_modules/gts/tsconfig-google.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "build"
+  },
+  "include": [
+    "*.ts",
+  ]
+}

--- a/src/apis/reseller/package.json
+++ b/src/apis/reseller/package.json
@@ -2,8 +2,8 @@
   "name": "@google/reseller",
   "version": "0.1.0",
   "description": "reseller",
-  "main": "index.js",
-  "types": "index.d.ts",
+  "main": "build/index.js",
+  "types": "build/index.d.ts",
   "keywords": ["google"],
   "author": "Google LLC",
   "license": "Apache-2.0",
@@ -18,7 +18,19 @@
   "engines": {
     "node": ">=6.0.0"
   },
+  "scripts": {
+    "fix": "gts fix",
+    "lint": "gts check",
+    "compile": "tsc -p .",
+    "prepare": "npm run compile",
+    "docs": "typedoc --out docs/"
+  },
   "dependencies": {
     "googleapis-common": "^0.4.0"
+  },
+  "devDependencies": {
+    "gts": "^0.9.0",
+    "typescript": "~3.2.0",
+    "typedoc": "^0.13.0"
   }
 }

--- a/src/apis/reseller/tsconfig.json
+++ b/src/apis/reseller/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./node_modules/gts/tsconfig-google.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "build"
+  },
+  "include": [
+    "*.ts",
+  ]
+}

--- a/src/apis/runtimeconfig/package.json
+++ b/src/apis/runtimeconfig/package.json
@@ -2,8 +2,8 @@
   "name": "@google/runtimeconfig",
   "version": "0.1.0",
   "description": "runtimeconfig",
-  "main": "index.js",
-  "types": "index.d.ts",
+  "main": "build/index.js",
+  "types": "build/index.d.ts",
   "keywords": ["google"],
   "author": "Google LLC",
   "license": "Apache-2.0",
@@ -18,7 +18,19 @@
   "engines": {
     "node": ">=6.0.0"
   },
+  "scripts": {
+    "fix": "gts fix",
+    "lint": "gts check",
+    "compile": "tsc -p .",
+    "prepare": "npm run compile",
+    "docs": "typedoc --out docs/"
+  },
   "dependencies": {
     "googleapis-common": "^0.4.0"
+  },
+  "devDependencies": {
+    "gts": "^0.9.0",
+    "typescript": "~3.2.0",
+    "typedoc": "^0.13.0"
   }
 }

--- a/src/apis/runtimeconfig/tsconfig.json
+++ b/src/apis/runtimeconfig/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./node_modules/gts/tsconfig-google.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "build"
+  },
+  "include": [
+    "*.ts",
+  ]
+}

--- a/src/apis/safebrowsing/package.json
+++ b/src/apis/safebrowsing/package.json
@@ -2,8 +2,8 @@
   "name": "@google/safebrowsing",
   "version": "0.1.0",
   "description": "safebrowsing",
-  "main": "index.js",
-  "types": "index.d.ts",
+  "main": "build/index.js",
+  "types": "build/index.d.ts",
   "keywords": ["google"],
   "author": "Google LLC",
   "license": "Apache-2.0",
@@ -18,7 +18,19 @@
   "engines": {
     "node": ">=6.0.0"
   },
+  "scripts": {
+    "fix": "gts fix",
+    "lint": "gts check",
+    "compile": "tsc -p .",
+    "prepare": "npm run compile",
+    "docs": "typedoc --out docs/"
+  },
   "dependencies": {
     "googleapis-common": "^0.4.0"
+  },
+  "devDependencies": {
+    "gts": "^0.9.0",
+    "typescript": "~3.2.0",
+    "typedoc": "^0.13.0"
   }
 }

--- a/src/apis/safebrowsing/tsconfig.json
+++ b/src/apis/safebrowsing/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./node_modules/gts/tsconfig-google.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "build"
+  },
+  "include": [
+    "*.ts",
+  ]
+}

--- a/src/apis/script/package.json
+++ b/src/apis/script/package.json
@@ -2,8 +2,8 @@
   "name": "@google/script",
   "version": "0.1.0",
   "description": "script",
-  "main": "index.js",
-  "types": "index.d.ts",
+  "main": "build/index.js",
+  "types": "build/index.d.ts",
   "keywords": ["google"],
   "author": "Google LLC",
   "license": "Apache-2.0",
@@ -18,7 +18,19 @@
   "engines": {
     "node": ">=6.0.0"
   },
+  "scripts": {
+    "fix": "gts fix",
+    "lint": "gts check",
+    "compile": "tsc -p .",
+    "prepare": "npm run compile",
+    "docs": "typedoc --out docs/"
+  },
   "dependencies": {
     "googleapis-common": "^0.4.0"
+  },
+  "devDependencies": {
+    "gts": "^0.9.0",
+    "typescript": "~3.2.0",
+    "typedoc": "^0.13.0"
   }
 }

--- a/src/apis/script/tsconfig.json
+++ b/src/apis/script/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./node_modules/gts/tsconfig-google.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "build"
+  },
+  "include": [
+    "*.ts",
+  ]
+}

--- a/src/apis/searchconsole/package.json
+++ b/src/apis/searchconsole/package.json
@@ -2,8 +2,8 @@
   "name": "@google/searchconsole",
   "version": "0.1.0",
   "description": "searchconsole",
-  "main": "index.js",
-  "types": "index.d.ts",
+  "main": "build/index.js",
+  "types": "build/index.d.ts",
   "keywords": ["google"],
   "author": "Google LLC",
   "license": "Apache-2.0",
@@ -18,7 +18,19 @@
   "engines": {
     "node": ">=6.0.0"
   },
+  "scripts": {
+    "fix": "gts fix",
+    "lint": "gts check",
+    "compile": "tsc -p .",
+    "prepare": "npm run compile",
+    "docs": "typedoc --out docs/"
+  },
   "dependencies": {
     "googleapis-common": "^0.4.0"
+  },
+  "devDependencies": {
+    "gts": "^0.9.0",
+    "typescript": "~3.2.0",
+    "typedoc": "^0.13.0"
   }
 }

--- a/src/apis/searchconsole/tsconfig.json
+++ b/src/apis/searchconsole/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./node_modules/gts/tsconfig-google.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "build"
+  },
+  "include": [
+    "*.ts",
+  ]
+}

--- a/src/apis/servicebroker/package.json
+++ b/src/apis/servicebroker/package.json
@@ -2,8 +2,8 @@
   "name": "@google/servicebroker",
   "version": "0.1.0",
   "description": "servicebroker",
-  "main": "index.js",
-  "types": "index.d.ts",
+  "main": "build/index.js",
+  "types": "build/index.d.ts",
   "keywords": ["google"],
   "author": "Google LLC",
   "license": "Apache-2.0",
@@ -18,7 +18,19 @@
   "engines": {
     "node": ">=6.0.0"
   },
+  "scripts": {
+    "fix": "gts fix",
+    "lint": "gts check",
+    "compile": "tsc -p .",
+    "prepare": "npm run compile",
+    "docs": "typedoc --out docs/"
+  },
   "dependencies": {
     "googleapis-common": "^0.4.0"
+  },
+  "devDependencies": {
+    "gts": "^0.9.0",
+    "typescript": "~3.2.0",
+    "typedoc": "^0.13.0"
   }
 }

--- a/src/apis/servicebroker/tsconfig.json
+++ b/src/apis/servicebroker/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./node_modules/gts/tsconfig-google.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "build"
+  },
+  "include": [
+    "*.ts",
+  ]
+}

--- a/src/apis/serviceconsumermanagement/package.json
+++ b/src/apis/serviceconsumermanagement/package.json
@@ -2,8 +2,8 @@
   "name": "@google/serviceconsumermanagement",
   "version": "0.1.0",
   "description": "serviceconsumermanagement",
-  "main": "index.js",
-  "types": "index.d.ts",
+  "main": "build/index.js",
+  "types": "build/index.d.ts",
   "keywords": ["google"],
   "author": "Google LLC",
   "license": "Apache-2.0",
@@ -18,7 +18,19 @@
   "engines": {
     "node": ">=6.0.0"
   },
+  "scripts": {
+    "fix": "gts fix",
+    "lint": "gts check",
+    "compile": "tsc -p .",
+    "prepare": "npm run compile",
+    "docs": "typedoc --out docs/"
+  },
   "dependencies": {
     "googleapis-common": "^0.4.0"
+  },
+  "devDependencies": {
+    "gts": "^0.9.0",
+    "typescript": "~3.2.0",
+    "typedoc": "^0.13.0"
   }
 }

--- a/src/apis/serviceconsumermanagement/tsconfig.json
+++ b/src/apis/serviceconsumermanagement/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./node_modules/gts/tsconfig-google.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "build"
+  },
+  "include": [
+    "*.ts",
+  ]
+}

--- a/src/apis/servicecontrol/package.json
+++ b/src/apis/servicecontrol/package.json
@@ -2,8 +2,8 @@
   "name": "@google/servicecontrol",
   "version": "0.1.0",
   "description": "servicecontrol",
-  "main": "index.js",
-  "types": "index.d.ts",
+  "main": "build/index.js",
+  "types": "build/index.d.ts",
   "keywords": ["google"],
   "author": "Google LLC",
   "license": "Apache-2.0",
@@ -18,7 +18,19 @@
   "engines": {
     "node": ">=6.0.0"
   },
+  "scripts": {
+    "fix": "gts fix",
+    "lint": "gts check",
+    "compile": "tsc -p .",
+    "prepare": "npm run compile",
+    "docs": "typedoc --out docs/"
+  },
   "dependencies": {
     "googleapis-common": "^0.4.0"
+  },
+  "devDependencies": {
+    "gts": "^0.9.0",
+    "typescript": "~3.2.0",
+    "typedoc": "^0.13.0"
   }
 }

--- a/src/apis/servicecontrol/tsconfig.json
+++ b/src/apis/servicecontrol/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./node_modules/gts/tsconfig-google.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "build"
+  },
+  "include": [
+    "*.ts",
+  ]
+}

--- a/src/apis/servicemanagement/package.json
+++ b/src/apis/servicemanagement/package.json
@@ -2,8 +2,8 @@
   "name": "@google/servicemanagement",
   "version": "0.1.0",
   "description": "servicemanagement",
-  "main": "index.js",
-  "types": "index.d.ts",
+  "main": "build/index.js",
+  "types": "build/index.d.ts",
   "keywords": ["google"],
   "author": "Google LLC",
   "license": "Apache-2.0",
@@ -18,7 +18,19 @@
   "engines": {
     "node": ">=6.0.0"
   },
+  "scripts": {
+    "fix": "gts fix",
+    "lint": "gts check",
+    "compile": "tsc -p .",
+    "prepare": "npm run compile",
+    "docs": "typedoc --out docs/"
+  },
   "dependencies": {
     "googleapis-common": "^0.4.0"
+  },
+  "devDependencies": {
+    "gts": "^0.9.0",
+    "typescript": "~3.2.0",
+    "typedoc": "^0.13.0"
   }
 }

--- a/src/apis/servicemanagement/tsconfig.json
+++ b/src/apis/servicemanagement/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./node_modules/gts/tsconfig-google.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "build"
+  },
+  "include": [
+    "*.ts",
+  ]
+}

--- a/src/apis/servicenetworking/package.json
+++ b/src/apis/servicenetworking/package.json
@@ -2,8 +2,8 @@
   "name": "@google/servicenetworking",
   "version": "0.1.0",
   "description": "servicenetworking",
-  "main": "index.js",
-  "types": "index.d.ts",
+  "main": "build/index.js",
+  "types": "build/index.d.ts",
   "keywords": ["google"],
   "author": "Google LLC",
   "license": "Apache-2.0",
@@ -18,7 +18,19 @@
   "engines": {
     "node": ">=6.0.0"
   },
+  "scripts": {
+    "fix": "gts fix",
+    "lint": "gts check",
+    "compile": "tsc -p .",
+    "prepare": "npm run compile",
+    "docs": "typedoc --out docs/"
+  },
   "dependencies": {
     "googleapis-common": "^0.4.0"
+  },
+  "devDependencies": {
+    "gts": "^0.9.0",
+    "typescript": "~3.2.0",
+    "typedoc": "^0.13.0"
   }
 }

--- a/src/apis/servicenetworking/tsconfig.json
+++ b/src/apis/servicenetworking/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./node_modules/gts/tsconfig-google.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "build"
+  },
+  "include": [
+    "*.ts",
+  ]
+}

--- a/src/apis/serviceusage/package.json
+++ b/src/apis/serviceusage/package.json
@@ -2,8 +2,8 @@
   "name": "@google/serviceusage",
   "version": "0.1.0",
   "description": "serviceusage",
-  "main": "index.js",
-  "types": "index.d.ts",
+  "main": "build/index.js",
+  "types": "build/index.d.ts",
   "keywords": ["google"],
   "author": "Google LLC",
   "license": "Apache-2.0",
@@ -18,7 +18,19 @@
   "engines": {
     "node": ">=6.0.0"
   },
+  "scripts": {
+    "fix": "gts fix",
+    "lint": "gts check",
+    "compile": "tsc -p .",
+    "prepare": "npm run compile",
+    "docs": "typedoc --out docs/"
+  },
   "dependencies": {
     "googleapis-common": "^0.4.0"
+  },
+  "devDependencies": {
+    "gts": "^0.9.0",
+    "typescript": "~3.2.0",
+    "typedoc": "^0.13.0"
   }
 }

--- a/src/apis/serviceusage/tsconfig.json
+++ b/src/apis/serviceusage/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./node_modules/gts/tsconfig-google.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "build"
+  },
+  "include": [
+    "*.ts",
+  ]
+}

--- a/src/apis/sheets/package.json
+++ b/src/apis/sheets/package.json
@@ -2,8 +2,8 @@
   "name": "@google/sheets",
   "version": "0.1.0",
   "description": "sheets",
-  "main": "index.js",
-  "types": "index.d.ts",
+  "main": "build/index.js",
+  "types": "build/index.d.ts",
   "keywords": ["google"],
   "author": "Google LLC",
   "license": "Apache-2.0",
@@ -18,7 +18,19 @@
   "engines": {
     "node": ">=6.0.0"
   },
+  "scripts": {
+    "fix": "gts fix",
+    "lint": "gts check",
+    "compile": "tsc -p .",
+    "prepare": "npm run compile",
+    "docs": "typedoc --out docs/"
+  },
   "dependencies": {
     "googleapis-common": "^0.4.0"
+  },
+  "devDependencies": {
+    "gts": "^0.9.0",
+    "typescript": "~3.2.0",
+    "typedoc": "^0.13.0"
   }
 }

--- a/src/apis/sheets/tsconfig.json
+++ b/src/apis/sheets/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./node_modules/gts/tsconfig-google.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "build"
+  },
+  "include": [
+    "*.ts",
+  ]
+}

--- a/src/apis/siteVerification/package.json
+++ b/src/apis/siteVerification/package.json
@@ -2,8 +2,8 @@
   "name": "@google/siteVerification",
   "version": "0.1.0",
   "description": "siteVerification",
-  "main": "index.js",
-  "types": "index.d.ts",
+  "main": "build/index.js",
+  "types": "build/index.d.ts",
   "keywords": ["google"],
   "author": "Google LLC",
   "license": "Apache-2.0",
@@ -18,7 +18,19 @@
   "engines": {
     "node": ">=6.0.0"
   },
+  "scripts": {
+    "fix": "gts fix",
+    "lint": "gts check",
+    "compile": "tsc -p .",
+    "prepare": "npm run compile",
+    "docs": "typedoc --out docs/"
+  },
   "dependencies": {
     "googleapis-common": "^0.4.0"
+  },
+  "devDependencies": {
+    "gts": "^0.9.0",
+    "typescript": "~3.2.0",
+    "typedoc": "^0.13.0"
   }
 }

--- a/src/apis/siteVerification/tsconfig.json
+++ b/src/apis/siteVerification/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./node_modules/gts/tsconfig-google.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "build"
+  },
+  "include": [
+    "*.ts",
+  ]
+}

--- a/src/apis/slides/package.json
+++ b/src/apis/slides/package.json
@@ -2,8 +2,8 @@
   "name": "@google/slides",
   "version": "0.1.0",
   "description": "slides",
-  "main": "index.js",
-  "types": "index.d.ts",
+  "main": "build/index.js",
+  "types": "build/index.d.ts",
   "keywords": ["google"],
   "author": "Google LLC",
   "license": "Apache-2.0",
@@ -18,7 +18,19 @@
   "engines": {
     "node": ">=6.0.0"
   },
+  "scripts": {
+    "fix": "gts fix",
+    "lint": "gts check",
+    "compile": "tsc -p .",
+    "prepare": "npm run compile",
+    "docs": "typedoc --out docs/"
+  },
   "dependencies": {
     "googleapis-common": "^0.4.0"
+  },
+  "devDependencies": {
+    "gts": "^0.9.0",
+    "typescript": "~3.2.0",
+    "typedoc": "^0.13.0"
   }
 }

--- a/src/apis/slides/tsconfig.json
+++ b/src/apis/slides/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./node_modules/gts/tsconfig-google.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "build"
+  },
+  "include": [
+    "*.ts",
+  ]
+}

--- a/src/apis/sourcerepo/package.json
+++ b/src/apis/sourcerepo/package.json
@@ -2,8 +2,8 @@
   "name": "@google/sourcerepo",
   "version": "0.1.0",
   "description": "sourcerepo",
-  "main": "index.js",
-  "types": "index.d.ts",
+  "main": "build/index.js",
+  "types": "build/index.d.ts",
   "keywords": ["google"],
   "author": "Google LLC",
   "license": "Apache-2.0",
@@ -18,7 +18,19 @@
   "engines": {
     "node": ">=6.0.0"
   },
+  "scripts": {
+    "fix": "gts fix",
+    "lint": "gts check",
+    "compile": "tsc -p .",
+    "prepare": "npm run compile",
+    "docs": "typedoc --out docs/"
+  },
   "dependencies": {
     "googleapis-common": "^0.4.0"
+  },
+  "devDependencies": {
+    "gts": "^0.9.0",
+    "typescript": "~3.2.0",
+    "typedoc": "^0.13.0"
   }
 }

--- a/src/apis/sourcerepo/tsconfig.json
+++ b/src/apis/sourcerepo/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./node_modules/gts/tsconfig-google.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "build"
+  },
+  "include": [
+    "*.ts",
+  ]
+}

--- a/src/apis/spanner/package.json
+++ b/src/apis/spanner/package.json
@@ -2,8 +2,8 @@
   "name": "@google/spanner",
   "version": "0.1.0",
   "description": "spanner",
-  "main": "index.js",
-  "types": "index.d.ts",
+  "main": "build/index.js",
+  "types": "build/index.d.ts",
   "keywords": ["google"],
   "author": "Google LLC",
   "license": "Apache-2.0",
@@ -18,7 +18,19 @@
   "engines": {
     "node": ">=6.0.0"
   },
+  "scripts": {
+    "fix": "gts fix",
+    "lint": "gts check",
+    "compile": "tsc -p .",
+    "prepare": "npm run compile",
+    "docs": "typedoc --out docs/"
+  },
   "dependencies": {
     "googleapis-common": "^0.4.0"
+  },
+  "devDependencies": {
+    "gts": "^0.9.0",
+    "typescript": "~3.2.0",
+    "typedoc": "^0.13.0"
   }
 }

--- a/src/apis/spanner/tsconfig.json
+++ b/src/apis/spanner/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./node_modules/gts/tsconfig-google.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "build"
+  },
+  "include": [
+    "*.ts",
+  ]
+}

--- a/src/apis/speech/package.json
+++ b/src/apis/speech/package.json
@@ -2,8 +2,8 @@
   "name": "@google/speech",
   "version": "0.1.0",
   "description": "speech",
-  "main": "index.js",
-  "types": "index.d.ts",
+  "main": "build/index.js",
+  "types": "build/index.d.ts",
   "keywords": ["google"],
   "author": "Google LLC",
   "license": "Apache-2.0",
@@ -18,7 +18,19 @@
   "engines": {
     "node": ">=6.0.0"
   },
+  "scripts": {
+    "fix": "gts fix",
+    "lint": "gts check",
+    "compile": "tsc -p .",
+    "prepare": "npm run compile",
+    "docs": "typedoc --out docs/"
+  },
   "dependencies": {
     "googleapis-common": "^0.4.0"
+  },
+  "devDependencies": {
+    "gts": "^0.9.0",
+    "typescript": "~3.2.0",
+    "typedoc": "^0.13.0"
   }
 }

--- a/src/apis/speech/tsconfig.json
+++ b/src/apis/speech/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./node_modules/gts/tsconfig-google.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "build"
+  },
+  "include": [
+    "*.ts",
+  ]
+}

--- a/src/apis/sqladmin/package.json
+++ b/src/apis/sqladmin/package.json
@@ -2,8 +2,8 @@
   "name": "@google/sqladmin",
   "version": "0.1.0",
   "description": "sqladmin",
-  "main": "index.js",
-  "types": "index.d.ts",
+  "main": "build/index.js",
+  "types": "build/index.d.ts",
   "keywords": ["google"],
   "author": "Google LLC",
   "license": "Apache-2.0",
@@ -18,7 +18,19 @@
   "engines": {
     "node": ">=6.0.0"
   },
+  "scripts": {
+    "fix": "gts fix",
+    "lint": "gts check",
+    "compile": "tsc -p .",
+    "prepare": "npm run compile",
+    "docs": "typedoc --out docs/"
+  },
   "dependencies": {
     "googleapis-common": "^0.4.0"
+  },
+  "devDependencies": {
+    "gts": "^0.9.0",
+    "typescript": "~3.2.0",
+    "typedoc": "^0.13.0"
   }
 }

--- a/src/apis/sqladmin/tsconfig.json
+++ b/src/apis/sqladmin/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./node_modules/gts/tsconfig-google.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "build"
+  },
+  "include": [
+    "*.ts",
+  ]
+}

--- a/src/apis/storage/package.json
+++ b/src/apis/storage/package.json
@@ -2,8 +2,8 @@
   "name": "@google/storage",
   "version": "0.1.0",
   "description": "storage",
-  "main": "index.js",
-  "types": "index.d.ts",
+  "main": "build/index.js",
+  "types": "build/index.d.ts",
   "keywords": ["google"],
   "author": "Google LLC",
   "license": "Apache-2.0",
@@ -18,7 +18,19 @@
   "engines": {
     "node": ">=6.0.0"
   },
+  "scripts": {
+    "fix": "gts fix",
+    "lint": "gts check",
+    "compile": "tsc -p .",
+    "prepare": "npm run compile",
+    "docs": "typedoc --out docs/"
+  },
   "dependencies": {
     "googleapis-common": "^0.4.0"
+  },
+  "devDependencies": {
+    "gts": "^0.9.0",
+    "typescript": "~3.2.0",
+    "typedoc": "^0.13.0"
   }
 }

--- a/src/apis/storage/tsconfig.json
+++ b/src/apis/storage/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./node_modules/gts/tsconfig-google.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "build"
+  },
+  "include": [
+    "*.ts",
+  ]
+}

--- a/src/apis/storagetransfer/package.json
+++ b/src/apis/storagetransfer/package.json
@@ -2,8 +2,8 @@
   "name": "@google/storagetransfer",
   "version": "0.1.0",
   "description": "storagetransfer",
-  "main": "index.js",
-  "types": "index.d.ts",
+  "main": "build/index.js",
+  "types": "build/index.d.ts",
   "keywords": ["google"],
   "author": "Google LLC",
   "license": "Apache-2.0",
@@ -18,7 +18,19 @@
   "engines": {
     "node": ">=6.0.0"
   },
+  "scripts": {
+    "fix": "gts fix",
+    "lint": "gts check",
+    "compile": "tsc -p .",
+    "prepare": "npm run compile",
+    "docs": "typedoc --out docs/"
+  },
   "dependencies": {
     "googleapis-common": "^0.4.0"
+  },
+  "devDependencies": {
+    "gts": "^0.9.0",
+    "typescript": "~3.2.0",
+    "typedoc": "^0.13.0"
   }
 }

--- a/src/apis/storagetransfer/tsconfig.json
+++ b/src/apis/storagetransfer/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./node_modules/gts/tsconfig-google.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "build"
+  },
+  "include": [
+    "*.ts",
+  ]
+}

--- a/src/apis/streetviewpublish/package.json
+++ b/src/apis/streetviewpublish/package.json
@@ -2,8 +2,8 @@
   "name": "@google/streetviewpublish",
   "version": "0.1.0",
   "description": "streetviewpublish",
-  "main": "index.js",
-  "types": "index.d.ts",
+  "main": "build/index.js",
+  "types": "build/index.d.ts",
   "keywords": ["google"],
   "author": "Google LLC",
   "license": "Apache-2.0",
@@ -18,7 +18,19 @@
   "engines": {
     "node": ">=6.0.0"
   },
+  "scripts": {
+    "fix": "gts fix",
+    "lint": "gts check",
+    "compile": "tsc -p .",
+    "prepare": "npm run compile",
+    "docs": "typedoc --out docs/"
+  },
   "dependencies": {
     "googleapis-common": "^0.4.0"
+  },
+  "devDependencies": {
+    "gts": "^0.9.0",
+    "typescript": "~3.2.0",
+    "typedoc": "^0.13.0"
   }
 }

--- a/src/apis/streetviewpublish/tsconfig.json
+++ b/src/apis/streetviewpublish/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./node_modules/gts/tsconfig-google.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "build"
+  },
+  "include": [
+    "*.ts",
+  ]
+}

--- a/src/apis/surveys/package.json
+++ b/src/apis/surveys/package.json
@@ -2,8 +2,8 @@
   "name": "@google/surveys",
   "version": "0.1.0",
   "description": "surveys",
-  "main": "index.js",
-  "types": "index.d.ts",
+  "main": "build/index.js",
+  "types": "build/index.d.ts",
   "keywords": ["google"],
   "author": "Google LLC",
   "license": "Apache-2.0",
@@ -18,7 +18,19 @@
   "engines": {
     "node": ">=6.0.0"
   },
+  "scripts": {
+    "fix": "gts fix",
+    "lint": "gts check",
+    "compile": "tsc -p .",
+    "prepare": "npm run compile",
+    "docs": "typedoc --out docs/"
+  },
   "dependencies": {
     "googleapis-common": "^0.4.0"
+  },
+  "devDependencies": {
+    "gts": "^0.9.0",
+    "typescript": "~3.2.0",
+    "typedoc": "^0.13.0"
   }
 }

--- a/src/apis/surveys/tsconfig.json
+++ b/src/apis/surveys/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./node_modules/gts/tsconfig-google.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "build"
+  },
+  "include": [
+    "*.ts",
+  ]
+}

--- a/src/apis/tagmanager/package.json
+++ b/src/apis/tagmanager/package.json
@@ -2,8 +2,8 @@
   "name": "@google/tagmanager",
   "version": "0.1.0",
   "description": "tagmanager",
-  "main": "index.js",
-  "types": "index.d.ts",
+  "main": "build/index.js",
+  "types": "build/index.d.ts",
   "keywords": ["google"],
   "author": "Google LLC",
   "license": "Apache-2.0",
@@ -18,7 +18,19 @@
   "engines": {
     "node": ">=6.0.0"
   },
+  "scripts": {
+    "fix": "gts fix",
+    "lint": "gts check",
+    "compile": "tsc -p .",
+    "prepare": "npm run compile",
+    "docs": "typedoc --out docs/"
+  },
   "dependencies": {
     "googleapis-common": "^0.4.0"
+  },
+  "devDependencies": {
+    "gts": "^0.9.0",
+    "typescript": "~3.2.0",
+    "typedoc": "^0.13.0"
   }
 }

--- a/src/apis/tagmanager/tsconfig.json
+++ b/src/apis/tagmanager/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./node_modules/gts/tsconfig-google.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "build"
+  },
+  "include": [
+    "*.ts",
+  ]
+}

--- a/src/apis/tasks/package.json
+++ b/src/apis/tasks/package.json
@@ -2,8 +2,8 @@
   "name": "@google/tasks",
   "version": "0.1.0",
   "description": "tasks",
-  "main": "index.js",
-  "types": "index.d.ts",
+  "main": "build/index.js",
+  "types": "build/index.d.ts",
   "keywords": ["google"],
   "author": "Google LLC",
   "license": "Apache-2.0",
@@ -18,7 +18,19 @@
   "engines": {
     "node": ">=6.0.0"
   },
+  "scripts": {
+    "fix": "gts fix",
+    "lint": "gts check",
+    "compile": "tsc -p .",
+    "prepare": "npm run compile",
+    "docs": "typedoc --out docs/"
+  },
   "dependencies": {
     "googleapis-common": "^0.4.0"
+  },
+  "devDependencies": {
+    "gts": "^0.9.0",
+    "typescript": "~3.2.0",
+    "typedoc": "^0.13.0"
   }
 }

--- a/src/apis/tasks/tsconfig.json
+++ b/src/apis/tasks/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./node_modules/gts/tsconfig-google.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "build"
+  },
+  "include": [
+    "*.ts",
+  ]
+}

--- a/src/apis/testing/package.json
+++ b/src/apis/testing/package.json
@@ -2,8 +2,8 @@
   "name": "@google/testing",
   "version": "0.1.0",
   "description": "testing",
-  "main": "index.js",
-  "types": "index.d.ts",
+  "main": "build/index.js",
+  "types": "build/index.d.ts",
   "keywords": ["google"],
   "author": "Google LLC",
   "license": "Apache-2.0",
@@ -18,7 +18,19 @@
   "engines": {
     "node": ">=6.0.0"
   },
+  "scripts": {
+    "fix": "gts fix",
+    "lint": "gts check",
+    "compile": "tsc -p .",
+    "prepare": "npm run compile",
+    "docs": "typedoc --out docs/"
+  },
   "dependencies": {
     "googleapis-common": "^0.4.0"
+  },
+  "devDependencies": {
+    "gts": "^0.9.0",
+    "typescript": "~3.2.0",
+    "typedoc": "^0.13.0"
   }
 }

--- a/src/apis/testing/tsconfig.json
+++ b/src/apis/testing/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./node_modules/gts/tsconfig-google.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "build"
+  },
+  "include": [
+    "*.ts",
+  ]
+}

--- a/src/apis/texttospeech/package.json
+++ b/src/apis/texttospeech/package.json
@@ -2,8 +2,8 @@
   "name": "@google/texttospeech",
   "version": "0.1.0",
   "description": "texttospeech",
-  "main": "index.js",
-  "types": "index.d.ts",
+  "main": "build/index.js",
+  "types": "build/index.d.ts",
   "keywords": ["google"],
   "author": "Google LLC",
   "license": "Apache-2.0",
@@ -18,7 +18,19 @@
   "engines": {
     "node": ">=6.0.0"
   },
+  "scripts": {
+    "fix": "gts fix",
+    "lint": "gts check",
+    "compile": "tsc -p .",
+    "prepare": "npm run compile",
+    "docs": "typedoc --out docs/"
+  },
   "dependencies": {
     "googleapis-common": "^0.4.0"
+  },
+  "devDependencies": {
+    "gts": "^0.9.0",
+    "typescript": "~3.2.0",
+    "typedoc": "^0.13.0"
   }
 }

--- a/src/apis/texttospeech/tsconfig.json
+++ b/src/apis/texttospeech/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./node_modules/gts/tsconfig-google.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "build"
+  },
+  "include": [
+    "*.ts",
+  ]
+}

--- a/src/apis/toolresults/package.json
+++ b/src/apis/toolresults/package.json
@@ -2,8 +2,8 @@
   "name": "@google/toolresults",
   "version": "0.1.0",
   "description": "toolresults",
-  "main": "index.js",
-  "types": "index.d.ts",
+  "main": "build/index.js",
+  "types": "build/index.d.ts",
   "keywords": ["google"],
   "author": "Google LLC",
   "license": "Apache-2.0",
@@ -18,7 +18,19 @@
   "engines": {
     "node": ">=6.0.0"
   },
+  "scripts": {
+    "fix": "gts fix",
+    "lint": "gts check",
+    "compile": "tsc -p .",
+    "prepare": "npm run compile",
+    "docs": "typedoc --out docs/"
+  },
   "dependencies": {
     "googleapis-common": "^0.4.0"
+  },
+  "devDependencies": {
+    "gts": "^0.9.0",
+    "typescript": "~3.2.0",
+    "typedoc": "^0.13.0"
   }
 }

--- a/src/apis/toolresults/tsconfig.json
+++ b/src/apis/toolresults/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./node_modules/gts/tsconfig-google.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "build"
+  },
+  "include": [
+    "*.ts",
+  ]
+}

--- a/src/apis/tpu/package.json
+++ b/src/apis/tpu/package.json
@@ -2,8 +2,8 @@
   "name": "@google/tpu",
   "version": "0.1.0",
   "description": "tpu",
-  "main": "index.js",
-  "types": "index.d.ts",
+  "main": "build/index.js",
+  "types": "build/index.d.ts",
   "keywords": ["google"],
   "author": "Google LLC",
   "license": "Apache-2.0",
@@ -18,7 +18,19 @@
   "engines": {
     "node": ">=6.0.0"
   },
+  "scripts": {
+    "fix": "gts fix",
+    "lint": "gts check",
+    "compile": "tsc -p .",
+    "prepare": "npm run compile",
+    "docs": "typedoc --out docs/"
+  },
   "dependencies": {
     "googleapis-common": "^0.4.0"
+  },
+  "devDependencies": {
+    "gts": "^0.9.0",
+    "typescript": "~3.2.0",
+    "typedoc": "^0.13.0"
   }
 }

--- a/src/apis/tpu/tsconfig.json
+++ b/src/apis/tpu/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./node_modules/gts/tsconfig-google.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "build"
+  },
+  "include": [
+    "*.ts",
+  ]
+}

--- a/src/apis/translate/package.json
+++ b/src/apis/translate/package.json
@@ -2,8 +2,8 @@
   "name": "@google/translate",
   "version": "0.1.0",
   "description": "translate",
-  "main": "index.js",
-  "types": "index.d.ts",
+  "main": "build/index.js",
+  "types": "build/index.d.ts",
   "keywords": ["google"],
   "author": "Google LLC",
   "license": "Apache-2.0",
@@ -18,7 +18,19 @@
   "engines": {
     "node": ">=6.0.0"
   },
+  "scripts": {
+    "fix": "gts fix",
+    "lint": "gts check",
+    "compile": "tsc -p .",
+    "prepare": "npm run compile",
+    "docs": "typedoc --out docs/"
+  },
   "dependencies": {
     "googleapis-common": "^0.4.0"
+  },
+  "devDependencies": {
+    "gts": "^0.9.0",
+    "typescript": "~3.2.0",
+    "typedoc": "^0.13.0"
   }
 }

--- a/src/apis/translate/tsconfig.json
+++ b/src/apis/translate/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./node_modules/gts/tsconfig-google.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "build"
+  },
+  "include": [
+    "*.ts",
+  ]
+}

--- a/src/apis/urlshortener/package.json
+++ b/src/apis/urlshortener/package.json
@@ -2,8 +2,8 @@
   "name": "@google/urlshortener",
   "version": "0.1.0",
   "description": "urlshortener",
-  "main": "index.js",
-  "types": "index.d.ts",
+  "main": "build/index.js",
+  "types": "build/index.d.ts",
   "keywords": ["google"],
   "author": "Google LLC",
   "license": "Apache-2.0",
@@ -18,7 +18,19 @@
   "engines": {
     "node": ">=6.0.0"
   },
+  "scripts": {
+    "fix": "gts fix",
+    "lint": "gts check",
+    "compile": "tsc -p .",
+    "prepare": "npm run compile",
+    "docs": "typedoc --out docs/"
+  },
   "dependencies": {
     "googleapis-common": "^0.4.0"
+  },
+  "devDependencies": {
+    "gts": "^0.9.0",
+    "typescript": "~3.2.0",
+    "typedoc": "^0.13.0"
   }
 }

--- a/src/apis/urlshortener/tsconfig.json
+++ b/src/apis/urlshortener/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./node_modules/gts/tsconfig-google.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "build"
+  },
+  "include": [
+    "*.ts",
+  ]
+}

--- a/src/apis/vault/package.json
+++ b/src/apis/vault/package.json
@@ -2,8 +2,8 @@
   "name": "@google/vault",
   "version": "0.1.0",
   "description": "vault",
-  "main": "index.js",
-  "types": "index.d.ts",
+  "main": "build/index.js",
+  "types": "build/index.d.ts",
   "keywords": ["google"],
   "author": "Google LLC",
   "license": "Apache-2.0",
@@ -18,7 +18,19 @@
   "engines": {
     "node": ">=6.0.0"
   },
+  "scripts": {
+    "fix": "gts fix",
+    "lint": "gts check",
+    "compile": "tsc -p .",
+    "prepare": "npm run compile",
+    "docs": "typedoc --out docs/"
+  },
   "dependencies": {
     "googleapis-common": "^0.4.0"
+  },
+  "devDependencies": {
+    "gts": "^0.9.0",
+    "typescript": "~3.2.0",
+    "typedoc": "^0.13.0"
   }
 }

--- a/src/apis/vault/tsconfig.json
+++ b/src/apis/vault/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./node_modules/gts/tsconfig-google.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "build"
+  },
+  "include": [
+    "*.ts",
+  ]
+}

--- a/src/apis/videointelligence/package.json
+++ b/src/apis/videointelligence/package.json
@@ -2,8 +2,8 @@
   "name": "@google/videointelligence",
   "version": "0.1.0",
   "description": "videointelligence",
-  "main": "index.js",
-  "types": "index.d.ts",
+  "main": "build/index.js",
+  "types": "build/index.d.ts",
   "keywords": ["google"],
   "author": "Google LLC",
   "license": "Apache-2.0",
@@ -18,7 +18,19 @@
   "engines": {
     "node": ">=6.0.0"
   },
+  "scripts": {
+    "fix": "gts fix",
+    "lint": "gts check",
+    "compile": "tsc -p .",
+    "prepare": "npm run compile",
+    "docs": "typedoc --out docs/"
+  },
   "dependencies": {
     "googleapis-common": "^0.4.0"
+  },
+  "devDependencies": {
+    "gts": "^0.9.0",
+    "typescript": "~3.2.0",
+    "typedoc": "^0.13.0"
   }
 }

--- a/src/apis/videointelligence/tsconfig.json
+++ b/src/apis/videointelligence/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./node_modules/gts/tsconfig-google.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "build"
+  },
+  "include": [
+    "*.ts",
+  ]
+}

--- a/src/apis/vision/package.json
+++ b/src/apis/vision/package.json
@@ -2,8 +2,8 @@
   "name": "@google/vision",
   "version": "0.1.0",
   "description": "vision",
-  "main": "index.js",
-  "types": "index.d.ts",
+  "main": "build/index.js",
+  "types": "build/index.d.ts",
   "keywords": ["google"],
   "author": "Google LLC",
   "license": "Apache-2.0",
@@ -18,7 +18,19 @@
   "engines": {
     "node": ">=6.0.0"
   },
+  "scripts": {
+    "fix": "gts fix",
+    "lint": "gts check",
+    "compile": "tsc -p .",
+    "prepare": "npm run compile",
+    "docs": "typedoc --out docs/"
+  },
   "dependencies": {
     "googleapis-common": "^0.4.0"
+  },
+  "devDependencies": {
+    "gts": "^0.9.0",
+    "typescript": "~3.2.0",
+    "typedoc": "^0.13.0"
   }
 }

--- a/src/apis/vision/tsconfig.json
+++ b/src/apis/vision/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./node_modules/gts/tsconfig-google.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "build"
+  },
+  "include": [
+    "*.ts",
+  ]
+}

--- a/src/apis/webfonts/package.json
+++ b/src/apis/webfonts/package.json
@@ -2,8 +2,8 @@
   "name": "@google/webfonts",
   "version": "0.1.0",
   "description": "webfonts",
-  "main": "index.js",
-  "types": "index.d.ts",
+  "main": "build/index.js",
+  "types": "build/index.d.ts",
   "keywords": ["google"],
   "author": "Google LLC",
   "license": "Apache-2.0",
@@ -18,7 +18,19 @@
   "engines": {
     "node": ">=6.0.0"
   },
+  "scripts": {
+    "fix": "gts fix",
+    "lint": "gts check",
+    "compile": "tsc -p .",
+    "prepare": "npm run compile",
+    "docs": "typedoc --out docs/"
+  },
   "dependencies": {
     "googleapis-common": "^0.4.0"
+  },
+  "devDependencies": {
+    "gts": "^0.9.0",
+    "typescript": "~3.2.0",
+    "typedoc": "^0.13.0"
   }
 }

--- a/src/apis/webfonts/tsconfig.json
+++ b/src/apis/webfonts/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./node_modules/gts/tsconfig-google.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "build"
+  },
+  "include": [
+    "*.ts",
+  ]
+}

--- a/src/apis/webmasters/package.json
+++ b/src/apis/webmasters/package.json
@@ -2,8 +2,8 @@
   "name": "@google/webmasters",
   "version": "0.1.0",
   "description": "webmasters",
-  "main": "index.js",
-  "types": "index.d.ts",
+  "main": "build/index.js",
+  "types": "build/index.d.ts",
   "keywords": ["google"],
   "author": "Google LLC",
   "license": "Apache-2.0",
@@ -18,7 +18,19 @@
   "engines": {
     "node": ">=6.0.0"
   },
+  "scripts": {
+    "fix": "gts fix",
+    "lint": "gts check",
+    "compile": "tsc -p .",
+    "prepare": "npm run compile",
+    "docs": "typedoc --out docs/"
+  },
   "dependencies": {
     "googleapis-common": "^0.4.0"
+  },
+  "devDependencies": {
+    "gts": "^0.9.0",
+    "typescript": "~3.2.0",
+    "typedoc": "^0.13.0"
   }
 }

--- a/src/apis/webmasters/tsconfig.json
+++ b/src/apis/webmasters/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./node_modules/gts/tsconfig-google.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "build"
+  },
+  "include": [
+    "*.ts",
+  ]
+}

--- a/src/apis/websecurityscanner/package.json
+++ b/src/apis/websecurityscanner/package.json
@@ -2,8 +2,8 @@
   "name": "@google/websecurityscanner",
   "version": "0.1.0",
   "description": "websecurityscanner",
-  "main": "index.js",
-  "types": "index.d.ts",
+  "main": "build/index.js",
+  "types": "build/index.d.ts",
   "keywords": ["google"],
   "author": "Google LLC",
   "license": "Apache-2.0",
@@ -18,7 +18,19 @@
   "engines": {
     "node": ">=6.0.0"
   },
+  "scripts": {
+    "fix": "gts fix",
+    "lint": "gts check",
+    "compile": "tsc -p .",
+    "prepare": "npm run compile",
+    "docs": "typedoc --out docs/"
+  },
   "dependencies": {
     "googleapis-common": "^0.4.0"
+  },
+  "devDependencies": {
+    "gts": "^0.9.0",
+    "typescript": "~3.2.0",
+    "typedoc": "^0.13.0"
   }
 }

--- a/src/apis/websecurityscanner/tsconfig.json
+++ b/src/apis/websecurityscanner/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./node_modules/gts/tsconfig-google.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "build"
+  },
+  "include": [
+    "*.ts",
+  ]
+}

--- a/src/apis/youtube/package.json
+++ b/src/apis/youtube/package.json
@@ -2,8 +2,8 @@
   "name": "@google/youtube",
   "version": "0.1.0",
   "description": "youtube",
-  "main": "index.js",
-  "types": "index.d.ts",
+  "main": "build/index.js",
+  "types": "build/index.d.ts",
   "keywords": ["google"],
   "author": "Google LLC",
   "license": "Apache-2.0",
@@ -18,7 +18,19 @@
   "engines": {
     "node": ">=6.0.0"
   },
+  "scripts": {
+    "fix": "gts fix",
+    "lint": "gts check",
+    "compile": "tsc -p .",
+    "prepare": "npm run compile",
+    "docs": "typedoc --out docs/"
+  },
   "dependencies": {
     "googleapis-common": "^0.4.0"
+  },
+  "devDependencies": {
+    "gts": "^0.9.0",
+    "typescript": "~3.2.0",
+    "typedoc": "^0.13.0"
   }
 }

--- a/src/apis/youtube/tsconfig.json
+++ b/src/apis/youtube/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./node_modules/gts/tsconfig-google.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "build"
+  },
+  "include": [
+    "*.ts",
+  ]
+}

--- a/src/apis/youtubeAnalytics/package.json
+++ b/src/apis/youtubeAnalytics/package.json
@@ -2,8 +2,8 @@
   "name": "@google/youtubeAnalytics",
   "version": "0.1.0",
   "description": "youtubeAnalytics",
-  "main": "index.js",
-  "types": "index.d.ts",
+  "main": "build/index.js",
+  "types": "build/index.d.ts",
   "keywords": ["google"],
   "author": "Google LLC",
   "license": "Apache-2.0",
@@ -18,7 +18,19 @@
   "engines": {
     "node": ">=6.0.0"
   },
+  "scripts": {
+    "fix": "gts fix",
+    "lint": "gts check",
+    "compile": "tsc -p .",
+    "prepare": "npm run compile",
+    "docs": "typedoc --out docs/"
+  },
   "dependencies": {
     "googleapis-common": "^0.4.0"
+  },
+  "devDependencies": {
+    "gts": "^0.9.0",
+    "typescript": "~3.2.0",
+    "typedoc": "^0.13.0"
   }
 }

--- a/src/apis/youtubeAnalytics/tsconfig.json
+++ b/src/apis/youtubeAnalytics/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./node_modules/gts/tsconfig-google.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "build"
+  },
+  "include": [
+    "*.ts",
+  ]
+}

--- a/src/apis/youtubereporting/package.json
+++ b/src/apis/youtubereporting/package.json
@@ -2,8 +2,8 @@
   "name": "@google/youtubereporting",
   "version": "0.1.0",
   "description": "youtubereporting",
-  "main": "index.js",
-  "types": "index.d.ts",
+  "main": "build/index.js",
+  "types": "build/index.d.ts",
   "keywords": ["google"],
   "author": "Google LLC",
   "license": "Apache-2.0",
@@ -18,7 +18,19 @@
   "engines": {
     "node": ">=6.0.0"
   },
+  "scripts": {
+    "fix": "gts fix",
+    "lint": "gts check",
+    "compile": "tsc -p .",
+    "prepare": "npm run compile",
+    "docs": "typedoc --out docs/"
+  },
   "dependencies": {
     "googleapis-common": "^0.4.0"
+  },
+  "devDependencies": {
+    "gts": "^0.9.0",
+    "typescript": "~3.2.0",
+    "typedoc": "^0.13.0"
   }
 }

--- a/src/apis/youtubereporting/tsconfig.json
+++ b/src/apis/youtubereporting/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./node_modules/gts/tsconfig-google.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "build"
+  },
+  "include": [
+    "*.ts",
+  ]
+}

--- a/src/generator/generator.ts
+++ b/src/generator/generator.ts
@@ -274,6 +274,10 @@ export class Generator {
           const rdPath = path.join(apisPath, file, 'README.md');
           const rdResult = this.env.render('README.md.njk', {name: file, desc});
           await writeFile(rdPath, rdResult);
+          // generate the tsconfig.json
+          const tsPath = path.join(apisPath, file, 'tsconfig.json');
+          const tsResult = this.env.render('tsconfig.json.njk');
+          await writeFile(tsPath, tsResult);
         }
       }
     }

--- a/src/generator/templates/package.json.njk
+++ b/src/generator/templates/package.json.njk
@@ -2,8 +2,8 @@
   "name": "@google/{{name}}",
   "version": "0.1.0",
   "description": "{{name}}",
-  "main": "index.js",
-  "types": "index.d.ts",
+  "main": "build/index.js",
+  "types": "build/index.d.ts",
   "keywords": ["google"],
   "author": "Google LLC",
   "license": "Apache-2.0",
@@ -18,7 +18,19 @@
   "engines": {
     "node": ">=6.0.0"
   },
+  "scripts": {
+    "fix": "gts fix",
+    "lint": "gts check",
+    "compile": "tsc -p .",
+    "prepare": "npm run compile",
+    "docs": "typedoc --out docs/"
+  },
   "dependencies": {
     "googleapis-common": "^0.4.0"
+  },
+  "devDependencies": {
+    "gts": "^0.9.0",
+    "typescript": "~3.2.0",
+    "typedoc": "^0.13.0"
   }
 }

--- a/src/generator/templates/tsconfig.json.njk
+++ b/src/generator/templates/tsconfig.json.njk
@@ -1,0 +1,10 @@
+{
+  "extends": "./node_modules/gts/tsconfig-google.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "build"
+  },
+  "include": [
+    "*.ts",
+  ]
+}


### PR DESCRIPTION
We need to break the `googleapis` module down into mini modules.  This PR adds `gts`, `typescript`, and `typedoc` as local dependencies of each sub module.  This will have no actual effect until a few follow up PRs start to light it up.