### PR TITLE
refactor: remove weird root binding

### DIFF
--- a/src/apis/abusiveexperiencereport/v1.ts
+++ b/src/apis/abusiveexperiencereport/v1.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace abusiveexperiencereport_v1 {
   export interface Options extends GlobalOptions {
     version: 'v1';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -97,24 +99,14 @@ export namespace abusiveexperiencereport_v1 {
    * @param {object=} options Options for Abusiveexperiencereport
    */
   export class Abusiveexperiencereport {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     sites: Resource$Sites;
     violatingSites: Resource$Violatingsites;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.sites = new Resource$Sites(this);
-      this.violatingSites = new Resource$Violatingsites(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.sites = new Resource$Sites();
+      this.violatingSites = new Resource$Violatingsites();
     }
   }
 
@@ -163,15 +155,7 @@ export namespace abusiveexperiencereport_v1 {
 
 
   export class Resource$Sites {
-    root: Abusiveexperiencereport;
-    constructor(root: Abusiveexperiencereport) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -226,7 +210,7 @@ export namespace abusiveexperiencereport_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$SiteSummaryResponse>(parameters, callback);
@@ -257,15 +241,7 @@ export namespace abusiveexperiencereport_v1 {
 
 
   export class Resource$Violatingsites {
-    root: Abusiveexperiencereport;
-    constructor(root: Abusiveexperiencereport) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -325,7 +301,7 @@ export namespace abusiveexperiencereport_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ViolatingSitesResponse>(parameters, callback);

--- a/src/apis/acceleratedmobilepageurl/v1.ts
+++ b/src/apis/acceleratedmobilepageurl/v1.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace acceleratedmobilepageurl_v1 {
   export interface Options extends GlobalOptions {
     version: 'v1';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -97,22 +99,12 @@ export namespace acceleratedmobilepageurl_v1 {
    * @param {object=} options Options for Acceleratedmobilepageurl
    */
   export class Acceleratedmobilepageurl {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     ampUrls: Resource$Ampurls;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.ampUrls = new Resource$Ampurls(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.ampUrls = new Resource$Ampurls();
     }
   }
 
@@ -185,15 +177,7 @@ export namespace acceleratedmobilepageurl_v1 {
 
 
   export class Resource$Ampurls {
-    root: Acceleratedmobilepageurl;
-    constructor(root: Acceleratedmobilepageurl) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -256,7 +240,7 @@ export namespace acceleratedmobilepageurl_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$BatchGetAmpUrlsResponse>(parameters, callback);

--- a/src/apis/accesscontextmanager/v1beta.ts
+++ b/src/apis/accesscontextmanager/v1beta.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace accesscontextmanager_v1beta {
   export interface Options extends GlobalOptions {
     version: 'v1beta';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -97,24 +99,14 @@ export namespace accesscontextmanager_v1beta {
    * @param {object=} options Options for Accesscontextmanager
    */
   export class Accesscontextmanager {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     accessPolicies: Resource$Accesspolicies;
     operations: Resource$Operations;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.accessPolicies = new Resource$Accesspolicies(this);
-      this.operations = new Resource$Operations(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.accessPolicies = new Resource$Accesspolicies();
+      this.operations = new Resource$Operations();
     }
   }
 
@@ -536,19 +528,11 @@ export namespace accesscontextmanager_v1beta {
 
 
   export class Resource$Accesspolicies {
-    root: Accesscontextmanager;
     accessLevels: Resource$Accesspolicies$Accesslevels;
     servicePerimeters: Resource$Accesspolicies$Serviceperimeters;
-    constructor(root: Accesscontextmanager) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.accessLevels = new Resource$Accesspolicies$Accesslevels(root);
-      this.servicePerimeters =
-          new Resource$Accesspolicies$Serviceperimeters(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.accessLevels = new Resource$Accesspolicies$Accesslevels();
+      this.servicePerimeters = new Resource$Accesspolicies$Serviceperimeters();
     }
 
 
@@ -614,7 +598,7 @@ export namespace accesscontextmanager_v1beta {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -683,7 +667,7 @@ export namespace accesscontextmanager_v1beta {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -746,7 +730,7 @@ export namespace accesscontextmanager_v1beta {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$AccessPolicy>(parameters, callback);
@@ -819,7 +803,7 @@ export namespace accesscontextmanager_v1beta {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListAccessPoliciesResponse>(
@@ -892,7 +876,7 @@ export namespace accesscontextmanager_v1beta {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -987,15 +971,7 @@ export namespace accesscontextmanager_v1beta {
   }
 
   export class Resource$Accesspolicies$Accesslevels {
-    root: Accesscontextmanager;
-    constructor(root: Accesscontextmanager) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -1060,7 +1036,7 @@ export namespace accesscontextmanager_v1beta {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -1129,7 +1105,7 @@ export namespace accesscontextmanager_v1beta {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -1193,7 +1169,7 @@ export namespace accesscontextmanager_v1beta {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$AccessLevel>(parameters, callback);
@@ -1265,7 +1241,7 @@ export namespace accesscontextmanager_v1beta {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListAccessLevelsResponse>(parameters, callback);
@@ -1337,7 +1313,7 @@ export namespace accesscontextmanager_v1beta {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -1454,15 +1430,7 @@ export namespace accesscontextmanager_v1beta {
 
 
   export class Resource$Accesspolicies$Serviceperimeters {
-    root: Accesscontextmanager;
-    constructor(root: Accesscontextmanager) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -1528,7 +1496,7 @@ export namespace accesscontextmanager_v1beta {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -1598,7 +1566,7 @@ export namespace accesscontextmanager_v1beta {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -1661,7 +1629,7 @@ export namespace accesscontextmanager_v1beta {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ServicePerimeter>(parameters, callback);
@@ -1737,7 +1705,7 @@ export namespace accesscontextmanager_v1beta {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListServicePerimetersResponse>(
@@ -1813,7 +1781,7 @@ export namespace accesscontextmanager_v1beta {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -1916,15 +1884,7 @@ export namespace accesscontextmanager_v1beta {
 
 
   export class Resource$Operations {
-    root: Accesscontextmanager;
-    constructor(root: Accesscontextmanager) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -1981,7 +1941,7 @@ export namespace accesscontextmanager_v1beta {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);

--- a/src/apis/adexchangebuyer/v1.2.ts
+++ b/src/apis/adexchangebuyer/v1.2.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace adexchangebuyer_v1_2 {
   export interface Options extends GlobalOptions {
     version: 'v1_2';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -81,24 +83,14 @@ export namespace adexchangebuyer_v1_2 {
    * @param {object=} options Options for Adexchangebuyer
    */
   export class Adexchangebuyer {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     accounts: Resource$Accounts;
     creatives: Resource$Creatives;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.accounts = new Resource$Accounts(this);
-      this.creatives = new Resource$Creatives(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.accounts = new Resource$Accounts();
+      this.creatives = new Resource$Creatives();
     }
   }
 
@@ -298,15 +290,7 @@ export namespace adexchangebuyer_v1_2 {
 
 
   export class Resource$Accounts {
-    root: Adexchangebuyer;
-    constructor(root: Adexchangebuyer) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -360,7 +344,7 @@ export namespace adexchangebuyer_v1_2 {
         params,
         requiredParams: ['id'],
         pathParams: ['id'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Account>(parameters, callback);
@@ -424,7 +408,7 @@ export namespace adexchangebuyer_v1_2 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$AccountsList>(parameters, callback);
@@ -489,7 +473,7 @@ export namespace adexchangebuyer_v1_2 {
         params,
         requiredParams: ['id'],
         pathParams: ['id'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Account>(parameters, callback);
@@ -554,7 +538,7 @@ export namespace adexchangebuyer_v1_2 {
         params,
         requiredParams: ['id'],
         pathParams: ['id'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Account>(parameters, callback);
@@ -616,15 +600,7 @@ export namespace adexchangebuyer_v1_2 {
 
 
   export class Resource$Creatives {
-    root: Adexchangebuyer;
-    constructor(root: Adexchangebuyer) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -682,7 +658,7 @@ export namespace adexchangebuyer_v1_2 {
         params,
         requiredParams: ['accountId', 'buyerCreativeId'],
         pathParams: ['accountId', 'buyerCreativeId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Creative>(parameters, callback);
@@ -746,7 +722,7 @@ export namespace adexchangebuyer_v1_2 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Creative>(parameters, callback);
@@ -814,7 +790,7 @@ export namespace adexchangebuyer_v1_2 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$CreativesList>(parameters, callback);

--- a/src/apis/adexchangebuyer/v1.3.ts
+++ b/src/apis/adexchangebuyer/v1.3.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace adexchangebuyer_v1_3 {
   export interface Options extends GlobalOptions {
     version: 'v1_3';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -81,10 +83,6 @@ export namespace adexchangebuyer_v1_3 {
    * @param {object=} options Options for Adexchangebuyer
    */
   export class Adexchangebuyer {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     accounts: Resource$Accounts;
     billingInfo: Resource$Billinginfo;
     budget: Resource$Budget;
@@ -94,21 +92,15 @@ export namespace adexchangebuyer_v1_3 {
     pretargetingConfig: Resource$Pretargetingconfig;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.accounts = new Resource$Accounts(this);
-      this.billingInfo = new Resource$Billinginfo(this);
-      this.budget = new Resource$Budget(this);
-      this.creatives = new Resource$Creatives(this);
-      this.directDeals = new Resource$Directdeals(this);
-      this.performanceReport = new Resource$Performancereport(this);
-      this.pretargetingConfig = new Resource$Pretargetingconfig(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.accounts = new Resource$Accounts();
+      this.billingInfo = new Resource$Billinginfo();
+      this.budget = new Resource$Budget();
+      this.creatives = new Resource$Creatives();
+      this.directDeals = new Resource$Directdeals();
+      this.performanceReport = new Resource$Performancereport();
+      this.pretargetingConfig = new Resource$Pretargetingconfig();
     }
   }
 
@@ -720,15 +712,7 @@ export namespace adexchangebuyer_v1_3 {
 
 
   export class Resource$Accounts {
-    root: Adexchangebuyer;
-    constructor(root: Adexchangebuyer) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -782,7 +766,7 @@ export namespace adexchangebuyer_v1_3 {
         params,
         requiredParams: ['id'],
         pathParams: ['id'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Account>(parameters, callback);
@@ -846,7 +830,7 @@ export namespace adexchangebuyer_v1_3 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$AccountsList>(parameters, callback);
@@ -911,7 +895,7 @@ export namespace adexchangebuyer_v1_3 {
         params,
         requiredParams: ['id'],
         pathParams: ['id'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Account>(parameters, callback);
@@ -976,7 +960,7 @@ export namespace adexchangebuyer_v1_3 {
         params,
         requiredParams: ['id'],
         pathParams: ['id'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Account>(parameters, callback);
@@ -1038,15 +1022,7 @@ export namespace adexchangebuyer_v1_3 {
 
 
   export class Resource$Billinginfo {
-    root: Adexchangebuyer;
-    constructor(root: Adexchangebuyer) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -1102,7 +1078,7 @@ export namespace adexchangebuyer_v1_3 {
         params,
         requiredParams: ['accountId'],
         pathParams: ['accountId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$BillingInfo>(parameters, callback);
@@ -1167,7 +1143,7 @@ export namespace adexchangebuyer_v1_3 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$BillingInfoList>(parameters, callback);
@@ -1197,15 +1173,7 @@ export namespace adexchangebuyer_v1_3 {
 
 
   export class Resource$Budget {
-    root: Adexchangebuyer;
-    constructor(root: Adexchangebuyer) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -1262,7 +1230,7 @@ export namespace adexchangebuyer_v1_3 {
         params,
         requiredParams: ['accountId', 'billingId'],
         pathParams: ['accountId', 'billingId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Budget>(parameters, callback);
@@ -1331,7 +1299,7 @@ export namespace adexchangebuyer_v1_3 {
         params,
         requiredParams: ['accountId', 'billingId'],
         pathParams: ['accountId', 'billingId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Budget>(parameters, callback);
@@ -1399,7 +1367,7 @@ export namespace adexchangebuyer_v1_3 {
         params,
         requiredParams: ['accountId', 'billingId'],
         pathParams: ['accountId', 'billingId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Budget>(parameters, callback);
@@ -1467,15 +1435,7 @@ export namespace adexchangebuyer_v1_3 {
 
 
   export class Resource$Creatives {
-    root: Adexchangebuyer;
-    constructor(root: Adexchangebuyer) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -1533,7 +1493,7 @@ export namespace adexchangebuyer_v1_3 {
         params,
         requiredParams: ['accountId', 'buyerCreativeId'],
         pathParams: ['accountId', 'buyerCreativeId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Creative>(parameters, callback);
@@ -1597,7 +1557,7 @@ export namespace adexchangebuyer_v1_3 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Creative>(parameters, callback);
@@ -1667,7 +1627,7 @@ export namespace adexchangebuyer_v1_3 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$CreativesList>(parameters, callback);
@@ -1738,15 +1698,7 @@ export namespace adexchangebuyer_v1_3 {
 
 
   export class Resource$Directdeals {
-    root: Adexchangebuyer;
-    constructor(root: Adexchangebuyer) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -1801,7 +1753,7 @@ export namespace adexchangebuyer_v1_3 {
         params,
         requiredParams: ['id'],
         pathParams: ['id'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$DirectDeal>(parameters, callback);
@@ -1865,7 +1817,7 @@ export namespace adexchangebuyer_v1_3 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$DirectDealsList>(parameters, callback);
@@ -1895,15 +1847,7 @@ export namespace adexchangebuyer_v1_3 {
 
 
   export class Resource$Performancereport {
-    root: Adexchangebuyer;
-    constructor(root: Adexchangebuyer) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -1968,7 +1912,7 @@ export namespace adexchangebuyer_v1_3 {
         params,
         requiredParams: ['accountId', 'endDateTime', 'startDateTime'],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$PerformanceReportList>(parameters, callback);
@@ -2012,15 +1956,7 @@ export namespace adexchangebuyer_v1_3 {
 
 
   export class Resource$Pretargetingconfig {
-    root: Adexchangebuyer;
-    constructor(root: Adexchangebuyer) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -2081,7 +2017,7 @@ export namespace adexchangebuyer_v1_3 {
         params,
         requiredParams: ['accountId', 'configId'],
         pathParams: ['accountId', 'configId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -2147,7 +2083,7 @@ export namespace adexchangebuyer_v1_3 {
         params,
         requiredParams: ['accountId', 'configId'],
         pathParams: ['accountId', 'configId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$PretargetingConfig>(parameters, callback);
@@ -2216,7 +2152,7 @@ export namespace adexchangebuyer_v1_3 {
         params,
         requiredParams: ['accountId'],
         pathParams: ['accountId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$PretargetingConfig>(parameters, callback);
@@ -2286,7 +2222,7 @@ export namespace adexchangebuyer_v1_3 {
         params,
         requiredParams: ['accountId'],
         pathParams: ['accountId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$PretargetingConfigList>(parameters, callback);
@@ -2358,7 +2294,7 @@ export namespace adexchangebuyer_v1_3 {
         params,
         requiredParams: ['accountId', 'configId'],
         pathParams: ['accountId', 'configId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$PretargetingConfig>(parameters, callback);
@@ -2429,7 +2365,7 @@ export namespace adexchangebuyer_v1_3 {
         params,
         requiredParams: ['accountId', 'configId'],
         pathParams: ['accountId', 'configId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$PretargetingConfig>(parameters, callback);

--- a/src/apis/adexchangebuyer/v1.4.ts
+++ b/src/apis/adexchangebuyer/v1.4.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace adexchangebuyer_v1_4 {
   export interface Options extends GlobalOptions {
     version: 'v1_4';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -81,10 +83,6 @@ export namespace adexchangebuyer_v1_4 {
    * @param {object=} options Options for Adexchangebuyer
    */
   export class Adexchangebuyer {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     accounts: Resource$Accounts;
     billingInfo: Resource$Billinginfo;
     budget: Resource$Budget;
@@ -99,27 +97,20 @@ export namespace adexchangebuyer_v1_4 {
     pubprofiles: Resource$Pubprofiles;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.accounts = new Resource$Accounts(this);
-      this.billingInfo = new Resource$Billinginfo(this);
-      this.budget = new Resource$Budget(this);
-      this.creatives = new Resource$Creatives(this);
-      this.marketplacedeals = new Resource$Marketplacedeals(this);
-      this.marketplacenotes = new Resource$Marketplacenotes(this);
-      this.marketplaceprivateauction =
-          new Resource$Marketplaceprivateauction(this);
-      this.performanceReport = new Resource$Performancereport(this);
-      this.pretargetingConfig = new Resource$Pretargetingconfig(this);
-      this.products = new Resource$Products(this);
-      this.proposals = new Resource$Proposals(this);
-      this.pubprofiles = new Resource$Pubprofiles(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.accounts = new Resource$Accounts();
+      this.billingInfo = new Resource$Billinginfo();
+      this.budget = new Resource$Budget();
+      this.creatives = new Resource$Creatives();
+      this.marketplacedeals = new Resource$Marketplacedeals();
+      this.marketplacenotes = new Resource$Marketplacenotes();
+      this.marketplaceprivateauction = new Resource$Marketplaceprivateauction();
+      this.performanceReport = new Resource$Performancereport();
+      this.pretargetingConfig = new Resource$Pretargetingconfig();
+      this.products = new Resource$Products();
+      this.proposals = new Resource$Proposals();
+      this.pubprofiles = new Resource$Pubprofiles();
     }
   }
 
@@ -1835,15 +1826,7 @@ export namespace adexchangebuyer_v1_4 {
 
 
   export class Resource$Accounts {
-    root: Adexchangebuyer;
-    constructor(root: Adexchangebuyer) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -1897,7 +1880,7 @@ export namespace adexchangebuyer_v1_4 {
         params,
         requiredParams: ['id'],
         pathParams: ['id'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Account>(parameters, callback);
@@ -1961,7 +1944,7 @@ export namespace adexchangebuyer_v1_4 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$AccountsList>(parameters, callback);
@@ -2027,7 +2010,7 @@ export namespace adexchangebuyer_v1_4 {
         params,
         requiredParams: ['id'],
         pathParams: ['id'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Account>(parameters, callback);
@@ -2093,7 +2076,7 @@ export namespace adexchangebuyer_v1_4 {
         params,
         requiredParams: ['id'],
         pathParams: ['id'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Account>(parameters, callback);
@@ -2163,15 +2146,7 @@ export namespace adexchangebuyer_v1_4 {
 
 
   export class Resource$Billinginfo {
-    root: Adexchangebuyer;
-    constructor(root: Adexchangebuyer) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -2227,7 +2202,7 @@ export namespace adexchangebuyer_v1_4 {
         params,
         requiredParams: ['accountId'],
         pathParams: ['accountId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$BillingInfo>(parameters, callback);
@@ -2292,7 +2267,7 @@ export namespace adexchangebuyer_v1_4 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$BillingInfoList>(parameters, callback);
@@ -2322,15 +2297,7 @@ export namespace adexchangebuyer_v1_4 {
 
 
   export class Resource$Budget {
-    root: Adexchangebuyer;
-    constructor(root: Adexchangebuyer) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -2387,7 +2354,7 @@ export namespace adexchangebuyer_v1_4 {
         params,
         requiredParams: ['accountId', 'billingId'],
         pathParams: ['accountId', 'billingId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Budget>(parameters, callback);
@@ -2456,7 +2423,7 @@ export namespace adexchangebuyer_v1_4 {
         params,
         requiredParams: ['accountId', 'billingId'],
         pathParams: ['accountId', 'billingId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Budget>(parameters, callback);
@@ -2524,7 +2491,7 @@ export namespace adexchangebuyer_v1_4 {
         params,
         requiredParams: ['accountId', 'billingId'],
         pathParams: ['accountId', 'billingId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Budget>(parameters, callback);
@@ -2592,15 +2559,7 @@ export namespace adexchangebuyer_v1_4 {
 
 
   export class Resource$Creatives {
-    root: Adexchangebuyer;
-    constructor(root: Adexchangebuyer) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -2662,7 +2621,7 @@ export namespace adexchangebuyer_v1_4 {
         params,
         requiredParams: ['accountId', 'buyerCreativeId', 'dealId'],
         pathParams: ['accountId', 'buyerCreativeId', 'dealId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -2727,7 +2686,7 @@ export namespace adexchangebuyer_v1_4 {
         params,
         requiredParams: ['accountId', 'buyerCreativeId'],
         pathParams: ['accountId', 'buyerCreativeId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Creative>(parameters, callback);
@@ -2791,7 +2750,7 @@ export namespace adexchangebuyer_v1_4 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Creative>(parameters, callback);
@@ -2862,7 +2821,7 @@ export namespace adexchangebuyer_v1_4 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$CreativesList>(parameters, callback);
@@ -2932,7 +2891,7 @@ export namespace adexchangebuyer_v1_4 {
         params,
         requiredParams: ['accountId', 'buyerCreativeId'],
         pathParams: ['accountId', 'buyerCreativeId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$CreativeDealIds>(parameters, callback);
@@ -3001,7 +2960,7 @@ export namespace adexchangebuyer_v1_4 {
         params,
         requiredParams: ['accountId', 'buyerCreativeId', 'dealId'],
         pathParams: ['accountId', 'buyerCreativeId', 'dealId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -3134,15 +3093,7 @@ export namespace adexchangebuyer_v1_4 {
 
 
   export class Resource$Marketplacedeals {
-    root: Adexchangebuyer;
-    constructor(root: Adexchangebuyer) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -3206,7 +3157,7 @@ export namespace adexchangebuyer_v1_4 {
         params,
         requiredParams: ['proposalId'],
         pathParams: ['proposalId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$DeleteOrderDealsResponse>(parameters, callback);
@@ -3276,7 +3227,7 @@ export namespace adexchangebuyer_v1_4 {
         params,
         requiredParams: ['proposalId'],
         pathParams: ['proposalId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$AddOrderDealsResponse>(parameters, callback);
@@ -3346,7 +3297,7 @@ export namespace adexchangebuyer_v1_4 {
         params,
         requiredParams: ['proposalId'],
         pathParams: ['proposalId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GetOrderDealsResponse>(parameters, callback);
@@ -3418,7 +3369,7 @@ export namespace adexchangebuyer_v1_4 {
         params,
         requiredParams: ['proposalId'],
         pathParams: ['proposalId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$EditAllOrderDealsResponse>(
@@ -3500,15 +3451,7 @@ export namespace adexchangebuyer_v1_4 {
 
 
   export class Resource$Marketplacenotes {
-    root: Adexchangebuyer;
-    constructor(root: Adexchangebuyer) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -3571,7 +3514,7 @@ export namespace adexchangebuyer_v1_4 {
         params,
         requiredParams: ['proposalId'],
         pathParams: ['proposalId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$AddOrderNotesResponse>(parameters, callback);
@@ -3641,7 +3584,7 @@ export namespace adexchangebuyer_v1_4 {
         params,
         requiredParams: ['proposalId'],
         pathParams: ['proposalId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GetOrderNotesResponse>(parameters, callback);
@@ -3690,15 +3633,7 @@ export namespace adexchangebuyer_v1_4 {
 
 
   export class Resource$Marketplaceprivateauction {
-    root: Adexchangebuyer;
-    constructor(root: Adexchangebuyer) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -3760,7 +3695,7 @@ export namespace adexchangebuyer_v1_4 {
         params,
         requiredParams: ['privateAuctionId'],
         pathParams: ['privateAuctionId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -3790,15 +3725,7 @@ export namespace adexchangebuyer_v1_4 {
 
 
   export class Resource$Performancereport {
-    root: Adexchangebuyer;
-    constructor(root: Adexchangebuyer) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -3863,7 +3790,7 @@ export namespace adexchangebuyer_v1_4 {
         params,
         requiredParams: ['accountId', 'endDateTime', 'startDateTime'],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$PerformanceReportList>(parameters, callback);
@@ -3907,15 +3834,7 @@ export namespace adexchangebuyer_v1_4 {
 
 
   export class Resource$Pretargetingconfig {
-    root: Adexchangebuyer;
-    constructor(root: Adexchangebuyer) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -3976,7 +3895,7 @@ export namespace adexchangebuyer_v1_4 {
         params,
         requiredParams: ['accountId', 'configId'],
         pathParams: ['accountId', 'configId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -4042,7 +3961,7 @@ export namespace adexchangebuyer_v1_4 {
         params,
         requiredParams: ['accountId', 'configId'],
         pathParams: ['accountId', 'configId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$PretargetingConfig>(parameters, callback);
@@ -4111,7 +4030,7 @@ export namespace adexchangebuyer_v1_4 {
         params,
         requiredParams: ['accountId'],
         pathParams: ['accountId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$PretargetingConfig>(parameters, callback);
@@ -4181,7 +4100,7 @@ export namespace adexchangebuyer_v1_4 {
         params,
         requiredParams: ['accountId'],
         pathParams: ['accountId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$PretargetingConfigList>(parameters, callback);
@@ -4253,7 +4172,7 @@ export namespace adexchangebuyer_v1_4 {
         params,
         requiredParams: ['accountId', 'configId'],
         pathParams: ['accountId', 'configId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$PretargetingConfig>(parameters, callback);
@@ -4324,7 +4243,7 @@ export namespace adexchangebuyer_v1_4 {
         params,
         requiredParams: ['accountId', 'configId'],
         pathParams: ['accountId', 'configId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$PretargetingConfig>(parameters, callback);
@@ -4440,15 +4359,7 @@ export namespace adexchangebuyer_v1_4 {
 
 
   export class Resource$Products {
-    root: Adexchangebuyer;
-    constructor(root: Adexchangebuyer) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -4502,7 +4413,7 @@ export namespace adexchangebuyer_v1_4 {
         params,
         requiredParams: ['productId'],
         pathParams: ['productId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Product>(parameters, callback);
@@ -4567,7 +4478,7 @@ export namespace adexchangebuyer_v1_4 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GetOffersResponse>(parameters, callback);
@@ -4602,15 +4513,7 @@ export namespace adexchangebuyer_v1_4 {
 
 
   export class Resource$Proposals {
-    root: Adexchangebuyer;
-    constructor(root: Adexchangebuyer) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -4664,7 +4567,7 @@ export namespace adexchangebuyer_v1_4 {
         params,
         requiredParams: ['proposalId'],
         pathParams: ['proposalId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Proposal>(parameters, callback);
@@ -4730,7 +4633,7 @@ export namespace adexchangebuyer_v1_4 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$CreateOrdersResponse>(parameters, callback);
@@ -4799,7 +4702,7 @@ export namespace adexchangebuyer_v1_4 {
         params,
         requiredParams: ['proposalId', 'revisionNumber', 'updateAction'],
         pathParams: ['proposalId', 'revisionNumber', 'updateAction'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Proposal>(parameters, callback);
@@ -4864,7 +4767,7 @@ export namespace adexchangebuyer_v1_4 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GetOrdersResponse>(parameters, callback);
@@ -4932,7 +4835,7 @@ export namespace adexchangebuyer_v1_4 {
         params,
         requiredParams: ['proposalId'],
         pathParams: ['proposalId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -5001,7 +4904,7 @@ export namespace adexchangebuyer_v1_4 {
         params,
         requiredParams: ['proposalId', 'revisionNumber', 'updateAction'],
         pathParams: ['proposalId', 'revisionNumber', 'updateAction'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Proposal>(parameters, callback);
@@ -5116,15 +5019,7 @@ export namespace adexchangebuyer_v1_4 {
 
 
   export class Resource$Pubprofiles {
-    root: Adexchangebuyer;
-    constructor(root: Adexchangebuyer) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -5188,7 +5083,7 @@ export namespace adexchangebuyer_v1_4 {
         params,
         requiredParams: ['accountId'],
         pathParams: ['accountId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GetPublisherProfilesByAccountIdResponse>(

--- a/src/apis/adexchangebuyer2/v2beta1.ts
+++ b/src/apis/adexchangebuyer2/v2beta1.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace adexchangebuyer2_v2beta1 {
   export interface Options extends GlobalOptions {
     version: 'v2beta1';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -98,24 +100,14 @@ export namespace adexchangebuyer2_v2beta1 {
    * @param {object=} options Options for Adexchangebuyer2
    */
   export class Adexchangebuyer2 {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     accounts: Resource$Accounts;
     bidders: Resource$Bidders;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.accounts = new Resource$Accounts(this);
-      this.bidders = new Resource$Bidders(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.accounts = new Resource$Accounts();
+      this.bidders = new Resource$Bidders();
     }
   }
 
@@ -2512,43 +2504,29 @@ export namespace adexchangebuyer2_v2beta1 {
 
 
   export class Resource$Accounts {
-    root: Adexchangebuyer2;
     clients: Resource$Accounts$Clients;
     creatives: Resource$Accounts$Creatives;
     finalizedProposals: Resource$Accounts$Finalizedproposals;
     products: Resource$Accounts$Products;
     proposals: Resource$Accounts$Proposals;
     publisherProfiles: Resource$Accounts$Publisherprofiles;
-    constructor(root: Adexchangebuyer2) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.clients = new Resource$Accounts$Clients(root);
-      this.creatives = new Resource$Accounts$Creatives(root);
-      this.finalizedProposals = new Resource$Accounts$Finalizedproposals(root);
-      this.products = new Resource$Accounts$Products(root);
-      this.proposals = new Resource$Accounts$Proposals(root);
-      this.publisherProfiles = new Resource$Accounts$Publisherprofiles(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.clients = new Resource$Accounts$Clients();
+      this.creatives = new Resource$Accounts$Creatives();
+      this.finalizedProposals = new Resource$Accounts$Finalizedproposals();
+      this.products = new Resource$Accounts$Products();
+      this.proposals = new Resource$Accounts$Proposals();
+      this.publisherProfiles = new Resource$Accounts$Publisherprofiles();
     }
   }
 
 
   export class Resource$Accounts$Clients {
-    root: Adexchangebuyer2;
     invitations: Resource$Accounts$Clients$Invitations;
     users: Resource$Accounts$Clients$Users;
-    constructor(root: Adexchangebuyer2) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.invitations = new Resource$Accounts$Clients$Invitations(root);
-      this.users = new Resource$Accounts$Clients$Users(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.invitations = new Resource$Accounts$Clients$Invitations();
+      this.users = new Resource$Accounts$Clients$Users();
     }
 
 
@@ -2610,7 +2588,7 @@ export namespace adexchangebuyer2_v2beta1 {
         params,
         requiredParams: ['accountId'],
         pathParams: ['accountId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Client>(parameters, callback);
@@ -2675,7 +2653,7 @@ export namespace adexchangebuyer2_v2beta1 {
         params,
         requiredParams: ['accountId', 'clientAccountId'],
         pathParams: ['accountId', 'clientAccountId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Client>(parameters, callback);
@@ -2746,7 +2724,7 @@ export namespace adexchangebuyer2_v2beta1 {
         params,
         requiredParams: ['accountId'],
         pathParams: ['accountId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListClientsResponse>(parameters, callback);
@@ -2816,7 +2794,7 @@ export namespace adexchangebuyer2_v2beta1 {
         params,
         requiredParams: ['accountId', 'clientAccountId'],
         pathParams: ['accountId', 'clientAccountId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Client>(parameters, callback);
@@ -2913,15 +2891,7 @@ export namespace adexchangebuyer2_v2beta1 {
   }
 
   export class Resource$Accounts$Clients$Invitations {
-    root: Adexchangebuyer2;
-    constructor(root: Adexchangebuyer2) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -2988,7 +2958,7 @@ export namespace adexchangebuyer2_v2beta1 {
         params,
         requiredParams: ['accountId', 'clientAccountId'],
         pathParams: ['accountId', 'clientAccountId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ClientUserInvitation>(parameters, callback);
@@ -3057,7 +3027,7 @@ export namespace adexchangebuyer2_v2beta1 {
         params,
         requiredParams: ['accountId', 'clientAccountId', 'invitationId'],
         pathParams: ['accountId', 'clientAccountId', 'invitationId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ClientUserInvitation>(parameters, callback);
@@ -3140,7 +3110,7 @@ export namespace adexchangebuyer2_v2beta1 {
         params,
         requiredParams: ['accountId', 'clientAccountId'],
         pathParams: ['accountId', 'clientAccountId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListClientUserInvitationsResponse>(
@@ -3229,15 +3199,7 @@ export namespace adexchangebuyer2_v2beta1 {
 
 
   export class Resource$Accounts$Clients$Users {
-    root: Adexchangebuyer2;
-    constructor(root: Adexchangebuyer2) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -3298,7 +3260,7 @@ export namespace adexchangebuyer2_v2beta1 {
         params,
         requiredParams: ['accountId', 'clientAccountId', 'userId'],
         pathParams: ['accountId', 'clientAccountId', 'userId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ClientUser>(parameters, callback);
@@ -3373,7 +3335,7 @@ export namespace adexchangebuyer2_v2beta1 {
         params,
         requiredParams: ['accountId', 'clientAccountId'],
         pathParams: ['accountId', 'clientAccountId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListClientUsersResponse>(parameters, callback);
@@ -3447,7 +3409,7 @@ export namespace adexchangebuyer2_v2beta1 {
         params,
         requiredParams: ['accountId', 'clientAccountId', 'userId'],
         pathParams: ['accountId', 'clientAccountId', 'userId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ClientUser>(parameters, callback);
@@ -3540,17 +3502,10 @@ export namespace adexchangebuyer2_v2beta1 {
 
 
   export class Resource$Accounts$Creatives {
-    root: Adexchangebuyer2;
     dealAssociations: Resource$Accounts$Creatives$Dealassociations;
-    constructor(root: Adexchangebuyer2) {
-      this.root = root;
-      this.getRoot.bind(this);
+    constructor() {
       this.dealAssociations =
-          new Resource$Accounts$Creatives$Dealassociations(root);
-    }
-
-    getRoot() {
-      return this.root;
+          new Resource$Accounts$Creatives$Dealassociations();
     }
 
 
@@ -3613,7 +3568,7 @@ export namespace adexchangebuyer2_v2beta1 {
         params,
         requiredParams: ['accountId'],
         pathParams: ['accountId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Creative>(parameters, callback);
@@ -3678,7 +3633,7 @@ export namespace adexchangebuyer2_v2beta1 {
         params,
         requiredParams: ['accountId', 'creativeId'],
         pathParams: ['accountId', 'creativeId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Creative>(parameters, callback);
@@ -3750,7 +3705,7 @@ export namespace adexchangebuyer2_v2beta1 {
         params,
         requiredParams: ['accountId'],
         pathParams: ['accountId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListCreativesResponse>(parameters, callback);
@@ -3822,7 +3777,7 @@ export namespace adexchangebuyer2_v2beta1 {
         params,
         requiredParams: ['accountId', 'creativeId'],
         pathParams: ['accountId', 'creativeId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -3892,7 +3847,7 @@ export namespace adexchangebuyer2_v2beta1 {
         params,
         requiredParams: ['accountId', 'creativeId'],
         pathParams: ['accountId', 'creativeId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Creative>(parameters, callback);
@@ -3964,7 +3919,7 @@ export namespace adexchangebuyer2_v2beta1 {
         params,
         requiredParams: ['accountId', 'creativeId'],
         pathParams: ['accountId', 'creativeId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -4123,15 +4078,7 @@ export namespace adexchangebuyer2_v2beta1 {
   }
 
   export class Resource$Accounts$Creatives$Dealassociations {
-    root: Adexchangebuyer2;
-    constructor(root: Adexchangebuyer2) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -4192,7 +4139,7 @@ export namespace adexchangebuyer2_v2beta1 {
         params,
         requiredParams: ['accountId', 'creativeId'],
         pathParams: ['accountId', 'creativeId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -4272,7 +4219,7 @@ export namespace adexchangebuyer2_v2beta1 {
         params,
         requiredParams: ['accountId', 'creativeId'],
         pathParams: ['accountId', 'creativeId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListDealAssociationsResponse>(
@@ -4347,7 +4294,7 @@ export namespace adexchangebuyer2_v2beta1 {
         params,
         requiredParams: ['accountId', 'creativeId'],
         pathParams: ['accountId', 'creativeId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -4444,15 +4391,7 @@ export namespace adexchangebuyer2_v2beta1 {
 
 
   export class Resource$Accounts$Finalizedproposals {
-    root: Adexchangebuyer2;
-    constructor(root: Adexchangebuyer2) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -4521,7 +4460,7 @@ export namespace adexchangebuyer2_v2beta1 {
         params,
         requiredParams: ['accountId'],
         pathParams: ['accountId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListProposalsResponse>(parameters, callback);
@@ -4566,15 +4505,7 @@ export namespace adexchangebuyer2_v2beta1 {
 
 
   export class Resource$Accounts$Products {
-    root: Adexchangebuyer2;
-    constructor(root: Adexchangebuyer2) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -4632,7 +4563,7 @@ export namespace adexchangebuyer2_v2beta1 {
         params,
         requiredParams: ['accountId', 'productId'],
         pathParams: ['accountId', 'productId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Product>(parameters, callback);
@@ -4705,7 +4636,7 @@ export namespace adexchangebuyer2_v2beta1 {
         params,
         requiredParams: ['accountId'],
         pathParams: ['accountId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListProductsResponse>(parameters, callback);
@@ -4762,15 +4693,7 @@ export namespace adexchangebuyer2_v2beta1 {
 
 
   export class Resource$Accounts$Proposals {
-    root: Adexchangebuyer2;
-    constructor(root: Adexchangebuyer2) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -4837,7 +4760,7 @@ export namespace adexchangebuyer2_v2beta1 {
         params,
         requiredParams: ['accountId', 'proposalId'],
         pathParams: ['accountId', 'proposalId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Proposal>(parameters, callback);
@@ -4910,7 +4833,7 @@ export namespace adexchangebuyer2_v2beta1 {
         params,
         requiredParams: ['accountId', 'proposalId'],
         pathParams: ['accountId', 'proposalId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Note>(parameters, callback);
@@ -4983,7 +4906,7 @@ export namespace adexchangebuyer2_v2beta1 {
         params,
         requiredParams: ['accountId', 'proposalId'],
         pathParams: ['accountId', 'proposalId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Proposal>(parameters, callback);
@@ -5060,7 +4983,7 @@ export namespace adexchangebuyer2_v2beta1 {
         params,
         requiredParams: ['accountId', 'proposalId'],
         pathParams: ['accountId', 'proposalId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Proposal>(parameters, callback);
@@ -5129,7 +5052,7 @@ export namespace adexchangebuyer2_v2beta1 {
         params,
         requiredParams: ['accountId'],
         pathParams: ['accountId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Proposal>(parameters, callback);
@@ -5195,7 +5118,7 @@ export namespace adexchangebuyer2_v2beta1 {
         params,
         requiredParams: ['accountId', 'proposalId'],
         pathParams: ['accountId', 'proposalId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Proposal>(parameters, callback);
@@ -5273,7 +5196,7 @@ export namespace adexchangebuyer2_v2beta1 {
         params,
         requiredParams: ['accountId'],
         pathParams: ['accountId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListProposalsResponse>(parameters, callback);
@@ -5348,7 +5271,7 @@ export namespace adexchangebuyer2_v2beta1 {
         params,
         requiredParams: ['accountId', 'proposalId'],
         pathParams: ['accountId', 'proposalId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Proposal>(parameters, callback);
@@ -5424,7 +5347,7 @@ export namespace adexchangebuyer2_v2beta1 {
         params,
         requiredParams: ['accountId', 'proposalId'],
         pathParams: ['accountId', 'proposalId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Proposal>(parameters, callback);
@@ -5503,7 +5426,7 @@ export namespace adexchangebuyer2_v2beta1 {
         params,
         requiredParams: ['accountId', 'proposalId'],
         pathParams: ['accountId', 'proposalId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Proposal>(parameters, callback);
@@ -5728,15 +5651,7 @@ export namespace adexchangebuyer2_v2beta1 {
 
 
   export class Resource$Accounts$Publisherprofiles {
-    root: Adexchangebuyer2;
-    constructor(root: Adexchangebuyer2) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -5796,7 +5711,7 @@ export namespace adexchangebuyer2_v2beta1 {
         params,
         requiredParams: ['accountId', 'publisherProfileId'],
         pathParams: ['accountId', 'publisherProfileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$PublisherProfile>(parameters, callback);
@@ -5871,7 +5786,7 @@ export namespace adexchangebuyer2_v2beta1 {
         params,
         requiredParams: ['accountId'],
         pathParams: ['accountId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListPublisherProfilesResponse>(
@@ -5923,49 +5838,27 @@ export namespace adexchangebuyer2_v2beta1 {
 
 
   export class Resource$Bidders {
-    root: Adexchangebuyer2;
     accounts: Resource$Bidders$Accounts;
     filterSets: Resource$Bidders$Filtersets;
-    constructor(root: Adexchangebuyer2) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.accounts = new Resource$Bidders$Accounts(root);
-      this.filterSets = new Resource$Bidders$Filtersets(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.accounts = new Resource$Bidders$Accounts();
+      this.filterSets = new Resource$Bidders$Filtersets();
     }
   }
 
 
   export class Resource$Bidders$Accounts {
-    root: Adexchangebuyer2;
     creatives: Resource$Bidders$Accounts$Creatives;
     filterSets: Resource$Bidders$Accounts$Filtersets;
-    constructor(root: Adexchangebuyer2) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.creatives = new Resource$Bidders$Accounts$Creatives(root);
-      this.filterSets = new Resource$Bidders$Accounts$Filtersets(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.creatives = new Resource$Bidders$Accounts$Creatives();
+      this.filterSets = new Resource$Bidders$Accounts$Filtersets();
     }
   }
 
 
   export class Resource$Bidders$Accounts$Creatives {
-    root: Adexchangebuyer2;
-    constructor(root: Adexchangebuyer2) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -6029,7 +5922,7 @@ export namespace adexchangebuyer2_v2beta1 {
         params,
         requiredParams: ['ownerName', 'creativeId'],
         pathParams: ['creativeId', 'ownerName'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -6062,7 +5955,6 @@ export namespace adexchangebuyer2_v2beta1 {
 
 
   export class Resource$Bidders$Accounts$Filtersets {
-    root: Adexchangebuyer2;
     bidMetrics: Resource$Bidders$Accounts$Filtersets$Bidmetrics;
     bidResponseErrors: Resource$Bidders$Accounts$Filtersets$Bidresponseerrors;
     bidResponsesWithoutBids:
@@ -6074,30 +5966,21 @@ export namespace adexchangebuyer2_v2beta1 {
     losingBids: Resource$Bidders$Accounts$Filtersets$Losingbids;
     nonBillableWinningBids:
         Resource$Bidders$Accounts$Filtersets$Nonbillablewinningbids;
-    constructor(root: Adexchangebuyer2) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.bidMetrics =
-          new Resource$Bidders$Accounts$Filtersets$Bidmetrics(root);
+    constructor() {
+      this.bidMetrics = new Resource$Bidders$Accounts$Filtersets$Bidmetrics();
       this.bidResponseErrors =
-          new Resource$Bidders$Accounts$Filtersets$Bidresponseerrors(root);
+          new Resource$Bidders$Accounts$Filtersets$Bidresponseerrors();
       this.bidResponsesWithoutBids =
-          new Resource$Bidders$Accounts$Filtersets$Bidresponseswithoutbids(
-              root);
+          new Resource$Bidders$Accounts$Filtersets$Bidresponseswithoutbids();
       this.filteredBidRequests =
-          new Resource$Bidders$Accounts$Filtersets$Filteredbidrequests(root);
+          new Resource$Bidders$Accounts$Filtersets$Filteredbidrequests();
       this.filteredBids =
-          new Resource$Bidders$Accounts$Filtersets$Filteredbids(root);
+          new Resource$Bidders$Accounts$Filtersets$Filteredbids();
       this.impressionMetrics =
-          new Resource$Bidders$Accounts$Filtersets$Impressionmetrics(root);
-      this.losingBids =
-          new Resource$Bidders$Accounts$Filtersets$Losingbids(root);
+          new Resource$Bidders$Accounts$Filtersets$Impressionmetrics();
+      this.losingBids = new Resource$Bidders$Accounts$Filtersets$Losingbids();
       this.nonBillableWinningBids =
-          new Resource$Bidders$Accounts$Filtersets$Nonbillablewinningbids(root);
-    }
-
-    getRoot() {
-      return this.root;
+          new Resource$Bidders$Accounts$Filtersets$Nonbillablewinningbids();
     }
 
 
@@ -6162,7 +6045,7 @@ export namespace adexchangebuyer2_v2beta1 {
         params,
         requiredParams: ['ownerName'],
         pathParams: ['ownerName'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$FilterSet>(parameters, callback);
@@ -6229,7 +6112,7 @@ export namespace adexchangebuyer2_v2beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -6293,7 +6176,7 @@ export namespace adexchangebuyer2_v2beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$FilterSet>(parameters, callback);
@@ -6364,7 +6247,7 @@ export namespace adexchangebuyer2_v2beta1 {
         params,
         requiredParams: ['ownerName'],
         pathParams: ['ownerName'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListFilterSetsResponse>(parameters, callback);
@@ -6466,15 +6349,7 @@ export namespace adexchangebuyer2_v2beta1 {
   }
 
   export class Resource$Bidders$Accounts$Filtersets$Bidmetrics {
-    root: Adexchangebuyer2;
-    constructor(root: Adexchangebuyer2) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -6540,7 +6415,7 @@ export namespace adexchangebuyer2_v2beta1 {
         params,
         requiredParams: ['filterSetName'],
         pathParams: ['filterSetName'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListBidMetricsResponse>(parameters, callback);
@@ -6582,15 +6457,7 @@ export namespace adexchangebuyer2_v2beta1 {
 
 
   export class Resource$Bidders$Accounts$Filtersets$Bidresponseerrors {
-    root: Adexchangebuyer2;
-    constructor(root: Adexchangebuyer2) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -6665,7 +6532,7 @@ export namespace adexchangebuyer2_v2beta1 {
         params,
         requiredParams: ['filterSetName'],
         pathParams: ['filterSetName'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListBidResponseErrorsResponse>(
@@ -6710,15 +6577,7 @@ export namespace adexchangebuyer2_v2beta1 {
 
 
   export class Resource$Bidders$Accounts$Filtersets$Bidresponseswithoutbids {
-    root: Adexchangebuyer2;
-    constructor(root: Adexchangebuyer2) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -6799,7 +6658,7 @@ export namespace adexchangebuyer2_v2beta1 {
         params,
         requiredParams: ['filterSetName'],
         pathParams: ['filterSetName'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListBidResponsesWithoutBidsResponse>(
@@ -6844,15 +6703,7 @@ export namespace adexchangebuyer2_v2beta1 {
 
 
   export class Resource$Bidders$Accounts$Filtersets$Filteredbidrequests {
-    root: Adexchangebuyer2;
-    constructor(root: Adexchangebuyer2) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -6929,7 +6780,7 @@ export namespace adexchangebuyer2_v2beta1 {
         params,
         requiredParams: ['filterSetName'],
         pathParams: ['filterSetName'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListFilteredBidRequestsResponse>(
@@ -6974,20 +6825,13 @@ export namespace adexchangebuyer2_v2beta1 {
 
 
   export class Resource$Bidders$Accounts$Filtersets$Filteredbids {
-    root: Adexchangebuyer2;
     creatives: Resource$Bidders$Accounts$Filtersets$Filteredbids$Creatives;
     details: Resource$Bidders$Accounts$Filtersets$Filteredbids$Details;
-    constructor(root: Adexchangebuyer2) {
-      this.root = root;
-      this.getRoot.bind(this);
+    constructor() {
       this.creatives =
-          new Resource$Bidders$Accounts$Filtersets$Filteredbids$Creatives(root);
+          new Resource$Bidders$Accounts$Filtersets$Filteredbids$Creatives();
       this.details =
-          new Resource$Bidders$Accounts$Filtersets$Filteredbids$Details(root);
-    }
-
-    getRoot() {
-      return this.root;
+          new Resource$Bidders$Accounts$Filtersets$Filteredbids$Details();
     }
 
 
@@ -7055,7 +6899,7 @@ export namespace adexchangebuyer2_v2beta1 {
         params,
         requiredParams: ['filterSetName'],
         pathParams: ['filterSetName'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListFilteredBidsResponse>(parameters, callback);
@@ -7096,15 +6940,7 @@ export namespace adexchangebuyer2_v2beta1 {
   }
 
   export class Resource$Bidders$Accounts$Filtersets$Filteredbids$Creatives {
-    root: Adexchangebuyer2;
-    constructor(root: Adexchangebuyer2) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -7184,7 +7020,7 @@ export namespace adexchangebuyer2_v2beta1 {
         params,
         requiredParams: ['filterSetName', 'creativeStatusId'],
         pathParams: ['creativeStatusId', 'filterSetName'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListCreativeStatusBreakdownByCreativeResponse>(
@@ -7235,15 +7071,7 @@ export namespace adexchangebuyer2_v2beta1 {
 
 
   export class Resource$Bidders$Accounts$Filtersets$Filteredbids$Details {
-    root: Adexchangebuyer2;
-    constructor(root: Adexchangebuyer2) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -7323,7 +7151,7 @@ export namespace adexchangebuyer2_v2beta1 {
         params,
         requiredParams: ['filterSetName', 'creativeStatusId'],
         pathParams: ['creativeStatusId', 'filterSetName'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListCreativeStatusBreakdownByDetailResponse>(
@@ -7377,15 +7205,7 @@ export namespace adexchangebuyer2_v2beta1 {
 
 
   export class Resource$Bidders$Accounts$Filtersets$Impressionmetrics {
-    root: Adexchangebuyer2;
-    constructor(root: Adexchangebuyer2) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -7460,7 +7280,7 @@ export namespace adexchangebuyer2_v2beta1 {
         params,
         requiredParams: ['filterSetName'],
         pathParams: ['filterSetName'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListImpressionMetricsResponse>(
@@ -7505,15 +7325,7 @@ export namespace adexchangebuyer2_v2beta1 {
 
 
   export class Resource$Bidders$Accounts$Filtersets$Losingbids {
-    root: Adexchangebuyer2;
-    constructor(root: Adexchangebuyer2) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -7580,7 +7392,7 @@ export namespace adexchangebuyer2_v2beta1 {
         params,
         requiredParams: ['filterSetName'],
         pathParams: ['filterSetName'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListLosingBidsResponse>(parameters, callback);
@@ -7622,15 +7434,7 @@ export namespace adexchangebuyer2_v2beta1 {
 
 
   export class Resource$Bidders$Accounts$Filtersets$Nonbillablewinningbids {
-    root: Adexchangebuyer2;
-    constructor(root: Adexchangebuyer2) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -7710,7 +7514,7 @@ export namespace adexchangebuyer2_v2beta1 {
         params,
         requiredParams: ['filterSetName'],
         pathParams: ['filterSetName'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListNonBillableWinningBidsResponse>(
@@ -7756,7 +7560,6 @@ export namespace adexchangebuyer2_v2beta1 {
 
 
   export class Resource$Bidders$Filtersets {
-    root: Adexchangebuyer2;
     bidMetrics: Resource$Bidders$Filtersets$Bidmetrics;
     bidResponseErrors: Resource$Bidders$Filtersets$Bidresponseerrors;
     bidResponsesWithoutBids:
@@ -7766,26 +7569,20 @@ export namespace adexchangebuyer2_v2beta1 {
     impressionMetrics: Resource$Bidders$Filtersets$Impressionmetrics;
     losingBids: Resource$Bidders$Filtersets$Losingbids;
     nonBillableWinningBids: Resource$Bidders$Filtersets$Nonbillablewinningbids;
-    constructor(root: Adexchangebuyer2) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.bidMetrics = new Resource$Bidders$Filtersets$Bidmetrics(root);
+    constructor() {
+      this.bidMetrics = new Resource$Bidders$Filtersets$Bidmetrics();
       this.bidResponseErrors =
-          new Resource$Bidders$Filtersets$Bidresponseerrors(root);
+          new Resource$Bidders$Filtersets$Bidresponseerrors();
       this.bidResponsesWithoutBids =
-          new Resource$Bidders$Filtersets$Bidresponseswithoutbids(root);
+          new Resource$Bidders$Filtersets$Bidresponseswithoutbids();
       this.filteredBidRequests =
-          new Resource$Bidders$Filtersets$Filteredbidrequests(root);
-      this.filteredBids = new Resource$Bidders$Filtersets$Filteredbids(root);
+          new Resource$Bidders$Filtersets$Filteredbidrequests();
+      this.filteredBids = new Resource$Bidders$Filtersets$Filteredbids();
       this.impressionMetrics =
-          new Resource$Bidders$Filtersets$Impressionmetrics(root);
-      this.losingBids = new Resource$Bidders$Filtersets$Losingbids(root);
+          new Resource$Bidders$Filtersets$Impressionmetrics();
+      this.losingBids = new Resource$Bidders$Filtersets$Losingbids();
       this.nonBillableWinningBids =
-          new Resource$Bidders$Filtersets$Nonbillablewinningbids(root);
-    }
-
-    getRoot() {
-      return this.root;
+          new Resource$Bidders$Filtersets$Nonbillablewinningbids();
     }
 
 
@@ -7850,7 +7647,7 @@ export namespace adexchangebuyer2_v2beta1 {
         params,
         requiredParams: ['ownerName'],
         pathParams: ['ownerName'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$FilterSet>(parameters, callback);
@@ -7917,7 +7714,7 @@ export namespace adexchangebuyer2_v2beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -7981,7 +7778,7 @@ export namespace adexchangebuyer2_v2beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$FilterSet>(parameters, callback);
@@ -8052,7 +7849,7 @@ export namespace adexchangebuyer2_v2beta1 {
         params,
         requiredParams: ['ownerName'],
         pathParams: ['ownerName'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListFilterSetsResponse>(parameters, callback);
@@ -8154,15 +7951,7 @@ export namespace adexchangebuyer2_v2beta1 {
   }
 
   export class Resource$Bidders$Filtersets$Bidmetrics {
-    root: Adexchangebuyer2;
-    constructor(root: Adexchangebuyer2) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -8226,7 +8015,7 @@ export namespace adexchangebuyer2_v2beta1 {
         params,
         requiredParams: ['filterSetName'],
         pathParams: ['filterSetName'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListBidMetricsResponse>(parameters, callback);
@@ -8268,15 +8057,7 @@ export namespace adexchangebuyer2_v2beta1 {
 
 
   export class Resource$Bidders$Filtersets$Bidresponseerrors {
-    root: Adexchangebuyer2;
-    constructor(root: Adexchangebuyer2) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -8347,7 +8128,7 @@ export namespace adexchangebuyer2_v2beta1 {
         params,
         requiredParams: ['filterSetName'],
         pathParams: ['filterSetName'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListBidResponseErrorsResponse>(
@@ -8392,15 +8173,7 @@ export namespace adexchangebuyer2_v2beta1 {
 
 
   export class Resource$Bidders$Filtersets$Bidresponseswithoutbids {
-    root: Adexchangebuyer2;
-    constructor(root: Adexchangebuyer2) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -8478,7 +8251,7 @@ export namespace adexchangebuyer2_v2beta1 {
         params,
         requiredParams: ['filterSetName'],
         pathParams: ['filterSetName'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListBidResponsesWithoutBidsResponse>(
@@ -8523,15 +8296,7 @@ export namespace adexchangebuyer2_v2beta1 {
 
 
   export class Resource$Bidders$Filtersets$Filteredbidrequests {
-    root: Adexchangebuyer2;
-    constructor(root: Adexchangebuyer2) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -8604,7 +8369,7 @@ export namespace adexchangebuyer2_v2beta1 {
         params,
         requiredParams: ['filterSetName'],
         pathParams: ['filterSetName'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListFilteredBidRequestsResponse>(
@@ -8649,19 +8414,11 @@ export namespace adexchangebuyer2_v2beta1 {
 
 
   export class Resource$Bidders$Filtersets$Filteredbids {
-    root: Adexchangebuyer2;
     creatives: Resource$Bidders$Filtersets$Filteredbids$Creatives;
     details: Resource$Bidders$Filtersets$Filteredbids$Details;
-    constructor(root: Adexchangebuyer2) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.creatives =
-          new Resource$Bidders$Filtersets$Filteredbids$Creatives(root);
-      this.details = new Resource$Bidders$Filtersets$Filteredbids$Details(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.creatives = new Resource$Bidders$Filtersets$Filteredbids$Creatives();
+      this.details = new Resource$Bidders$Filtersets$Filteredbids$Details();
     }
 
 
@@ -8727,7 +8484,7 @@ export namespace adexchangebuyer2_v2beta1 {
         params,
         requiredParams: ['filterSetName'],
         pathParams: ['filterSetName'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListFilteredBidsResponse>(parameters, callback);
@@ -8768,15 +8525,7 @@ export namespace adexchangebuyer2_v2beta1 {
   }
 
   export class Resource$Bidders$Filtersets$Filteredbids$Creatives {
-    root: Adexchangebuyer2;
-    constructor(root: Adexchangebuyer2) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -8852,7 +8601,7 @@ export namespace adexchangebuyer2_v2beta1 {
         params,
         requiredParams: ['filterSetName', 'creativeStatusId'],
         pathParams: ['creativeStatusId', 'filterSetName'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListCreativeStatusBreakdownByCreativeResponse>(
@@ -8903,15 +8652,7 @@ export namespace adexchangebuyer2_v2beta1 {
 
 
   export class Resource$Bidders$Filtersets$Filteredbids$Details {
-    root: Adexchangebuyer2;
-    constructor(root: Adexchangebuyer2) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -8987,7 +8728,7 @@ export namespace adexchangebuyer2_v2beta1 {
         params,
         requiredParams: ['filterSetName', 'creativeStatusId'],
         pathParams: ['creativeStatusId', 'filterSetName'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListCreativeStatusBreakdownByDetailResponse>(
@@ -9041,15 +8782,7 @@ export namespace adexchangebuyer2_v2beta1 {
 
 
   export class Resource$Bidders$Filtersets$Impressionmetrics {
-    root: Adexchangebuyer2;
-    constructor(root: Adexchangebuyer2) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -9120,7 +8853,7 @@ export namespace adexchangebuyer2_v2beta1 {
         params,
         requiredParams: ['filterSetName'],
         pathParams: ['filterSetName'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListImpressionMetricsResponse>(
@@ -9165,15 +8898,7 @@ export namespace adexchangebuyer2_v2beta1 {
 
 
   export class Resource$Bidders$Filtersets$Losingbids {
-    root: Adexchangebuyer2;
-    constructor(root: Adexchangebuyer2) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -9238,7 +8963,7 @@ export namespace adexchangebuyer2_v2beta1 {
         params,
         requiredParams: ['filterSetName'],
         pathParams: ['filterSetName'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListLosingBidsResponse>(parameters, callback);
@@ -9280,15 +9005,7 @@ export namespace adexchangebuyer2_v2beta1 {
 
 
   export class Resource$Bidders$Filtersets$Nonbillablewinningbids {
-    root: Adexchangebuyer2;
-    constructor(root: Adexchangebuyer2) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -9364,7 +9081,7 @@ export namespace adexchangebuyer2_v2beta1 {
         params,
         requiredParams: ['filterSetName'],
         pathParams: ['filterSetName'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListNonBillableWinningBidsResponse>(

--- a/src/apis/adexperiencereport/v1.ts
+++ b/src/apis/adexperiencereport/v1.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace adexperiencereport_v1 {
   export interface Options extends GlobalOptions {
     version: 'v1';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -97,24 +99,14 @@ export namespace adexperiencereport_v1 {
    * @param {object=} options Options for Adexperiencereport
    */
   export class Adexperiencereport {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     sites: Resource$Sites;
     violatingSites: Resource$Violatingsites;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.sites = new Resource$Sites(this);
-      this.violatingSites = new Resource$Violatingsites(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.sites = new Resource$Sites();
+      this.violatingSites = new Resource$Violatingsites();
     }
   }
 
@@ -180,15 +172,7 @@ export namespace adexperiencereport_v1 {
 
 
   export class Resource$Sites {
-    root: Adexperiencereport;
-    constructor(root: Adexperiencereport) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -243,7 +227,7 @@ export namespace adexperiencereport_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$SiteSummaryResponse>(parameters, callback);
@@ -274,15 +258,7 @@ export namespace adexperiencereport_v1 {
 
 
   export class Resource$Violatingsites {
-    root: Adexperiencereport;
-    constructor(root: Adexperiencereport) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -343,7 +319,7 @@ export namespace adexperiencereport_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ViolatingSitesResponse>(parameters, callback);

--- a/src/apis/admin/datatransfer_v1.ts
+++ b/src/apis/admin/datatransfer_v1.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace admin_datatransfer_v1 {
   export interface Options extends GlobalOptions {
     version: 'datatransfer_v1';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -79,24 +81,14 @@ export namespace admin_datatransfer_v1 {
    * @param {object=} options Options for Admin
    */
   export class Admin {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     applications: Resource$Applications;
     transfers: Resource$Transfers;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.applications = new Resource$Applications(this);
-      this.transfers = new Resource$Transfers(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.applications = new Resource$Applications();
+      this.transfers = new Resource$Transfers();
     }
   }
 
@@ -246,15 +238,7 @@ export namespace admin_datatransfer_v1 {
 
 
   export class Resource$Applications {
-    root: Admin;
-    constructor(root: Admin) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -311,7 +295,7 @@ export namespace admin_datatransfer_v1 {
         params,
         requiredParams: ['applicationId'],
         pathParams: ['applicationId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Application>(parameters, callback);
@@ -380,7 +364,7 @@ export namespace admin_datatransfer_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ApplicationsListResponse>(parameters, callback);
@@ -424,15 +408,7 @@ export namespace admin_datatransfer_v1 {
 
 
   export class Resource$Transfers {
-    root: Admin;
-    constructor(root: Admin) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -488,7 +464,7 @@ export namespace admin_datatransfer_v1 {
         params,
         requiredParams: ['dataTransferId'],
         pathParams: ['dataTransferId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$DataTransfer>(parameters, callback);
@@ -553,7 +529,7 @@ export namespace admin_datatransfer_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$DataTransfer>(parameters, callback);
@@ -626,7 +602,7 @@ export namespace admin_datatransfer_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$DataTransfersListResponse>(

--- a/src/apis/admin/directory_v1.ts
+++ b/src/apis/admin/directory_v1.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace admin_directory_v1 {
   export interface Options extends GlobalOptions {
     version: 'directory_v1';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -80,10 +82,6 @@ export namespace admin_directory_v1 {
    * @param {object=} options Options for Admin
    */
   export class Admin {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     asps: Resource$Asps;
     channels: Resource$Channels;
     chromeosdevices: Resource$Chromeosdevices;
@@ -106,35 +104,28 @@ export namespace admin_directory_v1 {
     verificationCodes: Resource$Verificationcodes;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.asps = new Resource$Asps(this);
-      this.channels = new Resource$Channels(this);
-      this.chromeosdevices = new Resource$Chromeosdevices(this);
-      this.customers = new Resource$Customers(this);
-      this.domainAliases = new Resource$Domainaliases(this);
-      this.domains = new Resource$Domains(this);
-      this.groups = new Resource$Groups(this);
-      this.members = new Resource$Members(this);
-      this.mobiledevices = new Resource$Mobiledevices(this);
-      this.notifications = new Resource$Notifications(this);
-      this.orgunits = new Resource$Orgunits(this);
-      this.privileges = new Resource$Privileges(this);
-      this.resolvedAppAccessSettings =
-          new Resource$Resolvedappaccesssettings(this);
-      this.resources = new Resource$Resources(this);
-      this.roleAssignments = new Resource$Roleassignments(this);
-      this.roles = new Resource$Roles(this);
-      this.schemas = new Resource$Schemas(this);
-      this.tokens = new Resource$Tokens(this);
-      this.users = new Resource$Users(this);
-      this.verificationCodes = new Resource$Verificationcodes(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.asps = new Resource$Asps();
+      this.channels = new Resource$Channels();
+      this.chromeosdevices = new Resource$Chromeosdevices();
+      this.customers = new Resource$Customers();
+      this.domainAliases = new Resource$Domainaliases();
+      this.domains = new Resource$Domains();
+      this.groups = new Resource$Groups();
+      this.members = new Resource$Members();
+      this.mobiledevices = new Resource$Mobiledevices();
+      this.notifications = new Resource$Notifications();
+      this.orgunits = new Resource$Orgunits();
+      this.privileges = new Resource$Privileges();
+      this.resolvedAppAccessSettings = new Resource$Resolvedappaccesssettings();
+      this.resources = new Resource$Resources();
+      this.roleAssignments = new Resource$Roleassignments();
+      this.roles = new Resource$Roles();
+      this.schemas = new Resource$Schemas();
+      this.tokens = new Resource$Tokens();
+      this.users = new Resource$Users();
+      this.verificationCodes = new Resource$Verificationcodes();
     }
   }
 
@@ -2457,15 +2448,7 @@ export namespace admin_directory_v1 {
 
 
   export class Resource$Asps {
-    root: Admin;
-    constructor(root: Admin) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -2523,7 +2506,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['userKey', 'codeId'],
         pathParams: ['codeId', 'userKey'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -2586,7 +2569,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['userKey', 'codeId'],
         pathParams: ['codeId', 'userKey'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Asp>(parameters, callback);
@@ -2650,7 +2633,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['userKey'],
         pathParams: ['userKey'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Asps>(parameters, callback);
@@ -2707,15 +2690,7 @@ export namespace admin_directory_v1 {
 
 
   export class Resource$Channels {
-    root: Admin;
-    constructor(root: Admin) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -2772,7 +2747,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -2797,15 +2772,7 @@ export namespace admin_directory_v1 {
 
 
   export class Resource$Chromeosdevices {
-    root: Admin;
-    constructor(root: Admin) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -2867,7 +2834,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['customerId', 'resourceId'],
         pathParams: ['customerId', 'resourceId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -2934,7 +2901,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['customerId', 'deviceId'],
         pathParams: ['customerId', 'deviceId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ChromeOsDevice>(parameters, callback);
@@ -3010,7 +2977,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['customerId'],
         pathParams: ['customerId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ChromeOsDevices>(parameters, callback);
@@ -3079,7 +3046,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['customerId', 'orgUnitPath'],
         pathParams: ['customerId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -3151,7 +3118,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['customerId', 'deviceId'],
         pathParams: ['customerId', 'deviceId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ChromeOsDevice>(parameters, callback);
@@ -3223,7 +3190,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['customerId', 'deviceId'],
         pathParams: ['customerId', 'deviceId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ChromeOsDevice>(parameters, callback);
@@ -3390,15 +3357,7 @@ export namespace admin_directory_v1 {
 
 
   export class Resource$Customers {
-    root: Admin;
-    constructor(root: Admin) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -3452,7 +3411,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['customerKey'],
         pathParams: ['customerKey'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Customer>(parameters, callback);
@@ -3517,7 +3476,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['customerKey'],
         pathParams: ['customerKey'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Customer>(parameters, callback);
@@ -3582,7 +3541,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['customerKey'],
         pathParams: ['customerKey'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Customer>(parameters, callback);
@@ -3638,15 +3597,7 @@ export namespace admin_directory_v1 {
 
 
   export class Resource$Domainaliases {
-    root: Admin;
-    constructor(root: Admin) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -3707,7 +3658,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['customer', 'domainAliasName'],
         pathParams: ['customer', 'domainAliasName'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -3773,7 +3724,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['customer', 'domainAliasName'],
         pathParams: ['customer', 'domainAliasName'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$DomainAlias>(parameters, callback);
@@ -3842,7 +3793,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['customer'],
         pathParams: ['customer'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$DomainAlias>(parameters, callback);
@@ -3910,7 +3861,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['customer'],
         pathParams: ['customer'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$DomainAliases>(parameters, callback);
@@ -3988,15 +3939,7 @@ export namespace admin_directory_v1 {
 
 
   export class Resource$Domains {
-    root: Admin;
-    constructor(root: Admin) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -4055,7 +3998,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['customer', 'domainName'],
         pathParams: ['customer', 'domainName'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -4119,7 +4062,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['customer', 'domainName'],
         pathParams: ['customer', 'domainName'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Domains>(parameters, callback);
@@ -4184,7 +4127,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['customer'],
         pathParams: ['customer'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Domains>(parameters, callback);
@@ -4248,7 +4191,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['customer'],
         pathParams: ['customer'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Domains2>(parameters, callback);
@@ -4318,16 +4261,9 @@ export namespace admin_directory_v1 {
 
 
   export class Resource$Groups {
-    root: Admin;
     aliases: Resource$Groups$Aliases;
-    constructor(root: Admin) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.aliases = new Resource$Groups$Aliases(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.aliases = new Resource$Groups$Aliases();
     }
 
 
@@ -4384,7 +4320,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['groupKey'],
         pathParams: ['groupKey'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -4445,7 +4381,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['groupKey'],
         pathParams: ['groupKey'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Group>(parameters, callback);
@@ -4509,7 +4445,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Group>(parameters, callback);
@@ -4581,7 +4517,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Groups>(parameters, callback);
@@ -4646,7 +4582,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['groupKey'],
         pathParams: ['groupKey'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Group>(parameters, callback);
@@ -4711,7 +4647,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['groupKey'],
         pathParams: ['groupKey'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Group>(parameters, callback);
@@ -4837,15 +4773,7 @@ export namespace admin_directory_v1 {
   }
 
   export class Resource$Groups$Aliases {
-    root: Admin;
-    constructor(root: Admin) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -4905,7 +4833,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['groupKey', 'alias'],
         pathParams: ['alias', 'groupKey'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -4972,7 +4900,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['groupKey'],
         pathParams: ['groupKey'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Alias>(parameters, callback);
@@ -5037,7 +4965,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['groupKey'],
         pathParams: ['groupKey'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Aliases>(parameters, callback);
@@ -5096,15 +5024,7 @@ export namespace admin_directory_v1 {
 
 
   export class Resource$Members {
-    root: Admin;
-    constructor(root: Admin) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -5162,7 +5082,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['groupKey', 'memberKey'],
         pathParams: ['groupKey', 'memberKey'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -5225,7 +5145,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['groupKey', 'memberKey'],
         pathParams: ['groupKey', 'memberKey'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Member>(parameters, callback);
@@ -5296,7 +5216,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['groupKey', 'memberKey'],
         pathParams: ['groupKey', 'memberKey'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$MembersHasMember>(parameters, callback);
@@ -5361,7 +5281,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['groupKey'],
         pathParams: ['groupKey'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Member>(parameters, callback);
@@ -5429,7 +5349,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['groupKey'],
         pathParams: ['groupKey'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Members>(parameters, callback);
@@ -5497,7 +5417,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['groupKey', 'memberKey'],
         pathParams: ['groupKey', 'memberKey'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Member>(parameters, callback);
@@ -5564,7 +5484,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['groupKey', 'memberKey'],
         pathParams: ['groupKey', 'memberKey'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Member>(parameters, callback);
@@ -5712,15 +5632,7 @@ export namespace admin_directory_v1 {
 
 
   export class Resource$Mobiledevices {
-    root: Admin;
-    constructor(root: Admin) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -5782,7 +5694,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['customerId', 'resourceId'],
         pathParams: ['customerId', 'resourceId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -5850,7 +5762,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['customerId', 'resourceId'],
         pathParams: ['customerId', 'resourceId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -5917,7 +5829,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['customerId', 'resourceId'],
         pathParams: ['customerId', 'resourceId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$MobileDevice>(parameters, callback);
@@ -5990,7 +5902,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['customerId'],
         pathParams: ['customerId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$MobileDevices>(parameters, callback);
@@ -6098,15 +6010,7 @@ export namespace admin_directory_v1 {
 
 
   export class Resource$Notifications {
-    root: Admin;
-    constructor(root: Admin) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -6167,7 +6071,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['customer', 'notificationId'],
         pathParams: ['customer', 'notificationId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -6233,7 +6137,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['customer', 'notificationId'],
         pathParams: ['customer', 'notificationId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Notification>(parameters, callback);
@@ -6303,7 +6207,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['customer'],
         pathParams: ['customer'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Notifications>(parameters, callback);
@@ -6374,7 +6278,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['customer', 'notificationId'],
         pathParams: ['customer', 'notificationId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Notification>(parameters, callback);
@@ -6445,7 +6349,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['customer', 'notificationId'],
         pathParams: ['customer', 'notificationId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Notification>(parameters, callback);
@@ -6559,15 +6463,7 @@ export namespace admin_directory_v1 {
 
 
   export class Resource$Orgunits {
-    root: Admin;
-    constructor(root: Admin) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -6626,7 +6522,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['customerId', 'orgUnitPath'],
         pathParams: ['customerId', 'orgUnitPath'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -6690,7 +6586,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['customerId', 'orgUnitPath'],
         pathParams: ['customerId', 'orgUnitPath'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$OrgUnit>(parameters, callback);
@@ -6756,7 +6652,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['customerId'],
         pathParams: ['customerId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$OrgUnit>(parameters, callback);
@@ -6823,7 +6719,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['customerId'],
         pathParams: ['customerId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$OrgUnits>(parameters, callback);
@@ -6891,7 +6787,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['customerId', 'orgUnitPath'],
         pathParams: ['customerId', 'orgUnitPath'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$OrgUnit>(parameters, callback);
@@ -6959,7 +6855,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['customerId', 'orgUnitPath'],
         pathParams: ['customerId', 'orgUnitPath'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$OrgUnit>(parameters, callback);
@@ -7077,15 +6973,7 @@ export namespace admin_directory_v1 {
 
 
   export class Resource$Privileges {
-    root: Admin;
-    constructor(root: Admin) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -7145,7 +7033,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['customer'],
         pathParams: ['customer'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Privileges>(parameters, callback);
@@ -7169,15 +7057,7 @@ export namespace admin_directory_v1 {
 
 
   export class Resource$Resolvedappaccesssettings {
-    root: Admin;
-    constructor(root: Admin) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -7239,7 +7119,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$AppAccessCollections>(parameters, callback);
@@ -7308,7 +7188,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TrustedApps>(parameters, callback);
@@ -7335,34 +7215,19 @@ export namespace admin_directory_v1 {
 
 
   export class Resource$Resources {
-    root: Admin;
     buildings: Resource$Resources$Buildings;
     calendars: Resource$Resources$Calendars;
     features: Resource$Resources$Features;
-    constructor(root: Admin) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.buildings = new Resource$Resources$Buildings(root);
-      this.calendars = new Resource$Resources$Calendars(root);
-      this.features = new Resource$Resources$Features(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.buildings = new Resource$Resources$Buildings();
+      this.calendars = new Resource$Resources$Calendars();
+      this.features = new Resource$Resources$Features();
     }
   }
 
 
   export class Resource$Resources$Buildings {
-    root: Admin;
-    constructor(root: Admin) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -7423,7 +7288,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['customer', 'buildingId'],
         pathParams: ['buildingId', 'customer'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -7488,7 +7353,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['customer', 'buildingId'],
         pathParams: ['buildingId', 'customer'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Building>(parameters, callback);
@@ -7557,7 +7422,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['customer'],
         pathParams: ['customer'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Building>(parameters, callback);
@@ -7628,7 +7493,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['customer'],
         pathParams: ['customer'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Buildings>(parameters, callback);
@@ -7698,7 +7563,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['customer', 'buildingId'],
         pathParams: ['buildingId', 'customer'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Building>(parameters, callback);
@@ -7768,7 +7633,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['customer', 'buildingId'],
         pathParams: ['buildingId', 'customer'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Building>(parameters, callback);
@@ -7904,15 +7769,7 @@ export namespace admin_directory_v1 {
 
 
   export class Resource$Resources$Calendars {
-    root: Admin;
-    constructor(root: Admin) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -7973,7 +7830,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['customer', 'calendarResourceId'],
         pathParams: ['calendarResourceId', 'customer'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -8039,7 +7896,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['customer', 'calendarResourceId'],
         pathParams: ['calendarResourceId', 'customer'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$CalendarResource>(parameters, callback);
@@ -8109,7 +7966,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['customer'],
         pathParams: ['customer'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$CalendarResource>(parameters, callback);
@@ -8182,7 +8039,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['customer'],
         pathParams: ['customer'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$CalendarResources>(parameters, callback);
@@ -8256,7 +8113,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['customer', 'calendarResourceId'],
         pathParams: ['calendarResourceId', 'customer'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$CalendarResource>(parameters, callback);
@@ -8329,7 +8186,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['customer', 'calendarResourceId'],
         pathParams: ['calendarResourceId', 'customer'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$CalendarResource>(parameters, callback);
@@ -8485,15 +8342,7 @@ export namespace admin_directory_v1 {
 
 
   export class Resource$Resources$Features {
-    root: Admin;
-    constructor(root: Admin) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -8554,7 +8403,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['customer', 'featureKey'],
         pathParams: ['customer', 'featureKey'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -8619,7 +8468,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['customer', 'featureKey'],
         pathParams: ['customer', 'featureKey'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Feature>(parameters, callback);
@@ -8688,7 +8537,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['customer'],
         pathParams: ['customer'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Feature>(parameters, callback);
@@ -8758,7 +8607,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['customer'],
         pathParams: ['customer'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Features>(parameters, callback);
@@ -8828,7 +8677,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['customer', 'featureKey'],
         pathParams: ['customer', 'featureKey'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Feature>(parameters, callback);
@@ -8897,7 +8746,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['customer', 'oldName'],
         pathParams: ['customer', 'oldName'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -8967,7 +8816,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['customer', 'featureKey'],
         pathParams: ['customer', 'featureKey'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Feature>(parameters, callback);
@@ -9127,15 +8976,7 @@ export namespace admin_directory_v1 {
 
 
   export class Resource$Roleassignments {
-    root: Admin;
-    constructor(root: Admin) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -9196,7 +9037,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['customer', 'roleAssignmentId'],
         pathParams: ['customer', 'roleAssignmentId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -9262,7 +9103,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['customer', 'roleAssignmentId'],
         pathParams: ['customer', 'roleAssignmentId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$RoleAssignment>(parameters, callback);
@@ -9331,7 +9172,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['customer'],
         pathParams: ['customer'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$RoleAssignment>(parameters, callback);
@@ -9403,7 +9244,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['customer'],
         pathParams: ['customer'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$RoleAssignments>(parameters, callback);
@@ -9495,15 +9336,7 @@ export namespace admin_directory_v1 {
 
 
   export class Resource$Roles {
-    root: Admin;
-    constructor(root: Admin) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -9561,7 +9394,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['customer', 'roleId'],
         pathParams: ['customer', 'roleId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -9624,7 +9457,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['customer', 'roleId'],
         pathParams: ['customer', 'roleId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Role>(parameters, callback);
@@ -9689,7 +9522,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['customer'],
         pathParams: ['customer'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Role>(parameters, callback);
@@ -9755,7 +9588,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['customer'],
         pathParams: ['customer'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Roles>(parameters, callback);
@@ -9822,7 +9655,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['customer', 'roleId'],
         pathParams: ['customer', 'roleId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Role>(parameters, callback);
@@ -9889,7 +9722,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['customer', 'roleId'],
         pathParams: ['customer', 'roleId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Role>(parameters, callback);
@@ -10007,15 +9840,7 @@ export namespace admin_directory_v1 {
 
 
   export class Resource$Schemas {
-    root: Admin;
-    constructor(root: Admin) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -10074,7 +9899,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['customerId', 'schemaKey'],
         pathParams: ['customerId', 'schemaKey'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -10138,7 +9963,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['customerId', 'schemaKey'],
         pathParams: ['customerId', 'schemaKey'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Schema>(parameters, callback);
@@ -10204,7 +10029,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['customerId'],
         pathParams: ['customerId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Schema>(parameters, callback);
@@ -10269,7 +10094,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['customerId'],
         pathParams: ['customerId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Schemas>(parameters, callback);
@@ -10337,7 +10162,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['customerId', 'schemaKey'],
         pathParams: ['customerId', 'schemaKey'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Schema>(parameters, callback);
@@ -10405,7 +10230,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['customerId', 'schemaKey'],
         pathParams: ['customerId', 'schemaKey'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Schema>(parameters, callback);
@@ -10515,15 +10340,7 @@ export namespace admin_directory_v1 {
 
 
   export class Resource$Tokens {
-    root: Admin;
-    constructor(root: Admin) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -10581,7 +10398,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['userKey', 'clientId'],
         pathParams: ['clientId', 'userKey'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -10644,7 +10461,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['userKey', 'clientId'],
         pathParams: ['clientId', 'userKey'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Token>(parameters, callback);
@@ -10709,7 +10526,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['userKey'],
         pathParams: ['userKey'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Tokens>(parameters, callback);
@@ -10766,18 +10583,11 @@ export namespace admin_directory_v1 {
 
 
   export class Resource$Users {
-    root: Admin;
     aliases: Resource$Users$Aliases;
     photos: Resource$Users$Photos;
-    constructor(root: Admin) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.aliases = new Resource$Users$Aliases(root);
-      this.photos = new Resource$Users$Photos(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.aliases = new Resource$Users$Aliases();
+      this.photos = new Resource$Users$Photos();
     }
 
 
@@ -10834,7 +10644,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['userKey'],
         pathParams: ['userKey'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -10898,7 +10708,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['userKey'],
         pathParams: ['userKey'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$User>(parameters, callback);
@@ -10962,7 +10772,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$User>(parameters, callback);
@@ -11037,7 +10847,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Users>(parameters, callback);
@@ -11102,7 +10912,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['userKey'],
         pathParams: ['userKey'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -11167,7 +10977,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['userKey'],
         pathParams: ['userKey'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$User>(parameters, callback);
@@ -11231,7 +11041,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['userKey'],
         pathParams: ['userKey'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -11296,7 +11106,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['userKey'],
         pathParams: ['userKey'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$User>(parameters, callback);
@@ -11372,7 +11182,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Channel>(parameters, callback);
@@ -11622,15 +11432,7 @@ export namespace admin_directory_v1 {
   }
 
   export class Resource$Users$Aliases {
-    root: Admin;
-    constructor(root: Admin) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -11690,7 +11492,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['userKey', 'alias'],
         pathParams: ['alias', 'userKey'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -11757,7 +11559,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['userKey'],
         pathParams: ['userKey'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Alias>(parameters, callback);
@@ -11823,7 +11625,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['userKey'],
         pathParams: ['userKey'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Aliases>(parameters, callback);
@@ -11892,7 +11694,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['userKey'],
         pathParams: ['userKey'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Channel>(parameters, callback);
@@ -11975,15 +11777,7 @@ export namespace admin_directory_v1 {
 
 
   export class Resource$Users$Photos {
-    root: Admin;
-    constructor(root: Admin) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -12042,7 +11836,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['userKey'],
         pathParams: ['userKey'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -12105,7 +11899,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['userKey'],
         pathParams: ['userKey'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$UserPhoto>(parameters, callback);
@@ -12173,7 +11967,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['userKey'],
         pathParams: ['userKey'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$UserPhoto>(parameters, callback);
@@ -12242,7 +12036,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['userKey'],
         pathParams: ['userKey'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$UserPhoto>(parameters, callback);
@@ -12313,15 +12107,7 @@ export namespace admin_directory_v1 {
 
 
   export class Resource$Verificationcodes {
-    root: Admin;
-    constructor(root: Admin) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -12381,7 +12167,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['userKey'],
         pathParams: ['userKey'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -12448,7 +12234,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['userKey'],
         pathParams: ['userKey'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -12517,7 +12303,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['userKey'],
         pathParams: ['userKey'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$VerificationCodes>(parameters, callback);

--- a/src/apis/admin/reports_v1.ts
+++ b/src/apis/admin/reports_v1.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace admin_reports_v1 {
   export interface Options extends GlobalOptions {
     version: 'reports_v1';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -80,10 +82,6 @@ export namespace admin_reports_v1 {
    * @param {object=} options Options for Admin
    */
   export class Admin {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     activities: Resource$Activities;
     channels: Resource$Channels;
     customerUsageReports: Resource$Customerusagereports;
@@ -91,19 +89,13 @@ export namespace admin_reports_v1 {
     userUsageReport: Resource$Userusagereport;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.activities = new Resource$Activities(this);
-      this.channels = new Resource$Channels(this);
-      this.customerUsageReports = new Resource$Customerusagereports(this);
-      this.entityUsageReports = new Resource$Entityusagereports(this);
-      this.userUsageReport = new Resource$Userusagereport(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.activities = new Resource$Activities();
+      this.channels = new Resource$Channels();
+      this.customerUsageReports = new Resource$Customerusagereports();
+      this.entityUsageReports = new Resource$Entityusagereports();
+      this.userUsageReport = new Resource$Userusagereport();
     }
   }
 
@@ -301,15 +293,7 @@ export namespace admin_reports_v1 {
 
 
   export class Resource$Activities {
-    root: Admin;
-    constructor(root: Admin) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -379,7 +363,7 @@ export namespace admin_reports_v1 {
         params,
         requiredParams: ['userKey', 'applicationName'],
         pathParams: ['applicationName', 'userKey'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Activities>(parameters, callback);
@@ -455,7 +439,7 @@ export namespace admin_reports_v1 {
         params,
         requiredParams: ['userKey', 'applicationName'],
         pathParams: ['applicationName', 'userKey'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Channel>(parameters, callback);
@@ -575,15 +559,7 @@ export namespace admin_reports_v1 {
 
 
   export class Resource$Channels {
-    root: Admin;
-    constructor(root: Admin) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -640,7 +616,7 @@ export namespace admin_reports_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -665,15 +641,7 @@ export namespace admin_reports_v1 {
 
 
   export class Resource$Customerusagereports {
-    root: Admin;
-    constructor(root: Admin) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -733,7 +701,7 @@ export namespace admin_reports_v1 {
         params,
         requiredParams: ['date'],
         pathParams: ['date'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$UsageReports>(parameters, callback);
@@ -772,15 +740,7 @@ export namespace admin_reports_v1 {
 
 
   export class Resource$Entityusagereports {
-    root: Admin;
-    constructor(root: Admin) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -846,7 +806,7 @@ export namespace admin_reports_v1 {
         params,
         requiredParams: ['entityType', 'entityKey', 'date'],
         pathParams: ['date', 'entityKey', 'entityType'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$UsageReports>(parameters, callback);
@@ -901,15 +861,7 @@ export namespace admin_reports_v1 {
 
 
   export class Resource$Userusagereport {
-    root: Admin;
-    constructor(root: Admin) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -973,7 +925,7 @@ export namespace admin_reports_v1 {
         params,
         requiredParams: ['userKey', 'date'],
         pathParams: ['date', 'userKey'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$UsageReports>(parameters, callback);

--- a/src/apis/adsense/v1.4.ts
+++ b/src/apis/adsense/v1.4.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace adsense_v1_4 {
   export interface Options extends GlobalOptions {
     version: 'v1_4';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -80,10 +82,6 @@ export namespace adsense_v1_4 {
    * @param {object=} options Options for Adsense
    */
   export class Adsense {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     accounts: Resource$Accounts;
     adclients: Resource$Adclients;
     adunits: Resource$Adunits;
@@ -96,24 +94,18 @@ export namespace adsense_v1_4 {
     urlchannels: Resource$Urlchannels;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.accounts = new Resource$Accounts(this);
-      this.adclients = new Resource$Adclients(this);
-      this.adunits = new Resource$Adunits(this);
-      this.alerts = new Resource$Alerts(this);
-      this.customchannels = new Resource$Customchannels(this);
-      this.metadata = new Resource$Metadata(this);
-      this.payments = new Resource$Payments(this);
-      this.reports = new Resource$Reports(this);
-      this.savedadstyles = new Resource$Savedadstyles(this);
-      this.urlchannels = new Resource$Urlchannels(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.accounts = new Resource$Accounts();
+      this.adclients = new Resource$Adclients();
+      this.adunits = new Resource$Adunits();
+      this.alerts = new Resource$Alerts();
+      this.customchannels = new Resource$Customchannels();
+      this.metadata = new Resource$Metadata();
+      this.payments = new Resource$Payments();
+      this.reports = new Resource$Reports();
+      this.savedadstyles = new Resource$Savedadstyles();
+      this.urlchannels = new Resource$Urlchannels();
     }
   }
 
@@ -666,7 +658,6 @@ export namespace adsense_v1_4 {
 
 
   export class Resource$Accounts {
-    root: Adsense;
     adclients: Resource$Accounts$Adclients;
     adunits: Resource$Accounts$Adunits;
     alerts: Resource$Accounts$Alerts;
@@ -675,21 +666,15 @@ export namespace adsense_v1_4 {
     reports: Resource$Accounts$Reports;
     savedadstyles: Resource$Accounts$Savedadstyles;
     urlchannels: Resource$Accounts$Urlchannels;
-    constructor(root: Adsense) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.adclients = new Resource$Accounts$Adclients(root);
-      this.adunits = new Resource$Accounts$Adunits(root);
-      this.alerts = new Resource$Accounts$Alerts(root);
-      this.customchannels = new Resource$Accounts$Customchannels(root);
-      this.payments = new Resource$Accounts$Payments(root);
-      this.reports = new Resource$Accounts$Reports(root);
-      this.savedadstyles = new Resource$Accounts$Savedadstyles(root);
-      this.urlchannels = new Resource$Accounts$Urlchannels(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.adclients = new Resource$Accounts$Adclients();
+      this.adunits = new Resource$Accounts$Adunits();
+      this.alerts = new Resource$Accounts$Alerts();
+      this.customchannels = new Resource$Accounts$Customchannels();
+      this.payments = new Resource$Accounts$Payments();
+      this.reports = new Resource$Accounts$Reports();
+      this.savedadstyles = new Resource$Accounts$Savedadstyles();
+      this.urlchannels = new Resource$Accounts$Urlchannels();
     }
 
 
@@ -745,7 +730,7 @@ export namespace adsense_v1_4 {
         params,
         requiredParams: ['accountId'],
         pathParams: ['accountId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Account>(parameters, callback);
@@ -810,7 +795,7 @@ export namespace adsense_v1_4 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Accounts>(parameters, callback);
@@ -855,15 +840,7 @@ export namespace adsense_v1_4 {
   }
 
   export class Resource$Accounts$Adclients {
-    root: Adsense;
-    constructor(root: Adsense) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -925,7 +902,7 @@ export namespace adsense_v1_4 {
         params,
         requiredParams: ['accountId', 'adClientId'],
         pathParams: ['accountId', 'adClientId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$AdCode>(parameters, callback);
@@ -994,7 +971,7 @@ export namespace adsense_v1_4 {
         params,
         requiredParams: ['accountId'],
         pathParams: ['accountId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$AdClients>(parameters, callback);
@@ -1046,16 +1023,9 @@ export namespace adsense_v1_4 {
 
 
   export class Resource$Accounts$Adunits {
-    root: Adsense;
     customchannels: Resource$Accounts$Adunits$Customchannels;
-    constructor(root: Adsense) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.customchannels = new Resource$Accounts$Adunits$Customchannels(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.customchannels = new Resource$Accounts$Adunits$Customchannels();
     }
 
 
@@ -1116,7 +1086,7 @@ export namespace adsense_v1_4 {
         params,
         requiredParams: ['accountId', 'adClientId', 'adUnitId'],
         pathParams: ['accountId', 'adClientId', 'adUnitId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$AdUnit>(parameters, callback);
@@ -1186,7 +1156,7 @@ export namespace adsense_v1_4 {
         params,
         requiredParams: ['accountId', 'adClientId', 'adUnitId'],
         pathParams: ['accountId', 'adClientId', 'adUnitId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$AdCode>(parameters, callback);
@@ -1259,7 +1229,7 @@ export namespace adsense_v1_4 {
         params,
         requiredParams: ['accountId', 'adClientId'],
         pathParams: ['accountId', 'adClientId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$AdUnits>(parameters, callback);
@@ -1342,15 +1312,7 @@ export namespace adsense_v1_4 {
   }
 
   export class Resource$Accounts$Adunits$Customchannels {
-    root: Adsense;
-    constructor(root: Adsense) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -1416,7 +1378,7 @@ export namespace adsense_v1_4 {
         params,
         requiredParams: ['accountId', 'adClientId', 'adUnitId'],
         pathParams: ['accountId', 'adClientId', 'adUnitId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$CustomChannels>(parameters, callback);
@@ -1461,15 +1423,7 @@ export namespace adsense_v1_4 {
 
 
   export class Resource$Accounts$Alerts {
-    root: Adsense;
-    constructor(root: Adsense) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -1530,7 +1484,7 @@ export namespace adsense_v1_4 {
         params,
         requiredParams: ['accountId', 'alertId'],
         pathParams: ['accountId', 'alertId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -1597,7 +1551,7 @@ export namespace adsense_v1_4 {
         params,
         requiredParams: ['accountId'],
         pathParams: ['accountId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Alerts>(parameters, callback);
@@ -1644,16 +1598,9 @@ export namespace adsense_v1_4 {
 
 
   export class Resource$Accounts$Customchannels {
-    root: Adsense;
     adunits: Resource$Accounts$Customchannels$Adunits;
-    constructor(root: Adsense) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.adunits = new Resource$Accounts$Customchannels$Adunits(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.adunits = new Resource$Accounts$Customchannels$Adunits();
     }
 
 
@@ -1715,7 +1662,7 @@ export namespace adsense_v1_4 {
         params,
         requiredParams: ['accountId', 'adClientId', 'customChannelId'],
         pathParams: ['accountId', 'adClientId', 'customChannelId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$CustomChannel>(parameters, callback);
@@ -1788,7 +1735,7 @@ export namespace adsense_v1_4 {
         params,
         requiredParams: ['accountId', 'adClientId'],
         pathParams: ['accountId', 'adClientId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$CustomChannels>(parameters, callback);
@@ -1847,15 +1794,7 @@ export namespace adsense_v1_4 {
   }
 
   export class Resource$Accounts$Customchannels$Adunits {
-    root: Adsense;
-    constructor(root: Adsense) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -1921,7 +1860,7 @@ export namespace adsense_v1_4 {
         params,
         requiredParams: ['accountId', 'adClientId', 'customChannelId'],
         pathParams: ['accountId', 'adClientId', 'customChannelId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$AdUnits>(parameters, callback);
@@ -1970,15 +1909,7 @@ export namespace adsense_v1_4 {
 
 
   export class Resource$Accounts$Payments {
-    root: Adsense;
-    constructor(root: Adsense) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -2037,7 +1968,7 @@ export namespace adsense_v1_4 {
         params,
         requiredParams: ['accountId'],
         pathParams: ['accountId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Payments>(parameters, callback);
@@ -2062,16 +1993,9 @@ export namespace adsense_v1_4 {
 
 
   export class Resource$Accounts$Reports {
-    root: Adsense;
     saved: Resource$Accounts$Reports$Saved;
-    constructor(root: Adsense) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.saved = new Resource$Accounts$Reports$Saved(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.saved = new Resource$Accounts$Reports$Saved();
     }
 
 
@@ -2151,7 +2075,7 @@ export namespace adsense_v1_4 {
         params,
         requiredParams: ['accountId', 'startDate', 'endDate'],
         pathParams: ['accountId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$AdsenseReportsGenerateResponse>(
@@ -2226,15 +2150,7 @@ export namespace adsense_v1_4 {
   }
 
   export class Resource$Accounts$Reports$Saved {
-    root: Adsense;
-    constructor(root: Adsense) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -2307,7 +2223,7 @@ export namespace adsense_v1_4 {
         params,
         requiredParams: ['accountId', 'savedReportId'],
         pathParams: ['accountId', 'savedReportId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$AdsenseReportsGenerateResponse>(
@@ -2379,7 +2295,7 @@ export namespace adsense_v1_4 {
         params,
         requiredParams: ['accountId'],
         pathParams: ['accountId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$SavedReports>(parameters, callback);
@@ -2445,15 +2361,7 @@ export namespace adsense_v1_4 {
 
 
   export class Resource$Accounts$Savedadstyles {
-    root: Adsense;
-    constructor(root: Adsense) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -2512,7 +2420,7 @@ export namespace adsense_v1_4 {
         params,
         requiredParams: ['accountId', 'savedAdStyleId'],
         pathParams: ['accountId', 'savedAdStyleId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$SavedAdStyle>(parameters, callback);
@@ -2582,7 +2490,7 @@ export namespace adsense_v1_4 {
         params,
         requiredParams: ['accountId'],
         pathParams: ['accountId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$SavedAdStyles>(parameters, callback);
@@ -2634,15 +2542,7 @@ export namespace adsense_v1_4 {
 
 
   export class Resource$Accounts$Urlchannels {
-    root: Adsense;
-    constructor(root: Adsense) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -2708,7 +2608,7 @@ export namespace adsense_v1_4 {
         params,
         requiredParams: ['accountId', 'adClientId'],
         pathParams: ['accountId', 'adClientId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$UrlChannels>(parameters, callback);
@@ -2749,15 +2649,7 @@ export namespace adsense_v1_4 {
 
 
   export class Resource$Adclients {
-    root: Adsense;
-    constructor(root: Adsense) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -2816,7 +2708,7 @@ export namespace adsense_v1_4 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$AdClients>(parameters, callback);
@@ -2847,16 +2739,9 @@ export namespace adsense_v1_4 {
 
 
   export class Resource$Adunits {
-    root: Adsense;
     customchannels: Resource$Adunits$Customchannels;
-    constructor(root: Adsense) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.customchannels = new Resource$Adunits$Customchannels(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.customchannels = new Resource$Adunits$Customchannels();
     }
 
 
@@ -2913,7 +2798,7 @@ export namespace adsense_v1_4 {
         params,
         requiredParams: ['adClientId', 'adUnitId'],
         pathParams: ['adClientId', 'adUnitId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$AdUnit>(parameters, callback);
@@ -2982,7 +2867,7 @@ export namespace adsense_v1_4 {
         params,
         requiredParams: ['adClientId', 'adUnitId'],
         pathParams: ['adClientId', 'adUnitId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$AdCode>(parameters, callback);
@@ -3050,7 +2935,7 @@ export namespace adsense_v1_4 {
         params,
         requiredParams: ['adClientId'],
         pathParams: ['adClientId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$AdUnits>(parameters, callback);
@@ -3119,15 +3004,7 @@ export namespace adsense_v1_4 {
   }
 
   export class Resource$Adunits$Customchannels {
-    root: Adsense;
-    constructor(root: Adsense) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -3192,7 +3069,7 @@ export namespace adsense_v1_4 {
         params,
         requiredParams: ['adClientId', 'adUnitId'],
         pathParams: ['adClientId', 'adUnitId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$CustomChannels>(parameters, callback);
@@ -3233,15 +3110,7 @@ export namespace adsense_v1_4 {
 
 
   export class Resource$Alerts {
-    root: Adsense;
-    constructor(root: Adsense) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -3298,7 +3167,7 @@ export namespace adsense_v1_4 {
         params,
         requiredParams: ['alertId'],
         pathParams: ['alertId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -3362,7 +3231,7 @@ export namespace adsense_v1_4 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Alerts>(parameters, callback);
@@ -3399,16 +3268,9 @@ export namespace adsense_v1_4 {
 
 
   export class Resource$Customchannels {
-    root: Adsense;
     adunits: Resource$Customchannels$Adunits;
-    constructor(root: Adsense) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.adunits = new Resource$Customchannels$Adunits(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.adunits = new Resource$Customchannels$Adunits();
     }
 
 
@@ -3468,7 +3330,7 @@ export namespace adsense_v1_4 {
         params,
         requiredParams: ['adClientId', 'customChannelId'],
         pathParams: ['adClientId', 'customChannelId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$CustomChannel>(parameters, callback);
@@ -3538,7 +3400,7 @@ export namespace adsense_v1_4 {
         params,
         requiredParams: ['adClientId'],
         pathParams: ['adClientId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$CustomChannels>(parameters, callback);
@@ -3589,15 +3451,7 @@ export namespace adsense_v1_4 {
   }
 
   export class Resource$Customchannels$Adunits {
-    root: Adsense;
-    constructor(root: Adsense) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -3662,7 +3516,7 @@ export namespace adsense_v1_4 {
         params,
         requiredParams: ['adClientId', 'customChannelId'],
         pathParams: ['adClientId', 'customChannelId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$AdUnits>(parameters, callback);
@@ -3707,32 +3561,17 @@ export namespace adsense_v1_4 {
 
 
   export class Resource$Metadata {
-    root: Adsense;
     dimensions: Resource$Metadata$Dimensions;
     metrics: Resource$Metadata$Metrics;
-    constructor(root: Adsense) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.dimensions = new Resource$Metadata$Dimensions(root);
-      this.metrics = new Resource$Metadata$Metrics(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.dimensions = new Resource$Metadata$Dimensions();
+      this.metrics = new Resource$Metadata$Metrics();
     }
   }
 
 
   export class Resource$Metadata$Dimensions {
-    root: Adsense;
-    constructor(root: Adsense) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -3791,7 +3630,7 @@ export namespace adsense_v1_4 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Metadata>(parameters, callback);
@@ -3811,15 +3650,7 @@ export namespace adsense_v1_4 {
 
 
   export class Resource$Metadata$Metrics {
-    root: Adsense;
-    constructor(root: Adsense) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -3878,7 +3709,7 @@ export namespace adsense_v1_4 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Metadata>(parameters, callback);
@@ -3899,15 +3730,7 @@ export namespace adsense_v1_4 {
 
 
   export class Resource$Payments {
-    root: Adsense;
-    constructor(root: Adsense) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -3963,7 +3786,7 @@ export namespace adsense_v1_4 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Payments>(parameters, callback);
@@ -3982,16 +3805,9 @@ export namespace adsense_v1_4 {
 
 
   export class Resource$Reports {
-    root: Adsense;
     saved: Resource$Reports$Saved;
-    constructor(root: Adsense) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.saved = new Resource$Reports$Saved(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.saved = new Resource$Reports$Saved();
     }
 
 
@@ -4069,7 +3885,7 @@ export namespace adsense_v1_4 {
         params,
         requiredParams: ['startDate', 'endDate'],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$AdsenseReportsGenerateResponse>(
@@ -4143,15 +3959,7 @@ export namespace adsense_v1_4 {
   }
 
   export class Resource$Reports$Saved {
-    root: Adsense;
-    constructor(root: Adsense) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -4221,7 +4029,7 @@ export namespace adsense_v1_4 {
         params,
         requiredParams: ['savedReportId'],
         pathParams: ['savedReportId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$AdsenseReportsGenerateResponse>(
@@ -4290,7 +4098,7 @@ export namespace adsense_v1_4 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$SavedReports>(parameters, callback);
@@ -4348,15 +4156,7 @@ export namespace adsense_v1_4 {
 
 
   export class Resource$Savedadstyles {
-    root: Adsense;
-    constructor(root: Adsense) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -4412,7 +4212,7 @@ export namespace adsense_v1_4 {
         params,
         requiredParams: ['savedAdStyleId'],
         pathParams: ['savedAdStyleId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$SavedAdStyle>(parameters, callback);
@@ -4479,7 +4279,7 @@ export namespace adsense_v1_4 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$SavedAdStyles>(parameters, callback);
@@ -4523,15 +4323,7 @@ export namespace adsense_v1_4 {
 
 
   export class Resource$Urlchannels {
-    root: Adsense;
-    constructor(root: Adsense) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -4593,7 +4385,7 @@ export namespace adsense_v1_4 {
         params,
         requiredParams: ['adClientId'],
         pathParams: ['adClientId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$UrlChannels>(parameters, callback);

--- a/src/apis/adsensehost/v4.1.ts
+++ b/src/apis/adsensehost/v4.1.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace adsensehost_v4_1 {
   export interface Options extends GlobalOptions {
     version: 'v4_1';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -80,10 +82,6 @@ export namespace adsensehost_v4_1 {
    * @param {object=} options Options for Adsensehost
    */
   export class Adsensehost {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     accounts: Resource$Accounts;
     adclients: Resource$Adclients;
     associationsessions: Resource$Associationsessions;
@@ -92,20 +90,14 @@ export namespace adsensehost_v4_1 {
     urlchannels: Resource$Urlchannels;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.accounts = new Resource$Accounts(this);
-      this.adclients = new Resource$Adclients(this);
-      this.associationsessions = new Resource$Associationsessions(this);
-      this.customchannels = new Resource$Customchannels(this);
-      this.reports = new Resource$Reports(this);
-      this.urlchannels = new Resource$Urlchannels(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.accounts = new Resource$Accounts();
+      this.adclients = new Resource$Adclients();
+      this.associationsessions = new Resource$Associationsessions();
+      this.customchannels = new Resource$Customchannels();
+      this.reports = new Resource$Reports();
+      this.urlchannels = new Resource$Urlchannels();
     }
   }
 
@@ -452,20 +444,13 @@ export namespace adsensehost_v4_1 {
 
 
   export class Resource$Accounts {
-    root: Adsensehost;
     adclients: Resource$Accounts$Adclients;
     adunits: Resource$Accounts$Adunits;
     reports: Resource$Accounts$Reports;
-    constructor(root: Adsensehost) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.adclients = new Resource$Accounts$Adclients(root);
-      this.adunits = new Resource$Accounts$Adunits(root);
-      this.reports = new Resource$Accounts$Reports(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.adclients = new Resource$Accounts$Adclients();
+      this.adunits = new Resource$Accounts$Adunits();
+      this.reports = new Resource$Accounts$Reports();
     }
 
 
@@ -520,7 +505,7 @@ export namespace adsensehost_v4_1 {
         params,
         requiredParams: ['accountId'],
         pathParams: ['accountId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Account>(parameters, callback);
@@ -585,7 +570,7 @@ export namespace adsensehost_v4_1 {
         params,
         requiredParams: ['filterAdClientId'],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Accounts>(parameters, callback);
@@ -619,15 +604,7 @@ export namespace adsensehost_v4_1 {
   }
 
   export class Resource$Accounts$Adclients {
-    root: Adsensehost;
-    constructor(root: Adsensehost) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -686,7 +663,7 @@ export namespace adsensehost_v4_1 {
         params,
         requiredParams: ['accountId', 'adClientId'],
         pathParams: ['accountId', 'adClientId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$AdClient>(parameters, callback);
@@ -756,7 +733,7 @@ export namespace adsensehost_v4_1 {
         params,
         requiredParams: ['accountId'],
         pathParams: ['accountId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$AdClients>(parameters, callback);
@@ -808,15 +785,7 @@ export namespace adsensehost_v4_1 {
 
 
   export class Resource$Accounts$Adunits {
-    root: Adsensehost;
-    constructor(root: Adsensehost) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -880,7 +849,7 @@ export namespace adsensehost_v4_1 {
         params,
         requiredParams: ['accountId', 'adClientId', 'adUnitId'],
         pathParams: ['accountId', 'adClientId', 'adUnitId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$AdUnit>(parameters, callback);
@@ -946,7 +915,7 @@ export namespace adsensehost_v4_1 {
         params,
         requiredParams: ['accountId', 'adClientId', 'adUnitId'],
         pathParams: ['accountId', 'adClientId', 'adUnitId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$AdUnit>(parameters, callback);
@@ -1018,7 +987,7 @@ export namespace adsensehost_v4_1 {
         params,
         requiredParams: ['accountId', 'adClientId', 'adUnitId'],
         pathParams: ['accountId', 'adClientId', 'adUnitId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$AdCode>(parameters, callback);
@@ -1089,7 +1058,7 @@ export namespace adsensehost_v4_1 {
         params,
         requiredParams: ['accountId', 'adClientId'],
         pathParams: ['accountId', 'adClientId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$AdUnit>(parameters, callback);
@@ -1161,7 +1130,7 @@ export namespace adsensehost_v4_1 {
         params,
         requiredParams: ['accountId', 'adClientId'],
         pathParams: ['accountId', 'adClientId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$AdUnits>(parameters, callback);
@@ -1233,7 +1202,7 @@ export namespace adsensehost_v4_1 {
         params,
         requiredParams: ['accountId', 'adClientId', 'adUnitId'],
         pathParams: ['accountId', 'adClientId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$AdUnit>(parameters, callback);
@@ -1304,7 +1273,7 @@ export namespace adsensehost_v4_1 {
         params,
         requiredParams: ['accountId', 'adClientId'],
         pathParams: ['accountId', 'adClientId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$AdUnit>(parameters, callback);
@@ -1479,15 +1448,7 @@ export namespace adsensehost_v4_1 {
 
 
   export class Resource$Accounts$Reports {
-    root: Adsensehost;
-    constructor(root: Adsensehost) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -1557,7 +1518,7 @@ export namespace adsensehost_v4_1 {
         params,
         requiredParams: ['accountId', 'startDate', 'endDate'],
         pathParams: ['accountId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Report>(parameters, callback);
@@ -1622,15 +1583,7 @@ export namespace adsensehost_v4_1 {
 
 
   export class Resource$Adclients {
-    root: Adsensehost;
-    constructor(root: Adsensehost) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -1685,7 +1638,7 @@ export namespace adsensehost_v4_1 {
         params,
         requiredParams: ['adClientId'],
         pathParams: ['adClientId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$AdClient>(parameters, callback);
@@ -1751,7 +1704,7 @@ export namespace adsensehost_v4_1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$AdClients>(parameters, callback);
@@ -1793,15 +1746,7 @@ export namespace adsensehost_v4_1 {
 
 
   export class Resource$Associationsessions {
-    root: Adsensehost;
-    constructor(root: Adsensehost) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -1865,7 +1810,7 @@ export namespace adsensehost_v4_1 {
         params,
         requiredParams: ['productCode', 'websiteUrl'],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$AssociationSession>(parameters, callback);
@@ -1933,7 +1878,7 @@ export namespace adsensehost_v4_1 {
         params,
         requiredParams: ['token'],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$AssociationSession>(parameters, callback);
@@ -1982,15 +1927,7 @@ export namespace adsensehost_v4_1 {
 
 
   export class Resource$Customchannels {
-    root: Adsensehost;
-    constructor(root: Adsensehost) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -2053,7 +1990,7 @@ export namespace adsensehost_v4_1 {
         params,
         requiredParams: ['adClientId', 'customChannelId'],
         pathParams: ['adClientId', 'customChannelId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$CustomChannel>(parameters, callback);
@@ -2119,7 +2056,7 @@ export namespace adsensehost_v4_1 {
         params,
         requiredParams: ['adClientId', 'customChannelId'],
         pathParams: ['adClientId', 'customChannelId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$CustomChannel>(parameters, callback);
@@ -2188,7 +2125,7 @@ export namespace adsensehost_v4_1 {
         params,
         requiredParams: ['adClientId'],
         pathParams: ['adClientId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$CustomChannel>(parameters, callback);
@@ -2257,7 +2194,7 @@ export namespace adsensehost_v4_1 {
         params,
         requiredParams: ['adClientId'],
         pathParams: ['adClientId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$CustomChannels>(parameters, callback);
@@ -2328,7 +2265,7 @@ export namespace adsensehost_v4_1 {
         params,
         requiredParams: ['adClientId', 'customChannelId'],
         pathParams: ['adClientId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$CustomChannel>(parameters, callback);
@@ -2397,7 +2334,7 @@ export namespace adsensehost_v4_1 {
         params,
         requiredParams: ['adClientId'],
         pathParams: ['adClientId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$CustomChannel>(parameters, callback);
@@ -2520,15 +2457,7 @@ export namespace adsensehost_v4_1 {
 
 
   export class Resource$Reports {
-    root: Adsensehost;
-    constructor(root: Adsensehost) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -2596,7 +2525,7 @@ export namespace adsensehost_v4_1 {
         params,
         requiredParams: ['startDate', 'endDate'],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Report>(parameters, callback);
@@ -2655,15 +2584,7 @@ export namespace adsensehost_v4_1 {
 
 
   export class Resource$Urlchannels {
-    root: Adsensehost;
-    constructor(root: Adsensehost) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -2726,7 +2647,7 @@ export namespace adsensehost_v4_1 {
         params,
         requiredParams: ['adClientId', 'urlChannelId'],
         pathParams: ['adClientId', 'urlChannelId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$UrlChannel>(parameters, callback);
@@ -2795,7 +2716,7 @@ export namespace adsensehost_v4_1 {
         params,
         requiredParams: ['adClientId'],
         pathParams: ['adClientId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$UrlChannel>(parameters, callback);
@@ -2863,7 +2784,7 @@ export namespace adsensehost_v4_1 {
         params,
         requiredParams: ['adClientId'],
         pathParams: ['adClientId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$UrlChannels>(parameters, callback);

--- a/src/apis/alertcenter/v1beta1.ts
+++ b/src/apis/alertcenter/v1beta1.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace alertcenter_v1beta1 {
   export interface Options extends GlobalOptions {
     version: 'v1beta1';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -96,22 +98,12 @@ export namespace alertcenter_v1beta1 {
    * @param {object=} options Options for Alertcenter
    */
   export class Alertcenter {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     alerts: Resource$Alerts;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.alerts = new Resource$Alerts(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.alerts = new Resource$Alerts();
     }
   }
 
@@ -574,16 +566,9 @@ export namespace alertcenter_v1beta1 {
 
 
   export class Resource$Alerts {
-    root: Alertcenter;
     feedback: Resource$Alerts$Feedback;
-    constructor(root: Alertcenter) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.feedback = new Resource$Alerts$Feedback(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.feedback = new Resource$Alerts$Feedback();
     }
 
 
@@ -646,7 +631,7 @@ export namespace alertcenter_v1beta1 {
         params,
         requiredParams: ['alertId'],
         pathParams: ['alertId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -708,7 +693,7 @@ export namespace alertcenter_v1beta1 {
         params,
         requiredParams: ['alertId'],
         pathParams: ['alertId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Alert>(parameters, callback);
@@ -776,7 +761,7 @@ export namespace alertcenter_v1beta1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListAlertsResponse>(parameters, callback);
@@ -862,15 +847,7 @@ export namespace alertcenter_v1beta1 {
   }
 
   export class Resource$Alerts$Feedback {
-    root: Alertcenter;
-    constructor(root: Alertcenter) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -932,7 +909,7 @@ export namespace alertcenter_v1beta1 {
         params,
         requiredParams: ['alertId'],
         pathParams: ['alertId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$AlertFeedback>(parameters, callback);
@@ -1003,7 +980,7 @@ export namespace alertcenter_v1beta1 {
         params,
         requiredParams: ['alertId'],
         pathParams: ['alertId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListAlertFeedbackResponse>(

--- a/src/apis/analytics/v2.4.ts
+++ b/src/apis/analytics/v2.4.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace analytics_v2_4 {
   export interface Options extends GlobalOptions {
     version: 'v2_4';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -79,39 +81,21 @@ export namespace analytics_v2_4 {
    * @param {object=} options Options for Analytics
    */
   export class Analytics {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     data: Resource$Data;
     management: Resource$Management;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.data = new Resource$Data(this);
-      this.management = new Resource$Management(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.data = new Resource$Data();
+      this.management = new Resource$Management();
     }
   }
 
 
 
   export class Resource$Data {
-    root: Analytics;
-    constructor(root: Analytics) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -172,7 +156,7 @@ export namespace analytics_v2_4 {
         params,
         requiredParams: ['ids', 'start-date', 'end-date', 'metrics'],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -241,38 +225,23 @@ export namespace analytics_v2_4 {
 
 
   export class Resource$Management {
-    root: Analytics;
     accounts: Resource$Management$Accounts;
     goals: Resource$Management$Goals;
     profiles: Resource$Management$Profiles;
     segments: Resource$Management$Segments;
     webproperties: Resource$Management$Webproperties;
-    constructor(root: Analytics) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.accounts = new Resource$Management$Accounts(root);
-      this.goals = new Resource$Management$Goals(root);
-      this.profiles = new Resource$Management$Profiles(root);
-      this.segments = new Resource$Management$Segments(root);
-      this.webproperties = new Resource$Management$Webproperties(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.accounts = new Resource$Management$Accounts();
+      this.goals = new Resource$Management$Goals();
+      this.profiles = new Resource$Management$Profiles();
+      this.segments = new Resource$Management$Segments();
+      this.webproperties = new Resource$Management$Webproperties();
     }
   }
 
 
   export class Resource$Management$Accounts {
-    root: Analytics;
-    constructor(root: Analytics) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -331,7 +300,7 @@ export namespace analytics_v2_4 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -361,15 +330,7 @@ export namespace analytics_v2_4 {
 
 
   export class Resource$Management$Goals {
-    root: Analytics;
-    constructor(root: Analytics) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -433,7 +394,7 @@ export namespace analytics_v2_4 {
         params,
         requiredParams: ['accountId', 'webPropertyId', 'profileId'],
         pathParams: ['accountId', 'profileId', 'webPropertyId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -480,15 +441,7 @@ export namespace analytics_v2_4 {
 
 
   export class Resource$Management$Profiles {
-    root: Analytics;
-    constructor(root: Analytics) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -551,7 +504,7 @@ export namespace analytics_v2_4 {
         params,
         requiredParams: ['accountId', 'webPropertyId'],
         pathParams: ['accountId', 'webPropertyId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -593,15 +546,7 @@ export namespace analytics_v2_4 {
 
 
   export class Resource$Management$Segments {
-    root: Analytics;
-    constructor(root: Analytics) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -660,7 +605,7 @@ export namespace analytics_v2_4 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -690,15 +635,7 @@ export namespace analytics_v2_4 {
 
 
   export class Resource$Management$Webproperties {
-    root: Analytics;
-    constructor(root: Analytics) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -760,7 +697,7 @@ export namespace analytics_v2_4 {
         params,
         requiredParams: ['accountId'],
         pathParams: ['accountId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);

--- a/src/apis/analytics/v3.ts
+++ b/src/apis/analytics/v3.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace analytics_v3 {
   export interface Options extends GlobalOptions {
     version: 'v3';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -79,10 +81,6 @@ export namespace analytics_v3 {
    * @param {object=} options Options for Analytics
    */
   export class Analytics {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     data: Resource$Data;
     management: Resource$Management;
     metadata: Resource$Metadata;
@@ -90,19 +88,13 @@ export namespace analytics_v3 {
     userDeletion: Resource$Userdeletion;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.data = new Resource$Data(this);
-      this.management = new Resource$Management(this);
-      this.metadata = new Resource$Metadata(this);
-      this.provisioning = new Resource$Provisioning(this);
-      this.userDeletion = new Resource$Userdeletion(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.data = new Resource$Data();
+      this.management = new Resource$Management();
+      this.metadata = new Resource$Metadata();
+      this.provisioning = new Resource$Provisioning();
+      this.userDeletion = new Resource$Userdeletion();
     }
   }
 
@@ -2801,34 +2793,19 @@ export namespace analytics_v3 {
 
 
   export class Resource$Data {
-    root: Analytics;
     ga: Resource$Data$Ga;
     mcf: Resource$Data$Mcf;
     realtime: Resource$Data$Realtime;
-    constructor(root: Analytics) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.ga = new Resource$Data$Ga(root);
-      this.mcf = new Resource$Data$Mcf(root);
-      this.realtime = new Resource$Data$Realtime(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.ga = new Resource$Data$Ga();
+      this.mcf = new Resource$Data$Mcf();
+      this.realtime = new Resource$Data$Realtime();
     }
   }
 
 
   export class Resource$Data$Ga {
-    root: Analytics;
-    constructor(root: Analytics) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -2894,7 +2871,7 @@ export namespace analytics_v3 {
         params,
         requiredParams: ['ids', 'start-date', 'end-date', 'metrics'],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GaData>(parameters, callback);
@@ -2977,15 +2954,7 @@ export namespace analytics_v3 {
 
 
   export class Resource$Data$Mcf {
-    root: Analytics;
-    constructor(root: Analytics) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -3048,7 +3017,7 @@ export namespace analytics_v3 {
         params,
         requiredParams: ['ids', 'start-date', 'end-date', 'metrics'],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$McfData>(parameters, callback);
@@ -3119,15 +3088,7 @@ export namespace analytics_v3 {
 
 
   export class Resource$Data$Realtime {
-    root: Analytics;
-    constructor(root: Analytics) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -3188,7 +3149,7 @@ export namespace analytics_v3 {
         params,
         requiredParams: ['ids', 'metrics'],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$RealtimeData>(parameters, callback);
@@ -3239,7 +3200,6 @@ export namespace analytics_v3 {
 
 
   export class Resource$Management {
-    root: Analytics;
     accounts: Resource$Management$Accounts;
     accountSummaries: Resource$Management$Accountsummaries;
     accountUserLinks: Resource$Management$Accountuserlinks;
@@ -3260,51 +3220,35 @@ export namespace analytics_v3 {
     webproperties: Resource$Management$Webproperties;
     webPropertyAdWordsLinks: Resource$Management$Webpropertyadwordslinks;
     webpropertyUserLinks: Resource$Management$Webpropertyuserlinks;
-    constructor(root: Analytics) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.accounts = new Resource$Management$Accounts(root);
-      this.accountSummaries = new Resource$Management$Accountsummaries(root);
-      this.accountUserLinks = new Resource$Management$Accountuserlinks(root);
-      this.clientId = new Resource$Management$Clientid(root);
-      this.customDataSources = new Resource$Management$Customdatasources(root);
-      this.customDimensions = new Resource$Management$Customdimensions(root);
-      this.customMetrics = new Resource$Management$Custommetrics(root);
-      this.experiments = new Resource$Management$Experiments(root);
-      this.filters = new Resource$Management$Filters(root);
-      this.goals = new Resource$Management$Goals(root);
-      this.profileFilterLinks =
-          new Resource$Management$Profilefilterlinks(root);
-      this.profiles = new Resource$Management$Profiles(root);
-      this.profileUserLinks = new Resource$Management$Profileuserlinks(root);
-      this.remarketingAudience =
-          new Resource$Management$Remarketingaudience(root);
-      this.segments = new Resource$Management$Segments(root);
-      this.unsampledReports = new Resource$Management$Unsampledreports(root);
-      this.uploads = new Resource$Management$Uploads(root);
-      this.webproperties = new Resource$Management$Webproperties(root);
+    constructor() {
+      this.accounts = new Resource$Management$Accounts();
+      this.accountSummaries = new Resource$Management$Accountsummaries();
+      this.accountUserLinks = new Resource$Management$Accountuserlinks();
+      this.clientId = new Resource$Management$Clientid();
+      this.customDataSources = new Resource$Management$Customdatasources();
+      this.customDimensions = new Resource$Management$Customdimensions();
+      this.customMetrics = new Resource$Management$Custommetrics();
+      this.experiments = new Resource$Management$Experiments();
+      this.filters = new Resource$Management$Filters();
+      this.goals = new Resource$Management$Goals();
+      this.profileFilterLinks = new Resource$Management$Profilefilterlinks();
+      this.profiles = new Resource$Management$Profiles();
+      this.profileUserLinks = new Resource$Management$Profileuserlinks();
+      this.remarketingAudience = new Resource$Management$Remarketingaudience();
+      this.segments = new Resource$Management$Segments();
+      this.unsampledReports = new Resource$Management$Unsampledreports();
+      this.uploads = new Resource$Management$Uploads();
+      this.webproperties = new Resource$Management$Webproperties();
       this.webPropertyAdWordsLinks =
-          new Resource$Management$Webpropertyadwordslinks(root);
+          new Resource$Management$Webpropertyadwordslinks();
       this.webpropertyUserLinks =
-          new Resource$Management$Webpropertyuserlinks(root);
-    }
-
-    getRoot() {
-      return this.root;
+          new Resource$Management$Webpropertyuserlinks();
     }
   }
 
 
   export class Resource$Management$Accounts {
-    root: Analytics;
-    constructor(root: Analytics) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -3364,7 +3308,7 @@ export namespace analytics_v3 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Accounts>(parameters, callback);
@@ -3394,15 +3338,7 @@ export namespace analytics_v3 {
 
 
   export class Resource$Management$Accountsummaries {
-    root: Analytics;
-    constructor(root: Analytics) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -3464,7 +3400,7 @@ export namespace analytics_v3 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$AccountSummaries>(parameters, callback);
@@ -3495,15 +3431,7 @@ export namespace analytics_v3 {
 
 
   export class Resource$Management$Accountuserlinks {
-    root: Analytics;
-    constructor(root: Analytics) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -3564,7 +3492,7 @@ export namespace analytics_v3 {
         params,
         requiredParams: ['accountId', 'linkId'],
         pathParams: ['accountId', 'linkId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -3634,7 +3562,7 @@ export namespace analytics_v3 {
         params,
         requiredParams: ['accountId'],
         pathParams: ['accountId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$EntityUserLink>(parameters, callback);
@@ -3705,7 +3633,7 @@ export namespace analytics_v3 {
         params,
         requiredParams: ['accountId'],
         pathParams: ['accountId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$EntityUserLinks>(parameters, callback);
@@ -3776,7 +3704,7 @@ export namespace analytics_v3 {
         params,
         requiredParams: ['accountId', 'linkId'],
         pathParams: ['accountId', 'linkId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$EntityUserLink>(parameters, callback);
@@ -3864,15 +3792,7 @@ export namespace analytics_v3 {
 
 
   export class Resource$Management$Clientid {
-    root: Analytics;
-    constructor(root: Analytics) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -3934,7 +3854,7 @@ export namespace analytics_v3 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$HashClientIdResponse>(parameters, callback);
@@ -3960,15 +3880,7 @@ export namespace analytics_v3 {
 
 
   export class Resource$Management$Customdatasources {
-    root: Analytics;
-    constructor(root: Analytics) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -4033,7 +3945,7 @@ export namespace analytics_v3 {
         params,
         requiredParams: ['accountId', 'webPropertyId'],
         pathParams: ['accountId', 'webPropertyId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$CustomDataSources>(parameters, callback);
@@ -4071,15 +3983,7 @@ export namespace analytics_v3 {
 
 
   export class Resource$Management$Customdimensions {
-    root: Analytics;
-    constructor(root: Analytics) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -4139,7 +4043,7 @@ export namespace analytics_v3 {
         params,
         requiredParams: ['accountId', 'webPropertyId', 'customDimensionId'],
         pathParams: ['accountId', 'customDimensionId', 'webPropertyId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$CustomDimension>(parameters, callback);
@@ -4210,7 +4114,7 @@ export namespace analytics_v3 {
         params,
         requiredParams: ['accountId', 'webPropertyId'],
         pathParams: ['accountId', 'webPropertyId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$CustomDimension>(parameters, callback);
@@ -4282,7 +4186,7 @@ export namespace analytics_v3 {
         params,
         requiredParams: ['accountId', 'webPropertyId'],
         pathParams: ['accountId', 'webPropertyId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$CustomDimensions>(parameters, callback);
@@ -4356,7 +4260,7 @@ export namespace analytics_v3 {
         params,
         requiredParams: ['accountId', 'webPropertyId', 'customDimensionId'],
         pathParams: ['accountId', 'customDimensionId', 'webPropertyId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$CustomDimension>(parameters, callback);
@@ -4429,7 +4333,7 @@ export namespace analytics_v3 {
         params,
         requiredParams: ['accountId', 'webPropertyId', 'customDimensionId'],
         pathParams: ['accountId', 'customDimensionId', 'webPropertyId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$CustomDimension>(parameters, callback);
@@ -4568,15 +4472,7 @@ export namespace analytics_v3 {
 
 
   export class Resource$Management$Custommetrics {
-    root: Analytics;
-    constructor(root: Analytics) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -4636,7 +4532,7 @@ export namespace analytics_v3 {
         params,
         requiredParams: ['accountId', 'webPropertyId', 'customMetricId'],
         pathParams: ['accountId', 'customMetricId', 'webPropertyId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$CustomMetric>(parameters, callback);
@@ -4707,7 +4603,7 @@ export namespace analytics_v3 {
         params,
         requiredParams: ['accountId', 'webPropertyId'],
         pathParams: ['accountId', 'webPropertyId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$CustomMetric>(parameters, callback);
@@ -4779,7 +4675,7 @@ export namespace analytics_v3 {
         params,
         requiredParams: ['accountId', 'webPropertyId'],
         pathParams: ['accountId', 'webPropertyId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$CustomMetrics>(parameters, callback);
@@ -4853,7 +4749,7 @@ export namespace analytics_v3 {
         params,
         requiredParams: ['accountId', 'webPropertyId', 'customMetricId'],
         pathParams: ['accountId', 'customMetricId', 'webPropertyId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$CustomMetric>(parameters, callback);
@@ -4926,7 +4822,7 @@ export namespace analytics_v3 {
         params,
         requiredParams: ['accountId', 'webPropertyId', 'customMetricId'],
         pathParams: ['accountId', 'customMetricId', 'webPropertyId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$CustomMetric>(parameters, callback);
@@ -5065,15 +4961,7 @@ export namespace analytics_v3 {
 
 
   export class Resource$Management$Experiments {
-    root: Analytics;
-    constructor(root: Analytics) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -5137,7 +5025,7 @@ export namespace analytics_v3 {
         requiredParams:
             ['accountId', 'webPropertyId', 'profileId', 'experimentId'],
         pathParams: ['accountId', 'experimentId', 'profileId', 'webPropertyId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -5206,7 +5094,7 @@ export namespace analytics_v3 {
         requiredParams:
             ['accountId', 'webPropertyId', 'profileId', 'experimentId'],
         pathParams: ['accountId', 'experimentId', 'profileId', 'webPropertyId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Experiment>(parameters, callback);
@@ -5278,7 +5166,7 @@ export namespace analytics_v3 {
         params,
         requiredParams: ['accountId', 'webPropertyId', 'profileId'],
         pathParams: ['accountId', 'profileId', 'webPropertyId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Experiment>(parameters, callback);
@@ -5351,7 +5239,7 @@ export namespace analytics_v3 {
         params,
         requiredParams: ['accountId', 'webPropertyId', 'profileId'],
         pathParams: ['accountId', 'profileId', 'webPropertyId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Experiments>(parameters, callback);
@@ -5426,7 +5314,7 @@ export namespace analytics_v3 {
         requiredParams:
             ['accountId', 'webPropertyId', 'profileId', 'experimentId'],
         pathParams: ['accountId', 'experimentId', 'profileId', 'webPropertyId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Experiment>(parameters, callback);
@@ -5500,7 +5388,7 @@ export namespace analytics_v3 {
         requiredParams:
             ['accountId', 'webPropertyId', 'profileId', 'experimentId'],
         pathParams: ['accountId', 'experimentId', 'profileId', 'webPropertyId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Experiment>(parameters, callback);
@@ -5673,15 +5561,7 @@ export namespace analytics_v3 {
 
 
   export class Resource$Management$Filters {
-    root: Analytics;
-    constructor(root: Analytics) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -5743,7 +5623,7 @@ export namespace analytics_v3 {
         params,
         requiredParams: ['accountId', 'filterId'],
         pathParams: ['accountId', 'filterId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Filter>(parameters, callback);
@@ -5808,7 +5688,7 @@ export namespace analytics_v3 {
         params,
         requiredParams: ['accountId', 'filterId'],
         pathParams: ['accountId', 'filterId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Filter>(parameters, callback);
@@ -5876,7 +5756,7 @@ export namespace analytics_v3 {
         params,
         requiredParams: ['accountId'],
         pathParams: ['accountId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Filter>(parameters, callback);
@@ -5945,7 +5825,7 @@ export namespace analytics_v3 {
         params,
         requiredParams: ['accountId'],
         pathParams: ['accountId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Filters>(parameters, callback);
@@ -6015,7 +5895,7 @@ export namespace analytics_v3 {
         params,
         requiredParams: ['accountId', 'filterId'],
         pathParams: ['accountId', 'filterId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Filter>(parameters, callback);
@@ -6085,7 +5965,7 @@ export namespace analytics_v3 {
         params,
         requiredParams: ['accountId', 'filterId'],
         pathParams: ['accountId', 'filterId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Filter>(parameters, callback);
@@ -6210,15 +6090,7 @@ export namespace analytics_v3 {
 
 
   export class Resource$Management$Goals {
-    root: Analytics;
-    constructor(root: Analytics) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -6278,7 +6150,7 @@ export namespace analytics_v3 {
         params,
         requiredParams: ['accountId', 'webPropertyId', 'profileId', 'goalId'],
         pathParams: ['accountId', 'goalId', 'profileId', 'webPropertyId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Goal>(parameters, callback);
@@ -6349,7 +6221,7 @@ export namespace analytics_v3 {
         params,
         requiredParams: ['accountId', 'webPropertyId', 'profileId'],
         pathParams: ['accountId', 'profileId', 'webPropertyId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Goal>(parameters, callback);
@@ -6421,7 +6293,7 @@ export namespace analytics_v3 {
         params,
         requiredParams: ['accountId', 'webPropertyId', 'profileId'],
         pathParams: ['accountId', 'profileId', 'webPropertyId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Goals>(parameters, callback);
@@ -6493,7 +6365,7 @@ export namespace analytics_v3 {
         params,
         requiredParams: ['accountId', 'webPropertyId', 'profileId', 'goalId'],
         pathParams: ['accountId', 'goalId', 'profileId', 'webPropertyId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Goal>(parameters, callback);
@@ -6565,7 +6437,7 @@ export namespace analytics_v3 {
         params,
         requiredParams: ['accountId', 'webPropertyId', 'profileId', 'goalId'],
         pathParams: ['accountId', 'goalId', 'profileId', 'webPropertyId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Goal>(parameters, callback);
@@ -6719,15 +6591,7 @@ export namespace analytics_v3 {
 
 
   export class Resource$Management$Profilefilterlinks {
-    root: Analytics;
-    constructor(root: Analytics) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -6790,7 +6654,7 @@ export namespace analytics_v3 {
         params,
         requiredParams: ['accountId', 'webPropertyId', 'profileId', 'linkId'],
         pathParams: ['accountId', 'linkId', 'profileId', 'webPropertyId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -6858,7 +6722,7 @@ export namespace analytics_v3 {
         params,
         requiredParams: ['accountId', 'webPropertyId', 'profileId', 'linkId'],
         pathParams: ['accountId', 'linkId', 'profileId', 'webPropertyId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ProfileFilterLink>(parameters, callback);
@@ -6930,7 +6794,7 @@ export namespace analytics_v3 {
         params,
         requiredParams: ['accountId', 'webPropertyId', 'profileId'],
         pathParams: ['accountId', 'profileId', 'webPropertyId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ProfileFilterLink>(parameters, callback);
@@ -7003,7 +6867,7 @@ export namespace analytics_v3 {
         params,
         requiredParams: ['accountId', 'webPropertyId', 'profileId'],
         pathParams: ['accountId', 'profileId', 'webPropertyId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ProfileFilterLinks>(parameters, callback);
@@ -7077,7 +6941,7 @@ export namespace analytics_v3 {
         params,
         requiredParams: ['accountId', 'webPropertyId', 'profileId', 'linkId'],
         pathParams: ['accountId', 'linkId', 'profileId', 'webPropertyId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ProfileFilterLink>(parameters, callback);
@@ -7150,7 +7014,7 @@ export namespace analytics_v3 {
         params,
         requiredParams: ['accountId', 'webPropertyId', 'profileId', 'linkId'],
         pathParams: ['accountId', 'linkId', 'profileId', 'webPropertyId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ProfileFilterLink>(parameters, callback);
@@ -7326,15 +7190,7 @@ export namespace analytics_v3 {
 
 
   export class Resource$Management$Profiles {
-    root: Analytics;
-    constructor(root: Analytics) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -7396,7 +7252,7 @@ export namespace analytics_v3 {
         params,
         requiredParams: ['accountId', 'webPropertyId', 'profileId'],
         pathParams: ['accountId', 'profileId', 'webPropertyId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -7462,7 +7318,7 @@ export namespace analytics_v3 {
         params,
         requiredParams: ['accountId', 'webPropertyId', 'profileId'],
         pathParams: ['accountId', 'profileId', 'webPropertyId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Profile>(parameters, callback);
@@ -7532,7 +7388,7 @@ export namespace analytics_v3 {
         params,
         requiredParams: ['accountId', 'webPropertyId'],
         pathParams: ['accountId', 'webPropertyId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Profile>(parameters, callback);
@@ -7603,7 +7459,7 @@ export namespace analytics_v3 {
         params,
         requiredParams: ['accountId', 'webPropertyId'],
         pathParams: ['accountId', 'webPropertyId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Profiles>(parameters, callback);
@@ -7675,7 +7531,7 @@ export namespace analytics_v3 {
         params,
         requiredParams: ['accountId', 'webPropertyId', 'profileId'],
         pathParams: ['accountId', 'profileId', 'webPropertyId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Profile>(parameters, callback);
@@ -7746,7 +7602,7 @@ export namespace analytics_v3 {
         params,
         requiredParams: ['accountId', 'webPropertyId', 'profileId'],
         pathParams: ['accountId', 'profileId', 'webPropertyId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Profile>(parameters, callback);
@@ -7899,15 +7755,7 @@ export namespace analytics_v3 {
 
 
   export class Resource$Management$Profileuserlinks {
-    root: Analytics;
-    constructor(root: Analytics) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -7970,7 +7818,7 @@ export namespace analytics_v3 {
         params,
         requiredParams: ['accountId', 'webPropertyId', 'profileId', 'linkId'],
         pathParams: ['accountId', 'linkId', 'profileId', 'webPropertyId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -8042,7 +7890,7 @@ export namespace analytics_v3 {
         params,
         requiredParams: ['accountId', 'webPropertyId', 'profileId'],
         pathParams: ['accountId', 'profileId', 'webPropertyId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$EntityUserLink>(parameters, callback);
@@ -8115,7 +7963,7 @@ export namespace analytics_v3 {
         params,
         requiredParams: ['accountId', 'webPropertyId', 'profileId'],
         pathParams: ['accountId', 'profileId', 'webPropertyId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$EntityUserLinks>(parameters, callback);
@@ -8189,7 +8037,7 @@ export namespace analytics_v3 {
         params,
         requiredParams: ['accountId', 'webPropertyId', 'profileId', 'linkId'],
         pathParams: ['accountId', 'linkId', 'profileId', 'webPropertyId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$EntityUserLink>(parameters, callback);
@@ -8313,15 +8161,7 @@ export namespace analytics_v3 {
 
 
   export class Resource$Management$Remarketingaudience {
-    root: Analytics;
-    constructor(root: Analytics) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -8384,7 +8224,7 @@ export namespace analytics_v3 {
         params,
         requiredParams: ['accountId', 'webPropertyId', 'remarketingAudienceId'],
         pathParams: ['accountId', 'remarketingAudienceId', 'webPropertyId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -8451,7 +8291,7 @@ export namespace analytics_v3 {
         params,
         requiredParams: ['accountId', 'webPropertyId', 'remarketingAudienceId'],
         pathParams: ['accountId', 'remarketingAudienceId', 'webPropertyId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$RemarketingAudience>(parameters, callback);
@@ -8523,7 +8363,7 @@ export namespace analytics_v3 {
         params,
         requiredParams: ['accountId', 'webPropertyId'],
         pathParams: ['accountId', 'webPropertyId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$RemarketingAudience>(parameters, callback);
@@ -8597,7 +8437,7 @@ export namespace analytics_v3 {
         params,
         requiredParams: ['accountId', 'webPropertyId'],
         pathParams: ['accountId', 'webPropertyId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$RemarketingAudiences>(parameters, callback);
@@ -8670,7 +8510,7 @@ export namespace analytics_v3 {
         params,
         requiredParams: ['accountId', 'webPropertyId', 'remarketingAudienceId'],
         pathParams: ['accountId', 'remarketingAudienceId', 'webPropertyId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$RemarketingAudience>(parameters, callback);
@@ -8743,7 +8583,7 @@ export namespace analytics_v3 {
         params,
         requiredParams: ['accountId', 'webPropertyId', 'remarketingAudienceId'],
         pathParams: ['accountId', 'remarketingAudienceId', 'webPropertyId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$RemarketingAudience>(parameters, callback);
@@ -8896,15 +8736,7 @@ export namespace analytics_v3 {
 
 
   export class Resource$Management$Segments {
-    root: Analytics;
-    constructor(root: Analytics) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -8964,7 +8796,7 @@ export namespace analytics_v3 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Segments>(parameters, callback);
@@ -8994,15 +8826,7 @@ export namespace analytics_v3 {
 
 
   export class Resource$Management$Unsampledreports {
-    root: Analytics;
-    constructor(root: Analytics) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -9067,7 +8891,7 @@ export namespace analytics_v3 {
             ['accountId', 'webPropertyId', 'profileId', 'unsampledReportId'],
         pathParams:
             ['accountId', 'profileId', 'unsampledReportId', 'webPropertyId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -9137,7 +8961,7 @@ export namespace analytics_v3 {
             ['accountId', 'webPropertyId', 'profileId', 'unsampledReportId'],
         pathParams:
             ['accountId', 'profileId', 'unsampledReportId', 'webPropertyId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$UnsampledReport>(parameters, callback);
@@ -9209,7 +9033,7 @@ export namespace analytics_v3 {
         params,
         requiredParams: ['accountId', 'webPropertyId', 'profileId'],
         pathParams: ['accountId', 'profileId', 'webPropertyId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$UnsampledReport>(parameters, callback);
@@ -9282,7 +9106,7 @@ export namespace analytics_v3 {
         params,
         requiredParams: ['accountId', 'webPropertyId', 'profileId'],
         pathParams: ['accountId', 'profileId', 'webPropertyId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$UnsampledReports>(parameters, callback);
@@ -9400,15 +9224,7 @@ export namespace analytics_v3 {
 
 
   export class Resource$Management$Uploads {
-    root: Analytics;
-    constructor(root: Analytics) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -9471,7 +9287,7 @@ export namespace analytics_v3 {
         params,
         requiredParams: ['accountId', 'webPropertyId', 'customDataSourceId'],
         pathParams: ['accountId', 'customDataSourceId', 'webPropertyId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -9540,7 +9356,7 @@ export namespace analytics_v3 {
             ['accountId', 'webPropertyId', 'customDataSourceId', 'uploadId'],
         pathParams:
             ['accountId', 'customDataSourceId', 'uploadId', 'webPropertyId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Upload>(parameters, callback);
@@ -9612,7 +9428,7 @@ export namespace analytics_v3 {
         params,
         requiredParams: ['accountId', 'webPropertyId', 'customDataSourceId'],
         pathParams: ['accountId', 'customDataSourceId', 'webPropertyId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Uploads>(parameters, callback);
@@ -9689,7 +9505,7 @@ export namespace analytics_v3 {
                 .replace(/([^:]\/)\/+/g, '$1'),
         requiredParams: ['accountId', 'webPropertyId', 'customDataSourceId'],
         pathParams: ['accountId', 'customDataSourceId', 'webPropertyId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Upload>(parameters, callback);
@@ -9816,15 +9632,7 @@ export namespace analytics_v3 {
 
 
   export class Resource$Management$Webproperties {
-    root: Analytics;
-    constructor(root: Analytics) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -9883,7 +9691,7 @@ export namespace analytics_v3 {
         params,
         requiredParams: ['accountId', 'webPropertyId'],
         pathParams: ['accountId', 'webPropertyId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Webproperty>(parameters, callback);
@@ -9955,7 +9763,7 @@ export namespace analytics_v3 {
         params,
         requiredParams: ['accountId'],
         pathParams: ['accountId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Webproperty>(parameters, callback);
@@ -10026,7 +9834,7 @@ export namespace analytics_v3 {
         params,
         requiredParams: ['accountId'],
         pathParams: ['accountId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Webproperties>(parameters, callback);
@@ -10098,7 +9906,7 @@ export namespace analytics_v3 {
         params,
         requiredParams: ['accountId', 'webPropertyId'],
         pathParams: ['accountId', 'webPropertyId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Webproperty>(parameters, callback);
@@ -10169,7 +9977,7 @@ export namespace analytics_v3 {
         params,
         requiredParams: ['accountId', 'webPropertyId'],
         pathParams: ['accountId', 'webPropertyId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Webproperty>(parameters, callback);
@@ -10280,15 +10088,7 @@ export namespace analytics_v3 {
 
 
   export class Resource$Management$Webpropertyadwordslinks {
-    root: Analytics;
-    constructor(root: Analytics) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -10353,7 +10153,7 @@ export namespace analytics_v3 {
         requiredParams:
             ['accountId', 'webPropertyId', 'webPropertyAdWordsLinkId'],
         pathParams: ['accountId', 'webPropertyAdWordsLinkId', 'webPropertyId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -10422,7 +10222,7 @@ export namespace analytics_v3 {
         requiredParams:
             ['accountId', 'webPropertyId', 'webPropertyAdWordsLinkId'],
         pathParams: ['accountId', 'webPropertyAdWordsLinkId', 'webPropertyId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$EntityAdWordsLink>(parameters, callback);
@@ -10495,7 +10295,7 @@ export namespace analytics_v3 {
         params,
         requiredParams: ['accountId', 'webPropertyId'],
         pathParams: ['accountId', 'webPropertyId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$EntityAdWordsLink>(parameters, callback);
@@ -10568,7 +10368,7 @@ export namespace analytics_v3 {
         params,
         requiredParams: ['accountId', 'webPropertyId'],
         pathParams: ['accountId', 'webPropertyId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$EntityAdWordsLinks>(parameters, callback);
@@ -10643,7 +10443,7 @@ export namespace analytics_v3 {
         requiredParams:
             ['accountId', 'webPropertyId', 'webPropertyAdWordsLinkId'],
         pathParams: ['accountId', 'webPropertyAdWordsLinkId', 'webPropertyId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$EntityAdWordsLink>(parameters, callback);
@@ -10718,7 +10518,7 @@ export namespace analytics_v3 {
         requiredParams:
             ['accountId', 'webPropertyId', 'webPropertyAdWordsLinkId'],
         pathParams: ['accountId', 'webPropertyAdWordsLinkId', 'webPropertyId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$EntityAdWordsLink>(parameters, callback);
@@ -10868,15 +10668,7 @@ export namespace analytics_v3 {
 
 
   export class Resource$Management$Webpropertyuserlinks {
-    root: Analytics;
-    constructor(root: Analytics) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -10939,7 +10731,7 @@ export namespace analytics_v3 {
         params,
         requiredParams: ['accountId', 'webPropertyId', 'linkId'],
         pathParams: ['accountId', 'linkId', 'webPropertyId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -11011,7 +10803,7 @@ export namespace analytics_v3 {
         params,
         requiredParams: ['accountId', 'webPropertyId'],
         pathParams: ['accountId', 'webPropertyId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$EntityUserLink>(parameters, callback);
@@ -11083,7 +10875,7 @@ export namespace analytics_v3 {
         params,
         requiredParams: ['accountId', 'webPropertyId'],
         pathParams: ['accountId', 'webPropertyId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$EntityUserLinks>(parameters, callback);
@@ -11156,7 +10948,7 @@ export namespace analytics_v3 {
         params,
         requiredParams: ['accountId', 'webPropertyId', 'linkId'],
         pathParams: ['accountId', 'linkId', 'webPropertyId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$EntityUserLink>(parameters, callback);
@@ -11263,30 +11055,15 @@ export namespace analytics_v3 {
 
 
   export class Resource$Metadata {
-    root: Analytics;
     columns: Resource$Metadata$Columns;
-    constructor(root: Analytics) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.columns = new Resource$Metadata$Columns(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.columns = new Resource$Metadata$Columns();
     }
   }
 
 
   export class Resource$Metadata$Columns {
-    root: Analytics;
-    constructor(root: Analytics) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -11345,7 +11122,7 @@ export namespace analytics_v3 {
         params,
         requiredParams: ['reportType'],
         pathParams: ['reportType'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Columns>(parameters, callback);
@@ -11372,15 +11149,7 @@ export namespace analytics_v3 {
 
 
   export class Resource$Provisioning {
-    root: Analytics;
-    constructor(root: Analytics) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -11441,7 +11210,7 @@ export namespace analytics_v3 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$AccountTicket>(parameters, callback);
@@ -11509,7 +11278,7 @@ export namespace analytics_v3 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$AccountTreeResponse>(parameters, callback);
@@ -11548,31 +11317,16 @@ export namespace analytics_v3 {
 
 
   export class Resource$Userdeletion {
-    root: Analytics;
     userDeletionRequest: Resource$Userdeletion$Userdeletionrequest;
-    constructor(root: Analytics) {
-      this.root = root;
-      this.getRoot.bind(this);
+    constructor() {
       this.userDeletionRequest =
-          new Resource$Userdeletion$Userdeletionrequest(root);
-    }
-
-    getRoot() {
-      return this.root;
+          new Resource$Userdeletion$Userdeletionrequest();
     }
   }
 
 
   export class Resource$Userdeletion$Userdeletionrequest {
-    root: Analytics;
-    constructor(root: Analytics) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -11634,7 +11388,7 @@ export namespace analytics_v3 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$UserDeletionRequest>(parameters, callback);

--- a/src/apis/analyticsreporting/v4.ts
+++ b/src/apis/analyticsreporting/v4.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace analyticsreporting_v4 {
   export interface Options extends GlobalOptions {
     version: 'v4';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -96,22 +98,12 @@ export namespace analyticsreporting_v4 {
    * @param {object=} options Options for Analyticsreporting
    */
   export class Analyticsreporting {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     reports: Resource$Reports;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.reports = new Resource$Reports(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.reports = new Resource$Reports();
     }
   }
 
@@ -1002,15 +994,7 @@ export namespace analyticsreporting_v4 {
 
 
   export class Resource$Reports {
-    root: Analyticsreporting;
-    constructor(root: Analyticsreporting) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -1070,7 +1054,7 @@ export namespace analyticsreporting_v4 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GetReportsResponse>(parameters, callback);

--- a/src/apis/androiddeviceprovisioning/v1.ts
+++ b/src/apis/androiddeviceprovisioning/v1.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace androiddeviceprovisioning_v1 {
   export interface Options extends GlobalOptions {
     version: 'v1';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -97,26 +99,16 @@ export namespace androiddeviceprovisioning_v1 {
    * @param {object=} options Options for Androiddeviceprovisioning
    */
   export class Androiddeviceprovisioning {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     customers: Resource$Customers;
     operations: Resource$Operations;
     partners: Resource$Partners;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.customers = new Resource$Customers(this);
-      this.operations = new Resource$Operations(this);
-      this.partners = new Resource$Partners(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.customers = new Resource$Customers();
+      this.operations = new Resource$Operations();
+      this.partners = new Resource$Partners();
     }
   }
 
@@ -930,20 +922,13 @@ export namespace androiddeviceprovisioning_v1 {
 
 
   export class Resource$Customers {
-    root: Androiddeviceprovisioning;
     configurations: Resource$Customers$Configurations;
     devices: Resource$Customers$Devices;
     dpcs: Resource$Customers$Dpcs;
-    constructor(root: Androiddeviceprovisioning) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.configurations = new Resource$Customers$Configurations(root);
-      this.devices = new Resource$Customers$Devices(root);
-      this.dpcs = new Resource$Customers$Dpcs(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.configurations = new Resource$Customers$Configurations();
+      this.devices = new Resource$Customers$Devices();
+      this.dpcs = new Resource$Customers$Dpcs();
     }
 
 
@@ -1007,7 +992,7 @@ export namespace androiddeviceprovisioning_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$CustomerListCustomersResponse>(
@@ -1037,15 +1022,7 @@ export namespace androiddeviceprovisioning_v1 {
   }
 
   export class Resource$Customers$Configurations {
-    root: Androiddeviceprovisioning;
-    constructor(root: Androiddeviceprovisioning) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -1108,7 +1085,7 @@ export namespace androiddeviceprovisioning_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Configuration>(parameters, callback);
@@ -1175,7 +1152,7 @@ export namespace androiddeviceprovisioning_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -1238,7 +1215,7 @@ export namespace androiddeviceprovisioning_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Configuration>(parameters, callback);
@@ -1315,7 +1292,7 @@ export namespace androiddeviceprovisioning_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$CustomerListConfigurationsResponse>(
@@ -1386,7 +1363,7 @@ export namespace androiddeviceprovisioning_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Configuration>(parameters, callback);
@@ -1483,15 +1460,7 @@ export namespace androiddeviceprovisioning_v1 {
 
 
   export class Resource$Customers$Devices {
-    root: Androiddeviceprovisioning;
-    constructor(root: Androiddeviceprovisioning) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -1555,7 +1524,7 @@ export namespace androiddeviceprovisioning_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -1617,7 +1586,7 @@ export namespace androiddeviceprovisioning_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Device>(parameters, callback);
@@ -1692,7 +1661,7 @@ export namespace androiddeviceprovisioning_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$CustomerListDevicesResponse>(
@@ -1762,7 +1731,7 @@ export namespace androiddeviceprovisioning_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -1832,7 +1801,7 @@ export namespace androiddeviceprovisioning_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -1934,15 +1903,7 @@ export namespace androiddeviceprovisioning_v1 {
 
 
   export class Resource$Customers$Dpcs {
-    root: Androiddeviceprovisioning;
-    constructor(root: Androiddeviceprovisioning) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -2004,7 +1965,7 @@ export namespace androiddeviceprovisioning_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$CustomerListDpcsResponse>(parameters, callback);
@@ -2031,15 +1992,7 @@ export namespace androiddeviceprovisioning_v1 {
 
 
   export class Resource$Operations {
-    root: Androiddeviceprovisioning;
-    constructor(root: Androiddeviceprovisioning) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -2096,7 +2049,7 @@ export namespace androiddeviceprovisioning_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -2120,34 +2073,19 @@ export namespace androiddeviceprovisioning_v1 {
 
 
   export class Resource$Partners {
-    root: Androiddeviceprovisioning;
     customers: Resource$Partners$Customers;
     devices: Resource$Partners$Devices;
     vendors: Resource$Partners$Vendors;
-    constructor(root: Androiddeviceprovisioning) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.customers = new Resource$Partners$Customers(root);
-      this.devices = new Resource$Partners$Devices(root);
-      this.vendors = new Resource$Partners$Vendors(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.customers = new Resource$Partners$Customers();
+      this.devices = new Resource$Partners$Devices();
+      this.vendors = new Resource$Partners$Vendors();
     }
   }
 
 
   export class Resource$Partners$Customers {
-    root: Androiddeviceprovisioning;
-    constructor(root: Androiddeviceprovisioning) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -2212,7 +2150,7 @@ export namespace androiddeviceprovisioning_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Company>(parameters, callback);
@@ -2285,7 +2223,7 @@ export namespace androiddeviceprovisioning_v1 {
         params,
         requiredParams: ['partnerId'],
         pathParams: ['partnerId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListCustomersResponse>(parameters, callback);
@@ -2337,15 +2275,7 @@ export namespace androiddeviceprovisioning_v1 {
 
 
   export class Resource$Partners$Devices {
-    root: Androiddeviceprovisioning;
-    constructor(root: Androiddeviceprovisioning) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -2409,7 +2339,7 @@ export namespace androiddeviceprovisioning_v1 {
         params,
         requiredParams: ['partnerId'],
         pathParams: ['partnerId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ClaimDeviceResponse>(parameters, callback);
@@ -2480,7 +2410,7 @@ export namespace androiddeviceprovisioning_v1 {
         params,
         requiredParams: ['partnerId'],
         pathParams: ['partnerId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -2560,7 +2490,7 @@ export namespace androiddeviceprovisioning_v1 {
         params,
         requiredParams: ['partnerId'],
         pathParams: ['partnerId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$FindDevicesByDeviceIdentifierResponse>(
@@ -2640,7 +2570,7 @@ export namespace androiddeviceprovisioning_v1 {
         params,
         requiredParams: ['partnerId'],
         pathParams: ['partnerId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$FindDevicesByOwnerResponse>(
@@ -2703,7 +2633,7 @@ export namespace androiddeviceprovisioning_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Device>(parameters, callback);
@@ -2775,7 +2705,7 @@ export namespace androiddeviceprovisioning_v1 {
         params,
         requiredParams: ['metadataOwnerId', 'deviceId'],
         pathParams: ['deviceId', 'metadataOwnerId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$DeviceMetadata>(parameters, callback);
@@ -2844,7 +2774,7 @@ export namespace androiddeviceprovisioning_v1 {
         params,
         requiredParams: ['partnerId'],
         pathParams: ['partnerId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -2915,7 +2845,7 @@ export namespace androiddeviceprovisioning_v1 {
         params,
         requiredParams: ['partnerId'],
         pathParams: ['partnerId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -2988,7 +2918,7 @@ export namespace androiddeviceprovisioning_v1 {
         params,
         requiredParams: ['partnerId'],
         pathParams: ['partnerId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -3155,16 +3085,9 @@ export namespace androiddeviceprovisioning_v1 {
 
 
   export class Resource$Partners$Vendors {
-    root: Androiddeviceprovisioning;
     customers: Resource$Partners$Vendors$Customers;
-    constructor(root: Androiddeviceprovisioning) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.customers = new Resource$Partners$Vendors$Customers(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.customers = new Resource$Partners$Vendors$Customers();
     }
 
 
@@ -3228,7 +3151,7 @@ export namespace androiddeviceprovisioning_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListVendorsResponse>(parameters, callback);
@@ -3260,15 +3183,7 @@ export namespace androiddeviceprovisioning_v1 {
   }
 
   export class Resource$Partners$Vendors$Customers {
-    root: Androiddeviceprovisioning;
-    constructor(root: Androiddeviceprovisioning) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -3336,7 +3251,7 @@ export namespace androiddeviceprovisioning_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListVendorCustomersResponse>(

--- a/src/apis/androidenterprise/v1.ts
+++ b/src/apis/androidenterprise/v1.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace androidenterprise_v1 {
   export interface Options extends GlobalOptions {
     version: 'v1';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -79,10 +81,6 @@ export namespace androidenterprise_v1 {
    * @param {object=} options Options for Androidenterprise
    */
   export class Androidenterprise {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     devices: Resource$Devices;
     enterprises: Resource$Enterprises;
     entitlements: Resource$Entitlements;
@@ -101,33 +99,27 @@ export namespace androidenterprise_v1 {
     webapps: Resource$Webapps;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.devices = new Resource$Devices(this);
-      this.enterprises = new Resource$Enterprises(this);
-      this.entitlements = new Resource$Entitlements(this);
-      this.grouplicenses = new Resource$Grouplicenses(this);
-      this.grouplicenseusers = new Resource$Grouplicenseusers(this);
-      this.installs = new Resource$Installs(this);
+      this.devices = new Resource$Devices();
+      this.enterprises = new Resource$Enterprises();
+      this.entitlements = new Resource$Entitlements();
+      this.grouplicenses = new Resource$Grouplicenses();
+      this.grouplicenseusers = new Resource$Grouplicenseusers();
+      this.installs = new Resource$Installs();
       this.managedconfigurationsfordevice =
-          new Resource$Managedconfigurationsfordevice(this);
+          new Resource$Managedconfigurationsfordevice();
       this.managedconfigurationsforuser =
-          new Resource$Managedconfigurationsforuser(this);
+          new Resource$Managedconfigurationsforuser();
       this.managedconfigurationssettings =
-          new Resource$Managedconfigurationssettings(this);
-      this.permissions = new Resource$Permissions(this);
-      this.products = new Resource$Products(this);
-      this.serviceaccountkeys = new Resource$Serviceaccountkeys(this);
-      this.storelayoutclusters = new Resource$Storelayoutclusters(this);
-      this.storelayoutpages = new Resource$Storelayoutpages(this);
-      this.users = new Resource$Users(this);
-      this.webapps = new Resource$Webapps(this);
-    }
-
-    getRoot() {
-      return this.root;
+          new Resource$Managedconfigurationssettings();
+      this.permissions = new Resource$Permissions();
+      this.products = new Resource$Products();
+      this.serviceaccountkeys = new Resource$Serviceaccountkeys();
+      this.storelayoutclusters = new Resource$Storelayoutclusters();
+      this.storelayoutpages = new Resource$Storelayoutpages();
+      this.users = new Resource$Users();
+      this.webapps = new Resource$Webapps();
     }
   }
 
@@ -1909,15 +1901,7 @@ export namespace androidenterprise_v1 {
 
 
   export class Resource$Devices {
-    root: Androidenterprise;
-    constructor(root: Androidenterprise) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -1975,7 +1959,7 @@ export namespace androidenterprise_v1 {
         params,
         requiredParams: ['enterpriseId', 'userId', 'deviceId'],
         pathParams: ['deviceId', 'enterpriseId', 'userId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Device>(parameters, callback);
@@ -2049,7 +2033,7 @@ export namespace androidenterprise_v1 {
         params,
         requiredParams: ['enterpriseId', 'userId', 'deviceId'],
         pathParams: ['deviceId', 'enterpriseId', 'userId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$DeviceState>(parameters, callback);
@@ -2117,7 +2101,7 @@ export namespace androidenterprise_v1 {
         params,
         requiredParams: ['enterpriseId', 'userId'],
         pathParams: ['enterpriseId', 'userId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$DevicesListResponse>(parameters, callback);
@@ -2187,7 +2171,7 @@ export namespace androidenterprise_v1 {
         params,
         requiredParams: ['enterpriseId', 'userId', 'deviceId'],
         pathParams: ['deviceId', 'enterpriseId', 'userId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Device>(parameters, callback);
@@ -2262,7 +2246,7 @@ export namespace androidenterprise_v1 {
         params,
         requiredParams: ['enterpriseId', 'userId', 'deviceId'],
         pathParams: ['deviceId', 'enterpriseId', 'userId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$DeviceState>(parameters, callback);
@@ -2332,7 +2316,7 @@ export namespace androidenterprise_v1 {
         params,
         requiredParams: ['enterpriseId', 'userId', 'deviceId'],
         pathParams: ['deviceId', 'enterpriseId', 'userId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Device>(parameters, callback);
@@ -2482,15 +2466,7 @@ export namespace androidenterprise_v1 {
 
 
   export class Resource$Enterprises {
-    root: Androidenterprise;
-    constructor(root: Androidenterprise) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -2553,7 +2529,7 @@ export namespace androidenterprise_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -2624,7 +2600,7 @@ export namespace androidenterprise_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Enterprise>(parameters, callback);
@@ -2699,7 +2675,7 @@ export namespace androidenterprise_v1 {
         params,
         requiredParams: ['enterpriseId'],
         pathParams: ['enterpriseId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$AdministratorWebToken>(parameters, callback);
@@ -2767,7 +2743,7 @@ export namespace androidenterprise_v1 {
         params,
         requiredParams: ['token'],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Enterprise>(parameters, callback);
@@ -2834,7 +2810,7 @@ export namespace androidenterprise_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$SignupInfo>(parameters, callback);
@@ -2897,7 +2873,7 @@ export namespace androidenterprise_v1 {
         params,
         requiredParams: ['enterpriseId'],
         pathParams: ['enterpriseId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Enterprise>(parameters, callback);
@@ -2970,7 +2946,7 @@ export namespace androidenterprise_v1 {
         params,
         requiredParams: ['enterpriseId'],
         pathParams: ['enterpriseId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$AndroidDevicePolicyConfig>(
@@ -3052,7 +3028,7 @@ export namespace androidenterprise_v1 {
         params,
         requiredParams: ['enterpriseId'],
         pathParams: ['enterpriseId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ServiceAccount>(parameters, callback);
@@ -3123,7 +3099,7 @@ export namespace androidenterprise_v1 {
         params,
         requiredParams: ['enterpriseId'],
         pathParams: ['enterpriseId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$StoreLayout>(parameters, callback);
@@ -3193,7 +3169,7 @@ export namespace androidenterprise_v1 {
         params,
         requiredParams: ['domain'],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$EnterprisesListResponse>(parameters, callback);
@@ -3275,7 +3251,7 @@ export namespace androidenterprise_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$NotificationSet>(parameters, callback);
@@ -3353,7 +3329,7 @@ export namespace androidenterprise_v1 {
         params,
         requiredParams: ['enterpriseId'],
         pathParams: ['enterpriseId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$EnterprisesSendTestPushNotificationResponse>(
@@ -3425,7 +3401,7 @@ export namespace androidenterprise_v1 {
         params,
         requiredParams: ['enterpriseId'],
         pathParams: ['enterpriseId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$EnterpriseAccount>(parameters, callback);
@@ -3499,7 +3475,7 @@ export namespace androidenterprise_v1 {
         params,
         requiredParams: ['enterpriseId'],
         pathParams: ['enterpriseId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$AndroidDevicePolicyConfig>(
@@ -3577,7 +3553,7 @@ export namespace androidenterprise_v1 {
         params,
         requiredParams: ['enterpriseId'],
         pathParams: ['enterpriseId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$StoreLayout>(parameters, callback);
@@ -3643,7 +3619,7 @@ export namespace androidenterprise_v1 {
         params,
         requiredParams: ['enterpriseId'],
         pathParams: ['enterpriseId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -3892,15 +3868,7 @@ export namespace androidenterprise_v1 {
 
 
   export class Resource$Entitlements {
-    root: Androidenterprise;
-    constructor(root: Androidenterprise) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -3962,7 +3930,7 @@ export namespace androidenterprise_v1 {
         params,
         requiredParams: ['enterpriseId', 'userId', 'entitlementId'],
         pathParams: ['enterpriseId', 'entitlementId', 'userId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -4028,7 +3996,7 @@ export namespace androidenterprise_v1 {
         params,
         requiredParams: ['enterpriseId', 'userId', 'entitlementId'],
         pathParams: ['enterpriseId', 'entitlementId', 'userId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Entitlement>(parameters, callback);
@@ -4098,7 +4066,7 @@ export namespace androidenterprise_v1 {
         params,
         requiredParams: ['enterpriseId', 'userId'],
         pathParams: ['enterpriseId', 'userId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$EntitlementsListResponse>(parameters, callback);
@@ -4171,7 +4139,7 @@ export namespace androidenterprise_v1 {
         params,
         requiredParams: ['enterpriseId', 'userId', 'entitlementId'],
         pathParams: ['enterpriseId', 'entitlementId', 'userId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Entitlement>(parameters, callback);
@@ -4244,7 +4212,7 @@ export namespace androidenterprise_v1 {
         params,
         requiredParams: ['enterpriseId', 'userId', 'entitlementId'],
         pathParams: ['enterpriseId', 'entitlementId', 'userId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Entitlement>(parameters, callback);
@@ -4380,15 +4348,7 @@ export namespace androidenterprise_v1 {
 
 
   export class Resource$Grouplicenses {
-    root: Androidenterprise;
-    constructor(root: Androidenterprise) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -4447,7 +4407,7 @@ export namespace androidenterprise_v1 {
         params,
         requiredParams: ['enterpriseId', 'groupLicenseId'],
         pathParams: ['enterpriseId', 'groupLicenseId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GroupLicense>(parameters, callback);
@@ -4518,7 +4478,7 @@ export namespace androidenterprise_v1 {
         params,
         requiredParams: ['enterpriseId'],
         pathParams: ['enterpriseId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GroupLicensesListResponse>(
@@ -4561,15 +4521,7 @@ export namespace androidenterprise_v1 {
 
 
   export class Resource$Grouplicenseusers {
-    root: Androidenterprise;
-    constructor(root: Androidenterprise) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -4638,7 +4590,7 @@ export namespace androidenterprise_v1 {
         params,
         requiredParams: ['enterpriseId', 'groupLicenseId'],
         pathParams: ['enterpriseId', 'groupLicenseId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GroupLicenseUsersListResponse>(
@@ -4670,15 +4622,7 @@ export namespace androidenterprise_v1 {
 
 
   export class Resource$Installs {
-    root: Androidenterprise;
-    constructor(root: Androidenterprise) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -4741,7 +4685,7 @@ export namespace androidenterprise_v1 {
         params,
         requiredParams: ['enterpriseId', 'userId', 'deviceId', 'installId'],
         pathParams: ['deviceId', 'enterpriseId', 'installId', 'userId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -4807,7 +4751,7 @@ export namespace androidenterprise_v1 {
         params,
         requiredParams: ['enterpriseId', 'userId', 'deviceId', 'installId'],
         pathParams: ['deviceId', 'enterpriseId', 'installId', 'userId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Install>(parameters, callback);
@@ -4878,7 +4822,7 @@ export namespace androidenterprise_v1 {
         params,
         requiredParams: ['enterpriseId', 'userId', 'deviceId'],
         pathParams: ['deviceId', 'enterpriseId', 'userId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$InstallsListResponse>(parameters, callback);
@@ -4950,7 +4894,7 @@ export namespace androidenterprise_v1 {
         params,
         requiredParams: ['enterpriseId', 'userId', 'deviceId', 'installId'],
         pathParams: ['deviceId', 'enterpriseId', 'installId', 'userId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Install>(parameters, callback);
@@ -5022,7 +4966,7 @@ export namespace androidenterprise_v1 {
         params,
         requiredParams: ['enterpriseId', 'userId', 'deviceId', 'installId'],
         pathParams: ['deviceId', 'enterpriseId', 'installId', 'userId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Install>(parameters, callback);
@@ -5160,15 +5104,7 @@ export namespace androidenterprise_v1 {
 
 
   export class Resource$Managedconfigurationsfordevice {
-    root: Androidenterprise;
-    constructor(root: Androidenterprise) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -5239,7 +5175,7 @@ export namespace androidenterprise_v1 {
           'deviceId', 'enterpriseId', 'managedConfigurationForDeviceId',
           'userId'
         ],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -5314,7 +5250,7 @@ export namespace androidenterprise_v1 {
           'deviceId', 'enterpriseId', 'managedConfigurationForDeviceId',
           'userId'
         ],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ManagedConfiguration>(parameters, callback);
@@ -5392,7 +5328,7 @@ export namespace androidenterprise_v1 {
         params,
         requiredParams: ['enterpriseId', 'userId', 'deviceId'],
         pathParams: ['deviceId', 'enterpriseId', 'userId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ManagedConfigurationsForDeviceListResponse>(
@@ -5475,7 +5411,7 @@ export namespace androidenterprise_v1 {
           'deviceId', 'enterpriseId', 'managedConfigurationForDeviceId',
           'userId'
         ],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ManagedConfiguration>(parameters, callback);
@@ -5557,7 +5493,7 @@ export namespace androidenterprise_v1 {
           'deviceId', 'enterpriseId', 'managedConfigurationForDeviceId',
           'userId'
         ],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ManagedConfiguration>(parameters, callback);
@@ -5700,15 +5636,7 @@ export namespace androidenterprise_v1 {
 
 
   export class Resource$Managedconfigurationsforuser {
-    root: Androidenterprise;
-    constructor(root: Androidenterprise) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -5772,7 +5700,7 @@ export namespace androidenterprise_v1 {
         requiredParams:
             ['enterpriseId', 'userId', 'managedConfigurationForUserId'],
         pathParams: ['enterpriseId', 'managedConfigurationForUserId', 'userId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -5842,7 +5770,7 @@ export namespace androidenterprise_v1 {
         requiredParams:
             ['enterpriseId', 'userId', 'managedConfigurationForUserId'],
         pathParams: ['enterpriseId', 'managedConfigurationForUserId', 'userId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ManagedConfiguration>(parameters, callback);
@@ -5919,7 +5847,7 @@ export namespace androidenterprise_v1 {
         params,
         requiredParams: ['enterpriseId', 'userId'],
         pathParams: ['enterpriseId', 'userId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ManagedConfigurationsForUserListResponse>(
@@ -6000,7 +5928,7 @@ export namespace androidenterprise_v1 {
         requiredParams:
             ['enterpriseId', 'userId', 'managedConfigurationForUserId'],
         pathParams: ['enterpriseId', 'managedConfigurationForUserId', 'userId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ManagedConfiguration>(parameters, callback);
@@ -6079,7 +6007,7 @@ export namespace androidenterprise_v1 {
         requiredParams:
             ['enterpriseId', 'userId', 'managedConfigurationForUserId'],
         pathParams: ['enterpriseId', 'managedConfigurationForUserId', 'userId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ManagedConfiguration>(parameters, callback);
@@ -6202,15 +6130,7 @@ export namespace androidenterprise_v1 {
 
 
   export class Resource$Managedconfigurationssettings {
-    root: Androidenterprise;
-    constructor(root: Androidenterprise) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -6280,7 +6200,7 @@ export namespace androidenterprise_v1 {
         params,
         requiredParams: ['enterpriseId', 'productId'],
         pathParams: ['enterpriseId', 'productId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ManagedConfigurationsSettingsListResponse>(
@@ -6312,15 +6232,7 @@ export namespace androidenterprise_v1 {
 
 
   export class Resource$Permissions {
-    root: Androidenterprise;
-    constructor(root: Androidenterprise) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -6378,7 +6290,7 @@ export namespace androidenterprise_v1 {
         params,
         requiredParams: ['permissionId'],
         pathParams: ['permissionId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Permission>(parameters, callback);
@@ -6406,15 +6318,7 @@ export namespace androidenterprise_v1 {
 
 
   export class Resource$Products {
-    root: Androidenterprise;
-    constructor(root: Androidenterprise) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -6478,7 +6382,7 @@ export namespace androidenterprise_v1 {
         params,
         requiredParams: ['enterpriseId', 'productId'],
         pathParams: ['enterpriseId', 'productId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -6566,7 +6470,7 @@ export namespace androidenterprise_v1 {
         params,
         requiredParams: ['enterpriseId', 'productId'],
         pathParams: ['enterpriseId', 'productId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ProductsGenerateApprovalUrlResponse>(
@@ -6633,7 +6537,7 @@ export namespace androidenterprise_v1 {
         params,
         requiredParams: ['enterpriseId', 'productId'],
         pathParams: ['enterpriseId', 'productId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Product>(parameters, callback);
@@ -6711,7 +6615,7 @@ export namespace androidenterprise_v1 {
         params,
         requiredParams: ['enterpriseId', 'productId'],
         pathParams: ['enterpriseId', 'productId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$AppRestrictionsSchema>(parameters, callback);
@@ -6782,7 +6686,7 @@ export namespace androidenterprise_v1 {
         params,
         requiredParams: ['enterpriseId', 'productId'],
         pathParams: ['enterpriseId', 'productId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ProductPermissions>(parameters, callback);
@@ -6855,7 +6759,7 @@ export namespace androidenterprise_v1 {
         params,
         requiredParams: ['enterpriseId'],
         pathParams: ['enterpriseId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ProductsListResponse>(parameters, callback);
@@ -6924,7 +6828,7 @@ export namespace androidenterprise_v1 {
         params,
         requiredParams: ['enterpriseId', 'productId'],
         pathParams: ['enterpriseId', 'productId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -7092,15 +6996,7 @@ export namespace androidenterprise_v1 {
 
 
   export class Resource$Serviceaccountkeys {
-    root: Androidenterprise;
-    constructor(root: Androidenterprise) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -7165,7 +7061,7 @@ export namespace androidenterprise_v1 {
         params,
         requiredParams: ['enterpriseId', 'keyId'],
         pathParams: ['enterpriseId', 'keyId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -7239,7 +7135,7 @@ export namespace androidenterprise_v1 {
         params,
         requiredParams: ['enterpriseId'],
         pathParams: ['enterpriseId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ServiceAccountKey>(parameters, callback);
@@ -7317,7 +7213,7 @@ export namespace androidenterprise_v1 {
         params,
         requiredParams: ['enterpriseId'],
         pathParams: ['enterpriseId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ServiceAccountKeysListResponse>(
@@ -7377,15 +7273,7 @@ export namespace androidenterprise_v1 {
 
 
   export class Resource$Storelayoutclusters {
-    root: Androidenterprise;
-    constructor(root: Androidenterprise) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -7447,7 +7335,7 @@ export namespace androidenterprise_v1 {
         params,
         requiredParams: ['enterpriseId', 'pageId', 'clusterId'],
         pathParams: ['clusterId', 'enterpriseId', 'pageId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -7514,7 +7402,7 @@ export namespace androidenterprise_v1 {
         params,
         requiredParams: ['enterpriseId', 'pageId', 'clusterId'],
         pathParams: ['clusterId', 'enterpriseId', 'pageId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$StoreCluster>(parameters, callback);
@@ -7585,7 +7473,7 @@ export namespace androidenterprise_v1 {
         params,
         requiredParams: ['enterpriseId', 'pageId'],
         pathParams: ['enterpriseId', 'pageId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$StoreCluster>(parameters, callback);
@@ -7662,7 +7550,7 @@ export namespace androidenterprise_v1 {
         params,
         requiredParams: ['enterpriseId', 'pageId'],
         pathParams: ['enterpriseId', 'pageId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$StoreLayoutClustersListResponse>(
@@ -7736,7 +7624,7 @@ export namespace androidenterprise_v1 {
         params,
         requiredParams: ['enterpriseId', 'pageId', 'clusterId'],
         pathParams: ['clusterId', 'enterpriseId', 'pageId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$StoreCluster>(parameters, callback);
@@ -7808,7 +7696,7 @@ export namespace androidenterprise_v1 {
         params,
         requiredParams: ['enterpriseId', 'pageId', 'clusterId'],
         pathParams: ['clusterId', 'enterpriseId', 'pageId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$StoreCluster>(parameters, callback);
@@ -7948,15 +7836,7 @@ export namespace androidenterprise_v1 {
 
 
   export class Resource$Storelayoutpages {
-    root: Androidenterprise;
-    constructor(root: Androidenterprise) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -8017,7 +7897,7 @@ export namespace androidenterprise_v1 {
         params,
         requiredParams: ['enterpriseId', 'pageId'],
         pathParams: ['enterpriseId', 'pageId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -8083,7 +7963,7 @@ export namespace androidenterprise_v1 {
         params,
         requiredParams: ['enterpriseId', 'pageId'],
         pathParams: ['enterpriseId', 'pageId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$StorePage>(parameters, callback);
@@ -8153,7 +8033,7 @@ export namespace androidenterprise_v1 {
         params,
         requiredParams: ['enterpriseId'],
         pathParams: ['enterpriseId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$StorePage>(parameters, callback);
@@ -8227,7 +8107,7 @@ export namespace androidenterprise_v1 {
         params,
         requiredParams: ['enterpriseId'],
         pathParams: ['enterpriseId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$StoreLayoutPagesListResponse>(
@@ -8301,7 +8181,7 @@ export namespace androidenterprise_v1 {
         params,
         requiredParams: ['enterpriseId', 'pageId'],
         pathParams: ['enterpriseId', 'pageId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$StorePage>(parameters, callback);
@@ -8372,7 +8252,7 @@ export namespace androidenterprise_v1 {
         params,
         requiredParams: ['enterpriseId', 'pageId'],
         pathParams: ['enterpriseId', 'pageId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$StorePage>(parameters, callback);
@@ -8488,15 +8368,7 @@ export namespace androidenterprise_v1 {
 
 
   export class Resource$Users {
-    root: Androidenterprise;
-    constructor(root: Androidenterprise) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -8555,7 +8427,7 @@ export namespace androidenterprise_v1 {
         params,
         requiredParams: ['enterpriseId', 'userId'],
         pathParams: ['enterpriseId', 'userId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -8630,7 +8502,7 @@ export namespace androidenterprise_v1 {
         params,
         requiredParams: ['enterpriseId', 'userId'],
         pathParams: ['enterpriseId', 'userId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$AuthenticationToken>(parameters, callback);
@@ -8702,7 +8574,7 @@ export namespace androidenterprise_v1 {
         params,
         requiredParams: ['enterpriseId', 'userId'],
         pathParams: ['enterpriseId', 'userId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$UserToken>(parameters, callback);
@@ -8766,7 +8638,7 @@ export namespace androidenterprise_v1 {
         params,
         requiredParams: ['enterpriseId', 'userId'],
         pathParams: ['enterpriseId', 'userId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$User>(parameters, callback);
@@ -8837,7 +8709,7 @@ export namespace androidenterprise_v1 {
         params,
         requiredParams: ['enterpriseId', 'userId'],
         pathParams: ['enterpriseId', 'userId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ProductSet>(parameters, callback);
@@ -8907,7 +8779,7 @@ export namespace androidenterprise_v1 {
         params,
         requiredParams: ['enterpriseId'],
         pathParams: ['enterpriseId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$User>(parameters, callback);
@@ -8977,7 +8849,7 @@ export namespace androidenterprise_v1 {
         params,
         requiredParams: ['enterpriseId', 'email'],
         pathParams: ['enterpriseId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$UsersListResponse>(parameters, callback);
@@ -9049,7 +8921,7 @@ export namespace androidenterprise_v1 {
         params,
         requiredParams: ['enterpriseId', 'userId'],
         pathParams: ['enterpriseId', 'userId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$User>(parameters, callback);
@@ -9119,7 +8991,7 @@ export namespace androidenterprise_v1 {
         params,
         requiredParams: ['enterpriseId', 'userId'],
         pathParams: ['enterpriseId', 'userId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -9188,7 +9060,7 @@ export namespace androidenterprise_v1 {
         params,
         requiredParams: ['enterpriseId', 'userId'],
         pathParams: ['enterpriseId', 'userId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -9263,7 +9135,7 @@ export namespace androidenterprise_v1 {
         params,
         requiredParams: ['enterpriseId', 'userId'],
         pathParams: ['enterpriseId', 'userId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ProductSet>(parameters, callback);
@@ -9335,7 +9207,7 @@ export namespace androidenterprise_v1 {
         params,
         requiredParams: ['enterpriseId', 'userId'],
         pathParams: ['enterpriseId', 'userId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$User>(parameters, callback);
@@ -9550,15 +9422,7 @@ export namespace androidenterprise_v1 {
 
 
   export class Resource$Webapps {
-    root: Androidenterprise;
-    constructor(root: Androidenterprise) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -9617,7 +9481,7 @@ export namespace androidenterprise_v1 {
         params,
         requiredParams: ['enterpriseId', 'webAppId'],
         pathParams: ['enterpriseId', 'webAppId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -9681,7 +9545,7 @@ export namespace androidenterprise_v1 {
         params,
         requiredParams: ['enterpriseId', 'webAppId'],
         pathParams: ['enterpriseId', 'webAppId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$WebApp>(parameters, callback);
@@ -9747,7 +9611,7 @@ export namespace androidenterprise_v1 {
         params,
         requiredParams: ['enterpriseId'],
         pathParams: ['enterpriseId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$WebApp>(parameters, callback);
@@ -9813,7 +9677,7 @@ export namespace androidenterprise_v1 {
         params,
         requiredParams: ['enterpriseId'],
         pathParams: ['enterpriseId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$WebAppsListResponse>(parameters, callback);
@@ -9881,7 +9745,7 @@ export namespace androidenterprise_v1 {
         params,
         requiredParams: ['enterpriseId', 'webAppId'],
         pathParams: ['enterpriseId', 'webAppId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$WebApp>(parameters, callback);
@@ -9949,7 +9813,7 @@ export namespace androidenterprise_v1 {
         params,
         requiredParams: ['enterpriseId', 'webAppId'],
         pathParams: ['enterpriseId', 'webAppId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$WebApp>(parameters, callback);

--- a/src/apis/androidmanagement/v1.ts
+++ b/src/apis/androidmanagement/v1.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace androidmanagement_v1 {
   export interface Options extends GlobalOptions {
     version: 'v1';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -97,24 +99,14 @@ export namespace androidmanagement_v1 {
    * @param {object=} options Options for Androidmanagement
    */
   export class Androidmanagement {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     enterprises: Resource$Enterprises;
     signupUrls: Resource$Signupurls;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.enterprises = new Resource$Enterprises(this);
-      this.signupUrls = new Resource$Signupurls(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.enterprises = new Resource$Enterprises();
+      this.signupUrls = new Resource$Signupurls();
     }
   }
 
@@ -1957,24 +1949,17 @@ export namespace androidmanagement_v1 {
 
 
   export class Resource$Enterprises {
-    root: Androidmanagement;
     applications: Resource$Enterprises$Applications;
     devices: Resource$Enterprises$Devices;
     enrollmentTokens: Resource$Enterprises$Enrollmenttokens;
     policies: Resource$Enterprises$Policies;
     webTokens: Resource$Enterprises$Webtokens;
-    constructor(root: Androidmanagement) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.applications = new Resource$Enterprises$Applications(root);
-      this.devices = new Resource$Enterprises$Devices(root);
-      this.enrollmentTokens = new Resource$Enterprises$Enrollmenttokens(root);
-      this.policies = new Resource$Enterprises$Policies(root);
-      this.webTokens = new Resource$Enterprises$Webtokens(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.applications = new Resource$Enterprises$Applications();
+      this.devices = new Resource$Enterprises$Devices();
+      this.enrollmentTokens = new Resource$Enterprises$Enrollmenttokens();
+      this.policies = new Resource$Enterprises$Policies();
+      this.webTokens = new Resource$Enterprises$Webtokens();
     }
 
 
@@ -2039,7 +2024,7 @@ export namespace androidmanagement_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Enterprise>(parameters, callback);
@@ -2101,7 +2086,7 @@ export namespace androidmanagement_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Enterprise>(parameters, callback);
@@ -2169,7 +2154,7 @@ export namespace androidmanagement_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Enterprise>(parameters, callback);
@@ -2240,15 +2225,7 @@ export namespace androidmanagement_v1 {
   }
 
   export class Resource$Enterprises$Applications {
-    root: Androidmanagement;
-    constructor(root: Androidmanagement) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -2305,7 +2282,7 @@ export namespace androidmanagement_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Application>(parameters, callback);
@@ -2337,16 +2314,9 @@ export namespace androidmanagement_v1 {
 
 
   export class Resource$Enterprises$Devices {
-    root: Androidmanagement;
     operations: Resource$Enterprises$Devices$Operations;
-    constructor(root: Androidmanagement) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.operations = new Resource$Enterprises$Devices$Operations(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.operations = new Resource$Enterprises$Devices$Operations();
     }
 
 
@@ -2407,7 +2377,7 @@ export namespace androidmanagement_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -2469,7 +2439,7 @@ export namespace androidmanagement_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Device>(parameters, callback);
@@ -2540,7 +2510,7 @@ export namespace androidmanagement_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -2610,7 +2580,7 @@ export namespace androidmanagement_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListDevicesResponse>(parameters, callback);
@@ -2678,7 +2648,7 @@ export namespace androidmanagement_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Device>(parameters, callback);
@@ -2782,15 +2752,7 @@ export namespace androidmanagement_v1 {
   }
 
   export class Resource$Enterprises$Devices$Operations {
-    root: Androidmanagement;
-    constructor(root: Androidmanagement) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -2859,7 +2821,7 @@ export namespace androidmanagement_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -2929,7 +2891,7 @@ export namespace androidmanagement_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -2994,7 +2956,7 @@ export namespace androidmanagement_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -3073,7 +3035,7 @@ export namespace androidmanagement_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListOperationsResponse>(parameters, callback);
@@ -3147,15 +3109,7 @@ export namespace androidmanagement_v1 {
 
 
   export class Resource$Enterprises$Enrollmenttokens {
-    root: Androidmanagement;
-    constructor(root: Androidmanagement) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -3217,7 +3171,7 @@ export namespace androidmanagement_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$EnrollmentToken>(parameters, callback);
@@ -3284,7 +3238,7 @@ export namespace androidmanagement_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -3327,15 +3281,7 @@ export namespace androidmanagement_v1 {
 
 
   export class Resource$Enterprises$Policies {
-    root: Androidmanagement;
-    constructor(root: Androidmanagement) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -3395,7 +3341,7 @@ export namespace androidmanagement_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -3457,7 +3403,7 @@ export namespace androidmanagement_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -3528,7 +3474,7 @@ export namespace androidmanagement_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListPoliciesResponse>(parameters, callback);
@@ -3596,7 +3542,7 @@ export namespace androidmanagement_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -3679,15 +3625,7 @@ export namespace androidmanagement_v1 {
 
 
   export class Resource$Enterprises$Webtokens {
-    root: Androidmanagement;
-    constructor(root: Androidmanagement) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -3749,7 +3687,7 @@ export namespace androidmanagement_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$WebToken>(parameters, callback);
@@ -3780,15 +3718,7 @@ export namespace androidmanagement_v1 {
 
 
   export class Resource$Signupurls {
-    root: Androidmanagement;
-    constructor(root: Androidmanagement) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -3848,7 +3778,7 @@ export namespace androidmanagement_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$SignupUrl>(parameters, callback);

--- a/src/apis/androidpublisher/v1.1.ts
+++ b/src/apis/androidpublisher/v1.1.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace androidpublisher_v1_1 {
   export interface Options extends GlobalOptions {
     version: 'v1_1';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -79,24 +81,14 @@ export namespace androidpublisher_v1_1 {
    * @param {object=} options Options for Androidpublisher
    */
   export class Androidpublisher {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     inapppurchases: Resource$Inapppurchases;
     purchases: Resource$Purchases;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.inapppurchases = new Resource$Inapppurchases(this);
-      this.purchases = new Resource$Purchases(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.inapppurchases = new Resource$Inapppurchases();
+      this.purchases = new Resource$Purchases();
     }
   }
 
@@ -171,15 +163,7 @@ export namespace androidpublisher_v1_1 {
 
 
   export class Resource$Inapppurchases {
-    root: Androidpublisher;
-    constructor(root: Androidpublisher) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -239,7 +223,7 @@ export namespace androidpublisher_v1_1 {
         params,
         requiredParams: ['packageName', 'productId', 'token'],
         pathParams: ['packageName', 'productId', 'token'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$InappPurchase>(parameters, callback);
@@ -274,15 +258,7 @@ export namespace androidpublisher_v1_1 {
 
 
   export class Resource$Purchases {
-    root: Androidpublisher;
-    constructor(root: Androidpublisher) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -343,7 +319,7 @@ export namespace androidpublisher_v1_1 {
         params,
         requiredParams: ['packageName', 'subscriptionId', 'token'],
         pathParams: ['packageName', 'subscriptionId', 'token'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -411,7 +387,7 @@ export namespace androidpublisher_v1_1 {
         params,
         requiredParams: ['packageName', 'subscriptionId', 'token'],
         pathParams: ['packageName', 'subscriptionId', 'token'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$SubscriptionPurchase>(parameters, callback);

--- a/src/apis/androidpublisher/v1.ts
+++ b/src/apis/androidpublisher/v1.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace androidpublisher_v1 {
   export interface Options extends GlobalOptions {
     version: 'v1';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -79,22 +81,12 @@ export namespace androidpublisher_v1 {
    * @param {object=} options Options for Androidpublisher
    */
   export class Androidpublisher {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     purchases: Resource$Purchases;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.purchases = new Resource$Purchases(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.purchases = new Resource$Purchases();
     }
   }
 
@@ -127,15 +119,7 @@ export namespace androidpublisher_v1 {
 
 
   export class Resource$Purchases {
-    root: Androidpublisher;
-    constructor(root: Androidpublisher) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -196,7 +180,7 @@ export namespace androidpublisher_v1 {
         params,
         requiredParams: ['packageName', 'subscriptionId', 'token'],
         pathParams: ['packageName', 'subscriptionId', 'token'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -264,7 +248,7 @@ export namespace androidpublisher_v1 {
         params,
         requiredParams: ['packageName', 'subscriptionId', 'token'],
         pathParams: ['packageName', 'subscriptionId', 'token'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$SubscriptionPurchase>(parameters, callback);

--- a/src/apis/androidpublisher/v2.ts
+++ b/src/apis/androidpublisher/v2.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace androidpublisher_v2 {
   export interface Options extends GlobalOptions {
     version: 'v2';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -79,10 +81,6 @@ export namespace androidpublisher_v2 {
    * @param {object=} options Options for Androidpublisher
    */
   export class Androidpublisher {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     edits: Resource$Edits;
     inappproducts: Resource$Inappproducts;
     orders: Resource$Orders;
@@ -90,19 +88,13 @@ export namespace androidpublisher_v2 {
     reviews: Resource$Reviews;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.edits = new Resource$Edits(this);
-      this.inappproducts = new Resource$Inappproducts(this);
-      this.orders = new Resource$Orders(this);
-      this.purchases = new Resource$Purchases(this);
-      this.reviews = new Resource$Reviews(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.edits = new Resource$Edits();
+      this.inappproducts = new Resource$Inappproducts();
+      this.orders = new Resource$Orders();
+      this.purchases = new Resource$Purchases();
+      this.reviews = new Resource$Reviews();
     }
   }
 
@@ -997,7 +989,6 @@ export namespace androidpublisher_v2 {
 
 
   export class Resource$Edits {
-    root: Androidpublisher;
     apklistings: Resource$Edits$Apklistings;
     apks: Resource$Edits$Apks;
     bundles: Resource$Edits$Bundles;
@@ -1008,23 +999,17 @@ export namespace androidpublisher_v2 {
     listings: Resource$Edits$Listings;
     testers: Resource$Edits$Testers;
     tracks: Resource$Edits$Tracks;
-    constructor(root: Androidpublisher) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.apklistings = new Resource$Edits$Apklistings(root);
-      this.apks = new Resource$Edits$Apks(root);
-      this.bundles = new Resource$Edits$Bundles(root);
-      this.deobfuscationfiles = new Resource$Edits$Deobfuscationfiles(root);
-      this.details = new Resource$Edits$Details(root);
-      this.expansionfiles = new Resource$Edits$Expansionfiles(root);
-      this.images = new Resource$Edits$Images(root);
-      this.listings = new Resource$Edits$Listings(root);
-      this.testers = new Resource$Edits$Testers(root);
-      this.tracks = new Resource$Edits$Tracks(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.apklistings = new Resource$Edits$Apklistings();
+      this.apks = new Resource$Edits$Apks();
+      this.bundles = new Resource$Edits$Bundles();
+      this.deobfuscationfiles = new Resource$Edits$Deobfuscationfiles();
+      this.details = new Resource$Edits$Details();
+      this.expansionfiles = new Resource$Edits$Expansionfiles();
+      this.images = new Resource$Edits$Images();
+      this.listings = new Resource$Edits$Listings();
+      this.testers = new Resource$Edits$Testers();
+      this.tracks = new Resource$Edits$Tracks();
     }
 
 
@@ -1085,7 +1070,7 @@ export namespace androidpublisher_v2 {
         params,
         requiredParams: ['packageName', 'editId'],
         pathParams: ['editId', 'packageName'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$AppEdit>(parameters, callback);
@@ -1153,7 +1138,7 @@ export namespace androidpublisher_v2 {
         params,
         requiredParams: ['packageName', 'editId'],
         pathParams: ['editId', 'packageName'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -1219,7 +1204,7 @@ export namespace androidpublisher_v2 {
         params,
         requiredParams: ['packageName', 'editId'],
         pathParams: ['editId', 'packageName'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$AppEdit>(parameters, callback);
@@ -1286,7 +1271,7 @@ export namespace androidpublisher_v2 {
         params,
         requiredParams: ['packageName'],
         pathParams: ['packageName'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$AppEdit>(parameters, callback);
@@ -1354,7 +1339,7 @@ export namespace androidpublisher_v2 {
         params,
         requiredParams: ['packageName', 'editId'],
         pathParams: ['editId', 'packageName'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$AppEdit>(parameters, callback);
@@ -1447,15 +1432,7 @@ export namespace androidpublisher_v2 {
   }
 
   export class Resource$Edits$Apklistings {
-    root: Androidpublisher;
-    constructor(root: Androidpublisher) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -1519,7 +1496,7 @@ export namespace androidpublisher_v2 {
         params,
         requiredParams: ['packageName', 'editId', 'apkVersionCode', 'language'],
         pathParams: ['apkVersionCode', 'editId', 'language', 'packageName'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -1589,7 +1566,7 @@ export namespace androidpublisher_v2 {
         params,
         requiredParams: ['packageName', 'editId', 'apkVersionCode'],
         pathParams: ['apkVersionCode', 'editId', 'packageName'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -1658,7 +1635,7 @@ export namespace androidpublisher_v2 {
         params,
         requiredParams: ['packageName', 'editId', 'apkVersionCode', 'language'],
         pathParams: ['apkVersionCode', 'editId', 'language', 'packageName'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ApkListing>(parameters, callback);
@@ -1730,7 +1707,7 @@ export namespace androidpublisher_v2 {
         params,
         requiredParams: ['packageName', 'editId', 'apkVersionCode'],
         pathParams: ['apkVersionCode', 'editId', 'packageName'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ApkListingsListResponse>(parameters, callback);
@@ -1804,7 +1781,7 @@ export namespace androidpublisher_v2 {
         params,
         requiredParams: ['packageName', 'editId', 'apkVersionCode', 'language'],
         pathParams: ['apkVersionCode', 'editId', 'language', 'packageName'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ApkListing>(parameters, callback);
@@ -1878,7 +1855,7 @@ export namespace androidpublisher_v2 {
         params,
         requiredParams: ['packageName', 'editId', 'apkVersionCode', 'language'],
         pathParams: ['apkVersionCode', 'editId', 'language', 'packageName'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ApkListing>(parameters, callback);
@@ -2057,15 +2034,7 @@ export namespace androidpublisher_v2 {
 
 
   export class Resource$Edits$Apks {
-    root: Androidpublisher;
-    constructor(root: Androidpublisher) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -2139,7 +2108,7 @@ export namespace androidpublisher_v2 {
         params,
         requiredParams: ['packageName', 'editId'],
         pathParams: ['editId', 'packageName'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ApksAddExternallyHostedResponse>(
@@ -2208,7 +2177,7 @@ export namespace androidpublisher_v2 {
         params,
         requiredParams: ['packageName', 'editId'],
         pathParams: ['editId', 'packageName'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ApksListResponse>(parameters, callback);
@@ -2282,7 +2251,7 @@ export namespace androidpublisher_v2 {
                 .replace(/([^:]\/)\/+/g, '$1'),
         requiredParams: ['packageName', 'editId'],
         pathParams: ['editId', 'packageName'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Apk>(parameters, callback);
@@ -2366,15 +2335,7 @@ export namespace androidpublisher_v2 {
 
 
   export class Resource$Edits$Bundles {
-    root: Androidpublisher;
-    constructor(root: Androidpublisher) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -2435,7 +2396,7 @@ export namespace androidpublisher_v2 {
         params,
         requiredParams: ['packageName', 'editId'],
         pathParams: ['editId', 'packageName'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$BundlesListResponse>(parameters, callback);
@@ -2517,7 +2478,7 @@ export namespace androidpublisher_v2 {
                 .replace(/([^:]\/)\/+/g, '$1'),
         requiredParams: ['packageName', 'editId'],
         pathParams: ['editId', 'packageName'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Bundle>(parameters, callback);
@@ -2586,15 +2547,7 @@ export namespace androidpublisher_v2 {
 
 
   export class Resource$Edits$Deobfuscationfiles {
-    root: Androidpublisher;
-    constructor(root: Androidpublisher) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -2680,7 +2633,7 @@ export namespace androidpublisher_v2 {
         pathParams: [
           'apkVersionCode', 'deobfuscationFileType', 'editId', 'packageName'
         ],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$DeobfuscationFilesUploadResponse>(
@@ -2736,15 +2689,7 @@ export namespace androidpublisher_v2 {
 
 
   export class Resource$Edits$Details {
-    root: Androidpublisher;
-    constructor(root: Androidpublisher) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -2804,7 +2749,7 @@ export namespace androidpublisher_v2 {
         params,
         requiredParams: ['packageName', 'editId'],
         pathParams: ['editId', 'packageName'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$AppDetails>(parameters, callback);
@@ -2876,7 +2821,7 @@ export namespace androidpublisher_v2 {
         params,
         requiredParams: ['packageName', 'editId'],
         pathParams: ['editId', 'packageName'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$AppDetails>(parameters, callback);
@@ -2947,7 +2892,7 @@ export namespace androidpublisher_v2 {
         params,
         requiredParams: ['packageName', 'editId'],
         pathParams: ['editId', 'packageName'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$AppDetails>(parameters, callback);
@@ -3021,15 +2966,7 @@ export namespace androidpublisher_v2 {
 
 
   export class Resource$Edits$Expansionfiles {
-    root: Androidpublisher;
-    constructor(root: Androidpublisher) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -3092,7 +3029,7 @@ export namespace androidpublisher_v2 {
             ['packageName', 'editId', 'apkVersionCode', 'expansionFileType'],
         pathParams:
             ['apkVersionCode', 'editId', 'expansionFileType', 'packageName'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ExpansionFile>(parameters, callback);
@@ -3169,7 +3106,7 @@ export namespace androidpublisher_v2 {
             ['packageName', 'editId', 'apkVersionCode', 'expansionFileType'],
         pathParams:
             ['apkVersionCode', 'editId', 'expansionFileType', 'packageName'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ExpansionFile>(parameters, callback);
@@ -3245,7 +3182,7 @@ export namespace androidpublisher_v2 {
             ['packageName', 'editId', 'apkVersionCode', 'expansionFileType'],
         pathParams:
             ['apkVersionCode', 'editId', 'expansionFileType', 'packageName'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ExpansionFile>(parameters, callback);
@@ -3331,7 +3268,7 @@ export namespace androidpublisher_v2 {
             ['packageName', 'editId', 'apkVersionCode', 'expansionFileType'],
         pathParams:
             ['apkVersionCode', 'editId', 'expansionFileType', 'packageName'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ExpansionFilesUploadResponse>(
@@ -3476,15 +3413,7 @@ export namespace androidpublisher_v2 {
 
 
   export class Resource$Edits$Images {
-    root: Androidpublisher;
-    constructor(root: Androidpublisher) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -3550,7 +3479,7 @@ export namespace androidpublisher_v2 {
             ['packageName', 'editId', 'language', 'imageType', 'imageId'],
         pathParams:
             ['editId', 'imageId', 'imageType', 'language', 'packageName'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -3624,7 +3553,7 @@ export namespace androidpublisher_v2 {
         params,
         requiredParams: ['packageName', 'editId', 'language', 'imageType'],
         pathParams: ['editId', 'imageType', 'language', 'packageName'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ImagesDeleteAllResponse>(parameters, callback);
@@ -3695,7 +3624,7 @@ export namespace androidpublisher_v2 {
         params,
         requiredParams: ['packageName', 'editId', 'language', 'imageType'],
         pathParams: ['editId', 'imageType', 'language', 'packageName'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ImagesListResponse>(parameters, callback);
@@ -3776,7 +3705,7 @@ export namespace androidpublisher_v2 {
                 .replace(/([^:]\/)\/+/g, '$1'),
         requiredParams: ['packageName', 'editId', 'language', 'imageType'],
         pathParams: ['editId', 'imageType', 'language', 'packageName'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ImagesUploadResponse>(parameters, callback);
@@ -3918,15 +3847,7 @@ export namespace androidpublisher_v2 {
 
 
   export class Resource$Edits$Listings {
-    root: Androidpublisher;
-    constructor(root: Androidpublisher) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -3988,7 +3909,7 @@ export namespace androidpublisher_v2 {
         params,
         requiredParams: ['packageName', 'editId', 'language'],
         pathParams: ['editId', 'language', 'packageName'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -4056,7 +3977,7 @@ export namespace androidpublisher_v2 {
         params,
         requiredParams: ['packageName', 'editId'],
         pathParams: ['editId', 'packageName'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -4122,7 +4043,7 @@ export namespace androidpublisher_v2 {
         params,
         requiredParams: ['packageName', 'editId', 'language'],
         pathParams: ['editId', 'language', 'packageName'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Listing>(parameters, callback);
@@ -4192,7 +4113,7 @@ export namespace androidpublisher_v2 {
         params,
         requiredParams: ['packageName', 'editId'],
         pathParams: ['editId', 'packageName'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListingsListResponse>(parameters, callback);
@@ -4264,7 +4185,7 @@ export namespace androidpublisher_v2 {
         params,
         requiredParams: ['packageName', 'editId', 'language'],
         pathParams: ['editId', 'language', 'packageName'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Listing>(parameters, callback);
@@ -4335,7 +4256,7 @@ export namespace androidpublisher_v2 {
         params,
         requiredParams: ['packageName', 'editId', 'language'],
         pathParams: ['editId', 'language', 'packageName'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Listing>(parameters, callback);
@@ -4480,15 +4401,7 @@ export namespace androidpublisher_v2 {
 
 
   export class Resource$Edits$Testers {
-    root: Androidpublisher;
-    constructor(root: Androidpublisher) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -4546,7 +4459,7 @@ export namespace androidpublisher_v2 {
         params,
         requiredParams: ['packageName', 'editId', 'track'],
         pathParams: ['editId', 'packageName', 'track'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Testers>(parameters, callback);
@@ -4616,7 +4529,7 @@ export namespace androidpublisher_v2 {
         params,
         requiredParams: ['packageName', 'editId', 'track'],
         pathParams: ['editId', 'packageName', 'track'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Testers>(parameters, callback);
@@ -4686,7 +4599,7 @@ export namespace androidpublisher_v2 {
         params,
         requiredParams: ['packageName', 'editId', 'track'],
         pathParams: ['editId', 'packageName', 'track'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Testers>(parameters, callback);
@@ -4775,15 +4688,7 @@ export namespace androidpublisher_v2 {
 
 
   export class Resource$Edits$Tracks {
-    root: Androidpublisher;
-    constructor(root: Androidpublisher) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -4842,7 +4747,7 @@ export namespace androidpublisher_v2 {
         params,
         requiredParams: ['packageName', 'editId', 'track'],
         pathParams: ['editId', 'packageName', 'track'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Track>(parameters, callback);
@@ -4911,7 +4816,7 @@ export namespace androidpublisher_v2 {
         params,
         requiredParams: ['packageName', 'editId'],
         pathParams: ['editId', 'packageName'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TracksListResponse>(parameters, callback);
@@ -4984,7 +4889,7 @@ export namespace androidpublisher_v2 {
         params,
         requiredParams: ['packageName', 'editId', 'track'],
         pathParams: ['editId', 'packageName', 'track'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Track>(parameters, callback);
@@ -5057,7 +4962,7 @@ export namespace androidpublisher_v2 {
         params,
         requiredParams: ['packageName', 'editId', 'track'],
         pathParams: ['editId', 'packageName', 'track'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Track>(parameters, callback);
@@ -5160,15 +5065,7 @@ export namespace androidpublisher_v2 {
 
 
   export class Resource$Inappproducts {
-    root: Androidpublisher;
-    constructor(root: Androidpublisher) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -5229,7 +5126,7 @@ export namespace androidpublisher_v2 {
         params,
         requiredParams: ['packageName', 'sku'],
         pathParams: ['packageName', 'sku'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -5295,7 +5192,7 @@ export namespace androidpublisher_v2 {
         params,
         requiredParams: ['packageName', 'sku'],
         pathParams: ['packageName', 'sku'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$InAppProduct>(parameters, callback);
@@ -5366,7 +5263,7 @@ export namespace androidpublisher_v2 {
         params,
         requiredParams: ['packageName'],
         pathParams: ['packageName'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$InAppProduct>(parameters, callback);
@@ -5440,7 +5337,7 @@ export namespace androidpublisher_v2 {
         params,
         requiredParams: ['packageName'],
         pathParams: ['packageName'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$InappproductsListResponse>(
@@ -5514,7 +5411,7 @@ export namespace androidpublisher_v2 {
         params,
         requiredParams: ['packageName', 'sku'],
         pathParams: ['packageName', 'sku'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$InAppProduct>(parameters, callback);
@@ -5586,7 +5483,7 @@ export namespace androidpublisher_v2 {
         params,
         requiredParams: ['packageName', 'sku'],
         pathParams: ['packageName', 'sku'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$InAppProduct>(parameters, callback);
@@ -5736,15 +5633,7 @@ export namespace androidpublisher_v2 {
 
 
   export class Resource$Orders {
-    root: Androidpublisher;
-    constructor(root: Androidpublisher) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -5804,7 +5693,7 @@ export namespace androidpublisher_v2 {
         params,
         requiredParams: ['packageName', 'orderId'],
         pathParams: ['orderId', 'packageName'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -5841,34 +5730,19 @@ export namespace androidpublisher_v2 {
 
 
   export class Resource$Purchases {
-    root: Androidpublisher;
     products: Resource$Purchases$Products;
     subscriptions: Resource$Purchases$Subscriptions;
     voidedpurchases: Resource$Purchases$Voidedpurchases;
-    constructor(root: Androidpublisher) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.products = new Resource$Purchases$Products(root);
-      this.subscriptions = new Resource$Purchases$Subscriptions(root);
-      this.voidedpurchases = new Resource$Purchases$Voidedpurchases(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.products = new Resource$Purchases$Products();
+      this.subscriptions = new Resource$Purchases$Subscriptions();
+      this.voidedpurchases = new Resource$Purchases$Voidedpurchases();
     }
   }
 
 
   export class Resource$Purchases$Products {
-    root: Androidpublisher;
-    constructor(root: Androidpublisher) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -5928,7 +5802,7 @@ export namespace androidpublisher_v2 {
         params,
         requiredParams: ['packageName', 'productId', 'token'],
         pathParams: ['packageName', 'productId', 'token'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ProductPurchase>(parameters, callback);
@@ -5963,15 +5837,7 @@ export namespace androidpublisher_v2 {
 
 
   export class Resource$Purchases$Subscriptions {
-    root: Androidpublisher;
-    constructor(root: Androidpublisher) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -6034,7 +5900,7 @@ export namespace androidpublisher_v2 {
         params,
         requiredParams: ['packageName', 'subscriptionId', 'token'],
         pathParams: ['packageName', 'subscriptionId', 'token'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -6116,7 +5982,7 @@ export namespace androidpublisher_v2 {
         params,
         requiredParams: ['packageName', 'subscriptionId', 'token'],
         pathParams: ['packageName', 'subscriptionId', 'token'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$SubscriptionPurchasesDeferResponse>(
@@ -6187,7 +6053,7 @@ export namespace androidpublisher_v2 {
         params,
         requiredParams: ['packageName', 'subscriptionId', 'token'],
         pathParams: ['packageName', 'subscriptionId', 'token'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$SubscriptionPurchase>(parameters, callback);
@@ -6257,7 +6123,7 @@ export namespace androidpublisher_v2 {
         params,
         requiredParams: ['packageName', 'subscriptionId', 'token'],
         pathParams: ['packageName', 'subscriptionId', 'token'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -6328,7 +6194,7 @@ export namespace androidpublisher_v2 {
         params,
         requiredParams: ['packageName', 'subscriptionId', 'token'],
         pathParams: ['packageName', 'subscriptionId', 'token'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -6456,15 +6322,7 @@ export namespace androidpublisher_v2 {
 
 
   export class Resource$Purchases$Voidedpurchases {
-    root: Androidpublisher;
-    constructor(root: Androidpublisher) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -6536,7 +6394,7 @@ export namespace androidpublisher_v2 {
         params,
         requiredParams: ['packageName'],
         pathParams: ['packageName'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$VoidedPurchasesListResponse>(
@@ -6594,15 +6452,7 @@ export namespace androidpublisher_v2 {
 
 
   export class Resource$Reviews {
-    root: Androidpublisher;
-    constructor(root: Androidpublisher) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -6660,7 +6510,7 @@ export namespace androidpublisher_v2 {
         params,
         requiredParams: ['packageName', 'reviewId'],
         pathParams: ['packageName', 'reviewId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Review>(parameters, callback);
@@ -6731,7 +6581,7 @@ export namespace androidpublisher_v2 {
         params,
         requiredParams: ['packageName'],
         pathParams: ['packageName'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ReviewsListResponse>(parameters, callback);
@@ -6801,7 +6651,7 @@ export namespace androidpublisher_v2 {
         params,
         requiredParams: ['packageName', 'reviewId'],
         pathParams: ['packageName', 'reviewId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ReviewsReplyResponse>(parameters, callback);

--- a/src/apis/androidpublisher/v3.ts
+++ b/src/apis/androidpublisher/v3.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace androidpublisher_v3 {
   export interface Options extends GlobalOptions {
     version: 'v3';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -79,10 +81,6 @@ export namespace androidpublisher_v3 {
    * @param {object=} options Options for Androidpublisher
    */
   export class Androidpublisher {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     edits: Resource$Edits;
     inappproducts: Resource$Inappproducts;
     orders: Resource$Orders;
@@ -90,19 +88,13 @@ export namespace androidpublisher_v3 {
     reviews: Resource$Reviews;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.edits = new Resource$Edits(this);
-      this.inappproducts = new Resource$Inappproducts(this);
-      this.orders = new Resource$Orders(this);
-      this.purchases = new Resource$Purchases(this);
-      this.reviews = new Resource$Reviews(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.edits = new Resource$Edits();
+      this.inappproducts = new Resource$Inappproducts();
+      this.orders = new Resource$Orders();
+      this.purchases = new Resource$Purchases();
+      this.reviews = new Resource$Reviews();
     }
   }
 
@@ -1022,7 +1014,6 @@ export namespace androidpublisher_v3 {
 
 
   export class Resource$Edits {
-    root: Androidpublisher;
     apks: Resource$Edits$Apks;
     bundles: Resource$Edits$Bundles;
     deobfuscationfiles: Resource$Edits$Deobfuscationfiles;
@@ -1032,22 +1023,16 @@ export namespace androidpublisher_v3 {
     listings: Resource$Edits$Listings;
     testers: Resource$Edits$Testers;
     tracks: Resource$Edits$Tracks;
-    constructor(root: Androidpublisher) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.apks = new Resource$Edits$Apks(root);
-      this.bundles = new Resource$Edits$Bundles(root);
-      this.deobfuscationfiles = new Resource$Edits$Deobfuscationfiles(root);
-      this.details = new Resource$Edits$Details(root);
-      this.expansionfiles = new Resource$Edits$Expansionfiles(root);
-      this.images = new Resource$Edits$Images(root);
-      this.listings = new Resource$Edits$Listings(root);
-      this.testers = new Resource$Edits$Testers(root);
-      this.tracks = new Resource$Edits$Tracks(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.apks = new Resource$Edits$Apks();
+      this.bundles = new Resource$Edits$Bundles();
+      this.deobfuscationfiles = new Resource$Edits$Deobfuscationfiles();
+      this.details = new Resource$Edits$Details();
+      this.expansionfiles = new Resource$Edits$Expansionfiles();
+      this.images = new Resource$Edits$Images();
+      this.listings = new Resource$Edits$Listings();
+      this.testers = new Resource$Edits$Testers();
+      this.tracks = new Resource$Edits$Tracks();
     }
 
 
@@ -1108,7 +1093,7 @@ export namespace androidpublisher_v3 {
         params,
         requiredParams: ['packageName', 'editId'],
         pathParams: ['editId', 'packageName'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$AppEdit>(parameters, callback);
@@ -1176,7 +1161,7 @@ export namespace androidpublisher_v3 {
         params,
         requiredParams: ['packageName', 'editId'],
         pathParams: ['editId', 'packageName'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -1242,7 +1227,7 @@ export namespace androidpublisher_v3 {
         params,
         requiredParams: ['packageName', 'editId'],
         pathParams: ['editId', 'packageName'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$AppEdit>(parameters, callback);
@@ -1309,7 +1294,7 @@ export namespace androidpublisher_v3 {
         params,
         requiredParams: ['packageName'],
         pathParams: ['packageName'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$AppEdit>(parameters, callback);
@@ -1377,7 +1362,7 @@ export namespace androidpublisher_v3 {
         params,
         requiredParams: ['packageName', 'editId'],
         pathParams: ['editId', 'packageName'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$AppEdit>(parameters, callback);
@@ -1470,15 +1455,7 @@ export namespace androidpublisher_v3 {
   }
 
   export class Resource$Edits$Apks {
-    root: Androidpublisher;
-    constructor(root: Androidpublisher) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -1552,7 +1529,7 @@ export namespace androidpublisher_v3 {
         params,
         requiredParams: ['packageName', 'editId'],
         pathParams: ['editId', 'packageName'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ApksAddExternallyHostedResponse>(
@@ -1621,7 +1598,7 @@ export namespace androidpublisher_v3 {
         params,
         requiredParams: ['packageName', 'editId'],
         pathParams: ['editId', 'packageName'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ApksListResponse>(parameters, callback);
@@ -1695,7 +1672,7 @@ export namespace androidpublisher_v3 {
                 .replace(/([^:]\/)\/+/g, '$1'),
         requiredParams: ['packageName', 'editId'],
         pathParams: ['editId', 'packageName'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Apk>(parameters, callback);
@@ -1779,15 +1756,7 @@ export namespace androidpublisher_v3 {
 
 
   export class Resource$Edits$Bundles {
-    root: Androidpublisher;
-    constructor(root: Androidpublisher) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -1848,7 +1817,7 @@ export namespace androidpublisher_v3 {
         params,
         requiredParams: ['packageName', 'editId'],
         pathParams: ['editId', 'packageName'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$BundlesListResponse>(parameters, callback);
@@ -1930,7 +1899,7 @@ export namespace androidpublisher_v3 {
                 .replace(/([^:]\/)\/+/g, '$1'),
         requiredParams: ['packageName', 'editId'],
         pathParams: ['editId', 'packageName'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Bundle>(parameters, callback);
@@ -1999,15 +1968,7 @@ export namespace androidpublisher_v3 {
 
 
   export class Resource$Edits$Deobfuscationfiles {
-    root: Androidpublisher;
-    constructor(root: Androidpublisher) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -2093,7 +2054,7 @@ export namespace androidpublisher_v3 {
         pathParams: [
           'apkVersionCode', 'deobfuscationFileType', 'editId', 'packageName'
         ],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$DeobfuscationFilesUploadResponse>(
@@ -2149,15 +2110,7 @@ export namespace androidpublisher_v3 {
 
 
   export class Resource$Edits$Details {
-    root: Androidpublisher;
-    constructor(root: Androidpublisher) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -2217,7 +2170,7 @@ export namespace androidpublisher_v3 {
         params,
         requiredParams: ['packageName', 'editId'],
         pathParams: ['editId', 'packageName'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$AppDetails>(parameters, callback);
@@ -2289,7 +2242,7 @@ export namespace androidpublisher_v3 {
         params,
         requiredParams: ['packageName', 'editId'],
         pathParams: ['editId', 'packageName'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$AppDetails>(parameters, callback);
@@ -2360,7 +2313,7 @@ export namespace androidpublisher_v3 {
         params,
         requiredParams: ['packageName', 'editId'],
         pathParams: ['editId', 'packageName'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$AppDetails>(parameters, callback);
@@ -2434,15 +2387,7 @@ export namespace androidpublisher_v3 {
 
 
   export class Resource$Edits$Expansionfiles {
-    root: Androidpublisher;
-    constructor(root: Androidpublisher) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -2505,7 +2450,7 @@ export namespace androidpublisher_v3 {
             ['packageName', 'editId', 'apkVersionCode', 'expansionFileType'],
         pathParams:
             ['apkVersionCode', 'editId', 'expansionFileType', 'packageName'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ExpansionFile>(parameters, callback);
@@ -2582,7 +2527,7 @@ export namespace androidpublisher_v3 {
             ['packageName', 'editId', 'apkVersionCode', 'expansionFileType'],
         pathParams:
             ['apkVersionCode', 'editId', 'expansionFileType', 'packageName'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ExpansionFile>(parameters, callback);
@@ -2658,7 +2603,7 @@ export namespace androidpublisher_v3 {
             ['packageName', 'editId', 'apkVersionCode', 'expansionFileType'],
         pathParams:
             ['apkVersionCode', 'editId', 'expansionFileType', 'packageName'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ExpansionFile>(parameters, callback);
@@ -2744,7 +2689,7 @@ export namespace androidpublisher_v3 {
             ['packageName', 'editId', 'apkVersionCode', 'expansionFileType'],
         pathParams:
             ['apkVersionCode', 'editId', 'expansionFileType', 'packageName'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ExpansionFilesUploadResponse>(
@@ -2889,15 +2834,7 @@ export namespace androidpublisher_v3 {
 
 
   export class Resource$Edits$Images {
-    root: Androidpublisher;
-    constructor(root: Androidpublisher) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -2963,7 +2900,7 @@ export namespace androidpublisher_v3 {
             ['packageName', 'editId', 'language', 'imageType', 'imageId'],
         pathParams:
             ['editId', 'imageId', 'imageType', 'language', 'packageName'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -3037,7 +2974,7 @@ export namespace androidpublisher_v3 {
         params,
         requiredParams: ['packageName', 'editId', 'language', 'imageType'],
         pathParams: ['editId', 'imageType', 'language', 'packageName'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ImagesDeleteAllResponse>(parameters, callback);
@@ -3108,7 +3045,7 @@ export namespace androidpublisher_v3 {
         params,
         requiredParams: ['packageName', 'editId', 'language', 'imageType'],
         pathParams: ['editId', 'imageType', 'language', 'packageName'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ImagesListResponse>(parameters, callback);
@@ -3189,7 +3126,7 @@ export namespace androidpublisher_v3 {
                 .replace(/([^:]\/)\/+/g, '$1'),
         requiredParams: ['packageName', 'editId', 'language', 'imageType'],
         pathParams: ['editId', 'imageType', 'language', 'packageName'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ImagesUploadResponse>(parameters, callback);
@@ -3331,15 +3268,7 @@ export namespace androidpublisher_v3 {
 
 
   export class Resource$Edits$Listings {
-    root: Androidpublisher;
-    constructor(root: Androidpublisher) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -3401,7 +3330,7 @@ export namespace androidpublisher_v3 {
         params,
         requiredParams: ['packageName', 'editId', 'language'],
         pathParams: ['editId', 'language', 'packageName'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -3469,7 +3398,7 @@ export namespace androidpublisher_v3 {
         params,
         requiredParams: ['packageName', 'editId'],
         pathParams: ['editId', 'packageName'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -3535,7 +3464,7 @@ export namespace androidpublisher_v3 {
         params,
         requiredParams: ['packageName', 'editId', 'language'],
         pathParams: ['editId', 'language', 'packageName'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Listing>(parameters, callback);
@@ -3605,7 +3534,7 @@ export namespace androidpublisher_v3 {
         params,
         requiredParams: ['packageName', 'editId'],
         pathParams: ['editId', 'packageName'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListingsListResponse>(parameters, callback);
@@ -3677,7 +3606,7 @@ export namespace androidpublisher_v3 {
         params,
         requiredParams: ['packageName', 'editId', 'language'],
         pathParams: ['editId', 'language', 'packageName'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Listing>(parameters, callback);
@@ -3748,7 +3677,7 @@ export namespace androidpublisher_v3 {
         params,
         requiredParams: ['packageName', 'editId', 'language'],
         pathParams: ['editId', 'language', 'packageName'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Listing>(parameters, callback);
@@ -3893,15 +3822,7 @@ export namespace androidpublisher_v3 {
 
 
   export class Resource$Edits$Testers {
-    root: Androidpublisher;
-    constructor(root: Androidpublisher) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -3959,7 +3880,7 @@ export namespace androidpublisher_v3 {
         params,
         requiredParams: ['packageName', 'editId', 'track'],
         pathParams: ['editId', 'packageName', 'track'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Testers>(parameters, callback);
@@ -4029,7 +3950,7 @@ export namespace androidpublisher_v3 {
         params,
         requiredParams: ['packageName', 'editId', 'track'],
         pathParams: ['editId', 'packageName', 'track'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Testers>(parameters, callback);
@@ -4099,7 +4020,7 @@ export namespace androidpublisher_v3 {
         params,
         requiredParams: ['packageName', 'editId', 'track'],
         pathParams: ['editId', 'packageName', 'track'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Testers>(parameters, callback);
@@ -4188,15 +4109,7 @@ export namespace androidpublisher_v3 {
 
 
   export class Resource$Edits$Tracks {
-    root: Androidpublisher;
-    constructor(root: Androidpublisher) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -4255,7 +4168,7 @@ export namespace androidpublisher_v3 {
         params,
         requiredParams: ['packageName', 'editId', 'track'],
         pathParams: ['editId', 'packageName', 'track'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Track>(parameters, callback);
@@ -4324,7 +4237,7 @@ export namespace androidpublisher_v3 {
         params,
         requiredParams: ['packageName', 'editId'],
         pathParams: ['editId', 'packageName'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TracksListResponse>(parameters, callback);
@@ -4397,7 +4310,7 @@ export namespace androidpublisher_v3 {
         params,
         requiredParams: ['packageName', 'editId', 'track'],
         pathParams: ['editId', 'packageName', 'track'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Track>(parameters, callback);
@@ -4470,7 +4383,7 @@ export namespace androidpublisher_v3 {
         params,
         requiredParams: ['packageName', 'editId', 'track'],
         pathParams: ['editId', 'packageName', 'track'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Track>(parameters, callback);
@@ -4573,15 +4486,7 @@ export namespace androidpublisher_v3 {
 
 
   export class Resource$Inappproducts {
-    root: Androidpublisher;
-    constructor(root: Androidpublisher) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -4642,7 +4547,7 @@ export namespace androidpublisher_v3 {
         params,
         requiredParams: ['packageName', 'sku'],
         pathParams: ['packageName', 'sku'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -4708,7 +4613,7 @@ export namespace androidpublisher_v3 {
         params,
         requiredParams: ['packageName', 'sku'],
         pathParams: ['packageName', 'sku'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$InAppProduct>(parameters, callback);
@@ -4779,7 +4684,7 @@ export namespace androidpublisher_v3 {
         params,
         requiredParams: ['packageName'],
         pathParams: ['packageName'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$InAppProduct>(parameters, callback);
@@ -4853,7 +4758,7 @@ export namespace androidpublisher_v3 {
         params,
         requiredParams: ['packageName'],
         pathParams: ['packageName'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$InappproductsListResponse>(
@@ -4927,7 +4832,7 @@ export namespace androidpublisher_v3 {
         params,
         requiredParams: ['packageName', 'sku'],
         pathParams: ['packageName', 'sku'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$InAppProduct>(parameters, callback);
@@ -4999,7 +4904,7 @@ export namespace androidpublisher_v3 {
         params,
         requiredParams: ['packageName', 'sku'],
         pathParams: ['packageName', 'sku'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$InAppProduct>(parameters, callback);
@@ -5149,15 +5054,7 @@ export namespace androidpublisher_v3 {
 
 
   export class Resource$Orders {
-    root: Androidpublisher;
-    constructor(root: Androidpublisher) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -5217,7 +5114,7 @@ export namespace androidpublisher_v3 {
         params,
         requiredParams: ['packageName', 'orderId'],
         pathParams: ['orderId', 'packageName'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -5254,34 +5151,19 @@ export namespace androidpublisher_v3 {
 
 
   export class Resource$Purchases {
-    root: Androidpublisher;
     products: Resource$Purchases$Products;
     subscriptions: Resource$Purchases$Subscriptions;
     voidedpurchases: Resource$Purchases$Voidedpurchases;
-    constructor(root: Androidpublisher) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.products = new Resource$Purchases$Products(root);
-      this.subscriptions = new Resource$Purchases$Subscriptions(root);
-      this.voidedpurchases = new Resource$Purchases$Voidedpurchases(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.products = new Resource$Purchases$Products();
+      this.subscriptions = new Resource$Purchases$Subscriptions();
+      this.voidedpurchases = new Resource$Purchases$Voidedpurchases();
     }
   }
 
 
   export class Resource$Purchases$Products {
-    root: Androidpublisher;
-    constructor(root: Androidpublisher) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -5341,7 +5223,7 @@ export namespace androidpublisher_v3 {
         params,
         requiredParams: ['packageName', 'productId', 'token'],
         pathParams: ['packageName', 'productId', 'token'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ProductPurchase>(parameters, callback);
@@ -5376,15 +5258,7 @@ export namespace androidpublisher_v3 {
 
 
   export class Resource$Purchases$Subscriptions {
-    root: Androidpublisher;
-    constructor(root: Androidpublisher) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -5447,7 +5321,7 @@ export namespace androidpublisher_v3 {
         params,
         requiredParams: ['packageName', 'subscriptionId', 'token'],
         pathParams: ['packageName', 'subscriptionId', 'token'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -5529,7 +5403,7 @@ export namespace androidpublisher_v3 {
         params,
         requiredParams: ['packageName', 'subscriptionId', 'token'],
         pathParams: ['packageName', 'subscriptionId', 'token'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$SubscriptionPurchasesDeferResponse>(
@@ -5600,7 +5474,7 @@ export namespace androidpublisher_v3 {
         params,
         requiredParams: ['packageName', 'subscriptionId', 'token'],
         pathParams: ['packageName', 'subscriptionId', 'token'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$SubscriptionPurchase>(parameters, callback);
@@ -5670,7 +5544,7 @@ export namespace androidpublisher_v3 {
         params,
         requiredParams: ['packageName', 'subscriptionId', 'token'],
         pathParams: ['packageName', 'subscriptionId', 'token'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -5741,7 +5615,7 @@ export namespace androidpublisher_v3 {
         params,
         requiredParams: ['packageName', 'subscriptionId', 'token'],
         pathParams: ['packageName', 'subscriptionId', 'token'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -5869,15 +5743,7 @@ export namespace androidpublisher_v3 {
 
 
   export class Resource$Purchases$Voidedpurchases {
-    root: Androidpublisher;
-    constructor(root: Androidpublisher) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -5949,7 +5815,7 @@ export namespace androidpublisher_v3 {
         params,
         requiredParams: ['packageName'],
         pathParams: ['packageName'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$VoidedPurchasesListResponse>(
@@ -6007,15 +5873,7 @@ export namespace androidpublisher_v3 {
 
 
   export class Resource$Reviews {
-    root: Androidpublisher;
-    constructor(root: Androidpublisher) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -6073,7 +5931,7 @@ export namespace androidpublisher_v3 {
         params,
         requiredParams: ['packageName', 'reviewId'],
         pathParams: ['packageName', 'reviewId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Review>(parameters, callback);
@@ -6144,7 +6002,7 @@ export namespace androidpublisher_v3 {
         params,
         requiredParams: ['packageName'],
         pathParams: ['packageName'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ReviewsListResponse>(parameters, callback);
@@ -6214,7 +6072,7 @@ export namespace androidpublisher_v3 {
         params,
         requiredParams: ['packageName', 'reviewId'],
         pathParams: ['packageName', 'reviewId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ReviewsReplyResponse>(parameters, callback);

--- a/src/apis/appengine/v1.ts
+++ b/src/apis/appengine/v1.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace appengine_v1 {
   export interface Options extends GlobalOptions {
     version: 'v1';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -96,22 +98,12 @@ export namespace appengine_v1 {
    * @param {object=} options Options for Appengine
    */
   export class Appengine {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     apps: Resource$Apps;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.apps = new Resource$Apps(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.apps = new Resource$Apps();
     }
   }
 
@@ -2000,7 +1992,6 @@ export namespace appengine_v1 {
 
 
   export class Resource$Apps {
-    root: Appengine;
     authorizedCertificates: Resource$Apps$Authorizedcertificates;
     authorizedDomains: Resource$Apps$Authorizeddomains;
     domainMappings: Resource$Apps$Domainmappings;
@@ -2008,21 +1999,14 @@ export namespace appengine_v1 {
     locations: Resource$Apps$Locations;
     operations: Resource$Apps$Operations;
     services: Resource$Apps$Services;
-    constructor(root: Appengine) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.authorizedCertificates =
-          new Resource$Apps$Authorizedcertificates(root);
-      this.authorizedDomains = new Resource$Apps$Authorizeddomains(root);
-      this.domainMappings = new Resource$Apps$Domainmappings(root);
-      this.firewall = new Resource$Apps$Firewall(root);
-      this.locations = new Resource$Apps$Locations(root);
-      this.operations = new Resource$Apps$Operations(root);
-      this.services = new Resource$Apps$Services(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.authorizedCertificates = new Resource$Apps$Authorizedcertificates();
+      this.authorizedDomains = new Resource$Apps$Authorizeddomains();
+      this.domainMappings = new Resource$Apps$Domainmappings();
+      this.firewall = new Resource$Apps$Firewall();
+      this.locations = new Resource$Apps$Locations();
+      this.operations = new Resource$Apps$Operations();
+      this.services = new Resource$Apps$Services();
     }
 
 
@@ -2086,7 +2070,7 @@ export namespace appengine_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -2148,7 +2132,7 @@ export namespace appengine_v1 {
         params,
         requiredParams: ['appsId'],
         pathParams: ['appsId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Application>(parameters, callback);
@@ -2218,7 +2202,7 @@ export namespace appengine_v1 {
         params,
         requiredParams: ['appsId'],
         pathParams: ['appsId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -2288,7 +2272,7 @@ export namespace appengine_v1 {
         params,
         requiredParams: ['appsId'],
         pathParams: ['appsId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -2361,15 +2345,7 @@ export namespace appengine_v1 {
   }
 
   export class Resource$Apps$Authorizedcertificates {
-    root: Appengine;
-    constructor(root: Appengine) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -2431,7 +2407,7 @@ export namespace appengine_v1 {
         params,
         requiredParams: ['appsId'],
         pathParams: ['appsId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$AuthorizedCertificate>(parameters, callback);
@@ -2500,7 +2476,7 @@ export namespace appengine_v1 {
         params,
         requiredParams: ['appsId', 'authorizedCertificatesId'],
         pathParams: ['appsId', 'authorizedCertificatesId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -2568,7 +2544,7 @@ export namespace appengine_v1 {
         params,
         requiredParams: ['appsId', 'authorizedCertificatesId'],
         pathParams: ['appsId', 'authorizedCertificatesId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$AuthorizedCertificate>(parameters, callback);
@@ -2647,7 +2623,7 @@ export namespace appengine_v1 {
         params,
         requiredParams: ['appsId'],
         pathParams: ['appsId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListAuthorizedCertificatesResponse>(
@@ -2726,7 +2702,7 @@ export namespace appengine_v1 {
         params,
         requiredParams: ['appsId', 'authorizedCertificatesId'],
         pathParams: ['appsId', 'authorizedCertificatesId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$AuthorizedCertificate>(parameters, callback);
@@ -2847,15 +2823,7 @@ export namespace appengine_v1 {
 
 
   export class Resource$Apps$Authorizeddomains {
-    root: Appengine;
-    constructor(root: Appengine) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -2922,7 +2890,7 @@ export namespace appengine_v1 {
         params,
         requiredParams: ['appsId'],
         pathParams: ['appsId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListAuthorizedDomainsResponse>(
@@ -2958,15 +2926,7 @@ export namespace appengine_v1 {
 
 
   export class Resource$Apps$Domainmappings {
-    root: Appengine;
-    constructor(root: Appengine) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -3031,7 +2991,7 @@ export namespace appengine_v1 {
         params,
         requiredParams: ['appsId'],
         pathParams: ['appsId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -3102,7 +3062,7 @@ export namespace appengine_v1 {
         params,
         requiredParams: ['appsId', 'domainMappingsId'],
         pathParams: ['appsId', 'domainMappingsId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -3167,7 +3127,7 @@ export namespace appengine_v1 {
         params,
         requiredParams: ['appsId', 'domainMappingsId'],
         pathParams: ['appsId', 'domainMappingsId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$DomainMapping>(parameters, callback);
@@ -3241,7 +3201,7 @@ export namespace appengine_v1 {
         params,
         requiredParams: ['appsId'],
         pathParams: ['appsId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListDomainMappingsResponse>(
@@ -3316,7 +3276,7 @@ export namespace appengine_v1 {
         params,
         requiredParams: ['appsId', 'domainMappingsId'],
         pathParams: ['appsId', 'domainMappingsId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -3433,30 +3393,15 @@ export namespace appengine_v1 {
 
 
   export class Resource$Apps$Firewall {
-    root: Appengine;
     ingressRules: Resource$Apps$Firewall$Ingressrules;
-    constructor(root: Appengine) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.ingressRules = new Resource$Apps$Firewall$Ingressrules(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.ingressRules = new Resource$Apps$Firewall$Ingressrules();
     }
   }
 
 
   export class Resource$Apps$Firewall$Ingressrules {
-    root: Appengine;
-    constructor(root: Appengine) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -3530,7 +3475,7 @@ export namespace appengine_v1 {
         params,
         requiredParams: ['appsId'],
         pathParams: ['appsId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$BatchUpdateIngressRulesResponse>(
@@ -3600,7 +3545,7 @@ export namespace appengine_v1 {
         params,
         requiredParams: ['appsId'],
         pathParams: ['appsId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$FirewallRule>(parameters, callback);
@@ -3668,7 +3613,7 @@ export namespace appengine_v1 {
         params,
         requiredParams: ['appsId', 'ingressRulesId'],
         pathParams: ['appsId', 'ingressRulesId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -3733,7 +3678,7 @@ export namespace appengine_v1 {
         params,
         requiredParams: ['appsId', 'ingressRulesId'],
         pathParams: ['appsId', 'ingressRulesId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$FirewallRule>(parameters, callback);
@@ -3804,7 +3749,7 @@ export namespace appengine_v1 {
         params,
         requiredParams: ['appsId'],
         pathParams: ['appsId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListIngressRulesResponse>(parameters, callback);
@@ -3875,7 +3820,7 @@ export namespace appengine_v1 {
         params,
         requiredParams: ['appsId', 'ingressRulesId'],
         pathParams: ['appsId', 'ingressRulesId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$FirewallRule>(parameters, callback);
@@ -4012,15 +3957,7 @@ export namespace appengine_v1 {
 
 
   export class Resource$Apps$Locations {
-    root: Appengine;
-    constructor(root: Appengine) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -4076,7 +4013,7 @@ export namespace appengine_v1 {
         params,
         requiredParams: ['appsId', 'locationsId'],
         pathParams: ['appsId', 'locationsId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Location>(parameters, callback);
@@ -4146,7 +4083,7 @@ export namespace appengine_v1 {
         params,
         requiredParams: ['appsId'],
         pathParams: ['appsId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListLocationsResponse>(parameters, callback);
@@ -4200,15 +4137,7 @@ export namespace appengine_v1 {
 
 
   export class Resource$Apps$Operations {
-    root: Appengine;
-    constructor(root: Appengine) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -4267,7 +4196,7 @@ export namespace appengine_v1 {
         params,
         requiredParams: ['appsId', 'operationsId'],
         pathParams: ['appsId', 'operationsId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -4346,7 +4275,7 @@ export namespace appengine_v1 {
         params,
         requiredParams: ['appsId'],
         pathParams: ['appsId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListOperationsResponse>(parameters, callback);
@@ -4399,16 +4328,9 @@ export namespace appengine_v1 {
 
 
   export class Resource$Apps$Services {
-    root: Appengine;
     versions: Resource$Apps$Services$Versions;
-    constructor(root: Appengine) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.versions = new Resource$Apps$Services$Versions(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.versions = new Resource$Apps$Services$Versions();
     }
 
 
@@ -4470,7 +4392,7 @@ export namespace appengine_v1 {
         params,
         requiredParams: ['appsId', 'servicesId'],
         pathParams: ['appsId', 'servicesId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -4533,7 +4455,7 @@ export namespace appengine_v1 {
         params,
         requiredParams: ['appsId', 'servicesId'],
         pathParams: ['appsId', 'servicesId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Service>(parameters, callback);
@@ -4602,7 +4524,7 @@ export namespace appengine_v1 {
         params,
         requiredParams: ['appsId'],
         pathParams: ['appsId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListServicesResponse>(parameters, callback);
@@ -4673,7 +4595,7 @@ export namespace appengine_v1 {
         params,
         requiredParams: ['appsId', 'servicesId'],
         pathParams: ['appsId', 'servicesId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -4782,16 +4704,9 @@ export namespace appengine_v1 {
   }
 
   export class Resource$Apps$Services$Versions {
-    root: Appengine;
     instances: Resource$Apps$Services$Versions$Instances;
-    constructor(root: Appengine) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.instances = new Resource$Apps$Services$Versions$Instances(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.instances = new Resource$Apps$Services$Versions$Instances();
     }
 
 
@@ -4855,7 +4770,7 @@ export namespace appengine_v1 {
         params,
         requiredParams: ['appsId', 'servicesId'],
         pathParams: ['appsId', 'servicesId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -4926,7 +4841,7 @@ export namespace appengine_v1 {
         params,
         requiredParams: ['appsId', 'servicesId', 'versionsId'],
         pathParams: ['appsId', 'servicesId', 'versionsId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -4995,7 +4910,7 @@ export namespace appengine_v1 {
         params,
         requiredParams: ['appsId', 'servicesId', 'versionsId'],
         pathParams: ['appsId', 'servicesId', 'versionsId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Version>(parameters, callback);
@@ -5068,7 +4983,7 @@ export namespace appengine_v1 {
         params,
         requiredParams: ['appsId', 'servicesId'],
         pathParams: ['appsId', 'servicesId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListVersionsResponse>(parameters, callback);
@@ -5170,7 +5085,7 @@ export namespace appengine_v1 {
         params,
         requiredParams: ['appsId', 'servicesId', 'versionsId'],
         pathParams: ['appsId', 'servicesId', 'versionsId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -5309,15 +5224,7 @@ export namespace appengine_v1 {
   }
 
   export class Resource$Apps$Services$Versions$Instances {
-    root: Appengine;
-    constructor(root: Appengine) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -5389,7 +5296,7 @@ export namespace appengine_v1 {
         params,
         requiredParams: ['appsId', 'servicesId', 'versionsId', 'instancesId'],
         pathParams: ['appsId', 'instancesId', 'servicesId', 'versionsId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -5462,7 +5369,7 @@ export namespace appengine_v1 {
         params,
         requiredParams: ['appsId', 'servicesId', 'versionsId', 'instancesId'],
         pathParams: ['appsId', 'instancesId', 'servicesId', 'versionsId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -5529,7 +5436,7 @@ export namespace appengine_v1 {
         params,
         requiredParams: ['appsId', 'servicesId', 'versionsId', 'instancesId'],
         pathParams: ['appsId', 'instancesId', 'servicesId', 'versionsId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Instance>(parameters, callback);
@@ -5606,7 +5513,7 @@ export namespace appengine_v1 {
         params,
         requiredParams: ['appsId', 'servicesId', 'versionsId'],
         pathParams: ['appsId', 'servicesId', 'versionsId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListInstancesResponse>(parameters, callback);

--- a/src/apis/appengine/v1alpha.ts
+++ b/src/apis/appengine/v1alpha.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace appengine_v1alpha {
   export interface Options extends GlobalOptions {
     version: 'v1alpha';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -96,22 +98,12 @@ export namespace appengine_v1alpha {
    * @param {object=} options Options for Appengine
    */
   export class Appengine {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     apps: Resource$Apps;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.apps = new Resource$Apps(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.apps = new Resource$Apps();
     }
   }
 
@@ -713,39 +705,23 @@ export namespace appengine_v1alpha {
 
 
   export class Resource$Apps {
-    root: Appengine;
     authorizedCertificates: Resource$Apps$Authorizedcertificates;
     authorizedDomains: Resource$Apps$Authorizeddomains;
     domainMappings: Resource$Apps$Domainmappings;
     locations: Resource$Apps$Locations;
     operations: Resource$Apps$Operations;
-    constructor(root: Appengine) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.authorizedCertificates =
-          new Resource$Apps$Authorizedcertificates(root);
-      this.authorizedDomains = new Resource$Apps$Authorizeddomains(root);
-      this.domainMappings = new Resource$Apps$Domainmappings(root);
-      this.locations = new Resource$Apps$Locations(root);
-      this.operations = new Resource$Apps$Operations(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.authorizedCertificates = new Resource$Apps$Authorizedcertificates();
+      this.authorizedDomains = new Resource$Apps$Authorizeddomains();
+      this.domainMappings = new Resource$Apps$Domainmappings();
+      this.locations = new Resource$Apps$Locations();
+      this.operations = new Resource$Apps$Operations();
     }
   }
 
 
   export class Resource$Apps$Authorizedcertificates {
-    root: Appengine;
-    constructor(root: Appengine) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -807,7 +783,7 @@ export namespace appengine_v1alpha {
         params,
         requiredParams: ['appsId'],
         pathParams: ['appsId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$AuthorizedCertificate>(parameters, callback);
@@ -876,7 +852,7 @@ export namespace appengine_v1alpha {
         params,
         requiredParams: ['appsId', 'authorizedCertificatesId'],
         pathParams: ['appsId', 'authorizedCertificatesId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -944,7 +920,7 @@ export namespace appengine_v1alpha {
         params,
         requiredParams: ['appsId', 'authorizedCertificatesId'],
         pathParams: ['appsId', 'authorizedCertificatesId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$AuthorizedCertificate>(parameters, callback);
@@ -1023,7 +999,7 @@ export namespace appengine_v1alpha {
         params,
         requiredParams: ['appsId'],
         pathParams: ['appsId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListAuthorizedCertificatesResponse>(
@@ -1102,7 +1078,7 @@ export namespace appengine_v1alpha {
         params,
         requiredParams: ['appsId', 'authorizedCertificatesId'],
         pathParams: ['appsId', 'authorizedCertificatesId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$AuthorizedCertificate>(parameters, callback);
@@ -1223,15 +1199,7 @@ export namespace appengine_v1alpha {
 
 
   export class Resource$Apps$Authorizeddomains {
-    root: Appengine;
-    constructor(root: Appengine) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -1298,7 +1266,7 @@ export namespace appengine_v1alpha {
         params,
         requiredParams: ['appsId'],
         pathParams: ['appsId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListAuthorizedDomainsResponse>(
@@ -1334,15 +1302,7 @@ export namespace appengine_v1alpha {
 
 
   export class Resource$Apps$Domainmappings {
-    root: Appengine;
-    constructor(root: Appengine) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -1408,7 +1368,7 @@ export namespace appengine_v1alpha {
         params,
         requiredParams: ['appsId'],
         pathParams: ['appsId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -1479,7 +1439,7 @@ export namespace appengine_v1alpha {
         params,
         requiredParams: ['appsId', 'domainMappingsId'],
         pathParams: ['appsId', 'domainMappingsId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -1544,7 +1504,7 @@ export namespace appengine_v1alpha {
         params,
         requiredParams: ['appsId', 'domainMappingsId'],
         pathParams: ['appsId', 'domainMappingsId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$DomainMapping>(parameters, callback);
@@ -1618,7 +1578,7 @@ export namespace appengine_v1alpha {
         params,
         requiredParams: ['appsId'],
         pathParams: ['appsId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListDomainMappingsResponse>(
@@ -1694,7 +1654,7 @@ export namespace appengine_v1alpha {
         params,
         requiredParams: ['appsId', 'domainMappingsId'],
         pathParams: ['appsId', 'domainMappingsId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -1827,15 +1787,7 @@ export namespace appengine_v1alpha {
 
 
   export class Resource$Apps$Locations {
-    root: Appengine;
-    constructor(root: Appengine) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -1891,7 +1843,7 @@ export namespace appengine_v1alpha {
         params,
         requiredParams: ['appsId', 'locationsId'],
         pathParams: ['appsId', 'locationsId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Location>(parameters, callback);
@@ -1961,7 +1913,7 @@ export namespace appengine_v1alpha {
         params,
         requiredParams: ['appsId'],
         pathParams: ['appsId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListLocationsResponse>(parameters, callback);
@@ -2015,15 +1967,7 @@ export namespace appengine_v1alpha {
 
 
   export class Resource$Apps$Operations {
-    root: Appengine;
-    constructor(root: Appengine) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -2083,7 +2027,7 @@ export namespace appengine_v1alpha {
         params,
         requiredParams: ['appsId', 'operationsId'],
         pathParams: ['appsId', 'operationsId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -2162,7 +2106,7 @@ export namespace appengine_v1alpha {
         params,
         requiredParams: ['appsId'],
         pathParams: ['appsId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListOperationsResponse>(parameters, callback);

--- a/src/apis/appengine/v1beta.ts
+++ b/src/apis/appengine/v1beta.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace appengine_v1beta {
   export interface Options extends GlobalOptions {
     version: 'v1beta';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -96,22 +98,12 @@ export namespace appengine_v1beta {
    * @param {object=} options Options for Appengine
    */
   export class Appengine {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     apps: Resource$Apps;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.apps = new Resource$Apps(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.apps = new Resource$Apps();
     }
   }
 
@@ -2093,7 +2085,6 @@ export namespace appengine_v1beta {
 
 
   export class Resource$Apps {
-    root: Appengine;
     authorizedCertificates: Resource$Apps$Authorizedcertificates;
     authorizedDomains: Resource$Apps$Authorizeddomains;
     domainMappings: Resource$Apps$Domainmappings;
@@ -2101,21 +2092,14 @@ export namespace appengine_v1beta {
     locations: Resource$Apps$Locations;
     operations: Resource$Apps$Operations;
     services: Resource$Apps$Services;
-    constructor(root: Appengine) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.authorizedCertificates =
-          new Resource$Apps$Authorizedcertificates(root);
-      this.authorizedDomains = new Resource$Apps$Authorizeddomains(root);
-      this.domainMappings = new Resource$Apps$Domainmappings(root);
-      this.firewall = new Resource$Apps$Firewall(root);
-      this.locations = new Resource$Apps$Locations(root);
-      this.operations = new Resource$Apps$Operations(root);
-      this.services = new Resource$Apps$Services(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.authorizedCertificates = new Resource$Apps$Authorizedcertificates();
+      this.authorizedDomains = new Resource$Apps$Authorizeddomains();
+      this.domainMappings = new Resource$Apps$Domainmappings();
+      this.firewall = new Resource$Apps$Firewall();
+      this.locations = new Resource$Apps$Locations();
+      this.operations = new Resource$Apps$Operations();
+      this.services = new Resource$Apps$Services();
     }
 
 
@@ -2179,7 +2163,7 @@ export namespace appengine_v1beta {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -2241,7 +2225,7 @@ export namespace appengine_v1beta {
         params,
         requiredParams: ['appsId'],
         pathParams: ['appsId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Application>(parameters, callback);
@@ -2311,7 +2295,7 @@ export namespace appengine_v1beta {
         params,
         requiredParams: ['appsId'],
         pathParams: ['appsId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -2381,7 +2365,7 @@ export namespace appengine_v1beta {
         params,
         requiredParams: ['appsId'],
         pathParams: ['appsId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -2454,15 +2438,7 @@ export namespace appengine_v1beta {
   }
 
   export class Resource$Apps$Authorizedcertificates {
-    root: Appengine;
-    constructor(root: Appengine) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -2524,7 +2500,7 @@ export namespace appengine_v1beta {
         params,
         requiredParams: ['appsId'],
         pathParams: ['appsId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$AuthorizedCertificate>(parameters, callback);
@@ -2593,7 +2569,7 @@ export namespace appengine_v1beta {
         params,
         requiredParams: ['appsId', 'authorizedCertificatesId'],
         pathParams: ['appsId', 'authorizedCertificatesId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -2661,7 +2637,7 @@ export namespace appengine_v1beta {
         params,
         requiredParams: ['appsId', 'authorizedCertificatesId'],
         pathParams: ['appsId', 'authorizedCertificatesId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$AuthorizedCertificate>(parameters, callback);
@@ -2740,7 +2716,7 @@ export namespace appengine_v1beta {
         params,
         requiredParams: ['appsId'],
         pathParams: ['appsId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListAuthorizedCertificatesResponse>(
@@ -2819,7 +2795,7 @@ export namespace appengine_v1beta {
         params,
         requiredParams: ['appsId', 'authorizedCertificatesId'],
         pathParams: ['appsId', 'authorizedCertificatesId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$AuthorizedCertificate>(parameters, callback);
@@ -2940,15 +2916,7 @@ export namespace appengine_v1beta {
 
 
   export class Resource$Apps$Authorizeddomains {
-    root: Appengine;
-    constructor(root: Appengine) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -3015,7 +2983,7 @@ export namespace appengine_v1beta {
         params,
         requiredParams: ['appsId'],
         pathParams: ['appsId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListAuthorizedDomainsResponse>(
@@ -3051,15 +3019,7 @@ export namespace appengine_v1beta {
 
 
   export class Resource$Apps$Domainmappings {
-    root: Appengine;
-    constructor(root: Appengine) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -3124,7 +3084,7 @@ export namespace appengine_v1beta {
         params,
         requiredParams: ['appsId'],
         pathParams: ['appsId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -3195,7 +3155,7 @@ export namespace appengine_v1beta {
         params,
         requiredParams: ['appsId', 'domainMappingsId'],
         pathParams: ['appsId', 'domainMappingsId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -3260,7 +3220,7 @@ export namespace appengine_v1beta {
         params,
         requiredParams: ['appsId', 'domainMappingsId'],
         pathParams: ['appsId', 'domainMappingsId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$DomainMapping>(parameters, callback);
@@ -3334,7 +3294,7 @@ export namespace appengine_v1beta {
         params,
         requiredParams: ['appsId'],
         pathParams: ['appsId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListDomainMappingsResponse>(
@@ -3409,7 +3369,7 @@ export namespace appengine_v1beta {
         params,
         requiredParams: ['appsId', 'domainMappingsId'],
         pathParams: ['appsId', 'domainMappingsId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -3526,30 +3486,15 @@ export namespace appengine_v1beta {
 
 
   export class Resource$Apps$Firewall {
-    root: Appengine;
     ingressRules: Resource$Apps$Firewall$Ingressrules;
-    constructor(root: Appengine) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.ingressRules = new Resource$Apps$Firewall$Ingressrules(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.ingressRules = new Resource$Apps$Firewall$Ingressrules();
     }
   }
 
 
   export class Resource$Apps$Firewall$Ingressrules {
-    root: Appengine;
-    constructor(root: Appengine) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -3623,7 +3568,7 @@ export namespace appengine_v1beta {
         params,
         requiredParams: ['appsId'],
         pathParams: ['appsId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$BatchUpdateIngressRulesResponse>(
@@ -3693,7 +3638,7 @@ export namespace appengine_v1beta {
         params,
         requiredParams: ['appsId'],
         pathParams: ['appsId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$FirewallRule>(parameters, callback);
@@ -3762,7 +3707,7 @@ export namespace appengine_v1beta {
         params,
         requiredParams: ['appsId', 'ingressRulesId'],
         pathParams: ['appsId', 'ingressRulesId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -3828,7 +3773,7 @@ export namespace appengine_v1beta {
         params,
         requiredParams: ['appsId', 'ingressRulesId'],
         pathParams: ['appsId', 'ingressRulesId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$FirewallRule>(parameters, callback);
@@ -3899,7 +3844,7 @@ export namespace appengine_v1beta {
         params,
         requiredParams: ['appsId'],
         pathParams: ['appsId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListIngressRulesResponse>(parameters, callback);
@@ -3971,7 +3916,7 @@ export namespace appengine_v1beta {
         params,
         requiredParams: ['appsId', 'ingressRulesId'],
         pathParams: ['appsId', 'ingressRulesId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$FirewallRule>(parameters, callback);
@@ -4108,15 +4053,7 @@ export namespace appengine_v1beta {
 
 
   export class Resource$Apps$Locations {
-    root: Appengine;
-    constructor(root: Appengine) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -4172,7 +4109,7 @@ export namespace appengine_v1beta {
         params,
         requiredParams: ['appsId', 'locationsId'],
         pathParams: ['appsId', 'locationsId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Location>(parameters, callback);
@@ -4242,7 +4179,7 @@ export namespace appengine_v1beta {
         params,
         requiredParams: ['appsId'],
         pathParams: ['appsId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListLocationsResponse>(parameters, callback);
@@ -4296,15 +4233,7 @@ export namespace appengine_v1beta {
 
 
   export class Resource$Apps$Operations {
-    root: Appengine;
-    constructor(root: Appengine) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -4363,7 +4292,7 @@ export namespace appengine_v1beta {
         params,
         requiredParams: ['appsId', 'operationsId'],
         pathParams: ['appsId', 'operationsId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -4442,7 +4371,7 @@ export namespace appengine_v1beta {
         params,
         requiredParams: ['appsId'],
         pathParams: ['appsId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListOperationsResponse>(parameters, callback);
@@ -4495,16 +4424,9 @@ export namespace appengine_v1beta {
 
 
   export class Resource$Apps$Services {
-    root: Appengine;
     versions: Resource$Apps$Services$Versions;
-    constructor(root: Appengine) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.versions = new Resource$Apps$Services$Versions(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.versions = new Resource$Apps$Services$Versions();
     }
 
 
@@ -4566,7 +4488,7 @@ export namespace appengine_v1beta {
         params,
         requiredParams: ['appsId', 'servicesId'],
         pathParams: ['appsId', 'servicesId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -4629,7 +4551,7 @@ export namespace appengine_v1beta {
         params,
         requiredParams: ['appsId', 'servicesId'],
         pathParams: ['appsId', 'servicesId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Service>(parameters, callback);
@@ -4698,7 +4620,7 @@ export namespace appengine_v1beta {
         params,
         requiredParams: ['appsId'],
         pathParams: ['appsId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListServicesResponse>(parameters, callback);
@@ -4769,7 +4691,7 @@ export namespace appengine_v1beta {
         params,
         requiredParams: ['appsId', 'servicesId'],
         pathParams: ['appsId', 'servicesId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -4878,16 +4800,9 @@ export namespace appengine_v1beta {
   }
 
   export class Resource$Apps$Services$Versions {
-    root: Appengine;
     instances: Resource$Apps$Services$Versions$Instances;
-    constructor(root: Appengine) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.instances = new Resource$Apps$Services$Versions$Instances(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.instances = new Resource$Apps$Services$Versions$Instances();
     }
 
 
@@ -4951,7 +4866,7 @@ export namespace appengine_v1beta {
         params,
         requiredParams: ['appsId', 'servicesId'],
         pathParams: ['appsId', 'servicesId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -5022,7 +4937,7 @@ export namespace appengine_v1beta {
         params,
         requiredParams: ['appsId', 'servicesId', 'versionsId'],
         pathParams: ['appsId', 'servicesId', 'versionsId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -5091,7 +5006,7 @@ export namespace appengine_v1beta {
         params,
         requiredParams: ['appsId', 'servicesId', 'versionsId'],
         pathParams: ['appsId', 'servicesId', 'versionsId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Version>(parameters, callback);
@@ -5164,7 +5079,7 @@ export namespace appengine_v1beta {
         params,
         requiredParams: ['appsId', 'servicesId'],
         pathParams: ['appsId', 'servicesId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListVersionsResponse>(parameters, callback);
@@ -5266,7 +5181,7 @@ export namespace appengine_v1beta {
         params,
         requiredParams: ['appsId', 'servicesId', 'versionsId'],
         pathParams: ['appsId', 'servicesId', 'versionsId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -5405,15 +5320,7 @@ export namespace appengine_v1beta {
   }
 
   export class Resource$Apps$Services$Versions$Instances {
-    root: Appengine;
-    constructor(root: Appengine) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -5485,7 +5392,7 @@ export namespace appengine_v1beta {
         params,
         requiredParams: ['appsId', 'servicesId', 'versionsId', 'instancesId'],
         pathParams: ['appsId', 'instancesId', 'servicesId', 'versionsId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -5558,7 +5465,7 @@ export namespace appengine_v1beta {
         params,
         requiredParams: ['appsId', 'servicesId', 'versionsId', 'instancesId'],
         pathParams: ['appsId', 'instancesId', 'servicesId', 'versionsId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -5625,7 +5532,7 @@ export namespace appengine_v1beta {
         params,
         requiredParams: ['appsId', 'servicesId', 'versionsId', 'instancesId'],
         pathParams: ['appsId', 'instancesId', 'servicesId', 'versionsId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Instance>(parameters, callback);
@@ -5702,7 +5609,7 @@ export namespace appengine_v1beta {
         params,
         requiredParams: ['appsId', 'servicesId', 'versionsId'],
         pathParams: ['appsId', 'servicesId', 'versionsId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListInstancesResponse>(parameters, callback);

--- a/src/apis/appengine/v1beta4.ts
+++ b/src/apis/appengine/v1beta4.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace appengine_v1beta4 {
   export interface Options extends GlobalOptions {
     version: 'v1beta4';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -96,22 +98,12 @@ export namespace appengine_v1beta4 {
    * @param {object=} options Options for Appengine
    */
   export class Appengine {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     apps: Resource$Apps;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.apps = new Resource$Apps(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.apps = new Resource$Apps();
     }
   }
 
@@ -1499,20 +1491,13 @@ export namespace appengine_v1beta4 {
 
 
   export class Resource$Apps {
-    root: Appengine;
     locations: Resource$Apps$Locations;
     modules: Resource$Apps$Modules;
     operations: Resource$Apps$Operations;
-    constructor(root: Appengine) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.locations = new Resource$Apps$Locations(root);
-      this.modules = new Resource$Apps$Modules(root);
-      this.operations = new Resource$Apps$Operations(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.locations = new Resource$Apps$Locations();
+      this.modules = new Resource$Apps$Modules();
+      this.operations = new Resource$Apps$Operations();
     }
 
 
@@ -1576,7 +1561,7 @@ export namespace appengine_v1beta4 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -1639,7 +1624,7 @@ export namespace appengine_v1beta4 {
         params,
         requiredParams: ['appsId'],
         pathParams: ['appsId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Application>(parameters, callback);
@@ -1710,7 +1695,7 @@ export namespace appengine_v1beta4 {
         params,
         requiredParams: ['appsId'],
         pathParams: ['appsId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -1774,15 +1759,7 @@ export namespace appengine_v1beta4 {
   }
 
   export class Resource$Apps$Locations {
-    root: Appengine;
-    constructor(root: Appengine) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -1838,7 +1815,7 @@ export namespace appengine_v1beta4 {
         params,
         requiredParams: ['appsId', 'locationsId'],
         pathParams: ['appsId', 'locationsId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Location>(parameters, callback);
@@ -1908,7 +1885,7 @@ export namespace appengine_v1beta4 {
         params,
         requiredParams: ['appsId'],
         pathParams: ['appsId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListLocationsResponse>(parameters, callback);
@@ -1962,16 +1939,9 @@ export namespace appengine_v1beta4 {
 
 
   export class Resource$Apps$Modules {
-    root: Appengine;
     versions: Resource$Apps$Modules$Versions;
-    constructor(root: Appengine) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.versions = new Resource$Apps$Modules$Versions(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.versions = new Resource$Apps$Modules$Versions();
     }
 
 
@@ -2033,7 +2003,7 @@ export namespace appengine_v1beta4 {
         params,
         requiredParams: ['appsId', 'modulesId'],
         pathParams: ['appsId', 'modulesId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -2095,7 +2065,7 @@ export namespace appengine_v1beta4 {
         params,
         requiredParams: ['appsId', 'modulesId'],
         pathParams: ['appsId', 'modulesId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Module>(parameters, callback);
@@ -2163,7 +2133,7 @@ export namespace appengine_v1beta4 {
         params,
         requiredParams: ['appsId'],
         pathParams: ['appsId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListModulesResponse>(parameters, callback);
@@ -2233,7 +2203,7 @@ export namespace appengine_v1beta4 {
         params,
         requiredParams: ['appsId', 'modulesId'],
         pathParams: ['appsId', 'modulesId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -2340,16 +2310,9 @@ export namespace appengine_v1beta4 {
   }
 
   export class Resource$Apps$Modules$Versions {
-    root: Appengine;
     instances: Resource$Apps$Modules$Versions$Instances;
-    constructor(root: Appengine) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.instances = new Resource$Apps$Modules$Versions$Instances(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.instances = new Resource$Apps$Modules$Versions$Instances();
     }
 
 
@@ -2413,7 +2376,7 @@ export namespace appengine_v1beta4 {
         params,
         requiredParams: ['appsId', 'modulesId'],
         pathParams: ['appsId', 'modulesId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -2484,7 +2447,7 @@ export namespace appengine_v1beta4 {
         params,
         requiredParams: ['appsId', 'modulesId', 'versionsId'],
         pathParams: ['appsId', 'modulesId', 'versionsId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -2553,7 +2516,7 @@ export namespace appengine_v1beta4 {
         params,
         requiredParams: ['appsId', 'modulesId', 'versionsId'],
         pathParams: ['appsId', 'modulesId', 'versionsId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Version>(parameters, callback);
@@ -2626,7 +2589,7 @@ export namespace appengine_v1beta4 {
         params,
         requiredParams: ['appsId', 'modulesId'],
         pathParams: ['appsId', 'modulesId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListVersionsResponse>(parameters, callback);
@@ -2713,7 +2676,7 @@ export namespace appengine_v1beta4 {
         params,
         requiredParams: ['appsId', 'modulesId', 'versionsId'],
         pathParams: ['appsId', 'modulesId', 'versionsId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -2852,15 +2815,7 @@ export namespace appengine_v1beta4 {
   }
 
   export class Resource$Apps$Modules$Versions$Instances {
-    root: Appengine;
-    constructor(root: Appengine) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -2932,7 +2887,7 @@ export namespace appengine_v1beta4 {
         params,
         requiredParams: ['appsId', 'modulesId', 'versionsId', 'instancesId'],
         pathParams: ['appsId', 'instancesId', 'modulesId', 'versionsId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -3005,7 +2960,7 @@ export namespace appengine_v1beta4 {
         params,
         requiredParams: ['appsId', 'modulesId', 'versionsId', 'instancesId'],
         pathParams: ['appsId', 'instancesId', 'modulesId', 'versionsId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -3072,7 +3027,7 @@ export namespace appengine_v1beta4 {
         params,
         requiredParams: ['appsId', 'modulesId', 'versionsId', 'instancesId'],
         pathParams: ['appsId', 'instancesId', 'modulesId', 'versionsId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Instance>(parameters, callback);
@@ -3148,7 +3103,7 @@ export namespace appengine_v1beta4 {
         params,
         requiredParams: ['appsId', 'modulesId', 'versionsId'],
         pathParams: ['appsId', 'modulesId', 'versionsId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListInstancesResponse>(parameters, callback);
@@ -3271,15 +3226,7 @@ export namespace appengine_v1beta4 {
 
 
   export class Resource$Apps$Operations {
-    root: Appengine;
-    constructor(root: Appengine) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -3339,7 +3286,7 @@ export namespace appengine_v1beta4 {
         params,
         requiredParams: ['appsId', 'operationsId'],
         pathParams: ['appsId', 'operationsId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -3418,7 +3365,7 @@ export namespace appengine_v1beta4 {
         params,
         requiredParams: ['appsId'],
         pathParams: ['appsId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListOperationsResponse>(parameters, callback);

--- a/src/apis/appengine/v1beta5.ts
+++ b/src/apis/appengine/v1beta5.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace appengine_v1beta5 {
   export interface Options extends GlobalOptions {
     version: 'v1beta5';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -96,22 +98,12 @@ export namespace appengine_v1beta5 {
    * @param {object=} options Options for Appengine
    */
   export class Appengine {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     apps: Resource$Apps;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.apps = new Resource$Apps(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.apps = new Resource$Apps();
     }
   }
 
@@ -1475,20 +1467,13 @@ export namespace appengine_v1beta5 {
 
 
   export class Resource$Apps {
-    root: Appengine;
     locations: Resource$Apps$Locations;
     operations: Resource$Apps$Operations;
     services: Resource$Apps$Services;
-    constructor(root: Appengine) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.locations = new Resource$Apps$Locations(root);
-      this.operations = new Resource$Apps$Operations(root);
-      this.services = new Resource$Apps$Services(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.locations = new Resource$Apps$Locations();
+      this.operations = new Resource$Apps$Operations();
+      this.services = new Resource$Apps$Services();
     }
 
 
@@ -1552,7 +1537,7 @@ export namespace appengine_v1beta5 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -1615,7 +1600,7 @@ export namespace appengine_v1beta5 {
         params,
         requiredParams: ['appsId'],
         pathParams: ['appsId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Application>(parameters, callback);
@@ -1686,7 +1671,7 @@ export namespace appengine_v1beta5 {
         params,
         requiredParams: ['appsId'],
         pathParams: ['appsId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -1751,15 +1736,7 @@ export namespace appengine_v1beta5 {
   }
 
   export class Resource$Apps$Locations {
-    root: Appengine;
-    constructor(root: Appengine) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -1815,7 +1792,7 @@ export namespace appengine_v1beta5 {
         params,
         requiredParams: ['appsId', 'locationsId'],
         pathParams: ['appsId', 'locationsId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Location>(parameters, callback);
@@ -1885,7 +1862,7 @@ export namespace appengine_v1beta5 {
         params,
         requiredParams: ['appsId'],
         pathParams: ['appsId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListLocationsResponse>(parameters, callback);
@@ -1939,15 +1916,7 @@ export namespace appengine_v1beta5 {
 
 
   export class Resource$Apps$Operations {
-    root: Appengine;
-    constructor(root: Appengine) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -2007,7 +1976,7 @@ export namespace appengine_v1beta5 {
         params,
         requiredParams: ['appsId', 'operationsId'],
         pathParams: ['appsId', 'operationsId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -2086,7 +2055,7 @@ export namespace appengine_v1beta5 {
         params,
         requiredParams: ['appsId'],
         pathParams: ['appsId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListOperationsResponse>(parameters, callback);
@@ -2139,16 +2108,9 @@ export namespace appengine_v1beta5 {
 
 
   export class Resource$Apps$Services {
-    root: Appengine;
     versions: Resource$Apps$Services$Versions;
-    constructor(root: Appengine) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.versions = new Resource$Apps$Services$Versions(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.versions = new Resource$Apps$Services$Versions();
     }
 
 
@@ -2210,7 +2172,7 @@ export namespace appengine_v1beta5 {
         params,
         requiredParams: ['appsId', 'servicesId'],
         pathParams: ['appsId', 'servicesId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -2273,7 +2235,7 @@ export namespace appengine_v1beta5 {
         params,
         requiredParams: ['appsId', 'servicesId'],
         pathParams: ['appsId', 'servicesId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Service>(parameters, callback);
@@ -2342,7 +2304,7 @@ export namespace appengine_v1beta5 {
         params,
         requiredParams: ['appsId'],
         pathParams: ['appsId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListServicesResponse>(parameters, callback);
@@ -2413,7 +2375,7 @@ export namespace appengine_v1beta5 {
         params,
         requiredParams: ['appsId', 'servicesId'],
         pathParams: ['appsId', 'servicesId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -2521,16 +2483,9 @@ export namespace appengine_v1beta5 {
   }
 
   export class Resource$Apps$Services$Versions {
-    root: Appengine;
     instances: Resource$Apps$Services$Versions$Instances;
-    constructor(root: Appengine) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.instances = new Resource$Apps$Services$Versions$Instances(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.instances = new Resource$Apps$Services$Versions$Instances();
     }
 
 
@@ -2594,7 +2549,7 @@ export namespace appengine_v1beta5 {
         params,
         requiredParams: ['appsId', 'servicesId'],
         pathParams: ['appsId', 'servicesId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -2665,7 +2620,7 @@ export namespace appengine_v1beta5 {
         params,
         requiredParams: ['appsId', 'servicesId', 'versionsId'],
         pathParams: ['appsId', 'servicesId', 'versionsId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -2734,7 +2689,7 @@ export namespace appengine_v1beta5 {
         params,
         requiredParams: ['appsId', 'servicesId', 'versionsId'],
         pathParams: ['appsId', 'servicesId', 'versionsId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Version>(parameters, callback);
@@ -2807,7 +2762,7 @@ export namespace appengine_v1beta5 {
         params,
         requiredParams: ['appsId', 'servicesId'],
         pathParams: ['appsId', 'servicesId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListVersionsResponse>(parameters, callback);
@@ -2894,7 +2849,7 @@ export namespace appengine_v1beta5 {
         params,
         requiredParams: ['appsId', 'servicesId', 'versionsId'],
         pathParams: ['appsId', 'servicesId', 'versionsId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -3033,15 +2988,7 @@ export namespace appengine_v1beta5 {
   }
 
   export class Resource$Apps$Services$Versions$Instances {
-    root: Appengine;
-    constructor(root: Appengine) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -3113,7 +3060,7 @@ export namespace appengine_v1beta5 {
         params,
         requiredParams: ['appsId', 'servicesId', 'versionsId', 'instancesId'],
         pathParams: ['appsId', 'instancesId', 'servicesId', 'versionsId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -3186,7 +3133,7 @@ export namespace appengine_v1beta5 {
         params,
         requiredParams: ['appsId', 'servicesId', 'versionsId', 'instancesId'],
         pathParams: ['appsId', 'instancesId', 'servicesId', 'versionsId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -3253,7 +3200,7 @@ export namespace appengine_v1beta5 {
         params,
         requiredParams: ['appsId', 'servicesId', 'versionsId', 'instancesId'],
         pathParams: ['appsId', 'instancesId', 'servicesId', 'versionsId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Instance>(parameters, callback);
@@ -3330,7 +3277,7 @@ export namespace appengine_v1beta5 {
         params,
         requiredParams: ['appsId', 'servicesId', 'versionsId'],
         pathParams: ['appsId', 'servicesId', 'versionsId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListInstancesResponse>(parameters, callback);

--- a/src/apis/appsactivity/v1.ts
+++ b/src/apis/appsactivity/v1.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace appsactivity_v1 {
   export interface Options extends GlobalOptions {
     version: 'v1';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -79,22 +81,12 @@ export namespace appsactivity_v1 {
    * @param {object=} options Options for Appsactivity
    */
   export class Appsactivity {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     activities: Resource$Activities;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.activities = new Resource$Activities(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.activities = new Resource$Activities();
     }
   }
 
@@ -325,15 +317,7 @@ export namespace appsactivity_v1 {
 
 
   export class Resource$Activities {
-    root: Appsactivity;
-    constructor(root: Appsactivity) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -403,7 +387,7 @@ export namespace appsactivity_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListActivitiesResponse>(parameters, callback);

--- a/src/apis/appstate/v1.ts
+++ b/src/apis/appstate/v1.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace appstate_v1 {
   export interface Options extends GlobalOptions {
     version: 'v1';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -79,22 +81,12 @@ export namespace appstate_v1 {
    * @param {object=} options Options for Appstate
    */
   export class Appstate {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     states: Resource$States;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.states = new Resource$States(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.states = new Resource$States();
     }
   }
 
@@ -173,15 +165,7 @@ export namespace appstate_v1 {
 
 
   export class Resource$States {
-    root: Appstate;
-    constructor(root: Appstate) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -242,7 +226,7 @@ export namespace appstate_v1 {
         params,
         requiredParams: ['stateKey'],
         pathParams: ['stateKey'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$WriteResult>(parameters, callback);
@@ -309,7 +293,7 @@ export namespace appstate_v1 {
         params,
         requiredParams: ['stateKey'],
         pathParams: ['stateKey'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -372,7 +356,7 @@ export namespace appstate_v1 {
         params,
         requiredParams: ['stateKey'],
         pathParams: ['stateKey'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GetResponse>(parameters, callback);
@@ -437,7 +421,7 @@ export namespace appstate_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListResponse>(parameters, callback);
@@ -506,7 +490,7 @@ export namespace appstate_v1 {
         params,
         requiredParams: ['stateKey'],
         pathParams: ['stateKey'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$WriteResult>(parameters, callback);

--- a/src/apis/bigquery/v2.ts
+++ b/src/apis/bigquery/v2.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace bigquery_v2 {
   export interface Options extends GlobalOptions {
     version: 'v2';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -79,10 +81,6 @@ export namespace bigquery_v2 {
    * @param {object=} options Options for Bigquery
    */
   export class Bigquery {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     datasets: Resource$Datasets;
     jobs: Resource$Jobs;
     projects: Resource$Projects;
@@ -90,19 +88,13 @@ export namespace bigquery_v2 {
     tables: Resource$Tables;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.datasets = new Resource$Datasets(this);
-      this.jobs = new Resource$Jobs(this);
-      this.projects = new Resource$Projects(this);
-      this.tabledata = new Resource$Tabledata(this);
-      this.tables = new Resource$Tables(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.datasets = new Resource$Datasets();
+      this.jobs = new Resource$Jobs();
+      this.projects = new Resource$Projects();
+      this.tabledata = new Resource$Tabledata();
+      this.tables = new Resource$Tables();
     }
   }
 
@@ -2276,15 +2268,7 @@ export namespace bigquery_v2 {
 
 
   export class Resource$Datasets {
-    root: Bigquery;
-    constructor(root: Bigquery) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -2399,7 +2383,7 @@ export namespace bigquery_v2 {
         params,
         requiredParams: ['projectId', 'datasetId'],
         pathParams: ['datasetId', 'projectId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -2518,7 +2502,7 @@ export namespace bigquery_v2 {
         params,
         requiredParams: ['projectId', 'datasetId'],
         pathParams: ['datasetId', 'projectId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Dataset>(parameters, callback);
@@ -2640,7 +2624,7 @@ export namespace bigquery_v2 {
         params,
         requiredParams: ['projectId'],
         pathParams: ['projectId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Dataset>(parameters, callback);
@@ -2776,7 +2760,7 @@ export namespace bigquery_v2 {
         params,
         requiredParams: ['projectId'],
         pathParams: ['projectId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$DatasetList>(parameters, callback);
@@ -2908,7 +2892,7 @@ export namespace bigquery_v2 {
         params,
         requiredParams: ['projectId', 'datasetId'],
         pathParams: ['datasetId', 'projectId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Dataset>(parameters, callback);
@@ -3039,7 +3023,7 @@ export namespace bigquery_v2 {
         params,
         requiredParams: ['projectId', 'datasetId'],
         pathParams: ['datasetId', 'projectId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Dataset>(parameters, callback);
@@ -3175,15 +3159,7 @@ export namespace bigquery_v2 {
 
 
   export class Resource$Jobs {
-    root: Bigquery;
-    constructor(root: Bigquery) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -3303,7 +3279,7 @@ export namespace bigquery_v2 {
         params,
         requiredParams: ['projectId', 'jobId'],
         pathParams: ['jobId', 'projectId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$JobCancelResponse>(parameters, callback);
@@ -3424,7 +3400,7 @@ export namespace bigquery_v2 {
         params,
         requiredParams: ['projectId', 'jobId'],
         pathParams: ['jobId', 'projectId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Job>(parameters, callback);
@@ -3569,7 +3545,7 @@ export namespace bigquery_v2 {
         params,
         requiredParams: ['projectId', 'jobId'],
         pathParams: ['jobId', 'projectId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GetQueryResultsResponse>(parameters, callback);
@@ -3703,7 +3679,7 @@ export namespace bigquery_v2 {
                       .replace(/([^:]\/)\/+/g, '$1'),
         requiredParams: ['projectId'],
         pathParams: ['projectId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Job>(parameters, callback);
@@ -3844,7 +3820,7 @@ export namespace bigquery_v2 {
         params,
         requiredParams: ['projectId'],
         pathParams: ['projectId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$JobList>(parameters, callback);
@@ -3968,7 +3944,7 @@ export namespace bigquery_v2 {
         params,
         requiredParams: ['projectId'],
         pathParams: ['projectId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$QueryResponse>(parameters, callback);
@@ -4153,15 +4129,7 @@ export namespace bigquery_v2 {
 
 
   export class Resource$Projects {
-    root: Bigquery;
-    constructor(root: Bigquery) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -4279,7 +4247,7 @@ export namespace bigquery_v2 {
         params,
         requiredParams: ['projectId'],
         pathParams: ['projectId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GetServiceAccountResponse>(
@@ -4409,7 +4377,7 @@ export namespace bigquery_v2 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ProjectList>(parameters, callback);
@@ -4450,15 +4418,7 @@ export namespace bigquery_v2 {
 
 
   export class Resource$Tabledata {
-    root: Bigquery;
-    constructor(root: Bigquery) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -4592,7 +4552,7 @@ export namespace bigquery_v2 {
         params,
         requiredParams: ['projectId', 'datasetId', 'tableId'],
         pathParams: ['datasetId', 'projectId', 'tableId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TableDataInsertAllResponse>(
@@ -4739,7 +4699,7 @@ export namespace bigquery_v2 {
         params,
         requiredParams: ['projectId', 'datasetId', 'tableId'],
         pathParams: ['datasetId', 'projectId', 'tableId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TableDataList>(parameters, callback);
@@ -4813,15 +4773,7 @@ export namespace bigquery_v2 {
 
 
   export class Resource$Tables {
-    root: Bigquery;
-    constructor(root: Bigquery) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -4938,7 +4890,7 @@ export namespace bigquery_v2 {
         params,
         requiredParams: ['projectId', 'datasetId', 'tableId'],
         pathParams: ['datasetId', 'projectId', 'tableId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -5065,7 +5017,7 @@ export namespace bigquery_v2 {
         params,
         requiredParams: ['projectId', 'datasetId', 'tableId'],
         pathParams: ['datasetId', 'projectId', 'tableId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Table>(parameters, callback);
@@ -5193,7 +5145,7 @@ export namespace bigquery_v2 {
         params,
         requiredParams: ['projectId', 'datasetId'],
         pathParams: ['datasetId', 'projectId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Table>(parameters, callback);
@@ -5333,7 +5285,7 @@ export namespace bigquery_v2 {
         params,
         requiredParams: ['projectId', 'datasetId'],
         pathParams: ['datasetId', 'projectId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TableList>(parameters, callback);
@@ -5470,7 +5422,7 @@ export namespace bigquery_v2 {
         params,
         requiredParams: ['projectId', 'datasetId', 'tableId'],
         pathParams: ['datasetId', 'projectId', 'tableId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Table>(parameters, callback);
@@ -5606,7 +5558,7 @@ export namespace bigquery_v2 {
         params,
         requiredParams: ['projectId', 'datasetId', 'tableId'],
         pathParams: ['datasetId', 'projectId', 'tableId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Table>(parameters, callback);

--- a/src/apis/bigquerydatatransfer/v1.ts
+++ b/src/apis/bigquerydatatransfer/v1.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace bigquerydatatransfer_v1 {
   export interface Options extends GlobalOptions {
     version: 'v1';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -97,22 +99,12 @@ export namespace bigquerydatatransfer_v1 {
    * @param {object=} options Options for Bigquerydatatransfer
    */
   export class Bigquerydatatransfer {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     projects: Resource$Projects;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.projects = new Resource$Projects(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.projects = new Resource$Projects();
     }
   }
 
@@ -654,34 +646,19 @@ export namespace bigquerydatatransfer_v1 {
 
 
   export class Resource$Projects {
-    root: Bigquerydatatransfer;
     dataSources: Resource$Projects$Datasources;
     locations: Resource$Projects$Locations;
     transferConfigs: Resource$Projects$Transferconfigs;
-    constructor(root: Bigquerydatatransfer) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.dataSources = new Resource$Projects$Datasources(root);
-      this.locations = new Resource$Projects$Locations(root);
-      this.transferConfigs = new Resource$Projects$Transferconfigs(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.dataSources = new Resource$Projects$Datasources();
+      this.locations = new Resource$Projects$Locations();
+      this.transferConfigs = new Resource$Projects$Transferconfigs();
     }
   }
 
 
   export class Resource$Projects$Datasources {
-    root: Bigquerydatatransfer;
-    constructor(root: Bigquerydatatransfer) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -749,7 +726,7 @@ export namespace bigquerydatatransfer_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$CheckValidCredsResponse>(parameters, callback);
@@ -813,7 +790,7 @@ export namespace bigquerydatatransfer_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$DataSource>(parameters, callback);
@@ -885,7 +862,7 @@ export namespace bigquerydatatransfer_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListDataSourcesResponse>(parameters, callback);
@@ -953,19 +930,11 @@ export namespace bigquerydatatransfer_v1 {
 
 
   export class Resource$Projects$Locations {
-    root: Bigquerydatatransfer;
     dataSources: Resource$Projects$Locations$Datasources;
     transferConfigs: Resource$Projects$Locations$Transferconfigs;
-    constructor(root: Bigquerydatatransfer) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.dataSources = new Resource$Projects$Locations$Datasources(root);
-      this.transferConfigs =
-          new Resource$Projects$Locations$Transferconfigs(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.dataSources = new Resource$Projects$Locations$Datasources();
+      this.transferConfigs = new Resource$Projects$Locations$Transferconfigs();
     }
 
 
@@ -1021,7 +990,7 @@ export namespace bigquerydatatransfer_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Location>(parameters, callback);
@@ -1093,7 +1062,7 @@ export namespace bigquerydatatransfer_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListLocationsResponse>(parameters, callback);
@@ -1141,15 +1110,7 @@ export namespace bigquerydatatransfer_v1 {
   }
 
   export class Resource$Projects$Locations$Datasources {
-    root: Bigquerydatatransfer;
-    constructor(root: Bigquerydatatransfer) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -1220,7 +1181,7 @@ export namespace bigquerydatatransfer_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$CheckValidCredsResponse>(parameters, callback);
@@ -1284,7 +1245,7 @@ export namespace bigquerydatatransfer_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$DataSource>(parameters, callback);
@@ -1356,7 +1317,7 @@ export namespace bigquerydatatransfer_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListDataSourcesResponse>(parameters, callback);
@@ -1424,16 +1385,9 @@ export namespace bigquerydatatransfer_v1 {
 
 
   export class Resource$Projects$Locations$Transferconfigs {
-    root: Bigquerydatatransfer;
     runs: Resource$Projects$Locations$Transferconfigs$Runs;
-    constructor(root: Bigquerydatatransfer) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.runs = new Resource$Projects$Locations$Transferconfigs$Runs(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.runs = new Resource$Projects$Locations$Transferconfigs$Runs();
     }
 
 
@@ -1499,7 +1453,7 @@ export namespace bigquerydatatransfer_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TransferConfig>(parameters, callback);
@@ -1568,7 +1522,7 @@ export namespace bigquerydatatransfer_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -1632,7 +1586,7 @@ export namespace bigquerydatatransfer_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TransferConfig>(parameters, callback);
@@ -1709,7 +1663,7 @@ export namespace bigquerydatatransfer_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListTransferConfigsResponse>(
@@ -1782,7 +1736,7 @@ export namespace bigquerydatatransfer_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TransferConfig>(parameters, callback);
@@ -1864,7 +1818,7 @@ export namespace bigquerydatatransfer_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ScheduleTransferRunsResponse>(
@@ -2033,18 +1987,10 @@ export namespace bigquerydatatransfer_v1 {
   }
 
   export class Resource$Projects$Locations$Transferconfigs$Runs {
-    root: Bigquerydatatransfer;
     transferLogs: Resource$Projects$Locations$Transferconfigs$Runs$Transferlogs;
-    constructor(root: Bigquerydatatransfer) {
-      this.root = root;
-      this.getRoot.bind(this);
+    constructor() {
       this.transferLogs =
-          new Resource$Projects$Locations$Transferconfigs$Runs$Transferlogs(
-              root);
-    }
-
-    getRoot() {
-      return this.root;
+          new Resource$Projects$Locations$Transferconfigs$Runs$Transferlogs();
     }
 
 
@@ -2107,7 +2053,7 @@ export namespace bigquerydatatransfer_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -2172,7 +2118,7 @@ export namespace bigquerydatatransfer_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TransferRun>(parameters, callback);
@@ -2247,7 +2193,7 @@ export namespace bigquerydatatransfer_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListTransferRunsResponse>(parameters, callback);
@@ -2318,15 +2264,7 @@ export namespace bigquerydatatransfer_v1 {
   }
 
   export class Resource$Projects$Locations$Transferconfigs$Runs$Transferlogs {
-    root: Bigquerydatatransfer;
-    constructor(root: Bigquerydatatransfer) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -2397,7 +2335,7 @@ export namespace bigquerydatatransfer_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListTransferLogsResponse>(parameters, callback);
@@ -2440,16 +2378,9 @@ export namespace bigquerydatatransfer_v1 {
 
 
   export class Resource$Projects$Transferconfigs {
-    root: Bigquerydatatransfer;
     runs: Resource$Projects$Transferconfigs$Runs;
-    constructor(root: Bigquerydatatransfer) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.runs = new Resource$Projects$Transferconfigs$Runs(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.runs = new Resource$Projects$Transferconfigs$Runs();
     }
 
 
@@ -2513,7 +2444,7 @@ export namespace bigquerydatatransfer_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TransferConfig>(parameters, callback);
@@ -2580,7 +2511,7 @@ export namespace bigquerydatatransfer_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -2643,7 +2574,7 @@ export namespace bigquerydatatransfer_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TransferConfig>(parameters, callback);
@@ -2719,7 +2650,7 @@ export namespace bigquerydatatransfer_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListTransferConfigsResponse>(
@@ -2791,7 +2722,7 @@ export namespace bigquerydatatransfer_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TransferConfig>(parameters, callback);
@@ -2870,7 +2801,7 @@ export namespace bigquerydatatransfer_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ScheduleTransferRunsResponse>(
@@ -3039,17 +2970,10 @@ export namespace bigquerydatatransfer_v1 {
   }
 
   export class Resource$Projects$Transferconfigs$Runs {
-    root: Bigquerydatatransfer;
     transferLogs: Resource$Projects$Transferconfigs$Runs$Transferlogs;
-    constructor(root: Bigquerydatatransfer) {
-      this.root = root;
-      this.getRoot.bind(this);
+    constructor() {
       this.transferLogs =
-          new Resource$Projects$Transferconfigs$Runs$Transferlogs(root);
-    }
-
-    getRoot() {
-      return this.root;
+          new Resource$Projects$Transferconfigs$Runs$Transferlogs();
     }
 
 
@@ -3109,7 +3033,7 @@ export namespace bigquerydatatransfer_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -3172,7 +3096,7 @@ export namespace bigquerydatatransfer_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TransferRun>(parameters, callback);
@@ -3245,7 +3169,7 @@ export namespace bigquerydatatransfer_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListTransferRunsResponse>(parameters, callback);
@@ -3316,15 +3240,7 @@ export namespace bigquerydatatransfer_v1 {
   }
 
   export class Resource$Projects$Transferconfigs$Runs$Transferlogs {
-    root: Bigquerydatatransfer;
-    constructor(root: Bigquerydatatransfer) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -3393,7 +3309,7 @@ export namespace bigquerydatatransfer_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListTransferLogsResponse>(parameters, callback);

--- a/src/apis/binaryauthorization/v1beta1.ts
+++ b/src/apis/binaryauthorization/v1beta1.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace binaryauthorization_v1beta1 {
   export interface Options extends GlobalOptions {
     version: 'v1beta1';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -97,22 +99,12 @@ export namespace binaryauthorization_v1beta1 {
    * @param {object=} options Options for Binaryauthorization
    */
   export class Binaryauthorization {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     projects: Resource$Projects;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.projects = new Resource$Projects(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.projects = new Resource$Projects();
     }
   }
 
@@ -438,18 +430,11 @@ export namespace binaryauthorization_v1beta1 {
 
 
   export class Resource$Projects {
-    root: Binaryauthorization;
     attestors: Resource$Projects$Attestors;
     policy: Resource$Projects$Policy;
-    constructor(root: Binaryauthorization) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.attestors = new Resource$Projects$Attestors(root);
-      this.policy = new Resource$Projects$Policy(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.attestors = new Resource$Projects$Attestors();
+      this.policy = new Resource$Projects$Policy();
     }
 
 
@@ -510,7 +495,7 @@ export namespace binaryauthorization_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -581,7 +566,7 @@ export namespace binaryauthorization_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -624,15 +609,7 @@ export namespace binaryauthorization_v1beta1 {
   }
 
   export class Resource$Projects$Attestors {
-    root: Binaryauthorization;
-    constructor(root: Binaryauthorization) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -696,7 +673,7 @@ export namespace binaryauthorization_v1beta1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Attestor>(parameters, callback);
@@ -763,7 +740,7 @@ export namespace binaryauthorization_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -825,7 +802,7 @@ export namespace binaryauthorization_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Attestor>(parameters, callback);
@@ -894,7 +871,7 @@ export namespace binaryauthorization_v1beta1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$IamPolicy>(parameters, callback);
@@ -966,7 +943,7 @@ export namespace binaryauthorization_v1beta1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListAttestorsResponse>(parameters, callback);
@@ -1036,7 +1013,7 @@ export namespace binaryauthorization_v1beta1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$IamPolicy>(parameters, callback);
@@ -1116,7 +1093,7 @@ export namespace binaryauthorization_v1beta1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TestIamPermissionsResponse>(
@@ -1185,7 +1162,7 @@ export namespace binaryauthorization_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Attestor>(parameters, callback);
@@ -1336,15 +1313,7 @@ export namespace binaryauthorization_v1beta1 {
 
 
   export class Resource$Projects$Policy {
-    root: Binaryauthorization;
-    constructor(root: Binaryauthorization) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -1406,7 +1375,7 @@ export namespace binaryauthorization_v1beta1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$IamPolicy>(parameters, callback);
@@ -1476,7 +1445,7 @@ export namespace binaryauthorization_v1beta1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$IamPolicy>(parameters, callback);
@@ -1555,7 +1524,7 @@ export namespace binaryauthorization_v1beta1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TestIamPermissionsResponse>(

--- a/src/apis/blogger/v2.ts
+++ b/src/apis/blogger/v2.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace blogger_v2 {
   export interface Options extends GlobalOptions {
     version: 'v2';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -79,10 +81,6 @@ export namespace blogger_v2 {
    * @param {object=} options Options for Blogger
    */
   export class Blogger {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     blogs: Resource$Blogs;
     comments: Resource$Comments;
     pages: Resource$Pages;
@@ -90,19 +88,13 @@ export namespace blogger_v2 {
     users: Resource$Users;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.blogs = new Resource$Blogs(this);
-      this.comments = new Resource$Comments(this);
-      this.pages = new Resource$Pages(this);
-      this.posts = new Resource$Posts(this);
-      this.users = new Resource$Users(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.blogs = new Resource$Blogs();
+      this.comments = new Resource$Comments();
+      this.pages = new Resource$Pages();
+      this.posts = new Resource$Posts();
+      this.users = new Resource$Users();
     }
   }
 
@@ -399,15 +391,7 @@ export namespace blogger_v2 {
 
 
   export class Resource$Blogs {
-    root: Blogger;
-    constructor(root: Blogger) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -461,7 +445,7 @@ export namespace blogger_v2 {
         params,
         requiredParams: ['blogId'],
         pathParams: ['blogId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Blog>(parameters, callback);
@@ -485,15 +469,7 @@ export namespace blogger_v2 {
 
 
   export class Resource$Comments {
-    root: Blogger;
-    constructor(root: Blogger) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -551,7 +527,7 @@ export namespace blogger_v2 {
         params,
         requiredParams: ['blogId', 'postId', 'commentId'],
         pathParams: ['blogId', 'commentId', 'postId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Comment>(parameters, callback);
@@ -622,7 +598,7 @@ export namespace blogger_v2 {
         params,
         requiredParams: ['blogId', 'postId'],
         pathParams: ['blogId', 'postId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$CommentList>(parameters, callback);
@@ -685,15 +661,7 @@ export namespace blogger_v2 {
 
 
   export class Resource$Pages {
-    root: Blogger;
-    constructor(root: Blogger) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -748,7 +716,7 @@ export namespace blogger_v2 {
         params,
         requiredParams: ['blogId', 'pageId'],
         pathParams: ['blogId', 'pageId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Page>(parameters, callback);
@@ -813,7 +781,7 @@ export namespace blogger_v2 {
         params,
         requiredParams: ['blogId'],
         pathParams: ['blogId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$PageList>(parameters, callback);
@@ -856,15 +824,7 @@ export namespace blogger_v2 {
 
 
   export class Resource$Posts {
-    root: Blogger;
-    constructor(root: Blogger) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -919,7 +879,7 @@ export namespace blogger_v2 {
         params,
         requiredParams: ['blogId', 'postId'],
         pathParams: ['blogId', 'postId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Post>(parameters, callback);
@@ -987,7 +947,7 @@ export namespace blogger_v2 {
         params,
         requiredParams: ['blogId'],
         pathParams: ['blogId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$PostList>(parameters, callback);
@@ -1042,16 +1002,9 @@ export namespace blogger_v2 {
 
 
   export class Resource$Users {
-    root: Blogger;
     blogs: Resource$Users$Blogs;
-    constructor(root: Blogger) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.blogs = new Resource$Users$Blogs(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.blogs = new Resource$Users$Blogs();
     }
 
 
@@ -1106,7 +1059,7 @@ export namespace blogger_v2 {
         params,
         requiredParams: ['userId'],
         pathParams: ['userId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$User>(parameters, callback);
@@ -1129,15 +1082,7 @@ export namespace blogger_v2 {
   }
 
   export class Resource$Users$Blogs {
-    root: Blogger;
-    constructor(root: Blogger) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -1194,7 +1139,7 @@ export namespace blogger_v2 {
         params,
         requiredParams: ['userId'],
         pathParams: ['userId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$BlogList>(parameters, callback);

--- a/src/apis/blogger/v3.ts
+++ b/src/apis/blogger/v3.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace blogger_v3 {
   export interface Options extends GlobalOptions {
     version: 'v3';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -79,10 +81,6 @@ export namespace blogger_v3 {
    * @param {object=} options Options for Blogger
    */
   export class Blogger {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     blogs: Resource$Blogs;
     blogUserInfos: Resource$Bloguserinfos;
     comments: Resource$Comments;
@@ -93,22 +91,16 @@ export namespace blogger_v3 {
     users: Resource$Users;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.blogs = new Resource$Blogs(this);
-      this.blogUserInfos = new Resource$Bloguserinfos(this);
-      this.comments = new Resource$Comments(this);
-      this.pages = new Resource$Pages(this);
-      this.pageViews = new Resource$Pageviews(this);
-      this.posts = new Resource$Posts(this);
-      this.postUserInfos = new Resource$Postuserinfos(this);
-      this.users = new Resource$Users(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.blogs = new Resource$Blogs();
+      this.blogUserInfos = new Resource$Bloguserinfos();
+      this.comments = new Resource$Comments();
+      this.pages = new Resource$Pages();
+      this.pageViews = new Resource$Pageviews();
+      this.posts = new Resource$Posts();
+      this.postUserInfos = new Resource$Postuserinfos();
+      this.users = new Resource$Users();
     }
   }
 
@@ -575,15 +567,7 @@ export namespace blogger_v3 {
 
 
   export class Resource$Blogs {
-    root: Blogger;
-    constructor(root: Blogger) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -639,7 +623,7 @@ export namespace blogger_v3 {
         params,
         requiredParams: ['blogId'],
         pathParams: ['blogId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Blog>(parameters, callback);
@@ -704,7 +688,7 @@ export namespace blogger_v3 {
         params,
         requiredParams: ['url'],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Blog>(parameters, callback);
@@ -773,7 +757,7 @@ export namespace blogger_v3 {
         params,
         requiredParams: ['userId'],
         pathParams: ['userId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$BlogList>(parameters, callback);
@@ -855,15 +839,7 @@ export namespace blogger_v3 {
 
 
   export class Resource$Bloguserinfos {
-    root: Blogger;
-    constructor(root: Blogger) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -921,7 +897,7 @@ export namespace blogger_v3 {
         params,
         requiredParams: ['userId', 'blogId'],
         pathParams: ['blogId', 'userId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$BlogUserInfo>(parameters, callback);
@@ -955,15 +931,7 @@ export namespace blogger_v3 {
 
 
   export class Resource$Comments {
-    root: Blogger;
-    constructor(root: Blogger) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -1024,7 +992,7 @@ export namespace blogger_v3 {
         params,
         requiredParams: ['blogId', 'postId', 'commentId'],
         pathParams: ['blogId', 'commentId', 'postId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Comment>(parameters, callback);
@@ -1091,7 +1059,7 @@ export namespace blogger_v3 {
         params,
         requiredParams: ['blogId', 'postId', 'commentId'],
         pathParams: ['blogId', 'commentId', 'postId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -1157,7 +1125,7 @@ export namespace blogger_v3 {
         params,
         requiredParams: ['blogId', 'postId', 'commentId'],
         pathParams: ['blogId', 'commentId', 'postId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Comment>(parameters, callback);
@@ -1231,7 +1199,7 @@ export namespace blogger_v3 {
         params,
         requiredParams: ['blogId', 'postId'],
         pathParams: ['blogId', 'postId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$CommentList>(parameters, callback);
@@ -1305,7 +1273,7 @@ export namespace blogger_v3 {
         params,
         requiredParams: ['blogId'],
         pathParams: ['blogId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$CommentList>(parameters, callback);
@@ -1375,7 +1343,7 @@ export namespace blogger_v3 {
         params,
         requiredParams: ['blogId', 'postId', 'commentId'],
         pathParams: ['blogId', 'commentId', 'postId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Comment>(parameters, callback);
@@ -1445,7 +1413,7 @@ export namespace blogger_v3 {
         params,
         requiredParams: ['blogId', 'postId', 'commentId'],
         pathParams: ['blogId', 'commentId', 'postId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Comment>(parameters, callback);
@@ -1642,15 +1610,7 @@ export namespace blogger_v3 {
 
 
   export class Resource$Pages {
-    root: Blogger;
-    constructor(root: Blogger) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -1707,7 +1667,7 @@ export namespace blogger_v3 {
         params,
         requiredParams: ['blogId', 'pageId'],
         pathParams: ['blogId', 'pageId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -1770,7 +1730,7 @@ export namespace blogger_v3 {
         params,
         requiredParams: ['blogId', 'pageId'],
         pathParams: ['blogId', 'pageId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Page>(parameters, callback);
@@ -1836,7 +1796,7 @@ export namespace blogger_v3 {
         params,
         requiredParams: ['blogId'],
         pathParams: ['blogId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Page>(parameters, callback);
@@ -1906,7 +1866,7 @@ export namespace blogger_v3 {
         params,
         requiredParams: ['blogId'],
         pathParams: ['blogId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$PageList>(parameters, callback);
@@ -1974,7 +1934,7 @@ export namespace blogger_v3 {
         params,
         requiredParams: ['blogId', 'pageId'],
         pathParams: ['blogId', 'pageId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Page>(parameters, callback);
@@ -2040,7 +2000,7 @@ export namespace blogger_v3 {
         params,
         requiredParams: ['blogId', 'pageId'],
         pathParams: ['blogId', 'pageId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Page>(parameters, callback);
@@ -2106,7 +2066,7 @@ export namespace blogger_v3 {
         params,
         requiredParams: ['blogId', 'pageId'],
         pathParams: ['blogId', 'pageId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Page>(parameters, callback);
@@ -2174,7 +2134,7 @@ export namespace blogger_v3 {
         params,
         requiredParams: ['blogId', 'pageId'],
         pathParams: ['blogId', 'pageId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Page>(parameters, callback);
@@ -2363,15 +2323,7 @@ export namespace blogger_v3 {
 
 
   export class Resource$Pageviews {
-    root: Blogger;
-    constructor(root: Blogger) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -2427,7 +2379,7 @@ export namespace blogger_v3 {
         params,
         requiredParams: ['blogId'],
         pathParams: ['blogId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Pageviews>(parameters, callback);
@@ -2455,15 +2407,7 @@ export namespace blogger_v3 {
 
 
   export class Resource$Posts {
-    root: Blogger;
-    constructor(root: Blogger) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -2520,7 +2464,7 @@ export namespace blogger_v3 {
         params,
         requiredParams: ['blogId', 'postId'],
         pathParams: ['blogId', 'postId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -2586,7 +2530,7 @@ export namespace blogger_v3 {
         params,
         requiredParams: ['blogId', 'postId'],
         pathParams: ['blogId', 'postId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Post>(parameters, callback);
@@ -2654,7 +2598,7 @@ export namespace blogger_v3 {
         params,
         requiredParams: ['blogId', 'path'],
         pathParams: ['blogId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Post>(parameters, callback);
@@ -2722,7 +2666,7 @@ export namespace blogger_v3 {
         params,
         requiredParams: ['blogId'],
         pathParams: ['blogId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Post>(parameters, callback);
@@ -2796,7 +2740,7 @@ export namespace blogger_v3 {
         params,
         requiredParams: ['blogId'],
         pathParams: ['blogId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$PostList>(parameters, callback);
@@ -2867,7 +2811,7 @@ export namespace blogger_v3 {
         params,
         requiredParams: ['blogId', 'postId'],
         pathParams: ['blogId', 'postId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Post>(parameters, callback);
@@ -2935,7 +2879,7 @@ export namespace blogger_v3 {
         params,
         requiredParams: ['blogId', 'postId'],
         pathParams: ['blogId', 'postId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Post>(parameters, callback);
@@ -3001,7 +2945,7 @@ export namespace blogger_v3 {
         params,
         requiredParams: ['blogId', 'postId'],
         pathParams: ['blogId', 'postId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Post>(parameters, callback);
@@ -3068,7 +3012,7 @@ export namespace blogger_v3 {
         params,
         requiredParams: ['blogId', 'q'],
         pathParams: ['blogId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$PostList>(parameters, callback);
@@ -3139,7 +3083,7 @@ export namespace blogger_v3 {
         params,
         requiredParams: ['blogId', 'postId'],
         pathParams: ['blogId', 'postId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Post>(parameters, callback);
@@ -3459,15 +3403,7 @@ export namespace blogger_v3 {
 
 
   export class Resource$Postuserinfos {
-    root: Blogger;
-    constructor(root: Blogger) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -3529,7 +3465,7 @@ export namespace blogger_v3 {
         params,
         requiredParams: ['userId', 'blogId', 'postId'],
         pathParams: ['blogId', 'postId', 'userId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$PostUserInfo>(parameters, callback);
@@ -3607,7 +3543,7 @@ export namespace blogger_v3 {
         params,
         requiredParams: ['userId', 'blogId'],
         pathParams: ['blogId', 'userId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$PostUserInfosList>(parameters, callback);
@@ -3699,15 +3635,7 @@ export namespace blogger_v3 {
 
 
   export class Resource$Users {
-    root: Blogger;
-    constructor(root: Blogger) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -3761,7 +3689,7 @@ export namespace blogger_v3 {
         params,
         requiredParams: ['userId'],
         pathParams: ['userId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$User>(parameters, callback);

--- a/src/apis/books/v1.ts
+++ b/src/apis/books/v1.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace books_v1 {
   export interface Options extends GlobalOptions {
     version: 'v1';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -79,10 +81,6 @@ export namespace books_v1 {
    * @param {object=} options Options for Books
    */
   export class Books {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     bookshelves: Resource$Bookshelves;
     cloudloading: Resource$Cloudloading;
     dictionary: Resource$Dictionary;
@@ -98,27 +96,21 @@ export namespace books_v1 {
     volumes: Resource$Volumes;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.bookshelves = new Resource$Bookshelves(this);
-      this.cloudloading = new Resource$Cloudloading(this);
-      this.dictionary = new Resource$Dictionary(this);
-      this.familysharing = new Resource$Familysharing(this);
-      this.layers = new Resource$Layers(this);
-      this.myconfig = new Resource$Myconfig(this);
-      this.mylibrary = new Resource$Mylibrary(this);
-      this.notification = new Resource$Notification(this);
-      this.onboarding = new Resource$Onboarding(this);
-      this.personalizedstream = new Resource$Personalizedstream(this);
-      this.promooffer = new Resource$Promooffer(this);
-      this.series = new Resource$Series(this);
-      this.volumes = new Resource$Volumes(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.bookshelves = new Resource$Bookshelves();
+      this.cloudloading = new Resource$Cloudloading();
+      this.dictionary = new Resource$Dictionary();
+      this.familysharing = new Resource$Familysharing();
+      this.layers = new Resource$Layers();
+      this.myconfig = new Resource$Myconfig();
+      this.mylibrary = new Resource$Mylibrary();
+      this.notification = new Resource$Notification();
+      this.onboarding = new Resource$Onboarding();
+      this.personalizedstream = new Resource$Personalizedstream();
+      this.promooffer = new Resource$Promooffer();
+      this.series = new Resource$Series();
+      this.volumes = new Resource$Volumes();
     }
   }
 
@@ -1156,16 +1148,9 @@ export namespace books_v1 {
 
 
   export class Resource$Bookshelves {
-    root: Books;
     volumes: Resource$Bookshelves$Volumes;
-    constructor(root: Books) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.volumes = new Resource$Bookshelves$Volumes(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.volumes = new Resource$Bookshelves$Volumes();
     }
 
 
@@ -1223,7 +1208,7 @@ export namespace books_v1 {
         params,
         requiredParams: ['userId', 'shelf'],
         pathParams: ['shelf', 'userId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Bookshelf>(parameters, callback);
@@ -1289,7 +1274,7 @@ export namespace books_v1 {
         params,
         requiredParams: ['userId'],
         pathParams: ['userId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Bookshelves>(parameters, callback);
@@ -1335,15 +1320,7 @@ export namespace books_v1 {
   }
 
   export class Resource$Bookshelves$Volumes {
-    root: Books;
-    constructor(root: Books) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -1408,7 +1385,7 @@ export namespace books_v1 {
         params,
         requiredParams: ['userId', 'shelf'],
         pathParams: ['shelf', 'userId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Volumes>(parameters, callback);
@@ -1454,15 +1431,7 @@ export namespace books_v1 {
 
 
   export class Resource$Cloudloading {
-    root: Books;
-    constructor(root: Books) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -1526,7 +1495,7 @@ export namespace books_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$BooksCloudloadingResource>(
@@ -1592,7 +1561,7 @@ export namespace books_v1 {
         params,
         requiredParams: ['volumeId'],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -1661,7 +1630,7 @@ export namespace books_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$BooksCloudloadingResource>(
@@ -1725,15 +1694,7 @@ export namespace books_v1 {
 
 
   export class Resource$Dictionary {
-    root: Books;
-    constructor(root: Books) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -1792,7 +1753,7 @@ export namespace books_v1 {
         params,
         requiredParams: ['cpksver'],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Metadata>(parameters, callback);
@@ -1817,15 +1778,7 @@ export namespace books_v1 {
 
 
   export class Resource$Familysharing {
-    root: Books;
-    constructor(root: Books) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -1885,7 +1838,7 @@ export namespace books_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$FamilyInfo>(parameters, callback);
@@ -1953,7 +1906,7 @@ export namespace books_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -2021,7 +1974,7 @@ export namespace books_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -2086,18 +2039,11 @@ export namespace books_v1 {
 
 
   export class Resource$Layers {
-    root: Books;
     annotationData: Resource$Layers$Annotationdata;
     volumeAnnotations: Resource$Layers$Volumeannotations;
-    constructor(root: Books) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.annotationData = new Resource$Layers$Annotationdata(root);
-      this.volumeAnnotations = new Resource$Layers$Volumeannotations(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.annotationData = new Resource$Layers$Annotationdata();
+      this.volumeAnnotations = new Resource$Layers$Volumeannotations();
     }
 
 
@@ -2157,7 +2103,7 @@ export namespace books_v1 {
         params,
         requiredParams: ['volumeId', 'summaryId'],
         pathParams: ['summaryId', 'volumeId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Layersummary>(parameters, callback);
@@ -2226,7 +2172,7 @@ export namespace books_v1 {
         params,
         requiredParams: ['volumeId'],
         pathParams: ['volumeId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Layersummaries>(parameters, callback);
@@ -2288,15 +2234,7 @@ export namespace books_v1 {
   }
 
   export class Resource$Layers$Annotationdata {
-    root: Books;
-    constructor(root: Books) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -2364,7 +2302,7 @@ export namespace books_v1 {
         requiredParams:
             ['volumeId', 'layerId', 'annotationDataId', 'contentVersion'],
         pathParams: ['annotationDataId', 'layerId', 'volumeId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Annotationdata>(parameters, callback);
@@ -2444,7 +2382,7 @@ export namespace books_v1 {
         params,
         requiredParams: ['volumeId', 'layerId', 'contentVersion'],
         pathParams: ['layerId', 'volumeId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Annotationsdata>(parameters, callback);
@@ -2574,15 +2512,7 @@ export namespace books_v1 {
 
 
   export class Resource$Layers$Volumeannotations {
-    root: Books;
-    constructor(root: Books) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -2644,7 +2574,7 @@ export namespace books_v1 {
         params,
         requiredParams: ['volumeId', 'layerId', 'annotationId'],
         pathParams: ['annotationId', 'layerId', 'volumeId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Volumeannotation>(parameters, callback);
@@ -2725,7 +2655,7 @@ export namespace books_v1 {
         params,
         requiredParams: ['volumeId', 'layerId', 'contentVersion'],
         pathParams: ['layerId', 'volumeId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Volumeannotations>(parameters, callback);
@@ -2840,15 +2770,7 @@ export namespace books_v1 {
 
 
   export class Resource$Myconfig {
-    root: Books;
-    constructor(root: Books) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -2907,7 +2829,7 @@ export namespace books_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Usersettings>(parameters, callback);
@@ -2978,7 +2900,7 @@ export namespace books_v1 {
         params,
         requiredParams: ['volumeIds', 'cpksver'],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$DownloadAccesses>(parameters, callback);
@@ -3050,7 +2972,7 @@ export namespace books_v1 {
         params,
         requiredParams: ['source', 'volumeId', 'nonce', 'cpksver'],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$RequestAccess>(parameters, callback);
@@ -3124,7 +3046,7 @@ export namespace books_v1 {
         params,
         requiredParams: ['source', 'nonce', 'cpksver'],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Volumes>(parameters, callback);
@@ -3194,7 +3116,7 @@ export namespace books_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Usersettings>(parameters, callback);
@@ -3324,34 +3246,19 @@ export namespace books_v1 {
 
 
   export class Resource$Mylibrary {
-    root: Books;
     annotations: Resource$Mylibrary$Annotations;
     bookshelves: Resource$Mylibrary$Bookshelves;
     readingpositions: Resource$Mylibrary$Readingpositions;
-    constructor(root: Books) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.annotations = new Resource$Mylibrary$Annotations(root);
-      this.bookshelves = new Resource$Mylibrary$Bookshelves(root);
-      this.readingpositions = new Resource$Mylibrary$Readingpositions(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.annotations = new Resource$Mylibrary$Annotations();
+      this.bookshelves = new Resource$Mylibrary$Bookshelves();
+      this.readingpositions = new Resource$Mylibrary$Readingpositions();
     }
   }
 
 
   export class Resource$Mylibrary$Annotations {
-    root: Books;
-    constructor(root: Books) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -3410,7 +3317,7 @@ export namespace books_v1 {
         params,
         requiredParams: ['annotationId'],
         pathParams: ['annotationId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -3481,7 +3388,7 @@ export namespace books_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Annotation>(parameters, callback);
@@ -3557,7 +3464,7 @@ export namespace books_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Annotations>(parameters, callback);
@@ -3625,7 +3532,7 @@ export namespace books_v1 {
         params,
         requiredParams: ['layerIds', 'volumeId'],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$AnnotationsSummary>(parameters, callback);
@@ -3694,7 +3601,7 @@ export namespace books_v1 {
         params,
         requiredParams: ['annotationId'],
         pathParams: ['annotationId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Annotation>(parameters, callback);
@@ -3841,16 +3748,9 @@ export namespace books_v1 {
 
 
   export class Resource$Mylibrary$Bookshelves {
-    root: Books;
     volumes: Resource$Mylibrary$Bookshelves$Volumes;
-    constructor(root: Books) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.volumes = new Resource$Mylibrary$Bookshelves$Volumes(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.volumes = new Resource$Mylibrary$Bookshelves$Volumes();
     }
 
 
@@ -3913,7 +3813,7 @@ export namespace books_v1 {
         params,
         requiredParams: ['shelf', 'volumeId'],
         pathParams: ['shelf'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -3980,7 +3880,7 @@ export namespace books_v1 {
         params,
         requiredParams: ['shelf'],
         pathParams: ['shelf'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -4045,7 +3945,7 @@ export namespace books_v1 {
         params,
         requiredParams: ['shelf'],
         pathParams: ['shelf'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Bookshelf>(parameters, callback);
@@ -4113,7 +4013,7 @@ export namespace books_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Bookshelves>(parameters, callback);
@@ -4182,7 +4082,7 @@ export namespace books_v1 {
         params,
         requiredParams: ['shelf', 'volumeId', 'volumePosition'],
         pathParams: ['shelf'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -4251,7 +4151,7 @@ export namespace books_v1 {
         params,
         requiredParams: ['shelf', 'volumeId'],
         pathParams: ['shelf'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -4380,15 +4280,7 @@ export namespace books_v1 {
   }
 
   export class Resource$Mylibrary$Bookshelves$Volumes {
-    root: Books;
-    constructor(root: Books) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -4454,7 +4346,7 @@ export namespace books_v1 {
         params,
         requiredParams: ['shelf'],
         pathParams: ['shelf'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Volumes>(parameters, callback);
@@ -4508,15 +4400,7 @@ export namespace books_v1 {
 
 
   export class Resource$Mylibrary$Readingpositions {
-    root: Books;
-    constructor(root: Books) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -4574,7 +4458,7 @@ export namespace books_v1 {
         params,
         requiredParams: ['volumeId'],
         pathParams: ['volumeId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ReadingPosition>(parameters, callback);
@@ -4648,7 +4532,7 @@ export namespace books_v1 {
         params,
         requiredParams: ['volumeId', 'timestamp', 'position'],
         pathParams: ['volumeId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -4718,15 +4602,7 @@ export namespace books_v1 {
 
 
   export class Resource$Notification {
-    root: Books;
-    constructor(root: Books) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -4783,7 +4659,7 @@ export namespace books_v1 {
         params,
         requiredParams: ['notification_id'],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Notification>(parameters, callback);
@@ -4816,15 +4692,7 @@ export namespace books_v1 {
 
 
   export class Resource$Onboarding {
-    root: Books;
-    constructor(root: Books) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -4883,7 +4751,7 @@ export namespace books_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Category>(parameters, callback);
@@ -4953,7 +4821,7 @@ export namespace books_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Volume2>(parameters, callback);
@@ -5009,15 +4877,7 @@ export namespace books_v1 {
 
 
   export class Resource$Personalizedstream {
-    root: Books;
-    constructor(root: Books) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -5075,7 +4935,7 @@ export namespace books_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Discoveryclusters>(parameters, callback);
@@ -5110,15 +4970,7 @@ export namespace books_v1 {
 
 
   export class Resource$Promooffer {
-    root: Books;
-    constructor(root: Books) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -5181,7 +5033,7 @@ export namespace books_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -5251,7 +5103,7 @@ export namespace books_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -5317,7 +5169,7 @@ export namespace books_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Offers>(parameters, callback);
@@ -5437,16 +5289,9 @@ export namespace books_v1 {
 
 
   export class Resource$Series {
-    root: Books;
     membership: Resource$Series$Membership;
-    constructor(root: Books) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.membership = new Resource$Series$Membership(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.membership = new Resource$Series$Membership();
     }
 
 
@@ -5501,7 +5346,7 @@ export namespace books_v1 {
         params,
         requiredParams: ['series_id'],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Series>(parameters, callback);
@@ -5524,15 +5369,7 @@ export namespace books_v1 {
   }
 
   export class Resource$Series$Membership {
-    root: Books;
-    constructor(root: Books) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -5590,7 +5427,7 @@ export namespace books_v1 {
         params,
         requiredParams: ['series_id'],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Seriesmembership>(parameters, callback);
@@ -5624,22 +5461,15 @@ export namespace books_v1 {
 
 
   export class Resource$Volumes {
-    root: Books;
     associated: Resource$Volumes$Associated;
     mybooks: Resource$Volumes$Mybooks;
     recommended: Resource$Volumes$Recommended;
     useruploaded: Resource$Volumes$Useruploaded;
-    constructor(root: Books) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.associated = new Resource$Volumes$Associated(root);
-      this.mybooks = new Resource$Volumes$Mybooks(root);
-      this.recommended = new Resource$Volumes$Recommended(root);
-      this.useruploaded = new Resource$Volumes$Useruploaded(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.associated = new Resource$Volumes$Associated();
+      this.mybooks = new Resource$Volumes$Mybooks();
+      this.recommended = new Resource$Volumes$Recommended();
+      this.useruploaded = new Resource$Volumes$Useruploaded();
     }
 
 
@@ -5700,7 +5530,7 @@ export namespace books_v1 {
         params,
         requiredParams: ['volumeId'],
         pathParams: ['volumeId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Volume>(parameters, callback);
@@ -5777,7 +5607,7 @@ export namespace books_v1 {
         params,
         requiredParams: ['q'],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Volumes>(parameters, callback);
@@ -5888,15 +5718,7 @@ export namespace books_v1 {
   }
 
   export class Resource$Volumes$Associated {
-    root: Books;
-    constructor(root: Books) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -5959,7 +5781,7 @@ export namespace books_v1 {
         params,
         requiredParams: ['volumeId'],
         pathParams: ['volumeId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Volumes>(parameters, callback);
@@ -6002,15 +5824,7 @@ export namespace books_v1 {
 
 
   export class Resource$Volumes$Mybooks {
-    root: Books;
-    constructor(root: Books) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -6075,7 +5889,7 @@ export namespace books_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Volumes>(parameters, callback);
@@ -6126,15 +5940,7 @@ export namespace books_v1 {
 
 
   export class Resource$Volumes$Recommended {
-    root: Books;
-    constructor(root: Books) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -6195,7 +6001,7 @@ export namespace books_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Volumes>(parameters, callback);
@@ -6274,7 +6080,7 @@ export namespace books_v1 {
         params,
         requiredParams: ['rating', 'volumeId'],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$BooksVolumesRecommendedRateResponse>(
@@ -6336,15 +6142,7 @@ export namespace books_v1 {
 
 
   export class Resource$Volumes$Useruploaded {
-    root: Books;
-    constructor(root: Books) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -6408,7 +6206,7 @@ export namespace books_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Volumes>(parameters, callback);

--- a/src/apis/calendar/v3.ts
+++ b/src/apis/calendar/v3.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace calendar_v3 {
   export interface Options extends GlobalOptions {
     version: 'v3';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -79,10 +81,6 @@ export namespace calendar_v3 {
    * @param {object=} options Options for Calendar
    */
   export class Calendar {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     acl: Resource$Acl;
     calendarList: Resource$Calendarlist;
     calendars: Resource$Calendars;
@@ -93,22 +91,16 @@ export namespace calendar_v3 {
     settings: Resource$Settings;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.acl = new Resource$Acl(this);
-      this.calendarList = new Resource$Calendarlist(this);
-      this.calendars = new Resource$Calendars(this);
-      this.channels = new Resource$Channels(this);
-      this.colors = new Resource$Colors(this);
-      this.events = new Resource$Events(this);
-      this.freebusy = new Resource$Freebusy(this);
-      this.settings = new Resource$Settings(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.acl = new Resource$Acl();
+      this.calendarList = new Resource$Calendarlist();
+      this.calendars = new Resource$Calendars();
+      this.channels = new Resource$Channels();
+      this.colors = new Resource$Colors();
+      this.events = new Resource$Events();
+      this.freebusy = new Resource$Freebusy();
+      this.settings = new Resource$Settings();
     }
   }
 
@@ -1240,15 +1232,7 @@ export namespace calendar_v3 {
 
 
   export class Resource$Acl {
-    root: Calendar;
-    constructor(root: Calendar) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -1306,7 +1290,7 @@ export namespace calendar_v3 {
         params,
         requiredParams: ['calendarId', 'ruleId'],
         pathParams: ['calendarId', 'ruleId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -1369,7 +1353,7 @@ export namespace calendar_v3 {
         params,
         requiredParams: ['calendarId', 'ruleId'],
         pathParams: ['calendarId', 'ruleId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$AclRule>(parameters, callback);
@@ -1435,7 +1419,7 @@ export namespace calendar_v3 {
         params,
         requiredParams: ['calendarId'],
         pathParams: ['calendarId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$AclRule>(parameters, callback);
@@ -1503,7 +1487,7 @@ export namespace calendar_v3 {
         params,
         requiredParams: ['calendarId'],
         pathParams: ['calendarId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Acl>(parameters, callback);
@@ -1572,7 +1556,7 @@ export namespace calendar_v3 {
         params,
         requiredParams: ['calendarId', 'ruleId'],
         pathParams: ['calendarId', 'ruleId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$AclRule>(parameters, callback);
@@ -1640,7 +1624,7 @@ export namespace calendar_v3 {
         params,
         requiredParams: ['calendarId', 'ruleId'],
         pathParams: ['calendarId', 'ruleId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$AclRule>(parameters, callback);
@@ -1709,7 +1693,7 @@ export namespace calendar_v3 {
         params,
         requiredParams: ['calendarId'],
         pathParams: ['calendarId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Channel>(parameters, callback);
@@ -1922,15 +1906,7 @@ export namespace calendar_v3 {
 
 
   export class Resource$Calendarlist {
-    root: Calendar;
-    constructor(root: Calendar) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -1988,7 +1964,7 @@ export namespace calendar_v3 {
         params,
         requiredParams: ['calendarId'],
         pathParams: ['calendarId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -2050,7 +2026,7 @@ export namespace calendar_v3 {
         params,
         requiredParams: ['calendarId'],
         pathParams: ['calendarId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$CalendarListEntry>(parameters, callback);
@@ -2118,7 +2094,7 @@ export namespace calendar_v3 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$CalendarListEntry>(parameters, callback);
@@ -2189,7 +2165,7 @@ export namespace calendar_v3 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$CalendarList>(parameters, callback);
@@ -2258,7 +2234,7 @@ export namespace calendar_v3 {
         params,
         requiredParams: ['calendarId'],
         pathParams: ['calendarId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$CalendarListEntry>(parameters, callback);
@@ -2327,7 +2303,7 @@ export namespace calendar_v3 {
         params,
         requiredParams: ['calendarId'],
         pathParams: ['calendarId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$CalendarListEntry>(parameters, callback);
@@ -2398,7 +2374,7 @@ export namespace calendar_v3 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Channel>(parameters, callback);
@@ -2611,15 +2587,7 @@ export namespace calendar_v3 {
 
 
   export class Resource$Calendars {
-    root: Calendar;
-    constructor(root: Calendar) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -2676,7 +2644,7 @@ export namespace calendar_v3 {
         params,
         requiredParams: ['calendarId'],
         pathParams: ['calendarId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -2740,7 +2708,7 @@ export namespace calendar_v3 {
         params,
         requiredParams: ['calendarId'],
         pathParams: ['calendarId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -2801,7 +2769,7 @@ export namespace calendar_v3 {
         params,
         requiredParams: ['calendarId'],
         pathParams: ['calendarId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Calendar>(parameters, callback);
@@ -2865,7 +2833,7 @@ export namespace calendar_v3 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Calendar>(parameters, callback);
@@ -2931,7 +2899,7 @@ export namespace calendar_v3 {
         params,
         requiredParams: ['calendarId'],
         pathParams: ['calendarId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Calendar>(parameters, callback);
@@ -2996,7 +2964,7 @@ export namespace calendar_v3 {
         params,
         requiredParams: ['calendarId'],
         pathParams: ['calendarId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Calendar>(parameters, callback);
@@ -3096,15 +3064,7 @@ export namespace calendar_v3 {
 
 
   export class Resource$Channels {
-    root: Calendar;
-    constructor(root: Calendar) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -3160,7 +3120,7 @@ export namespace calendar_v3 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -3185,15 +3145,7 @@ export namespace calendar_v3 {
 
 
   export class Resource$Colors {
-    root: Calendar;
-    constructor(root: Calendar) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -3246,7 +3198,7 @@ export namespace calendar_v3 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Colors>(parameters, callback);
@@ -3265,15 +3217,7 @@ export namespace calendar_v3 {
 
 
   export class Resource$Events {
-    root: Calendar;
-    constructor(root: Calendar) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -3333,7 +3277,7 @@ export namespace calendar_v3 {
         params,
         requiredParams: ['calendarId', 'eventId'],
         pathParams: ['calendarId', 'eventId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -3399,7 +3343,7 @@ export namespace calendar_v3 {
         params,
         requiredParams: ['calendarId', 'eventId'],
         pathParams: ['calendarId', 'eventId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Event>(parameters, callback);
@@ -3442,7 +3386,7 @@ import(paramsOrCallback?: Params$Resource$Events$Import|BodyResponseCallback<Sch
     options = {};
                                                                                                                                                                                                                                                        }
 
-                                                                                                                                                                                                                                                       const rootUrl = options.rootUrl || 'https://www.googleapis.com/'; const parameters = {options: Object.assign({url: (rootUrl + '/calendar/v3/calendars/{calendarId}/events/import').replace(/([^:]\/)\/+/g, '$1'), method: 'POST'}, options), params, requiredParams: ['calendarId'], pathParams: ['calendarId'], context: this.getRoot()}; if(callback) {
+                                                                                                                                                                                                                                                       const rootUrl = options.rootUrl || 'https://www.googleapis.com/'; const parameters = {options: Object.assign({url: (rootUrl + '/calendar/v3/calendars/{calendarId}/events/import').replace(/([^:]\/)\/+/g, '$1'), method: 'POST'}, options), params, requiredParams: ['calendarId'], pathParams: ['calendarId'], context}; if(callback) {
     createAPIRequest<Schema$Event>(parameters, callback);
                                                                                                                                                                                                                                                        } else {
     return createAPIRequest<Schema$Event>(parameters);
@@ -3508,7 +3452,7 @@ import(paramsOrCallback?: Params$Resource$Events$Import|BodyResponseCallback<Sch
         params,
         requiredParams: ['calendarId'],
         pathParams: ['calendarId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Event>(parameters, callback);
@@ -3585,7 +3529,7 @@ import(paramsOrCallback?: Params$Resource$Events$Import|BodyResponseCallback<Sch
         params,
         requiredParams: ['calendarId', 'eventId'],
         pathParams: ['calendarId', 'eventId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Events>(parameters, callback);
@@ -3666,7 +3610,7 @@ import(paramsOrCallback?: Params$Resource$Events$Import|BodyResponseCallback<Sch
         params,
         requiredParams: ['calendarId'],
         pathParams: ['calendarId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Events>(parameters, callback);
@@ -3736,7 +3680,7 @@ import(paramsOrCallback?: Params$Resource$Events$Import|BodyResponseCallback<Sch
         params,
         requiredParams: ['calendarId', 'eventId', 'destination'],
         pathParams: ['calendarId', 'eventId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Event>(parameters, callback);
@@ -3809,7 +3753,7 @@ import(paramsOrCallback?: Params$Resource$Events$Import|BodyResponseCallback<Sch
         params,
         requiredParams: ['calendarId', 'eventId'],
         pathParams: ['calendarId', 'eventId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Event>(parameters, callback);
@@ -3877,7 +3821,7 @@ import(paramsOrCallback?: Params$Resource$Events$Import|BodyResponseCallback<Sch
         params,
         requiredParams: ['calendarId', 'text'],
         pathParams: ['calendarId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Event>(parameters, callback);
@@ -3950,7 +3894,7 @@ import(paramsOrCallback?: Params$Resource$Events$Import|BodyResponseCallback<Sch
         params,
         requiredParams: ['calendarId', 'eventId'],
         pathParams: ['calendarId', 'eventId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Event>(parameters, callback);
@@ -4033,7 +3977,7 @@ import(paramsOrCallback?: Params$Resource$Events$Import|BodyResponseCallback<Sch
         params,
         requiredParams: ['calendarId'],
         pathParams: ['calendarId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Channel>(parameters, callback);
@@ -4715,15 +4659,7 @@ import(paramsOrCallback?: Params$Resource$Events$Import|BodyResponseCallback<Sch
 
 
   export class Resource$Freebusy {
-    root: Calendar;
-    constructor(root: Calendar) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -4781,7 +4717,7 @@ import(paramsOrCallback?: Params$Resource$Events$Import|BodyResponseCallback<Sch
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$FreeBusyResponse>(parameters, callback);
@@ -4806,15 +4742,7 @@ import(paramsOrCallback?: Params$Resource$Events$Import|BodyResponseCallback<Sch
 
 
   export class Resource$Settings {
-    root: Calendar;
-    constructor(root: Calendar) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -4868,7 +4796,7 @@ import(paramsOrCallback?: Params$Resource$Events$Import|BodyResponseCallback<Sch
         params,
         requiredParams: ['setting'],
         pathParams: ['setting'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Setting>(parameters, callback);
@@ -4934,7 +4862,7 @@ import(paramsOrCallback?: Params$Resource$Events$Import|BodyResponseCallback<Sch
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Settings>(parameters, callback);
@@ -5001,7 +4929,7 @@ import(paramsOrCallback?: Params$Resource$Events$Import|BodyResponseCallback<Sch
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Channel>(parameters, callback);

--- a/src/apis/chat/v1.ts
+++ b/src/apis/chat/v1.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace chat_v1 {
   export interface Options extends GlobalOptions {
     version: 'v1';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -96,22 +98,12 @@ export namespace chat_v1 {
    * @param {object=} options Options for Chat
    */
   export class Chat {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     spaces: Resource$Spaces;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.spaces = new Resource$Spaces(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.spaces = new Resource$Spaces();
     }
   }
 
@@ -649,18 +641,11 @@ export namespace chat_v1 {
 
 
   export class Resource$Spaces {
-    root: Chat;
     members: Resource$Spaces$Members;
     messages: Resource$Spaces$Messages;
-    constructor(root: Chat) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.members = new Resource$Spaces$Members(root);
-      this.messages = new Resource$Spaces$Messages(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.members = new Resource$Spaces$Members();
+      this.messages = new Resource$Spaces$Messages();
     }
 
 
@@ -714,7 +699,7 @@ export namespace chat_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Space>(parameters, callback);
@@ -779,7 +764,7 @@ export namespace chat_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListSpacesResponse>(parameters, callback);
@@ -819,15 +804,7 @@ export namespace chat_v1 {
   }
 
   export class Resource$Spaces$Members {
-    root: Chat;
-    constructor(root: Chat) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -882,7 +859,7 @@ export namespace chat_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Membership>(parameters, callback);
@@ -951,7 +928,7 @@ export namespace chat_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListMembershipsResponse>(parameters, callback);
@@ -1000,15 +977,7 @@ export namespace chat_v1 {
 
 
   export class Resource$Spaces$Messages {
-    root: Chat;
-    constructor(root: Chat) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -1069,7 +1038,7 @@ export namespace chat_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Message>(parameters, callback);
@@ -1134,7 +1103,7 @@ export namespace chat_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -1195,7 +1164,7 @@ export namespace chat_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Message>(parameters, callback);
@@ -1262,7 +1231,7 @@ export namespace chat_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Message>(parameters, callback);

--- a/src/apis/civicinfo/v2.ts
+++ b/src/apis/civicinfo/v2.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace civicinfo_v2 {
   export interface Options extends GlobalOptions {
     version: 'v2';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -80,26 +82,16 @@ export namespace civicinfo_v2 {
    * @param {object=} options Options for Civicinfo
    */
   export class Civicinfo {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     divisions: Resource$Divisions;
     elections: Resource$Elections;
     representatives: Resource$Representatives;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.divisions = new Resource$Divisions(this);
-      this.elections = new Resource$Elections(this);
-      this.representatives = new Resource$Representatives(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.divisions = new Resource$Divisions();
+      this.elections = new Resource$Elections();
+      this.representatives = new Resource$Representatives();
     }
   }
 
@@ -994,15 +986,7 @@ export namespace civicinfo_v2 {
 
 
   export class Resource$Divisions {
-    root: Civicinfo;
-    constructor(root: Civicinfo) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -1062,7 +1046,7 @@ export namespace civicinfo_v2 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$DivisionSearchResponse>(parameters, callback);
@@ -1095,15 +1079,7 @@ export namespace civicinfo_v2 {
 
 
   export class Resource$Elections {
-    root: Civicinfo;
-    constructor(root: Civicinfo) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -1165,7 +1141,7 @@ export namespace civicinfo_v2 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ElectionsQueryResponse>(parameters, callback);
@@ -1238,7 +1214,7 @@ export namespace civicinfo_v2 {
         params,
         requiredParams: ['address'],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$VoterInfoResponse>(parameters, callback);
@@ -1299,15 +1275,7 @@ export namespace civicinfo_v2 {
 
 
   export class Resource$Representatives {
-    root: Civicinfo;
-    constructor(root: Civicinfo) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -1380,7 +1348,7 @@ export namespace civicinfo_v2 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$RepresentativeInfoResponse>(
@@ -1457,7 +1425,7 @@ export namespace civicinfo_v2 {
         params,
         requiredParams: ['ocdId'],
         pathParams: ['ocdId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$RepresentativeInfoData>(parameters, callback);

--- a/src/apis/classroom/v1.ts
+++ b/src/apis/classroom/v1.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace classroom_v1 {
   export interface Options extends GlobalOptions {
     version: 'v1';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -96,28 +98,18 @@ export namespace classroom_v1 {
    * @param {object=} options Options for Classroom
    */
   export class Classroom {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     courses: Resource$Courses;
     invitations: Resource$Invitations;
     registrations: Resource$Registrations;
     userProfiles: Resource$Userprofiles;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.courses = new Resource$Courses(this);
-      this.invitations = new Resource$Invitations(this);
-      this.registrations = new Resource$Registrations(this);
-      this.userProfiles = new Resource$Userprofiles(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.courses = new Resource$Courses();
+      this.invitations = new Resource$Invitations();
+      this.registrations = new Resource$Registrations();
+      this.userProfiles = new Resource$Userprofiles();
     }
   }
 
@@ -1355,24 +1347,17 @@ export namespace classroom_v1 {
 
 
   export class Resource$Courses {
-    root: Classroom;
     aliases: Resource$Courses$Aliases;
     announcements: Resource$Courses$Announcements;
     courseWork: Resource$Courses$Coursework;
     students: Resource$Courses$Students;
     teachers: Resource$Courses$Teachers;
-    constructor(root: Classroom) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.aliases = new Resource$Courses$Aliases(root);
-      this.announcements = new Resource$Courses$Announcements(root);
-      this.courseWork = new Resource$Courses$Coursework(root);
-      this.students = new Resource$Courses$Students(root);
-      this.teachers = new Resource$Courses$Teachers(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.aliases = new Resource$Courses$Aliases();
+      this.announcements = new Resource$Courses$Announcements();
+      this.courseWork = new Resource$Courses$Coursework();
+      this.students = new Resource$Courses$Students();
+      this.teachers = new Resource$Courses$Teachers();
     }
 
 
@@ -1436,7 +1421,7 @@ export namespace classroom_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Course>(parameters, callback);
@@ -1502,7 +1487,7 @@ export namespace classroom_v1 {
         params,
         requiredParams: ['id'],
         pathParams: ['id'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -1565,7 +1550,7 @@ export namespace classroom_v1 {
         params,
         requiredParams: ['id'],
         pathParams: ['id'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Course>(parameters, callback);
@@ -1638,7 +1623,7 @@ export namespace classroom_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListCoursesResponse>(parameters, callback);
@@ -1709,7 +1694,7 @@ export namespace classroom_v1 {
         params,
         requiredParams: ['id'],
         pathParams: ['id'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Course>(parameters, callback);
@@ -1777,7 +1762,7 @@ export namespace classroom_v1 {
         params,
         requiredParams: ['id'],
         pathParams: ['id'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Course>(parameters, callback);
@@ -1908,15 +1893,7 @@ export namespace classroom_v1 {
   }
 
   export class Resource$Courses$Aliases {
-    root: Classroom;
-    constructor(root: Classroom) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -1983,7 +1960,7 @@ export namespace classroom_v1 {
         params,
         requiredParams: ['courseId'],
         pathParams: ['courseId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$CourseAlias>(parameters, callback);
@@ -2055,7 +2032,7 @@ export namespace classroom_v1 {
         params,
         requiredParams: ['courseId', 'alias'],
         pathParams: ['alias', 'courseId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -2129,7 +2106,7 @@ export namespace classroom_v1 {
         params,
         requiredParams: ['courseId'],
         pathParams: ['courseId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListCourseAliasesResponse>(
@@ -2203,15 +2180,7 @@ export namespace classroom_v1 {
 
 
   export class Resource$Courses$Announcements {
-    root: Classroom;
-    constructor(root: Classroom) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -2278,7 +2247,7 @@ export namespace classroom_v1 {
         params,
         requiredParams: ['courseId'],
         pathParams: ['courseId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Announcement>(parameters, callback);
@@ -2353,7 +2322,7 @@ export namespace classroom_v1 {
         params,
         requiredParams: ['courseId', 'id'],
         pathParams: ['courseId', 'id'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -2421,7 +2390,7 @@ export namespace classroom_v1 {
         params,
         requiredParams: ['courseId', 'id'],
         pathParams: ['courseId', 'id'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Announcement>(parameters, callback);
@@ -2501,7 +2470,7 @@ export namespace classroom_v1 {
         params,
         requiredParams: ['courseId'],
         pathParams: ['courseId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListAnnouncementsResponse>(
@@ -2579,7 +2548,7 @@ export namespace classroom_v1 {
         params,
         requiredParams: ['courseId', 'id'],
         pathParams: ['courseId', 'id'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Announcement>(parameters, callback);
@@ -2655,7 +2624,7 @@ export namespace classroom_v1 {
         params,
         requiredParams: ['courseId', 'id'],
         pathParams: ['courseId', 'id'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Announcement>(parameters, callback);
@@ -2814,17 +2783,10 @@ export namespace classroom_v1 {
 
 
   export class Resource$Courses$Coursework {
-    root: Classroom;
     studentSubmissions: Resource$Courses$Coursework$Studentsubmissions;
-    constructor(root: Classroom) {
-      this.root = root;
-      this.getRoot.bind(this);
+    constructor() {
       this.studentSubmissions =
-          new Resource$Courses$Coursework$Studentsubmissions(root);
-    }
-
-    getRoot() {
-      return this.root;
+          new Resource$Courses$Coursework$Studentsubmissions();
     }
 
 
@@ -2897,7 +2859,7 @@ export namespace classroom_v1 {
         params,
         requiredParams: ['courseId'],
         pathParams: ['courseId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$CourseWork>(parameters, callback);
@@ -2972,7 +2934,7 @@ export namespace classroom_v1 {
         params,
         requiredParams: ['courseId', 'id'],
         pathParams: ['courseId', 'id'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -3040,7 +3002,7 @@ export namespace classroom_v1 {
         params,
         requiredParams: ['courseId', 'id'],
         pathParams: ['courseId', 'id'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$CourseWork>(parameters, callback);
@@ -3118,7 +3080,7 @@ export namespace classroom_v1 {
         params,
         requiredParams: ['courseId'],
         pathParams: ['courseId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListCourseWorkResponse>(parameters, callback);
@@ -3194,7 +3156,7 @@ export namespace classroom_v1 {
         params,
         requiredParams: ['courseId', 'id'],
         pathParams: ['courseId', 'id'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$CourseWork>(parameters, callback);
@@ -3276,7 +3238,7 @@ export namespace classroom_v1 {
         params,
         requiredParams: ['courseId', 'id'],
         pathParams: ['courseId', 'id'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$CourseWork>(parameters, callback);
@@ -3436,15 +3398,7 @@ export namespace classroom_v1 {
   }
 
   export class Resource$Courses$Coursework$Studentsubmissions {
-    root: Classroom;
-    constructor(root: Classroom) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -3510,7 +3464,7 @@ export namespace classroom_v1 {
         params,
         requiredParams: ['courseId', 'courseWorkId', 'id'],
         pathParams: ['courseId', 'courseWorkId', 'id'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$StudentSubmission>(parameters, callback);
@@ -3601,7 +3555,7 @@ export namespace classroom_v1 {
         params,
         requiredParams: ['courseId', 'courseWorkId'],
         pathParams: ['courseId', 'courseWorkId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListStudentSubmissionsResponse>(
@@ -3692,7 +3646,7 @@ export namespace classroom_v1 {
         params,
         requiredParams: ['courseId', 'courseWorkId', 'id'],
         pathParams: ['courseId', 'courseWorkId', 'id'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$StudentSubmission>(parameters, callback);
@@ -3778,7 +3732,7 @@ export namespace classroom_v1 {
         params,
         requiredParams: ['courseId', 'courseWorkId', 'id'],
         pathParams: ['courseId', 'courseWorkId', 'id'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$StudentSubmission>(parameters, callback);
@@ -3864,7 +3818,7 @@ export namespace classroom_v1 {
         params,
         requiredParams: ['courseId', 'courseWorkId', 'id'],
         pathParams: ['courseId', 'courseWorkId', 'id'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -3950,7 +3904,7 @@ export namespace classroom_v1 {
         params,
         requiredParams: ['courseId', 'courseWorkId', 'id'],
         pathParams: ['courseId', 'courseWorkId', 'id'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -4034,7 +3988,7 @@ export namespace classroom_v1 {
         params,
         requiredParams: ['courseId', 'courseWorkId', 'id'],
         pathParams: ['courseId', 'courseWorkId', 'id'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -4255,15 +4209,7 @@ export namespace classroom_v1 {
 
 
   export class Resource$Courses$Students {
-    root: Classroom;
-    constructor(root: Classroom) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -4332,7 +4278,7 @@ export namespace classroom_v1 {
         params,
         requiredParams: ['courseId'],
         pathParams: ['courseId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Student>(parameters, callback);
@@ -4403,7 +4349,7 @@ export namespace classroom_v1 {
         params,
         requiredParams: ['courseId', 'userId'],
         pathParams: ['courseId', 'userId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -4470,7 +4416,7 @@ export namespace classroom_v1 {
         params,
         requiredParams: ['courseId', 'userId'],
         pathParams: ['courseId', 'userId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Student>(parameters, callback);
@@ -4543,7 +4489,7 @@ export namespace classroom_v1 {
         params,
         requiredParams: ['courseId'],
         pathParams: ['courseId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListStudentsResponse>(parameters, callback);
@@ -4643,15 +4589,7 @@ export namespace classroom_v1 {
 
 
   export class Resource$Courses$Teachers {
-    root: Classroom;
-    constructor(root: Classroom) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -4719,7 +4657,7 @@ export namespace classroom_v1 {
         params,
         requiredParams: ['courseId'],
         pathParams: ['courseId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Teacher>(parameters, callback);
@@ -4791,7 +4729,7 @@ export namespace classroom_v1 {
         params,
         requiredParams: ['courseId', 'userId'],
         pathParams: ['courseId', 'userId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -4858,7 +4796,7 @@ export namespace classroom_v1 {
         params,
         requiredParams: ['courseId', 'userId'],
         pathParams: ['courseId', 'userId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Teacher>(parameters, callback);
@@ -4931,7 +4869,7 @@ export namespace classroom_v1 {
         params,
         requiredParams: ['courseId'],
         pathParams: ['courseId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListTeachersResponse>(parameters, callback);
@@ -5025,15 +4963,7 @@ export namespace classroom_v1 {
 
 
   export class Resource$Invitations {
-    root: Classroom;
-    constructor(root: Classroom) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -5100,7 +5030,7 @@ export namespace classroom_v1 {
         params,
         requiredParams: ['id'],
         pathParams: ['id'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -5174,7 +5104,7 @@ export namespace classroom_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Invitation>(parameters, callback);
@@ -5243,7 +5173,7 @@ export namespace classroom_v1 {
         params,
         requiredParams: ['id'],
         pathParams: ['id'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -5308,7 +5238,7 @@ export namespace classroom_v1 {
         params,
         requiredParams: ['id'],
         pathParams: ['id'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Invitation>(parameters, callback);
@@ -5380,7 +5310,7 @@ export namespace classroom_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListInvitationsResponse>(parameters, callback);
@@ -5471,15 +5401,7 @@ export namespace classroom_v1 {
 
 
   export class Resource$Registrations {
-    root: Classroom;
-    constructor(root: Classroom) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -5559,7 +5481,7 @@ export namespace classroom_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Registration>(parameters, callback);
@@ -5626,7 +5548,7 @@ export namespace classroom_v1 {
         params,
         requiredParams: ['registrationId'],
         pathParams: ['registrationId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -5664,19 +5586,12 @@ export namespace classroom_v1 {
 
 
   export class Resource$Userprofiles {
-    root: Classroom;
     guardianInvitations: Resource$Userprofiles$Guardianinvitations;
     guardians: Resource$Userprofiles$Guardians;
-    constructor(root: Classroom) {
-      this.root = root;
-      this.getRoot.bind(this);
+    constructor() {
       this.guardianInvitations =
-          new Resource$Userprofiles$Guardianinvitations(root);
-      this.guardians = new Resource$Userprofiles$Guardians(root);
-    }
-
-    getRoot() {
-      return this.root;
+          new Resource$Userprofiles$Guardianinvitations();
+      this.guardians = new Resource$Userprofiles$Guardians();
     }
 
 
@@ -5735,7 +5650,7 @@ export namespace classroom_v1 {
         params,
         requiredParams: ['userId'],
         pathParams: ['userId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$UserProfile>(parameters, callback);
@@ -5760,15 +5675,7 @@ export namespace classroom_v1 {
   }
 
   export class Resource$Userprofiles$Guardianinvitations {
-    root: Classroom;
-    constructor(root: Classroom) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -5854,7 +5761,7 @@ export namespace classroom_v1 {
         params,
         requiredParams: ['studentId'],
         pathParams: ['studentId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GuardianInvitation>(parameters, callback);
@@ -5930,7 +5837,7 @@ export namespace classroom_v1 {
         params,
         requiredParams: ['studentId', 'invitationId'],
         pathParams: ['invitationId', 'studentId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GuardianInvitation>(parameters, callback);
@@ -6022,7 +5929,7 @@ export namespace classroom_v1 {
         params,
         requiredParams: ['studentId'],
         pathParams: ['studentId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListGuardianInvitationsResponse>(
@@ -6110,7 +6017,7 @@ export namespace classroom_v1 {
         params,
         requiredParams: ['studentId', 'invitationId'],
         pathParams: ['invitationId', 'studentId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GuardianInvitation>(parameters, callback);
@@ -6225,15 +6132,7 @@ export namespace classroom_v1 {
 
 
   export class Resource$Userprofiles$Guardians {
-    root: Classroom;
-    constructor(root: Classroom) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -6305,7 +6204,7 @@ export namespace classroom_v1 {
         params,
         requiredParams: ['studentId', 'guardianId'],
         pathParams: ['guardianId', 'studentId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -6379,7 +6278,7 @@ export namespace classroom_v1 {
         params,
         requiredParams: ['studentId', 'guardianId'],
         pathParams: ['guardianId', 'studentId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Guardian>(parameters, callback);
@@ -6465,7 +6364,7 @@ export namespace classroom_v1 {
         params,
         requiredParams: ['studentId'],
         pathParams: ['studentId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListGuardiansResponse>(parameters, callback);

--- a/src/apis/cloudasset/v1beta1.ts
+++ b/src/apis/cloudasset/v1beta1.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace cloudasset_v1beta1 {
   export interface Options extends GlobalOptions {
     version: 'v1beta1';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -96,24 +98,14 @@ export namespace cloudasset_v1beta1 {
    * @param {object=} options Options for Cloudasset
    */
   export class Cloudasset {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     organizations: Resource$Organizations;
     projects: Resource$Projects;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.organizations = new Resource$Organizations(this);
-      this.projects = new Resource$Projects(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.organizations = new Resource$Organizations();
+      this.projects = new Resource$Projects();
     }
   }
 
@@ -543,16 +535,9 @@ export namespace cloudasset_v1beta1 {
 
 
   export class Resource$Organizations {
-    root: Cloudasset;
     operations: Resource$Organizations$Operations;
-    constructor(root: Cloudasset) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.operations = new Resource$Organizations$Operations(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.operations = new Resource$Organizations$Operations();
     }
 
 
@@ -627,7 +612,7 @@ export namespace cloudasset_v1beta1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$BatchGetAssetsHistoryResponse>(
@@ -700,7 +685,7 @@ export namespace cloudasset_v1beta1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -769,15 +754,7 @@ export namespace cloudasset_v1beta1 {
   }
 
   export class Resource$Organizations$Operations {
-    root: Cloudasset;
-    constructor(root: Cloudasset) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -834,7 +811,7 @@ export namespace cloudasset_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -860,16 +837,9 @@ export namespace cloudasset_v1beta1 {
 
 
   export class Resource$Projects {
-    root: Cloudasset;
     operations: Resource$Projects$Operations;
-    constructor(root: Cloudasset) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.operations = new Resource$Projects$Operations(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.operations = new Resource$Projects$Operations();
     }
 
 
@@ -944,7 +914,7 @@ export namespace cloudasset_v1beta1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$BatchGetAssetsHistoryResponse>(
@@ -1017,7 +987,7 @@ export namespace cloudasset_v1beta1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -1086,15 +1056,7 @@ export namespace cloudasset_v1beta1 {
   }
 
   export class Resource$Projects$Operations {
-    root: Cloudasset;
-    constructor(root: Cloudasset) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -1151,7 +1113,7 @@ export namespace cloudasset_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);

--- a/src/apis/cloudbilling/v1.ts
+++ b/src/apis/cloudbilling/v1.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace cloudbilling_v1 {
   export interface Options extends GlobalOptions {
     version: 'v1';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -97,26 +99,16 @@ export namespace cloudbilling_v1 {
    * @param {object=} options Options for Cloudbilling
    */
   export class Cloudbilling {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     billingAccounts: Resource$Billingaccounts;
     projects: Resource$Projects;
     services: Resource$Services;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.billingAccounts = new Resource$Billingaccounts(this);
-      this.projects = new Resource$Projects(this);
-      this.services = new Resource$Services(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.billingAccounts = new Resource$Billingaccounts();
+      this.projects = new Resource$Projects();
+      this.services = new Resource$Services();
     }
   }
 
@@ -678,16 +670,9 @@ export namespace cloudbilling_v1 {
 
 
   export class Resource$Billingaccounts {
-    root: Cloudbilling;
     projects: Resource$Billingaccounts$Projects;
-    constructor(root: Cloudbilling) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.projects = new Resource$Billingaccounts$Projects(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.projects = new Resource$Billingaccounts$Projects();
     }
 
 
@@ -755,7 +740,7 @@ export namespace cloudbilling_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$BillingAccount>(parameters, callback);
@@ -874,7 +859,7 @@ export namespace cloudbilling_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$BillingAccount>(parameters, callback);
@@ -943,7 +928,7 @@ export namespace cloudbilling_v1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -1082,7 +1067,7 @@ export namespace cloudbilling_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListBillingAccountsResponse>(
@@ -1156,7 +1141,7 @@ export namespace cloudbilling_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$BillingAccount>(parameters, callback);
@@ -1226,7 +1211,7 @@ export namespace cloudbilling_v1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -1303,7 +1288,7 @@ export namespace cloudbilling_v1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TestIamPermissionsResponse>(
@@ -1441,15 +1426,7 @@ export namespace cloudbilling_v1 {
   }
 
   export class Resource$Billingaccounts$Projects {
-    root: Cloudbilling;
-    constructor(root: Cloudbilling) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -1589,7 +1566,7 @@ export namespace cloudbilling_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListProjectBillingInfoResponse>(
@@ -1630,15 +1607,7 @@ export namespace cloudbilling_v1 {
 
 
   export class Resource$Projects {
-    root: Cloudbilling;
-    constructor(root: Cloudbilling) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -1756,7 +1725,7 @@ export namespace cloudbilling_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ProjectBillingInfo>(parameters, callback);
@@ -1909,7 +1878,7 @@ export namespace cloudbilling_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ProjectBillingInfo>(parameters, callback);
@@ -1953,16 +1922,9 @@ export namespace cloudbilling_v1 {
 
 
   export class Resource$Services {
-    root: Cloudbilling;
     skus: Resource$Services$Skus;
-    constructor(root: Cloudbilling) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.skus = new Resource$Services$Skus(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.skus = new Resource$Services$Skus();
     }
 
 
@@ -2085,7 +2047,7 @@ export namespace cloudbilling_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListServicesResponse>(parameters, callback);
@@ -2114,15 +2076,7 @@ export namespace cloudbilling_v1 {
   }
 
   export class Resource$Services$Skus {
-    root: Cloudbilling;
-    constructor(root: Cloudbilling) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -2253,7 +2207,7 @@ export namespace cloudbilling_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListSkusResponse>(parameters, callback);

--- a/src/apis/cloudbuild/v1.ts
+++ b/src/apis/cloudbuild/v1.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace cloudbuild_v1 {
   export interface Options extends GlobalOptions {
     version: 'v1';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -96,24 +98,14 @@ export namespace cloudbuild_v1 {
    * @param {object=} options Options for Cloudbuild
    */
   export class Cloudbuild {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     operations: Resource$Operations;
     projects: Resource$Projects;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.operations = new Resource$Operations(this);
-      this.projects = new Resource$Projects(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.operations = new Resource$Operations();
+      this.projects = new Resource$Projects();
     }
   }
 
@@ -904,15 +896,7 @@ export namespace cloudbuild_v1 {
 
 
   export class Resource$Operations {
-    root: Cloudbuild;
-    constructor(root: Cloudbuild) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -979,7 +963,7 @@ export namespace cloudbuild_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -1042,7 +1026,7 @@ export namespace cloudbuild_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -1118,7 +1102,7 @@ export namespace cloudbuild_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListOperationsResponse>(parameters, callback);
@@ -1182,32 +1166,17 @@ export namespace cloudbuild_v1 {
 
 
   export class Resource$Projects {
-    root: Cloudbuild;
     builds: Resource$Projects$Builds;
     triggers: Resource$Projects$Triggers;
-    constructor(root: Cloudbuild) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.builds = new Resource$Projects$Builds(root);
-      this.triggers = new Resource$Projects$Triggers(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.builds = new Resource$Projects$Builds();
+      this.triggers = new Resource$Projects$Triggers();
     }
   }
 
 
   export class Resource$Projects$Builds {
-    root: Cloudbuild;
-    constructor(root: Cloudbuild) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -1268,7 +1237,7 @@ export namespace cloudbuild_v1 {
         params,
         requiredParams: ['projectId', 'id'],
         pathParams: ['id', 'projectId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Build>(parameters, callback);
@@ -1339,7 +1308,7 @@ export namespace cloudbuild_v1 {
         params,
         requiredParams: ['projectId'],
         pathParams: ['projectId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -1404,7 +1373,7 @@ export namespace cloudbuild_v1 {
         params,
         requiredParams: ['projectId', 'id'],
         pathParams: ['id', 'projectId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Build>(parameters, callback);
@@ -1476,7 +1445,7 @@ export namespace cloudbuild_v1 {
         params,
         requiredParams: ['projectId'],
         pathParams: ['projectId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListBuildsResponse>(parameters, callback);
@@ -1561,7 +1530,7 @@ export namespace cloudbuild_v1 {
         params,
         requiredParams: ['projectId', 'id'],
         pathParams: ['id', 'projectId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -1673,15 +1642,7 @@ export namespace cloudbuild_v1 {
 
 
   export class Resource$Projects$Triggers {
-    root: Cloudbuild;
-    constructor(root: Cloudbuild) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -1742,7 +1703,7 @@ export namespace cloudbuild_v1 {
         params,
         requiredParams: ['projectId'],
         pathParams: ['projectId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$BuildTrigger>(parameters, callback);
@@ -1810,7 +1771,7 @@ export namespace cloudbuild_v1 {
         params,
         requiredParams: ['projectId', 'triggerId'],
         pathParams: ['projectId', 'triggerId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -1875,7 +1836,7 @@ export namespace cloudbuild_v1 {
         params,
         requiredParams: ['projectId', 'triggerId'],
         pathParams: ['projectId', 'triggerId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$BuildTrigger>(parameters, callback);
@@ -1945,7 +1906,7 @@ export namespace cloudbuild_v1 {
         params,
         requiredParams: ['projectId'],
         pathParams: ['projectId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListBuildTriggersResponse>(
@@ -2016,7 +1977,7 @@ export namespace cloudbuild_v1 {
         params,
         requiredParams: ['projectId', 'triggerId'],
         pathParams: ['projectId', 'triggerId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$BuildTrigger>(parameters, callback);
@@ -2082,7 +2043,7 @@ export namespace cloudbuild_v1 {
         params,
         requiredParams: ['projectId', 'triggerId'],
         pathParams: ['projectId', 'triggerId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);

--- a/src/apis/clouddebugger/v2.ts
+++ b/src/apis/clouddebugger/v2.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace clouddebugger_v2 {
   export interface Options extends GlobalOptions {
     version: 'v2';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -97,24 +99,14 @@ export namespace clouddebugger_v2 {
    * @param {object=} options Options for Clouddebugger
    */
   export class Clouddebugger {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     controller: Resource$Controller;
     debugger: Resource$Debugger;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.controller = new Resource$Controller(this);
-      this.debugger = new Resource$Debugger(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.controller = new Resource$Controller();
+      this.debugger = new Resource$Debugger();
     }
   }
 
@@ -754,31 +746,17 @@ export namespace clouddebugger_v2 {
 
 
   export class Resource$Controller {
-    root: Clouddebugger;
     debuggees: Resource$Controller$Debuggees;
-    constructor(root: Clouddebugger) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.debuggees = new Resource$Controller$Debuggees(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.debuggees = new Resource$Controller$Debuggees();
     }
   }
 
 
   export class Resource$Controller$Debuggees {
-    root: Clouddebugger;
     breakpoints: Resource$Controller$Debuggees$Breakpoints;
-    constructor(root: Clouddebugger) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.breakpoints = new Resource$Controller$Debuggees$Breakpoints(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.breakpoints = new Resource$Controller$Debuggees$Breakpoints();
     }
 
 
@@ -901,7 +879,7 @@ export namespace clouddebugger_v2 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$RegisterDebuggeeResponse>(parameters, callback);
@@ -926,15 +904,7 @@ export namespace clouddebugger_v2 {
   }
 
   export class Resource$Controller$Debuggees$Breakpoints {
-    root: Clouddebugger;
-    constructor(root: Clouddebugger) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -1064,7 +1034,7 @@ export namespace clouddebugger_v2 {
         params,
         requiredParams: ['debuggeeId'],
         pathParams: ['debuggeeId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListActiveBreakpointsResponse>(
@@ -1210,7 +1180,7 @@ export namespace clouddebugger_v2 {
         params,
         requiredParams: ['debuggeeId', 'id'],
         pathParams: ['debuggeeId', 'id'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$UpdateActiveBreakpointResponse>(
@@ -1274,31 +1244,17 @@ export namespace clouddebugger_v2 {
 
 
   export class Resource$Debugger {
-    root: Clouddebugger;
     debuggees: Resource$Debugger$Debuggees;
-    constructor(root: Clouddebugger) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.debuggees = new Resource$Debugger$Debuggees(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.debuggees = new Resource$Debugger$Debuggees();
     }
   }
 
 
   export class Resource$Debugger$Debuggees {
-    root: Clouddebugger;
     breakpoints: Resource$Debugger$Debuggees$Breakpoints;
-    constructor(root: Clouddebugger) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.breakpoints = new Resource$Debugger$Debuggees$Breakpoints(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.breakpoints = new Resource$Debugger$Debuggees$Breakpoints();
     }
 
 
@@ -1411,7 +1367,7 @@ export namespace clouddebugger_v2 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListDebuggeesResponse>(parameters, callback);
@@ -1445,15 +1401,7 @@ export namespace clouddebugger_v2 {
   }
 
   export class Resource$Debugger$Debuggees$Breakpoints {
-    root: Clouddebugger;
-    constructor(root: Clouddebugger) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -1569,7 +1517,7 @@ export namespace clouddebugger_v2 {
         params,
         requiredParams: ['debuggeeId', 'breakpointId'],
         pathParams: ['breakpointId', 'debuggeeId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -1692,7 +1640,7 @@ export namespace clouddebugger_v2 {
         params,
         requiredParams: ['debuggeeId', 'breakpointId'],
         pathParams: ['breakpointId', 'debuggeeId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GetBreakpointResponse>(parameters, callback);
@@ -1818,7 +1766,7 @@ export namespace clouddebugger_v2 {
         params,
         requiredParams: ['debuggeeId'],
         pathParams: ['debuggeeId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListBreakpointsResponse>(parameters, callback);
@@ -1941,7 +1889,7 @@ export namespace clouddebugger_v2 {
         params,
         requiredParams: ['debuggeeId'],
         pathParams: ['debuggeeId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$SetBreakpointResponse>(parameters, callback);

--- a/src/apis/clouderrorreporting/v1beta1.ts
+++ b/src/apis/clouderrorreporting/v1beta1.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace clouderrorreporting_v1beta1 {
   export interface Options extends GlobalOptions {
     version: 'v1beta1';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -98,22 +100,12 @@ export namespace clouderrorreporting_v1beta1 {
    * @param {object=} options Options for Clouderrorreporting
    */
   export class Clouderrorreporting {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     projects: Resource$Projects;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.projects = new Resource$Projects(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.projects = new Resource$Projects();
     }
   }
 
@@ -479,20 +471,13 @@ export namespace clouderrorreporting_v1beta1 {
 
 
   export class Resource$Projects {
-    root: Clouderrorreporting;
     events: Resource$Projects$Events;
     groups: Resource$Projects$Groups;
     groupStats: Resource$Projects$Groupstats;
-    constructor(root: Clouderrorreporting) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.events = new Resource$Projects$Events(root);
-      this.groups = new Resource$Projects$Groups(root);
-      this.groupStats = new Resource$Projects$Groupstats(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.events = new Resource$Projects$Events();
+      this.groups = new Resource$Projects$Groups();
+      this.groupStats = new Resource$Projects$Groupstats();
     }
 
 
@@ -556,7 +541,7 @@ export namespace clouderrorreporting_v1beta1 {
         params,
         requiredParams: ['projectName'],
         pathParams: ['projectName'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$DeleteEventsResponse>(parameters, callback);
@@ -583,15 +568,7 @@ export namespace clouderrorreporting_v1beta1 {
   }
 
   export class Resource$Projects$Events {
-    root: Clouderrorreporting;
-    constructor(root: Clouderrorreporting) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -659,7 +636,7 @@ export namespace clouderrorreporting_v1beta1 {
         params,
         requiredParams: ['projectName'],
         pathParams: ['projectName'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListEventsResponse>(parameters, callback);
@@ -735,7 +712,7 @@ export namespace clouderrorreporting_v1beta1 {
         params,
         requiredParams: ['projectName'],
         pathParams: ['projectName'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ReportErrorEventResponse>(parameters, callback);
@@ -814,15 +791,7 @@ export namespace clouderrorreporting_v1beta1 {
 
 
   export class Resource$Projects$Groups {
-    root: Clouderrorreporting;
-    constructor(root: Clouderrorreporting) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -879,7 +848,7 @@ export namespace clouderrorreporting_v1beta1 {
         params,
         requiredParams: ['groupName'],
         pathParams: ['groupName'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ErrorGroup>(parameters, callback);
@@ -948,7 +917,7 @@ export namespace clouderrorreporting_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ErrorGroup>(parameters, callback);
@@ -997,15 +966,7 @@ export namespace clouderrorreporting_v1beta1 {
 
 
   export class Resource$Projects$Groupstats {
-    root: Clouderrorreporting;
-    constructor(root: Clouderrorreporting) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -1078,7 +1039,7 @@ export namespace clouderrorreporting_v1beta1 {
         params,
         requiredParams: ['projectName'],
         pathParams: ['projectName'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListGroupStatsResponse>(parameters, callback);

--- a/src/apis/cloudfunctions/v1.ts
+++ b/src/apis/cloudfunctions/v1.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace cloudfunctions_v1 {
   export interface Options extends GlobalOptions {
     version: 'v1';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -96,24 +98,14 @@ export namespace cloudfunctions_v1 {
    * @param {object=} options Options for Cloudfunctions
    */
   export class Cloudfunctions {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     operations: Resource$Operations;
     projects: Resource$Projects;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.operations = new Resource$Operations(this);
-      this.projects = new Resource$Projects(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.operations = new Resource$Operations();
+      this.projects = new Resource$Projects();
     }
   }
 
@@ -819,15 +811,7 @@ export namespace cloudfunctions_v1 {
 
 
   export class Resource$Operations {
-    root: Cloudfunctions;
-    constructor(root: Cloudfunctions) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -884,7 +868,7 @@ export namespace cloudfunctions_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -961,7 +945,7 @@ export namespace cloudfunctions_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListOperationsResponse>(parameters, callback);
@@ -1008,31 +992,17 @@ export namespace cloudfunctions_v1 {
 
 
   export class Resource$Projects {
-    root: Cloudfunctions;
     locations: Resource$Projects$Locations;
-    constructor(root: Cloudfunctions) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.locations = new Resource$Projects$Locations(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.locations = new Resource$Projects$Locations();
     }
   }
 
 
   export class Resource$Projects$Locations {
-    root: Cloudfunctions;
     functions: Resource$Projects$Locations$Functions;
-    constructor(root: Cloudfunctions) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.functions = new Resource$Projects$Locations$Functions(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.functions = new Resource$Projects$Locations$Functions();
     }
 
 
@@ -1098,7 +1068,7 @@ export namespace cloudfunctions_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListLocationsResponse>(parameters, callback);
@@ -1134,15 +1104,7 @@ export namespace cloudfunctions_v1 {
   }
 
   export class Resource$Projects$Locations$Functions {
-    root: Cloudfunctions;
-    constructor(root: Cloudfunctions) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -1205,7 +1167,7 @@ export namespace cloudfunctions_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$CallFunctionResponse>(parameters, callback);
@@ -1276,7 +1238,7 @@ export namespace cloudfunctions_v1 {
         params,
         requiredParams: ['location'],
         pathParams: ['location'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -1345,7 +1307,7 @@ export namespace cloudfunctions_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -1428,7 +1390,7 @@ export namespace cloudfunctions_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GenerateDownloadUrlResponse>(
@@ -1513,7 +1475,7 @@ export namespace cloudfunctions_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GenerateUploadUrlResponse>(
@@ -1577,7 +1539,7 @@ export namespace cloudfunctions_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$CloudFunction>(parameters, callback);
@@ -1647,7 +1609,7 @@ export namespace cloudfunctions_v1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -1718,7 +1680,7 @@ export namespace cloudfunctions_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListFunctionsResponse>(parameters, callback);
@@ -1787,7 +1749,7 @@ export namespace cloudfunctions_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -1858,7 +1820,7 @@ export namespace cloudfunctions_v1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -1940,7 +1902,7 @@ export namespace cloudfunctions_v1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TestIamPermissionsResponse>(

--- a/src/apis/cloudfunctions/v1beta2.ts
+++ b/src/apis/cloudfunctions/v1beta2.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace cloudfunctions_v1beta2 {
   export interface Options extends GlobalOptions {
     version: 'v1beta2';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -96,24 +98,14 @@ export namespace cloudfunctions_v1beta2 {
    * @param {object=} options Options for Cloudfunctions
    */
   export class Cloudfunctions {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     operations: Resource$Operations;
     projects: Resource$Projects;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.operations = new Resource$Operations(this);
-      this.projects = new Resource$Projects(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.operations = new Resource$Operations();
+      this.projects = new Resource$Projects();
     }
   }
 
@@ -634,15 +626,7 @@ export namespace cloudfunctions_v1beta2 {
 
 
   export class Resource$Operations {
-    root: Cloudfunctions;
-    constructor(root: Cloudfunctions) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -699,7 +683,7 @@ export namespace cloudfunctions_v1beta2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -777,7 +761,7 @@ export namespace cloudfunctions_v1beta2 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListOperationsResponse>(parameters, callback);
@@ -824,31 +808,17 @@ export namespace cloudfunctions_v1beta2 {
 
 
   export class Resource$Projects {
-    root: Cloudfunctions;
     locations: Resource$Projects$Locations;
-    constructor(root: Cloudfunctions) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.locations = new Resource$Projects$Locations(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.locations = new Resource$Projects$Locations();
     }
   }
 
 
   export class Resource$Projects$Locations {
-    root: Cloudfunctions;
     functions: Resource$Projects$Locations$Functions;
-    constructor(root: Cloudfunctions) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.functions = new Resource$Projects$Locations$Functions(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.functions = new Resource$Projects$Locations$Functions();
     }
 
 
@@ -914,7 +884,7 @@ export namespace cloudfunctions_v1beta2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListLocationsResponse>(parameters, callback);
@@ -950,15 +920,7 @@ export namespace cloudfunctions_v1beta2 {
   }
 
   export class Resource$Projects$Locations$Functions {
-    root: Cloudfunctions;
-    constructor(root: Cloudfunctions) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -1022,7 +984,7 @@ export namespace cloudfunctions_v1beta2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$CallFunctionResponse>(parameters, callback);
@@ -1093,7 +1055,7 @@ export namespace cloudfunctions_v1beta2 {
         params,
         requiredParams: ['location'],
         pathParams: ['location'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -1162,7 +1124,7 @@ export namespace cloudfunctions_v1beta2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -1245,7 +1207,7 @@ export namespace cloudfunctions_v1beta2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GenerateDownloadUrlResponse>(
@@ -1330,7 +1292,7 @@ export namespace cloudfunctions_v1beta2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GenerateUploadUrlResponse>(
@@ -1394,7 +1356,7 @@ export namespace cloudfunctions_v1beta2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$CloudFunction>(parameters, callback);
@@ -1465,7 +1427,7 @@ export namespace cloudfunctions_v1beta2 {
         params,
         requiredParams: ['location'],
         pathParams: ['location'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListFunctionsResponse>(parameters, callback);
@@ -1533,7 +1495,7 @@ export namespace cloudfunctions_v1beta2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);

--- a/src/apis/cloudiot/v1.ts
+++ b/src/apis/cloudiot/v1.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace cloudiot_v1 {
   export interface Options extends GlobalOptions {
     version: 'v1';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -97,22 +99,12 @@ export namespace cloudiot_v1 {
    * @param {object=} options Options for Cloudiot
    */
   export class Cloudiot {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     projects: Resource$Projects;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.projects = new Resource$Projects(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.projects = new Resource$Projects();
     }
   }
 
@@ -838,48 +830,27 @@ export namespace cloudiot_v1 {
 
 
   export class Resource$Projects {
-    root: Cloudiot;
     locations: Resource$Projects$Locations;
-    constructor(root: Cloudiot) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.locations = new Resource$Projects$Locations(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.locations = new Resource$Projects$Locations();
     }
   }
 
 
   export class Resource$Projects$Locations {
-    root: Cloudiot;
     registries: Resource$Projects$Locations$Registries;
-    constructor(root: Cloudiot) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.registries = new Resource$Projects$Locations$Registries(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.registries = new Resource$Projects$Locations$Registries();
     }
   }
 
 
   export class Resource$Projects$Locations$Registries {
-    root: Cloudiot;
     devices: Resource$Projects$Locations$Registries$Devices;
     groups: Resource$Projects$Locations$Registries$Groups;
-    constructor(root: Cloudiot) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.devices = new Resource$Projects$Locations$Registries$Devices(root);
-      this.groups = new Resource$Projects$Locations$Registries$Groups(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.devices = new Resource$Projects$Locations$Registries$Devices();
+      this.groups = new Resource$Projects$Locations$Registries$Groups();
     }
 
 
@@ -952,7 +923,7 @@ export namespace cloudiot_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$BindDeviceToGatewayResponse>(
@@ -1021,7 +992,7 @@ export namespace cloudiot_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$DeviceRegistry>(parameters, callback);
@@ -1086,7 +1057,7 @@ export namespace cloudiot_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -1148,7 +1119,7 @@ export namespace cloudiot_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$DeviceRegistry>(parameters, callback);
@@ -1218,7 +1189,7 @@ export namespace cloudiot_v1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -1292,7 +1263,7 @@ export namespace cloudiot_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListDeviceRegistriesResponse>(
@@ -1362,7 +1333,7 @@ export namespace cloudiot_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$DeviceRegistry>(parameters, callback);
@@ -1432,7 +1403,7 @@ export namespace cloudiot_v1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -1513,7 +1484,7 @@ export namespace cloudiot_v1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TestIamPermissionsResponse>(
@@ -1594,7 +1565,7 @@ export namespace cloudiot_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$UnbindDeviceFromGatewayResponse>(
@@ -1794,22 +1765,13 @@ export namespace cloudiot_v1 {
   }
 
   export class Resource$Projects$Locations$Registries$Devices {
-    root: Cloudiot;
     configVersions:
         Resource$Projects$Locations$Registries$Devices$Configversions;
     states: Resource$Projects$Locations$Registries$Devices$States;
-    constructor(root: Cloudiot) {
-      this.root = root;
-      this.getRoot.bind(this);
+    constructor() {
       this.configVersions =
-          new Resource$Projects$Locations$Registries$Devices$Configversions(
-              root);
-      this.states =
-          new Resource$Projects$Locations$Registries$Devices$States(root);
-    }
-
-    getRoot() {
-      return this.root;
+          new Resource$Projects$Locations$Registries$Devices$Configversions();
+      this.states = new Resource$Projects$Locations$Registries$Devices$States();
     }
 
 
@@ -1872,7 +1834,7 @@ export namespace cloudiot_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Device>(parameters, callback);
@@ -1939,7 +1901,7 @@ export namespace cloudiot_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -2003,7 +1965,7 @@ export namespace cloudiot_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Device>(parameters, callback);
@@ -2080,7 +2042,7 @@ export namespace cloudiot_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListDevicesResponse>(parameters, callback);
@@ -2157,7 +2119,7 @@ export namespace cloudiot_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$DeviceConfig>(parameters, callback);
@@ -2226,7 +2188,7 @@ export namespace cloudiot_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Device>(parameters, callback);
@@ -2317,7 +2279,7 @@ export namespace cloudiot_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$SendCommandToDeviceResponse>(
@@ -2514,15 +2476,7 @@ export namespace cloudiot_v1 {
   }
 
   export class Resource$Projects$Locations$Registries$Devices$Configversions {
-    root: Cloudiot;
-    constructor(root: Cloudiot) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -2598,7 +2552,7 @@ export namespace cloudiot_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListDeviceConfigVersionsResponse>(
@@ -2634,15 +2588,7 @@ export namespace cloudiot_v1 {
 
 
   export class Resource$Projects$Locations$Registries$Devices$States {
-    root: Cloudiot;
-    constructor(root: Cloudiot) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -2710,7 +2656,7 @@ export namespace cloudiot_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListDeviceStatesResponse>(parameters, callback);
@@ -2745,17 +2691,10 @@ export namespace cloudiot_v1 {
 
 
   export class Resource$Projects$Locations$Registries$Groups {
-    root: Cloudiot;
     devices: Resource$Projects$Locations$Registries$Groups$Devices;
-    constructor(root: Cloudiot) {
-      this.root = root;
-      this.getRoot.bind(this);
+    constructor() {
       this.devices =
-          new Resource$Projects$Locations$Registries$Groups$Devices(root);
-    }
-
-    getRoot() {
-      return this.root;
+          new Resource$Projects$Locations$Registries$Groups$Devices();
     }
 
 
@@ -2828,7 +2767,7 @@ export namespace cloudiot_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$BindDeviceToGatewayResponse>(
@@ -2902,7 +2841,7 @@ export namespace cloudiot_v1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -2975,7 +2914,7 @@ export namespace cloudiot_v1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -3056,7 +2995,7 @@ export namespace cloudiot_v1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TestIamPermissionsResponse>(
@@ -3138,7 +3077,7 @@ export namespace cloudiot_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$UnbindDeviceFromGatewayResponse>(
@@ -3242,23 +3181,14 @@ export namespace cloudiot_v1 {
   }
 
   export class Resource$Projects$Locations$Registries$Groups$Devices {
-    root: Cloudiot;
     configVersions:
         Resource$Projects$Locations$Registries$Groups$Devices$Configversions;
     states: Resource$Projects$Locations$Registries$Groups$Devices$States;
-    constructor(root: Cloudiot) {
-      this.root = root;
-      this.getRoot.bind(this);
+    constructor() {
       this.configVersions =
-          new Resource$Projects$Locations$Registries$Groups$Devices$Configversions(
-              root);
+          new Resource$Projects$Locations$Registries$Groups$Devices$Configversions();
       this.states =
-          new Resource$Projects$Locations$Registries$Groups$Devices$States(
-              root);
-    }
-
-    getRoot() {
-      return this.root;
+          new Resource$Projects$Locations$Registries$Groups$Devices$States();
     }
 
 
@@ -3319,7 +3249,7 @@ export namespace cloudiot_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Device>(parameters, callback);
@@ -3399,7 +3329,7 @@ export namespace cloudiot_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListDevicesResponse>(parameters, callback);
@@ -3476,7 +3406,7 @@ export namespace cloudiot_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$DeviceConfig>(parameters, callback);
@@ -3548,7 +3478,7 @@ export namespace cloudiot_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Device>(parameters, callback);
@@ -3640,7 +3570,7 @@ export namespace cloudiot_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$SendCommandToDeviceResponse>(
@@ -3804,15 +3734,7 @@ export namespace cloudiot_v1 {
 
   export class
       Resource$Projects$Locations$Registries$Groups$Devices$Configversions {
-    root: Cloudiot;
-    constructor(root: Cloudiot) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -3889,7 +3811,7 @@ export namespace cloudiot_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListDeviceConfigVersionsResponse>(
@@ -3925,15 +3847,7 @@ export namespace cloudiot_v1 {
 
 
   export class Resource$Projects$Locations$Registries$Groups$Devices$States {
-    root: Cloudiot;
-    constructor(root: Cloudiot) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -4001,7 +3915,7 @@ export namespace cloudiot_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListDeviceStatesResponse>(parameters, callback);

--- a/src/apis/cloudkms/v1.ts
+++ b/src/apis/cloudkms/v1.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace cloudkms_v1 {
   export interface Options extends GlobalOptions {
     version: 'v1';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -97,22 +99,12 @@ export namespace cloudkms_v1 {
    * @param {object=} options Options for Cloudkms
    */
   export class Cloudkms {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     projects: Resource$Projects;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.projects = new Resource$Projects(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.projects = new Resource$Projects();
     }
   }
 
@@ -738,31 +730,17 @@ export namespace cloudkms_v1 {
 
 
   export class Resource$Projects {
-    root: Cloudkms;
     locations: Resource$Projects$Locations;
-    constructor(root: Cloudkms) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.locations = new Resource$Projects$Locations(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.locations = new Resource$Projects$Locations();
     }
   }
 
 
   export class Resource$Projects$Locations {
-    root: Cloudkms;
     keyRings: Resource$Projects$Locations$Keyrings;
-    constructor(root: Cloudkms) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.keyRings = new Resource$Projects$Locations$Keyrings(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.keyRings = new Resource$Projects$Locations$Keyrings();
     }
 
 
@@ -817,7 +795,7 @@ export namespace cloudkms_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Location>(parameters, callback);
@@ -888,7 +866,7 @@ export namespace cloudkms_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListLocationsResponse>(parameters, callback);
@@ -936,17 +914,9 @@ export namespace cloudkms_v1 {
   }
 
   export class Resource$Projects$Locations$Keyrings {
-    root: Cloudkms;
     cryptoKeys: Resource$Projects$Locations$Keyrings$Cryptokeys;
-    constructor(root: Cloudkms) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.cryptoKeys =
-          new Resource$Projects$Locations$Keyrings$Cryptokeys(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.cryptoKeys = new Resource$Projects$Locations$Keyrings$Cryptokeys();
     }
 
 
@@ -1008,7 +978,7 @@ export namespace cloudkms_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$KeyRing>(parameters, callback);
@@ -1069,7 +1039,7 @@ export namespace cloudkms_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$KeyRing>(parameters, callback);
@@ -1137,7 +1107,7 @@ export namespace cloudkms_v1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -1207,7 +1177,7 @@ export namespace cloudkms_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListKeyRingsResponse>(parameters, callback);
@@ -1276,7 +1246,7 @@ export namespace cloudkms_v1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -1356,7 +1326,7 @@ export namespace cloudkms_v1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TestIamPermissionsResponse>(
@@ -1478,19 +1448,11 @@ export namespace cloudkms_v1 {
   }
 
   export class Resource$Projects$Locations$Keyrings$Cryptokeys {
-    root: Cloudkms;
     cryptoKeyVersions:
         Resource$Projects$Locations$Keyrings$Cryptokeys$Cryptokeyversions;
-    constructor(root: Cloudkms) {
-      this.root = root;
-      this.getRoot.bind(this);
+    constructor() {
       this.cryptoKeyVersions =
-          new Resource$Projects$Locations$Keyrings$Cryptokeys$Cryptokeyversions(
-              root);
-    }
-
-    getRoot() {
-      return this.root;
+          new Resource$Projects$Locations$Keyrings$Cryptokeys$Cryptokeyversions();
     }
 
 
@@ -1556,7 +1518,7 @@ export namespace cloudkms_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$CryptoKey>(parameters, callback);
@@ -1627,7 +1589,7 @@ export namespace cloudkms_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$DecryptResponse>(parameters, callback);
@@ -1698,7 +1660,7 @@ export namespace cloudkms_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$EncryptResponse>(parameters, callback);
@@ -1763,7 +1725,7 @@ export namespace cloudkms_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$CryptoKey>(parameters, callback);
@@ -1835,7 +1797,7 @@ export namespace cloudkms_v1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -1908,7 +1870,7 @@ export namespace cloudkms_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListCryptoKeysResponse>(parameters, callback);
@@ -1978,7 +1940,7 @@ export namespace cloudkms_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$CryptoKey>(parameters, callback);
@@ -2051,7 +2013,7 @@ export namespace cloudkms_v1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -2134,7 +2096,7 @@ export namespace cloudkms_v1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TestIamPermissionsResponse>(
@@ -2211,7 +2173,7 @@ export namespace cloudkms_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$CryptoKey>(parameters, callback);
@@ -2412,15 +2374,7 @@ export namespace cloudkms_v1 {
 
   export class
       Resource$Projects$Locations$Keyrings$Cryptokeys$Cryptokeyversions {
-    root: Cloudkms;
-    constructor(root: Cloudkms) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -2492,7 +2446,7 @@ export namespace cloudkms_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$AsymmetricDecryptResponse>(
@@ -2571,7 +2525,7 @@ export namespace cloudkms_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$AsymmetricSignResponse>(parameters, callback);
@@ -2646,7 +2600,7 @@ export namespace cloudkms_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$CryptoKeyVersion>(parameters, callback);
@@ -2725,7 +2679,7 @@ export namespace cloudkms_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$CryptoKeyVersion>(parameters, callback);
@@ -2793,7 +2747,7 @@ export namespace cloudkms_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$CryptoKeyVersion>(parameters, callback);
@@ -2867,7 +2821,7 @@ export namespace cloudkms_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$PublicKey>(parameters, callback);
@@ -2948,7 +2902,7 @@ export namespace cloudkms_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListCryptoKeyVersionsResponse>(
@@ -3026,7 +2980,7 @@ export namespace cloudkms_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$CryptoKeyVersion>(parameters, callback);
@@ -3102,7 +3056,7 @@ export namespace cloudkms_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$CryptoKeyVersion>(parameters, callback);

--- a/src/apis/cloudprofiler/v2.ts
+++ b/src/apis/cloudprofiler/v2.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace cloudprofiler_v2 {
   export interface Options extends GlobalOptions {
     version: 'v2';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -96,22 +98,12 @@ export namespace cloudprofiler_v2 {
    * @param {object=} options Options for Cloudprofiler
    */
   export class Cloudprofiler {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     projects: Resource$Projects;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.projects = new Resource$Projects(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.projects = new Resource$Projects();
     }
   }
 
@@ -205,30 +197,15 @@ export namespace cloudprofiler_v2 {
 
 
   export class Resource$Projects {
-    root: Cloudprofiler;
     profiles: Resource$Projects$Profiles;
-    constructor(root: Cloudprofiler) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.profiles = new Resource$Projects$Profiles(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.profiles = new Resource$Projects$Profiles();
     }
   }
 
 
   export class Resource$Projects$Profiles {
-    root: Cloudprofiler;
-    constructor(root: Cloudprofiler) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -298,7 +275,7 @@ export namespace cloudprofiler_v2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Profile>(parameters, callback);
@@ -368,7 +345,7 @@ export namespace cloudprofiler_v2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Profile>(parameters, callback);
@@ -439,7 +416,7 @@ export namespace cloudprofiler_v2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Profile>(parameters, callback);

--- a/src/apis/cloudresourcemanager/v1.ts
+++ b/src/apis/cloudresourcemanager/v1.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace cloudresourcemanager_v1 {
   export interface Options extends GlobalOptions {
     version: 'v1';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -97,10 +99,6 @@ export namespace cloudresourcemanager_v1 {
    * @param {object=} options Options for Cloudresourcemanager
    */
   export class Cloudresourcemanager {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     folders: Resource$Folders;
     liens: Resource$Liens;
     operations: Resource$Operations;
@@ -108,19 +106,13 @@ export namespace cloudresourcemanager_v1 {
     projects: Resource$Projects;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.folders = new Resource$Folders(this);
-      this.liens = new Resource$Liens(this);
-      this.operations = new Resource$Operations(this);
-      this.organizations = new Resource$Organizations(this);
-      this.projects = new Resource$Projects(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.folders = new Resource$Folders();
+      this.liens = new Resource$Liens();
+      this.operations = new Resource$Operations();
+      this.organizations = new Resource$Organizations();
+      this.projects = new Resource$Projects();
     }
   }
 
@@ -1146,15 +1138,7 @@ export namespace cloudresourcemanager_v1 {
 
 
   export class Resource$Folders {
-    root: Cloudresourcemanager;
-    constructor(root: Cloudresourcemanager) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -1269,7 +1253,7 @@ export namespace cloudresourcemanager_v1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -1399,7 +1383,7 @@ export namespace cloudresourcemanager_v1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$OrgPolicy>(parameters, callback);
@@ -1527,7 +1511,7 @@ export namespace cloudresourcemanager_v1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$OrgPolicy>(parameters, callback);
@@ -1680,7 +1664,7 @@ export namespace cloudresourcemanager_v1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListAvailableOrgPolicyConstraintsResponse>(
@@ -1823,7 +1807,7 @@ export namespace cloudresourcemanager_v1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListOrgPoliciesResponse>(parameters, callback);
@@ -1950,7 +1934,7 @@ export namespace cloudresourcemanager_v1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$OrgPolicy>(parameters, callback);
@@ -2065,15 +2049,7 @@ export namespace cloudresourcemanager_v1 {
 
 
   export class Resource$Liens {
-    root: Cloudresourcemanager;
-    constructor(root: Cloudresourcemanager) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -2188,7 +2164,7 @@ export namespace cloudresourcemanager_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Lien>(parameters, callback);
@@ -2305,7 +2281,7 @@ export namespace cloudresourcemanager_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -2369,7 +2345,7 @@ export namespace cloudresourcemanager_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Lien>(parameters, callback);
@@ -2502,7 +2478,7 @@ export namespace cloudresourcemanager_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListLiensResponse>(parameters, callback);
@@ -2571,15 +2547,7 @@ export namespace cloudresourcemanager_v1 {
 
 
   export class Resource$Operations {
-    root: Cloudresourcemanager;
-    constructor(root: Cloudresourcemanager) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -2689,7 +2657,7 @@ export namespace cloudresourcemanager_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -2713,15 +2681,7 @@ export namespace cloudresourcemanager_v1 {
 
 
   export class Resource$Organizations {
-    root: Cloudresourcemanager;
-    constructor(root: Cloudresourcemanager) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -2835,7 +2795,7 @@ export namespace cloudresourcemanager_v1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -2951,7 +2911,7 @@ export namespace cloudresourcemanager_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Organization>(parameters, callback);
@@ -3081,7 +3041,7 @@ export namespace cloudresourcemanager_v1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$OrgPolicy>(parameters, callback);
@@ -3211,7 +3171,7 @@ export namespace cloudresourcemanager_v1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -3340,7 +3300,7 @@ export namespace cloudresourcemanager_v1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$OrgPolicy>(parameters, callback);
@@ -3496,7 +3456,7 @@ export namespace cloudresourcemanager_v1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListAvailableOrgPolicyConstraintsResponse>(
@@ -3642,7 +3602,7 @@ export namespace cloudresourcemanager_v1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListOrgPoliciesResponse>(parameters, callback);
@@ -3786,7 +3746,7 @@ export namespace cloudresourcemanager_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$SearchOrganizationsResponse>(
@@ -3917,7 +3877,7 @@ export namespace cloudresourcemanager_v1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -4045,7 +4005,7 @@ export namespace cloudresourcemanager_v1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$OrgPolicy>(parameters, callback);
@@ -4181,7 +4141,7 @@ export namespace cloudresourcemanager_v1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TestIamPermissionsResponse>(
@@ -4377,15 +4337,7 @@ export namespace cloudresourcemanager_v1 {
 
 
   export class Resource$Projects {
-    root: Cloudresourcemanager;
-    constructor(root: Cloudresourcemanager) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -4500,7 +4452,7 @@ export namespace cloudresourcemanager_v1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -4632,7 +4584,7 @@ export namespace cloudresourcemanager_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -4758,7 +4710,7 @@ export namespace cloudresourcemanager_v1 {
         params,
         requiredParams: ['projectId'],
         pathParams: ['projectId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -4876,7 +4828,7 @@ export namespace cloudresourcemanager_v1 {
         params,
         requiredParams: ['projectId'],
         pathParams: ['projectId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Project>(parameters, callback);
@@ -5004,7 +4956,7 @@ export namespace cloudresourcemanager_v1 {
         params,
         requiredParams: ['projectId'],
         pathParams: ['projectId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GetAncestryResponse>(parameters, callback);
@@ -5134,7 +5086,7 @@ export namespace cloudresourcemanager_v1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$OrgPolicy>(parameters, callback);
@@ -5263,7 +5215,7 @@ export namespace cloudresourcemanager_v1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -5391,7 +5343,7 @@ export namespace cloudresourcemanager_v1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$OrgPolicy>(parameters, callback);
@@ -5527,7 +5479,7 @@ export namespace cloudresourcemanager_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListProjectsResponse>(parameters, callback);
@@ -5680,7 +5632,7 @@ export namespace cloudresourcemanager_v1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListAvailableOrgPolicyConstraintsResponse>(
@@ -5823,7 +5775,7 @@ export namespace cloudresourcemanager_v1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListOrgPoliciesResponse>(parameters, callback);
@@ -5975,7 +5927,7 @@ export namespace cloudresourcemanager_v1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -6102,7 +6054,7 @@ export namespace cloudresourcemanager_v1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$OrgPolicy>(parameters, callback);
@@ -6235,7 +6187,7 @@ export namespace cloudresourcemanager_v1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TestIamPermissionsResponse>(
@@ -6363,7 +6315,7 @@ export namespace cloudresourcemanager_v1 {
         params,
         requiredParams: ['projectId'],
         pathParams: ['projectId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -6491,7 +6443,7 @@ export namespace cloudresourcemanager_v1 {
         params,
         requiredParams: ['projectId'],
         pathParams: ['projectId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Project>(parameters, callback);

--- a/src/apis/cloudresourcemanager/v1beta1.ts
+++ b/src/apis/cloudresourcemanager/v1beta1.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace cloudresourcemanager_v1beta1 {
   export interface Options extends GlobalOptions {
     version: 'v1beta1';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -97,24 +99,14 @@ export namespace cloudresourcemanager_v1beta1 {
    * @param {object=} options Options for Cloudresourcemanager
    */
   export class Cloudresourcemanager {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     organizations: Resource$Organizations;
     projects: Resource$Projects;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.organizations = new Resource$Organizations(this);
-      this.projects = new Resource$Projects(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.organizations = new Resource$Organizations();
+      this.projects = new Resource$Projects();
     }
   }
 
@@ -588,15 +580,7 @@ export namespace cloudresourcemanager_v1beta1 {
 
 
   export class Resource$Organizations {
-    root: Cloudresourcemanager;
-    constructor(root: Cloudresourcemanager) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -706,7 +690,7 @@ export namespace cloudresourcemanager_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Organization>(parameters, callback);
@@ -833,7 +817,7 @@ export namespace cloudresourcemanager_v1beta1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -971,7 +955,7 @@ export namespace cloudresourcemanager_v1beta1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListOrganizationsResponse>(
@@ -1099,7 +1083,7 @@ export namespace cloudresourcemanager_v1beta1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -1234,7 +1218,7 @@ export namespace cloudresourcemanager_v1beta1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TestIamPermissionsResponse>(
@@ -1364,7 +1348,7 @@ export namespace cloudresourcemanager_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Organization>(parameters, callback);
@@ -1498,15 +1482,7 @@ export namespace cloudresourcemanager_v1beta1 {
 
 
   export class Resource$Projects {
-    root: Cloudresourcemanager;
-    constructor(root: Cloudresourcemanager) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -1628,7 +1604,7 @@ export namespace cloudresourcemanager_v1beta1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Project>(parameters, callback);
@@ -1754,7 +1730,7 @@ export namespace cloudresourcemanager_v1beta1 {
         params,
         requiredParams: ['projectId'],
         pathParams: ['projectId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -1872,7 +1848,7 @@ export namespace cloudresourcemanager_v1beta1 {
         params,
         requiredParams: ['projectId'],
         pathParams: ['projectId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Project>(parameters, callback);
@@ -2000,7 +1976,7 @@ export namespace cloudresourcemanager_v1beta1 {
         params,
         requiredParams: ['projectId'],
         pathParams: ['projectId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GetAncestryResponse>(parameters, callback);
@@ -2127,7 +2103,7 @@ export namespace cloudresourcemanager_v1beta1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -2264,7 +2240,7 @@ export namespace cloudresourcemanager_v1beta1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListProjectsResponse>(parameters, callback);
@@ -2412,7 +2388,7 @@ export namespace cloudresourcemanager_v1beta1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -2544,7 +2520,7 @@ export namespace cloudresourcemanager_v1beta1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TestIamPermissionsResponse>(
@@ -2672,7 +2648,7 @@ export namespace cloudresourcemanager_v1beta1 {
         params,
         requiredParams: ['projectId'],
         pathParams: ['projectId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -2800,7 +2776,7 @@ export namespace cloudresourcemanager_v1beta1 {
         params,
         requiredParams: ['projectId'],
         pathParams: ['projectId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Project>(parameters, callback);

--- a/src/apis/cloudresourcemanager/v2.ts
+++ b/src/apis/cloudresourcemanager/v2.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace cloudresourcemanager_v2 {
   export interface Options extends GlobalOptions {
     version: 'v2';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -97,24 +99,14 @@ export namespace cloudresourcemanager_v2 {
    * @param {object=} options Options for Cloudresourcemanager
    */
   export class Cloudresourcemanager {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     folders: Resource$Folders;
     operations: Resource$Operations;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.folders = new Resource$Folders(this);
-      this.operations = new Resource$Operations(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.folders = new Resource$Folders();
+      this.operations = new Resource$Operations();
     }
   }
 
@@ -588,15 +580,7 @@ export namespace cloudresourcemanager_v2 {
 
 
   export class Resource$Folders {
-    root: Cloudresourcemanager;
-    constructor(root: Cloudresourcemanager) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -672,7 +656,7 @@ export namespace cloudresourcemanager_v2 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -741,7 +725,7 @@ export namespace cloudresourcemanager_v2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Folder>(parameters, callback);
@@ -805,7 +789,7 @@ export namespace cloudresourcemanager_v2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Folder>(parameters, callback);
@@ -877,7 +861,7 @@ export namespace cloudresourcemanager_v2 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -950,7 +934,7 @@ export namespace cloudresourcemanager_v2 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListFoldersResponse>(parameters, callback);
@@ -1028,7 +1012,7 @@ export namespace cloudresourcemanager_v2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -1104,7 +1088,7 @@ export namespace cloudresourcemanager_v2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Folder>(parameters, callback);
@@ -1175,7 +1159,7 @@ export namespace cloudresourcemanager_v2 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$SearchFoldersResponse>(parameters, callback);
@@ -1247,7 +1231,7 @@ export namespace cloudresourcemanager_v2 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -1325,7 +1309,7 @@ export namespace cloudresourcemanager_v2 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TestIamPermissionsResponse>(
@@ -1399,7 +1383,7 @@ export namespace cloudresourcemanager_v2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Folder>(parameters, callback);
@@ -1604,15 +1588,7 @@ export namespace cloudresourcemanager_v2 {
 
 
   export class Resource$Operations {
-    root: Cloudresourcemanager;
-    constructor(root: Cloudresourcemanager) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -1669,7 +1645,7 @@ export namespace cloudresourcemanager_v2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);

--- a/src/apis/cloudresourcemanager/v2beta1.ts
+++ b/src/apis/cloudresourcemanager/v2beta1.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace cloudresourcemanager_v2beta1 {
   export interface Options extends GlobalOptions {
     version: 'v2beta1';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -97,24 +99,14 @@ export namespace cloudresourcemanager_v2beta1 {
    * @param {object=} options Options for Cloudresourcemanager
    */
   export class Cloudresourcemanager {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     folders: Resource$Folders;
     operations: Resource$Operations;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.folders = new Resource$Folders(this);
-      this.operations = new Resource$Operations(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.folders = new Resource$Folders();
+      this.operations = new Resource$Operations();
     }
   }
 
@@ -588,15 +580,7 @@ export namespace cloudresourcemanager_v2beta1 {
 
 
   export class Resource$Folders {
-    root: Cloudresourcemanager;
-    constructor(root: Cloudresourcemanager) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -672,7 +656,7 @@ export namespace cloudresourcemanager_v2beta1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -741,7 +725,7 @@ export namespace cloudresourcemanager_v2beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Folder>(parameters, callback);
@@ -805,7 +789,7 @@ export namespace cloudresourcemanager_v2beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Folder>(parameters, callback);
@@ -877,7 +861,7 @@ export namespace cloudresourcemanager_v2beta1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -950,7 +934,7 @@ export namespace cloudresourcemanager_v2beta1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListFoldersResponse>(parameters, callback);
@@ -1028,7 +1012,7 @@ export namespace cloudresourcemanager_v2beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -1104,7 +1088,7 @@ export namespace cloudresourcemanager_v2beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Folder>(parameters, callback);
@@ -1175,7 +1159,7 @@ export namespace cloudresourcemanager_v2beta1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$SearchFoldersResponse>(parameters, callback);
@@ -1247,7 +1231,7 @@ export namespace cloudresourcemanager_v2beta1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -1325,7 +1309,7 @@ export namespace cloudresourcemanager_v2beta1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TestIamPermissionsResponse>(
@@ -1399,7 +1383,7 @@ export namespace cloudresourcemanager_v2beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Folder>(parameters, callback);
@@ -1604,15 +1588,7 @@ export namespace cloudresourcemanager_v2beta1 {
 
 
   export class Resource$Operations {
-    root: Cloudresourcemanager;
-    constructor(root: Cloudresourcemanager) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -1669,7 +1645,7 @@ export namespace cloudresourcemanager_v2beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);

--- a/src/apis/cloudscheduler/v1beta1.ts
+++ b/src/apis/cloudscheduler/v1beta1.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace cloudscheduler_v1beta1 {
   export interface Options extends GlobalOptions {
     version: 'v1beta1';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -96,22 +98,12 @@ export namespace cloudscheduler_v1beta1 {
    * @param {object=} options Options for Cloudscheduler
    */
   export class Cloudscheduler {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     projects: Resource$Projects;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.projects = new Resource$Projects(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.projects = new Resource$Projects();
     }
   }
 
@@ -616,31 +608,17 @@ export namespace cloudscheduler_v1beta1 {
 
 
   export class Resource$Projects {
-    root: Cloudscheduler;
     locations: Resource$Projects$Locations;
-    constructor(root: Cloudscheduler) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.locations = new Resource$Projects$Locations(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.locations = new Resource$Projects$Locations();
     }
   }
 
 
   export class Resource$Projects$Locations {
-    root: Cloudscheduler;
     jobs: Resource$Projects$Locations$Jobs;
-    constructor(root: Cloudscheduler) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.jobs = new Resource$Projects$Locations$Jobs(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.jobs = new Resource$Projects$Locations$Jobs();
     }
 
 
@@ -696,7 +674,7 @@ export namespace cloudscheduler_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Location>(parameters, callback);
@@ -768,7 +746,7 @@ export namespace cloudscheduler_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListLocationsResponse>(parameters, callback);
@@ -816,15 +794,7 @@ export namespace cloudscheduler_v1beta1 {
   }
 
   export class Resource$Projects$Locations$Jobs {
-    root: Cloudscheduler;
-    constructor(root: Cloudscheduler) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -885,7 +855,7 @@ export namespace cloudscheduler_v1beta1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Job>(parameters, callback);
@@ -951,7 +921,7 @@ export namespace cloudscheduler_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -1013,7 +983,7 @@ export namespace cloudscheduler_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Job>(parameters, callback);
@@ -1083,7 +1053,7 @@ export namespace cloudscheduler_v1beta1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListJobsResponse>(parameters, callback);
@@ -1156,7 +1126,7 @@ export namespace cloudscheduler_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Job>(parameters, callback);
@@ -1227,7 +1197,7 @@ export namespace cloudscheduler_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Job>(parameters, callback);
@@ -1298,7 +1268,7 @@ export namespace cloudscheduler_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Job>(parameters, callback);
@@ -1363,7 +1333,7 @@ export namespace cloudscheduler_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Job>(parameters, callback);

--- a/src/apis/cloudsearch/v1.ts
+++ b/src/apis/cloudsearch/v1.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace cloudsearch_v1 {
   export interface Options extends GlobalOptions {
     version: 'v1';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -97,10 +99,6 @@ export namespace cloudsearch_v1 {
    * @param {object=} options Options for Cloudsearch
    */
   export class Cloudsearch {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     debug: Resource$Debug;
     indexing: Resource$Indexing;
     media: Resource$Media;
@@ -110,21 +108,15 @@ export namespace cloudsearch_v1 {
     stats: Resource$Stats;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.debug = new Resource$Debug(this);
-      this.indexing = new Resource$Indexing(this);
-      this.media = new Resource$Media(this);
-      this.operations = new Resource$Operations(this);
-      this.query = new Resource$Query(this);
-      this.settings = new Resource$Settings(this);
-      this.stats = new Resource$Stats(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.debug = new Resource$Debug();
+      this.indexing = new Resource$Indexing();
+      this.media = new Resource$Media();
+      this.operations = new Resource$Operations();
+      this.query = new Resource$Query();
+      this.settings = new Resource$Settings();
+      this.stats = new Resource$Stats();
     }
   }
 
@@ -2571,48 +2563,27 @@ export namespace cloudsearch_v1 {
 
 
   export class Resource$Debug {
-    root: Cloudsearch;
     datasources: Resource$Debug$Datasources;
     identitysources: Resource$Debug$Identitysources;
-    constructor(root: Cloudsearch) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.datasources = new Resource$Debug$Datasources(root);
-      this.identitysources = new Resource$Debug$Identitysources(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.datasources = new Resource$Debug$Datasources();
+      this.identitysources = new Resource$Debug$Identitysources();
     }
   }
 
 
   export class Resource$Debug$Datasources {
-    root: Cloudsearch;
     items: Resource$Debug$Datasources$Items;
-    constructor(root: Cloudsearch) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.items = new Resource$Debug$Datasources$Items(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.items = new Resource$Debug$Datasources$Items();
     }
   }
 
 
   export class Resource$Debug$Datasources$Items {
-    root: Cloudsearch;
     unmappedids: Resource$Debug$Datasources$Items$Unmappedids;
-    constructor(root: Cloudsearch) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.unmappedids = new Resource$Debug$Datasources$Items$Unmappedids(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.unmappedids = new Resource$Debug$Datasources$Items$Unmappedids();
     }
 
 
@@ -2676,7 +2647,7 @@ export namespace cloudsearch_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$CheckAccessResponse>(parameters, callback);
@@ -2752,7 +2723,7 @@ export namespace cloudsearch_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$SearchItemsByViewUrlResponse>(
@@ -2805,15 +2776,7 @@ export namespace cloudsearch_v1 {
   }
 
   export class Resource$Debug$Datasources$Items$Unmappedids {
-    root: Cloudsearch;
-    constructor(root: Cloudsearch) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -2882,7 +2845,7 @@ export namespace cloudsearch_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListUnmappedIdentitiesResponse>(
@@ -2924,32 +2887,17 @@ export namespace cloudsearch_v1 {
 
 
   export class Resource$Debug$Identitysources {
-    root: Cloudsearch;
     items: Resource$Debug$Identitysources$Items;
     unmappedids: Resource$Debug$Identitysources$Unmappedids;
-    constructor(root: Cloudsearch) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.items = new Resource$Debug$Identitysources$Items(root);
-      this.unmappedids = new Resource$Debug$Identitysources$Unmappedids(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.items = new Resource$Debug$Identitysources$Items();
+      this.unmappedids = new Resource$Debug$Identitysources$Unmappedids();
     }
   }
 
 
   export class Resource$Debug$Identitysources$Items {
-    root: Cloudsearch;
-    constructor(root: Cloudsearch) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -3026,7 +2974,7 @@ export namespace cloudsearch_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListItemNamesForUnmappedIdentityResponse>(
@@ -3075,15 +3023,7 @@ export namespace cloudsearch_v1 {
 
 
   export class Resource$Debug$Identitysources$Unmappedids {
-    root: Cloudsearch;
-    constructor(root: Cloudsearch) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -3153,7 +3093,7 @@ export namespace cloudsearch_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListUnmappedIdentitiesResponse>(
@@ -3199,31 +3139,17 @@ export namespace cloudsearch_v1 {
 
 
   export class Resource$Indexing {
-    root: Cloudsearch;
     datasources: Resource$Indexing$Datasources;
-    constructor(root: Cloudsearch) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.datasources = new Resource$Indexing$Datasources(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.datasources = new Resource$Indexing$Datasources();
     }
   }
 
 
   export class Resource$Indexing$Datasources {
-    root: Cloudsearch;
     items: Resource$Indexing$Datasources$Items;
-    constructor(root: Cloudsearch) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.items = new Resource$Indexing$Datasources$Items(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.items = new Resource$Indexing$Datasources$Items();
     }
 
 
@@ -3285,7 +3211,7 @@ export namespace cloudsearch_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -3352,7 +3278,7 @@ export namespace cloudsearch_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Schema>(parameters, callback);
@@ -3420,7 +3346,7 @@ export namespace cloudsearch_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -3485,15 +3411,7 @@ export namespace cloudsearch_v1 {
   }
 
   export class Resource$Indexing$Datasources$Items {
-    root: Cloudsearch;
-    constructor(root: Cloudsearch) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -3557,7 +3475,7 @@ export namespace cloudsearch_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -3628,7 +3546,7 @@ export namespace cloudsearch_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -3692,7 +3610,7 @@ export namespace cloudsearch_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Item>(parameters, callback);
@@ -3762,7 +3680,7 @@ export namespace cloudsearch_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -3834,7 +3752,7 @@ export namespace cloudsearch_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListItemsResponse>(parameters, callback);
@@ -3910,7 +3828,7 @@ export namespace cloudsearch_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$PollItemsResponse>(parameters, callback);
@@ -3977,7 +3895,7 @@ export namespace cloudsearch_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Item>(parameters, callback);
@@ -4047,7 +3965,7 @@ export namespace cloudsearch_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -4117,7 +4035,7 @@ export namespace cloudsearch_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$UploadItemRef>(parameters, callback);
@@ -4337,15 +4255,7 @@ export namespace cloudsearch_v1 {
 
 
   export class Resource$Media {
-    root: Cloudsearch;
-    constructor(root: Cloudsearch) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -4415,7 +4325,7 @@ export namespace cloudsearch_v1 {
                       .replace(/([^:]\/)\/+/g, '$1'),
         requiredParams: ['resourceName'],
         pathParams: ['resourceName'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Media>(parameters, callback);
@@ -4460,15 +4370,7 @@ export namespace cloudsearch_v1 {
 
 
   export class Resource$Operations {
-    root: Cloudsearch;
-    constructor(root: Cloudsearch) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -4524,7 +4426,7 @@ export namespace cloudsearch_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -4548,16 +4450,9 @@ export namespace cloudsearch_v1 {
 
 
   export class Resource$Query {
-    root: Cloudsearch;
     sources: Resource$Query$Sources;
-    constructor(root: Cloudsearch) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.sources = new Resource$Query$Sources(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.sources = new Resource$Query$Sources();
     }
 
 
@@ -4618,7 +4513,7 @@ export namespace cloudsearch_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$SearchResponse>(parameters, callback);
@@ -4683,7 +4578,7 @@ export namespace cloudsearch_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$SuggestResponse>(parameters, callback);
@@ -4719,15 +4614,7 @@ export namespace cloudsearch_v1 {
   }
 
   export class Resource$Query$Sources {
-    root: Cloudsearch;
-    constructor(root: Cloudsearch) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -4792,7 +4679,7 @@ export namespace cloudsearch_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListQuerySourcesResponse>(parameters, callback);
@@ -4842,32 +4729,17 @@ export namespace cloudsearch_v1 {
 
 
   export class Resource$Settings {
-    root: Cloudsearch;
     datasources: Resource$Settings$Datasources;
     searchapplications: Resource$Settings$Searchapplications;
-    constructor(root: Cloudsearch) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.datasources = new Resource$Settings$Datasources(root);
-      this.searchapplications = new Resource$Settings$Searchapplications(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.datasources = new Resource$Settings$Datasources();
+      this.searchapplications = new Resource$Settings$Searchapplications();
     }
   }
 
 
   export class Resource$Settings$Datasources {
-    root: Cloudsearch;
-    constructor(root: Cloudsearch) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -4927,7 +4799,7 @@ export namespace cloudsearch_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -4995,7 +4867,7 @@ export namespace cloudsearch_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -5059,7 +4931,7 @@ export namespace cloudsearch_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$DataSource>(parameters, callback);
@@ -5129,7 +5001,7 @@ export namespace cloudsearch_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListDataSourceResponse>(parameters, callback);
@@ -5197,7 +5069,7 @@ export namespace cloudsearch_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -5297,15 +5169,7 @@ export namespace cloudsearch_v1 {
 
 
   export class Resource$Settings$Searchapplications {
-    root: Cloudsearch;
-    constructor(root: Cloudsearch) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -5365,7 +5229,7 @@ export namespace cloudsearch_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -5433,7 +5297,7 @@ export namespace cloudsearch_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -5497,7 +5361,7 @@ export namespace cloudsearch_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$SearchApplication>(parameters, callback);
@@ -5571,7 +5435,7 @@ export namespace cloudsearch_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListSearchApplicationsResponse>(
@@ -5642,7 +5506,7 @@ export namespace cloudsearch_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -5710,7 +5574,7 @@ export namespace cloudsearch_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -5831,16 +5695,9 @@ export namespace cloudsearch_v1 {
 
 
   export class Resource$Stats {
-    root: Cloudsearch;
     index: Resource$Stats$Index;
-    constructor(root: Cloudsearch) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.index = new Resource$Stats$Index(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.index = new Resource$Stats$Index();
     }
 
 
@@ -5908,7 +5765,7 @@ export namespace cloudsearch_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GetCustomerIndexStatsResponse>(
@@ -5953,30 +5810,15 @@ export namespace cloudsearch_v1 {
   }
 
   export class Resource$Stats$Index {
-    root: Cloudsearch;
     datasources: Resource$Stats$Index$Datasources;
-    constructor(root: Cloudsearch) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.datasources = new Resource$Stats$Index$Datasources(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.datasources = new Resource$Stats$Index$Datasources();
     }
   }
 
 
   export class Resource$Stats$Index$Datasources {
-    root: Cloudsearch;
-    constructor(root: Cloudsearch) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -6044,7 +5886,7 @@ export namespace cloudsearch_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GetDataSourceIndexStatsResponse>(

--- a/src/apis/cloudshell/v1.ts
+++ b/src/apis/cloudshell/v1.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace cloudshell_v1 {
   export interface Options extends GlobalOptions {
     version: 'v1';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -97,22 +99,12 @@ export namespace cloudshell_v1 {
    * @param {object=} options Options for Cloudshell
    */
   export class Cloudshell {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     operations: Resource$Operations;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.operations = new Resource$Operations(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.operations = new Resource$Operations();
     }
   }
 
@@ -332,15 +324,7 @@ export namespace cloudshell_v1 {
 
 
   export class Resource$Operations {
-    root: Cloudshell;
-    constructor(root: Cloudshell) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -407,7 +391,7 @@ export namespace cloudshell_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -474,7 +458,7 @@ export namespace cloudshell_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -537,7 +521,7 @@ export namespace cloudshell_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -613,7 +597,7 @@ export namespace cloudshell_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListOperationsResponse>(parameters, callback);

--- a/src/apis/cloudshell/v1alpha1.ts
+++ b/src/apis/cloudshell/v1alpha1.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace cloudshell_v1alpha1 {
   export interface Options extends GlobalOptions {
     version: 'v1alpha1';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -97,22 +99,12 @@ export namespace cloudshell_v1alpha1 {
    * @param {object=} options Options for Cloudshell
    */
   export class Cloudshell {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     users: Resource$Users;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.users = new Resource$Users(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.users = new Resource$Users();
     }
   }
 
@@ -345,31 +337,17 @@ export namespace cloudshell_v1alpha1 {
 
 
   export class Resource$Users {
-    root: Cloudshell;
     environments: Resource$Users$Environments;
-    constructor(root: Cloudshell) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.environments = new Resource$Users$Environments(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.environments = new Resource$Users$Environments();
     }
   }
 
 
   export class Resource$Users$Environments {
-    root: Cloudshell;
     publicKeys: Resource$Users$Environments$Publickeys;
-    constructor(root: Cloudshell) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.publicKeys = new Resource$Users$Environments$Publickeys(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.publicKeys = new Resource$Users$Environments$Publickeys();
     }
 
 
@@ -432,7 +410,7 @@ export namespace cloudshell_v1alpha1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -496,7 +474,7 @@ export namespace cloudshell_v1alpha1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Environment>(parameters, callback);
@@ -565,7 +543,7 @@ export namespace cloudshell_v1alpha1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Environment>(parameters, callback);
@@ -638,7 +616,7 @@ export namespace cloudshell_v1alpha1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -725,15 +703,7 @@ export namespace cloudshell_v1alpha1 {
   }
 
   export class Resource$Users$Environments$Publickeys {
-    root: Cloudshell;
-    constructor(root: Cloudshell) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -797,7 +767,7 @@ export namespace cloudshell_v1alpha1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$PublicKey>(parameters, callback);
@@ -865,7 +835,7 @@ export namespace cloudshell_v1alpha1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);

--- a/src/apis/cloudtasks/v2beta2.ts
+++ b/src/apis/cloudtasks/v2beta2.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace cloudtasks_v2beta2 {
   export interface Options extends GlobalOptions {
     version: 'v2beta2';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -96,22 +98,12 @@ export namespace cloudtasks_v2beta2 {
    * @param {object=} options Options for Cloudtasks
    */
   export class Cloudtasks {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     projects: Resource$Projects;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.projects = new Resource$Projects(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.projects = new Resource$Projects();
     }
   }
 
@@ -1099,31 +1091,17 @@ export namespace cloudtasks_v2beta2 {
 
 
   export class Resource$Projects {
-    root: Cloudtasks;
     locations: Resource$Projects$Locations;
-    constructor(root: Cloudtasks) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.locations = new Resource$Projects$Locations(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.locations = new Resource$Projects$Locations();
     }
   }
 
 
   export class Resource$Projects$Locations {
-    root: Cloudtasks;
     queues: Resource$Projects$Locations$Queues;
-    constructor(root: Cloudtasks) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.queues = new Resource$Projects$Locations$Queues(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.queues = new Resource$Projects$Locations$Queues();
     }
 
 
@@ -1232,7 +1210,7 @@ export namespace cloudtasks_v2beta2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Location>(parameters, callback);
@@ -1369,7 +1347,7 @@ export namespace cloudtasks_v2beta2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListLocationsResponse>(parameters, callback);
@@ -1417,16 +1395,9 @@ export namespace cloudtasks_v2beta2 {
   }
 
   export class Resource$Projects$Locations$Queues {
-    root: Cloudtasks;
     tasks: Resource$Projects$Locations$Queues$Tasks;
-    constructor(root: Cloudtasks) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.tasks = new Resource$Projects$Locations$Queues$Tasks(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.tasks = new Resource$Projects$Locations$Queues$Tasks();
     }
 
 
@@ -1555,7 +1526,7 @@ export namespace cloudtasks_v2beta2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Queue>(parameters, callback);
@@ -1680,7 +1651,7 @@ export namespace cloudtasks_v2beta2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -1795,7 +1766,7 @@ export namespace cloudtasks_v2beta2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Queue>(parameters, callback);
@@ -1925,7 +1896,7 @@ export namespace cloudtasks_v2beta2 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -2064,7 +2035,7 @@ export namespace cloudtasks_v2beta2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListQueuesResponse>(parameters, callback);
@@ -2208,7 +2179,7 @@ export namespace cloudtasks_v2beta2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Queue>(parameters, callback);
@@ -2336,7 +2307,7 @@ export namespace cloudtasks_v2beta2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Queue>(parameters, callback);
@@ -2464,7 +2435,7 @@ export namespace cloudtasks_v2beta2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Queue>(parameters, callback);
@@ -2595,7 +2566,7 @@ export namespace cloudtasks_v2beta2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Queue>(parameters, callback);
@@ -2726,7 +2697,7 @@ export namespace cloudtasks_v2beta2 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -2865,7 +2836,7 @@ export namespace cloudtasks_v2beta2 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TestIamPermissionsResponse>(
@@ -3103,15 +3074,7 @@ export namespace cloudtasks_v2beta2 {
   }
 
   export class Resource$Projects$Locations$Queues$Tasks {
-    root: Cloudtasks;
-    constructor(root: Cloudtasks) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -3235,7 +3198,7 @@ export namespace cloudtasks_v2beta2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -3366,7 +3329,7 @@ export namespace cloudtasks_v2beta2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Task>(parameters, callback);
@@ -3496,7 +3459,7 @@ export namespace cloudtasks_v2beta2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Task>(parameters, callback);
@@ -3617,7 +3580,7 @@ export namespace cloudtasks_v2beta2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -3735,7 +3698,7 @@ export namespace cloudtasks_v2beta2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Task>(parameters, callback);
@@ -3812,7 +3775,7 @@ export namespace cloudtasks_v2beta2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$LeaseTasksResponse>(parameters, callback);
@@ -3955,7 +3918,7 @@ export namespace cloudtasks_v2beta2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListTasksResponse>(parameters, callback);
@@ -4086,7 +4049,7 @@ export namespace cloudtasks_v2beta2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Task>(parameters, callback);
@@ -4221,7 +4184,7 @@ export namespace cloudtasks_v2beta2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Task>(parameters, callback);

--- a/src/apis/cloudtasks/v2beta3.ts
+++ b/src/apis/cloudtasks/v2beta3.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace cloudtasks_v2beta3 {
   export interface Options extends GlobalOptions {
     version: 'v2beta3';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -96,22 +98,12 @@ export namespace cloudtasks_v2beta3 {
    * @param {object=} options Options for Cloudtasks
    */
   export class Cloudtasks {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     projects: Resource$Projects;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.projects = new Resource$Projects(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.projects = new Resource$Projects();
     }
   }
 
@@ -899,31 +891,17 @@ export namespace cloudtasks_v2beta3 {
 
 
   export class Resource$Projects {
-    root: Cloudtasks;
     locations: Resource$Projects$Locations;
-    constructor(root: Cloudtasks) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.locations = new Resource$Projects$Locations(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.locations = new Resource$Projects$Locations();
     }
   }
 
 
   export class Resource$Projects$Locations {
-    root: Cloudtasks;
     queues: Resource$Projects$Locations$Queues;
-    constructor(root: Cloudtasks) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.queues = new Resource$Projects$Locations$Queues(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.queues = new Resource$Projects$Locations$Queues();
     }
 
 
@@ -978,7 +956,7 @@ export namespace cloudtasks_v2beta3 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Location>(parameters, callback);
@@ -1049,7 +1027,7 @@ export namespace cloudtasks_v2beta3 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListLocationsResponse>(parameters, callback);
@@ -1097,16 +1075,9 @@ export namespace cloudtasks_v2beta3 {
   }
 
   export class Resource$Projects$Locations$Queues {
-    root: Cloudtasks;
     tasks: Resource$Projects$Locations$Queues$Tasks;
-    constructor(root: Cloudtasks) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.tasks = new Resource$Projects$Locations$Queues$Tasks(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.tasks = new Resource$Projects$Locations$Queues$Tasks();
     }
 
 
@@ -1174,7 +1145,7 @@ export namespace cloudtasks_v2beta3 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Queue>(parameters, callback);
@@ -1246,7 +1217,7 @@ export namespace cloudtasks_v2beta3 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -1307,7 +1278,7 @@ export namespace cloudtasks_v2beta3 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Queue>(parameters, callback);
@@ -1379,7 +1350,7 @@ export namespace cloudtasks_v2beta3 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -1449,7 +1420,7 @@ export namespace cloudtasks_v2beta3 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListQueuesResponse>(parameters, callback);
@@ -1524,7 +1495,7 @@ export namespace cloudtasks_v2beta3 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Queue>(parameters, callback);
@@ -1594,7 +1565,7 @@ export namespace cloudtasks_v2beta3 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Queue>(parameters, callback);
@@ -1664,7 +1635,7 @@ export namespace cloudtasks_v2beta3 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Queue>(parameters, callback);
@@ -1737,7 +1708,7 @@ export namespace cloudtasks_v2beta3 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Queue>(parameters, callback);
@@ -1810,7 +1781,7 @@ export namespace cloudtasks_v2beta3 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -1890,7 +1861,7 @@ export namespace cloudtasks_v2beta3 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TestIamPermissionsResponse>(
@@ -2128,15 +2099,7 @@ export namespace cloudtasks_v2beta3 {
   }
 
   export class Resource$Projects$Locations$Queues$Tasks {
-    root: Cloudtasks;
-    constructor(root: Cloudtasks) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -2199,7 +2162,7 @@ export namespace cloudtasks_v2beta3 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Task>(parameters, callback);
@@ -2267,7 +2230,7 @@ export namespace cloudtasks_v2beta3 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -2329,7 +2292,7 @@ export namespace cloudtasks_v2beta3 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Task>(parameters, callback);
@@ -2402,7 +2365,7 @@ export namespace cloudtasks_v2beta3 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListTasksResponse>(parameters, callback);
@@ -2477,7 +2440,7 @@ export namespace cloudtasks_v2beta3 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Task>(parameters, callback);

--- a/src/apis/cloudtrace/v1.ts
+++ b/src/apis/cloudtrace/v1.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace cloudtrace_v1 {
   export interface Options extends GlobalOptions {
     version: 'v1';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -100,22 +102,12 @@ export namespace cloudtrace_v1 {
    * @param {object=} options Options for Cloudtrace
    */
   export class Cloudtrace {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     projects: Resource$Projects;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.projects = new Resource$Projects(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.projects = new Resource$Projects();
     }
   }
 
@@ -234,16 +226,9 @@ export namespace cloudtrace_v1 {
 
 
   export class Resource$Projects {
-    root: Cloudtrace;
     traces: Resource$Projects$Traces;
-    constructor(root: Cloudtrace) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.traces = new Resource$Projects$Traces(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.traces = new Resource$Projects$Traces();
     }
 
 
@@ -364,7 +349,7 @@ export namespace cloudtrace_v1 {
         params,
         requiredParams: ['projectId'],
         pathParams: ['projectId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -393,15 +378,7 @@ export namespace cloudtrace_v1 {
   }
 
   export class Resource$Projects$Traces {
-    root: Cloudtrace;
-    constructor(root: Cloudtrace) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -513,7 +490,7 @@ export namespace cloudtrace_v1 {
         params,
         requiredParams: ['projectId', 'traceId'],
         pathParams: ['projectId', 'traceId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Trace>(parameters, callback);
@@ -654,7 +631,7 @@ export namespace cloudtrace_v1 {
         params,
         requiredParams: ['projectId'],
         pathParams: ['projectId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListTracesResponse>(parameters, callback);

--- a/src/apis/cloudtrace/v2.ts
+++ b/src/apis/cloudtrace/v2.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace cloudtrace_v2 {
   export interface Options extends GlobalOptions {
     version: 'v2';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -100,22 +102,12 @@ export namespace cloudtrace_v2 {
    * @param {object=} options Options for Cloudtrace
    */
   export class Cloudtrace {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     projects: Resource$Projects;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.projects = new Resource$Projects(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.projects = new Resource$Projects();
     }
   }
 
@@ -534,31 +526,17 @@ export namespace cloudtrace_v2 {
 
 
   export class Resource$Projects {
-    root: Cloudtrace;
     traces: Resource$Projects$Traces;
-    constructor(root: Cloudtrace) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.traces = new Resource$Projects$Traces(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.traces = new Resource$Projects$Traces();
     }
   }
 
 
   export class Resource$Projects$Traces {
-    root: Cloudtrace;
     spans: Resource$Projects$Traces$Spans;
-    constructor(root: Cloudtrace) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.spans = new Resource$Projects$Traces$Spans(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.spans = new Resource$Projects$Traces$Spans();
     }
 
 
@@ -620,7 +598,7 @@ export namespace cloudtrace_v2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -650,15 +628,7 @@ export namespace cloudtrace_v2 {
   }
 
   export class Resource$Projects$Traces$Spans {
-    root: Cloudtrace;
-    constructor(root: Cloudtrace) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -717,7 +687,7 @@ export namespace cloudtrace_v2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Span>(parameters, callback);

--- a/src/apis/composer/v1.ts
+++ b/src/apis/composer/v1.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace composer_v1 {
   export interface Options extends GlobalOptions {
     version: 'v1';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -96,22 +98,12 @@ export namespace composer_v1 {
    * @param {object=} options Options for Composer
    */
   export class Composer {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     projects: Resource$Projects;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.projects = new Resource$Projects(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.projects = new Resource$Projects();
     }
   }
 
@@ -500,47 +492,25 @@ export namespace composer_v1 {
 
 
   export class Resource$Projects {
-    root: Composer;
     locations: Resource$Projects$Locations;
-    constructor(root: Composer) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.locations = new Resource$Projects$Locations(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.locations = new Resource$Projects$Locations();
     }
   }
 
 
   export class Resource$Projects$Locations {
-    root: Composer;
     environments: Resource$Projects$Locations$Environments;
     operations: Resource$Projects$Locations$Operations;
-    constructor(root: Composer) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.environments = new Resource$Projects$Locations$Environments(root);
-      this.operations = new Resource$Projects$Locations$Operations(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.environments = new Resource$Projects$Locations$Environments();
+      this.operations = new Resource$Projects$Locations$Operations();
     }
   }
 
 
   export class Resource$Projects$Locations$Environments {
-    root: Composer;
-    constructor(root: Composer) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -602,7 +572,7 @@ export namespace composer_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -669,7 +639,7 @@ export namespace composer_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -731,7 +701,7 @@ export namespace composer_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Environment>(parameters, callback);
@@ -801,7 +771,7 @@ export namespace composer_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListEnvironmentsResponse>(parameters, callback);
@@ -870,7 +840,7 @@ export namespace composer_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -1043,15 +1013,7 @@ export namespace composer_v1 {
 
 
   export class Resource$Projects$Locations$Operations {
-    root: Composer;
-    constructor(root: Composer) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -1112,7 +1074,7 @@ export namespace composer_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -1176,7 +1138,7 @@ export namespace composer_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -1255,7 +1217,7 @@ export namespace composer_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListOperationsResponse>(parameters, callback);

--- a/src/apis/composer/v1beta1.ts
+++ b/src/apis/composer/v1beta1.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace composer_v1beta1 {
   export interface Options extends GlobalOptions {
     version: 'v1beta1';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -96,22 +98,12 @@ export namespace composer_v1beta1 {
    * @param {object=} options Options for Composer
    */
   export class Composer {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     projects: Resource$Projects;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.projects = new Resource$Projects(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.projects = new Resource$Projects();
     }
   }
 
@@ -515,47 +507,25 @@ export namespace composer_v1beta1 {
 
 
   export class Resource$Projects {
-    root: Composer;
     locations: Resource$Projects$Locations;
-    constructor(root: Composer) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.locations = new Resource$Projects$Locations(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.locations = new Resource$Projects$Locations();
     }
   }
 
 
   export class Resource$Projects$Locations {
-    root: Composer;
     environments: Resource$Projects$Locations$Environments;
     operations: Resource$Projects$Locations$Operations;
-    constructor(root: Composer) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.environments = new Resource$Projects$Locations$Environments(root);
-      this.operations = new Resource$Projects$Locations$Operations(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.environments = new Resource$Projects$Locations$Environments();
+      this.operations = new Resource$Projects$Locations$Operations();
     }
   }
 
 
   export class Resource$Projects$Locations$Environments {
-    root: Composer;
-    constructor(root: Composer) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -617,7 +587,7 @@ export namespace composer_v1beta1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -684,7 +654,7 @@ export namespace composer_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -746,7 +716,7 @@ export namespace composer_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Environment>(parameters, callback);
@@ -816,7 +786,7 @@ export namespace composer_v1beta1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListEnvironmentsResponse>(parameters, callback);
@@ -885,7 +855,7 @@ export namespace composer_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -1058,15 +1028,7 @@ export namespace composer_v1beta1 {
 
 
   export class Resource$Projects$Locations$Operations {
-    root: Composer;
-    constructor(root: Composer) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -1127,7 +1089,7 @@ export namespace composer_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -1191,7 +1153,7 @@ export namespace composer_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -1270,7 +1232,7 @@ export namespace composer_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListOperationsResponse>(parameters, callback);

--- a/src/apis/compute/alpha.ts
+++ b/src/apis/compute/alpha.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace compute_alpha {
   export interface Options extends GlobalOptions {
     version: 'alpha';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -79,10 +81,6 @@ export namespace compute_alpha {
    * @param {object=} options Options for Compute
    */
   export class Compute {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     acceleratorTypes: Resource$Acceleratortypes;
     addresses: Resource$Addresses;
     allocations: Resource$Allocations;
@@ -154,86 +152,79 @@ export namespace compute_alpha {
     zones: Resource$Zones;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.acceleratorTypes = new Resource$Acceleratortypes(this);
-      this.addresses = new Resource$Addresses(this);
-      this.allocations = new Resource$Allocations(this);
-      this.autoscalers = new Resource$Autoscalers(this);
-      this.backendBuckets = new Resource$Backendbuckets(this);
-      this.backendServices = new Resource$Backendservices(this);
-      this.disks = new Resource$Disks(this);
-      this.diskTypes = new Resource$Disktypes(this);
-      this.firewalls = new Resource$Firewalls(this);
-      this.forwardingRules = new Resource$Forwardingrules(this);
-      this.globalAddresses = new Resource$Globaladdresses(this);
-      this.globalForwardingRules = new Resource$Globalforwardingrules(this);
-      this.globalOperations = new Resource$Globaloperations(this);
+      this.acceleratorTypes = new Resource$Acceleratortypes();
+      this.addresses = new Resource$Addresses();
+      this.allocations = new Resource$Allocations();
+      this.autoscalers = new Resource$Autoscalers();
+      this.backendBuckets = new Resource$Backendbuckets();
+      this.backendServices = new Resource$Backendservices();
+      this.disks = new Resource$Disks();
+      this.diskTypes = new Resource$Disktypes();
+      this.firewalls = new Resource$Firewalls();
+      this.forwardingRules = new Resource$Forwardingrules();
+      this.globalAddresses = new Resource$Globaladdresses();
+      this.globalForwardingRules = new Resource$Globalforwardingrules();
+      this.globalOperations = new Resource$Globaloperations();
       this.globalOrganizationOperations =
-          new Resource$Globalorganizationoperations(this);
-      this.healthChecks = new Resource$Healthchecks(this);
-      this.httpHealthChecks = new Resource$Httphealthchecks(this);
-      this.httpsHealthChecks = new Resource$Httpshealthchecks(this);
-      this.images = new Resource$Images(this);
-      this.instanceGroupManagers = new Resource$Instancegroupmanagers(this);
-      this.instanceGroups = new Resource$Instancegroups(this);
-      this.instances = new Resource$Instances(this);
-      this.instanceTemplates = new Resource$Instancetemplates(this);
-      this.interconnectAttachments = new Resource$Interconnectattachments(this);
-      this.interconnectLocations = new Resource$Interconnectlocations(this);
-      this.interconnects = new Resource$Interconnects(this);
-      this.licenseCodes = new Resource$Licensecodes(this);
-      this.licenses = new Resource$Licenses(this);
-      this.machineImages = new Resource$Machineimages(this);
-      this.machineTypes = new Resource$Machinetypes(this);
-      this.networkEndpointGroups = new Resource$Networkendpointgroups(this);
-      this.networks = new Resource$Networks(this);
-      this.nodeGroups = new Resource$Nodegroups(this);
-      this.nodeTemplates = new Resource$Nodetemplates(this);
-      this.nodeTypes = new Resource$Nodetypes(this);
-      this.projects = new Resource$Projects(this);
-      this.regionAutoscalers = new Resource$Regionautoscalers(this);
-      this.regionBackendServices = new Resource$Regionbackendservices(this);
-      this.regionCommitments = new Resource$Regioncommitments(this);
-      this.regionDisks = new Resource$Regiondisks(this);
-      this.regionDiskTypes = new Resource$Regiondisktypes(this);
-      this.regionHealthChecks = new Resource$Regionhealthchecks(this);
+          new Resource$Globalorganizationoperations();
+      this.healthChecks = new Resource$Healthchecks();
+      this.httpHealthChecks = new Resource$Httphealthchecks();
+      this.httpsHealthChecks = new Resource$Httpshealthchecks();
+      this.images = new Resource$Images();
+      this.instanceGroupManagers = new Resource$Instancegroupmanagers();
+      this.instanceGroups = new Resource$Instancegroups();
+      this.instances = new Resource$Instances();
+      this.instanceTemplates = new Resource$Instancetemplates();
+      this.interconnectAttachments = new Resource$Interconnectattachments();
+      this.interconnectLocations = new Resource$Interconnectlocations();
+      this.interconnects = new Resource$Interconnects();
+      this.licenseCodes = new Resource$Licensecodes();
+      this.licenses = new Resource$Licenses();
+      this.machineImages = new Resource$Machineimages();
+      this.machineTypes = new Resource$Machinetypes();
+      this.networkEndpointGroups = new Resource$Networkendpointgroups();
+      this.networks = new Resource$Networks();
+      this.nodeGroups = new Resource$Nodegroups();
+      this.nodeTemplates = new Resource$Nodetemplates();
+      this.nodeTypes = new Resource$Nodetypes();
+      this.projects = new Resource$Projects();
+      this.regionAutoscalers = new Resource$Regionautoscalers();
+      this.regionBackendServices = new Resource$Regionbackendservices();
+      this.regionCommitments = new Resource$Regioncommitments();
+      this.regionDisks = new Resource$Regiondisks();
+      this.regionDiskTypes = new Resource$Regiondisktypes();
+      this.regionHealthChecks = new Resource$Regionhealthchecks();
       this.regionInstanceGroupManagers =
-          new Resource$Regioninstancegroupmanagers(this);
-      this.regionInstanceGroups = new Resource$Regioninstancegroups(this);
-      this.regionOperations = new Resource$Regionoperations(this);
-      this.regions = new Resource$Regions(this);
-      this.regionSslCertificates = new Resource$Regionsslcertificates(this);
-      this.regionTargetHttpProxies = new Resource$Regiontargethttpproxies(this);
-      this.regionTargetHttpsProxies =
-          new Resource$Regiontargethttpsproxies(this);
-      this.regionUrlMaps = new Resource$Regionurlmaps(this);
-      this.resourcePolicies = new Resource$Resourcepolicies(this);
-      this.routers = new Resource$Routers(this);
-      this.routes = new Resource$Routes(this);
-      this.securityPolicies = new Resource$Securitypolicies(this);
-      this.snapshots = new Resource$Snapshots(this);
-      this.sslCertificates = new Resource$Sslcertificates(this);
-      this.sslPolicies = new Resource$Sslpolicies(this);
-      this.subnetworks = new Resource$Subnetworks(this);
-      this.targetHttpProxies = new Resource$Targethttpproxies(this);
-      this.targetHttpsProxies = new Resource$Targethttpsproxies(this);
-      this.targetInstances = new Resource$Targetinstances(this);
-      this.targetPools = new Resource$Targetpools(this);
-      this.targetSslProxies = new Resource$Targetsslproxies(this);
-      this.targetTcpProxies = new Resource$Targettcpproxies(this);
-      this.targetVpnGateways = new Resource$Targetvpngateways(this);
-      this.urlMaps = new Resource$Urlmaps(this);
-      this.vpnGateways = new Resource$Vpngateways(this);
-      this.vpnTunnels = new Resource$Vpntunnels(this);
-      this.zoneOperations = new Resource$Zoneoperations(this);
-      this.zones = new Resource$Zones(this);
-    }
-
-    getRoot() {
-      return this.root;
+          new Resource$Regioninstancegroupmanagers();
+      this.regionInstanceGroups = new Resource$Regioninstancegroups();
+      this.regionOperations = new Resource$Regionoperations();
+      this.regions = new Resource$Regions();
+      this.regionSslCertificates = new Resource$Regionsslcertificates();
+      this.regionTargetHttpProxies = new Resource$Regiontargethttpproxies();
+      this.regionTargetHttpsProxies = new Resource$Regiontargethttpsproxies();
+      this.regionUrlMaps = new Resource$Regionurlmaps();
+      this.resourcePolicies = new Resource$Resourcepolicies();
+      this.routers = new Resource$Routers();
+      this.routes = new Resource$Routes();
+      this.securityPolicies = new Resource$Securitypolicies();
+      this.snapshots = new Resource$Snapshots();
+      this.sslCertificates = new Resource$Sslcertificates();
+      this.sslPolicies = new Resource$Sslpolicies();
+      this.subnetworks = new Resource$Subnetworks();
+      this.targetHttpProxies = new Resource$Targethttpproxies();
+      this.targetHttpsProxies = new Resource$Targethttpsproxies();
+      this.targetInstances = new Resource$Targetinstances();
+      this.targetPools = new Resource$Targetpools();
+      this.targetSslProxies = new Resource$Targetsslproxies();
+      this.targetTcpProxies = new Resource$Targettcpproxies();
+      this.targetVpnGateways = new Resource$Targetvpngateways();
+      this.urlMaps = new Resource$Urlmaps();
+      this.vpnGateways = new Resource$Vpngateways();
+      this.vpnTunnels = new Resource$Vpntunnels();
+      this.zoneOperations = new Resource$Zoneoperations();
+      this.zones = new Resource$Zones();
     }
   }
 
@@ -14151,15 +14142,7 @@ export namespace compute_alpha {
 
 
   export class Resource$Acceleratortypes {
-    root: Compute;
-    constructor(root: Compute) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -14231,7 +14214,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$AcceleratorTypeAggregatedList>(
@@ -14300,7 +14283,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'acceleratorType'],
         pathParams: ['acceleratorType', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$AcceleratorType>(parameters, callback);
@@ -14375,7 +14358,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone'],
         pathParams: ['project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$AcceleratorTypeList>(parameters, callback);
@@ -14522,15 +14505,7 @@ export namespace compute_alpha {
 
 
   export class Resource$Addresses {
-    root: Compute;
-    constructor(root: Compute) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -14597,7 +14572,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$AddressAggregatedList>(parameters, callback);
@@ -14667,7 +14642,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'address'],
         pathParams: ['address', 'project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -14732,7 +14707,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'address'],
         pathParams: ['address', 'project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Address>(parameters, callback);
@@ -14803,7 +14778,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -14876,7 +14851,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$AddressList>(parameters, callback);
@@ -14950,7 +14925,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'resource'],
         pathParams: ['project', 'region', 'resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -15024,7 +14999,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'resource'],
         pathParams: ['project', 'region', 'resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -15297,15 +15272,7 @@ export namespace compute_alpha {
 
 
   export class Resource$Allocations {
-    root: Compute;
-    constructor(root: Compute) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -15372,7 +15339,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$AllocationAggregatedList>(parameters, callback);
@@ -15444,7 +15411,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'allocation'],
         pathParams: ['allocation', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -15510,7 +15477,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'allocation'],
         pathParams: ['allocation', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Allocation>(parameters, callback);
@@ -15581,7 +15548,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'resource'],
         pathParams: ['project', 'resource', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -15653,7 +15620,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone'],
         pathParams: ['project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -15726,7 +15693,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone'],
         pathParams: ['project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$AllocationList>(parameters, callback);
@@ -15798,7 +15765,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'resource'],
         pathParams: ['project', 'resource', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -15872,7 +15839,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'resource'],
         pathParams: ['project', 'resource', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -15945,7 +15912,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'allocation'],
         pathParams: ['allocation', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -16265,15 +16232,7 @@ export namespace compute_alpha {
 
 
   export class Resource$Autoscalers {
-    root: Compute;
-    constructor(root: Compute) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -16340,7 +16299,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$AutoscalerAggregatedList>(parameters, callback);
@@ -16412,7 +16371,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'autoscaler'],
         pathParams: ['autoscaler', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -16479,7 +16438,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'autoscaler'],
         pathParams: ['autoscaler', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Autoscaler>(parameters, callback);
@@ -16552,7 +16511,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone'],
         pathParams: ['project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -16625,7 +16584,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone'],
         pathParams: ['project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$AutoscalerList>(parameters, callback);
@@ -16699,7 +16658,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone'],
         pathParams: ['project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -16773,7 +16732,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'resource'],
         pathParams: ['project', 'resource', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -16847,7 +16806,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone'],
         pathParams: ['project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -17160,15 +17119,7 @@ export namespace compute_alpha {
 
 
   export class Resource$Backendbuckets {
-    root: Compute;
-    constructor(root: Compute) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -17234,7 +17185,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'backendBucket'],
         pathParams: ['backendBucket', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -17305,7 +17256,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'backendBucket'],
         pathParams: ['backendBucket', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -17378,7 +17329,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'backendBucket', 'keyName'],
         pathParams: ['backendBucket', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -17445,7 +17396,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'backendBucket'],
         pathParams: ['backendBucket', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$BackendBucket>(parameters, callback);
@@ -17515,7 +17466,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -17586,7 +17537,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -17658,7 +17609,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$BackendBucketList>(parameters, callback);
@@ -17732,7 +17683,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'backendBucket'],
         pathParams: ['backendBucket', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -17803,7 +17754,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -17876,7 +17827,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -17949,7 +17900,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'backendBucket'],
         pathParams: ['backendBucket', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -18287,15 +18238,7 @@ export namespace compute_alpha {
 
 
   export class Resource$Backendservices {
-    root: Compute;
-    constructor(root: Compute) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -18361,7 +18304,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'backendService'],
         pathParams: ['backendService', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -18441,7 +18384,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$BackendServiceAggregatedList>(
@@ -18514,7 +18457,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'backendService'],
         pathParams: ['backendService', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -18587,7 +18530,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'backendService', 'keyName'],
         pathParams: ['backendService', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -18654,7 +18597,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'backendService'],
         pathParams: ['backendService', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$BackendService>(parameters, callback);
@@ -18728,7 +18671,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'backendService'],
         pathParams: ['backendService', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$BackendServiceGroupHealth>(
@@ -18802,7 +18745,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -18875,7 +18818,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$BackendServiceList>(parameters, callback);
@@ -18951,7 +18894,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'backendService'],
         pathParams: ['backendService', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -19023,7 +18966,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'backendService'],
         pathParams: ['backendService', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -19096,7 +19039,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -19171,7 +19114,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'backendService'],
         pathParams: ['backendService', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -19584,15 +19527,7 @@ export namespace compute_alpha {
 
 
   export class Resource$Disks {
-    root: Compute;
-    constructor(root: Compute) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -19660,7 +19595,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'disk'],
         pathParams: ['disk', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -19733,7 +19668,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$DiskAggregatedList>(parameters, callback);
@@ -19807,7 +19742,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'disk'],
         pathParams: ['disk', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -19880,7 +19815,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'disk'],
         pathParams: ['disk', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -19946,7 +19881,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'disk'],
         pathParams: ['disk', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Disk>(parameters, callback);
@@ -20017,7 +19952,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'resource'],
         pathParams: ['project', 'resource', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -20091,7 +20026,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone'],
         pathParams: ['project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -20162,7 +20097,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone'],
         pathParams: ['project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$DiskList>(parameters, callback);
@@ -20236,7 +20171,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'disk'],
         pathParams: ['disk', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -20308,7 +20243,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'disk'],
         pathParams: ['disk', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -20380,7 +20315,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'resource'],
         pathParams: ['project', 'resource', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -20453,7 +20388,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'resource'],
         pathParams: ['project', 'resource', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -20527,7 +20462,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'resource'],
         pathParams: ['project', 'resource', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -21003,15 +20938,7 @@ export namespace compute_alpha {
 
 
   export class Resource$Disktypes {
-    root: Compute;
-    constructor(root: Compute) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -21078,7 +21005,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$DiskTypeAggregatedList>(parameters, callback);
@@ -21144,7 +21071,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'diskType'],
         pathParams: ['diskType', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$DiskType>(parameters, callback);
@@ -21215,7 +21142,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone'],
         pathParams: ['project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$DiskTypeList>(parameters, callback);
@@ -21360,15 +21287,7 @@ export namespace compute_alpha {
 
 
   export class Resource$Firewalls {
-    root: Compute;
-    constructor(root: Compute) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -21430,7 +21349,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'firewall'],
         pathParams: ['firewall', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -21494,7 +21413,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'firewall'],
         pathParams: ['firewall', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Firewall>(parameters, callback);
@@ -21563,7 +21482,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -21634,7 +21553,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$FirewallList>(parameters, callback);
@@ -21706,7 +21625,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'firewall'],
         pathParams: ['firewall', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -21779,7 +21698,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -21851,7 +21770,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'firewall'],
         pathParams: ['firewall', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -22077,15 +21996,7 @@ export namespace compute_alpha {
 
 
   export class Resource$Forwardingrules {
-    root: Compute;
-    constructor(root: Compute) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -22157,7 +22068,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ForwardingRuleAggregatedList>(
@@ -22231,7 +22142,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'forwardingRule'],
         pathParams: ['forwardingRule', 'project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -22298,7 +22209,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'forwardingRule'],
         pathParams: ['forwardingRule', 'project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ForwardingRule>(parameters, callback);
@@ -22371,7 +22282,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -22446,7 +22357,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ForwardingRuleList>(parameters, callback);
@@ -22522,7 +22433,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'forwardingRule'],
         pathParams: ['forwardingRule', 'project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -22596,7 +22507,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'resource'],
         pathParams: ['project', 'region', 'resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -22670,7 +22581,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'forwardingRule'],
         pathParams: ['forwardingRule', 'project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -22744,7 +22655,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'resource'],
         pathParams: ['project', 'region', 'resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -23097,15 +23008,7 @@ export namespace compute_alpha {
 
 
   export class Resource$Globaladdresses {
-    root: Compute;
-    constructor(root: Compute) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -23169,7 +23072,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'address'],
         pathParams: ['address', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -23235,7 +23138,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'address'],
         pathParams: ['address', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Address>(parameters, callback);
@@ -23306,7 +23209,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -23378,7 +23281,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$AddressList>(parameters, callback);
@@ -23450,7 +23353,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -23523,7 +23426,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -23708,15 +23611,7 @@ export namespace compute_alpha {
 
 
   export class Resource$Globalforwardingrules {
-    root: Compute;
-    constructor(root: Compute) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -23780,7 +23675,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'forwardingRule'],
         pathParams: ['forwardingRule', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -23847,7 +23742,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'forwardingRule'],
         pathParams: ['forwardingRule', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ForwardingRule>(parameters, callback);
@@ -23918,7 +23813,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -23991,7 +23886,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ForwardingRuleList>(parameters, callback);
@@ -24066,7 +23961,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'forwardingRule'],
         pathParams: ['forwardingRule', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -24138,7 +24033,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -24211,7 +24106,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'forwardingRule'],
         pathParams: ['forwardingRule', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -24285,7 +24180,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -24538,15 +24433,7 @@ export namespace compute_alpha {
 
 
   export class Resource$Globaloperations {
-    root: Compute;
-    constructor(root: Compute) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -24613,7 +24500,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$OperationAggregatedList>(parameters, callback);
@@ -24681,7 +24568,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'operation'],
         pathParams: ['operation', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -24748,7 +24635,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'operation'],
         pathParams: ['operation', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -24821,7 +24708,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$OperationList>(parameters, callback);
@@ -24899,7 +24786,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'operation'],
         pathParams: ['operation', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -25070,15 +24957,7 @@ export namespace compute_alpha {
 
 
   export class Resource$Globalorganizationoperations {
-    root: Compute;
-    constructor(root: Compute) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -25139,7 +25018,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['operation'],
         pathParams: ['operation'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -25206,7 +25085,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['operation'],
         pathParams: ['operation'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -25279,7 +25158,7 @@ export namespace compute_alpha {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$OperationList>(parameters, callback);
@@ -25357,7 +25236,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['operation'],
         pathParams: ['operation'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -25473,15 +25352,7 @@ export namespace compute_alpha {
 
 
   export class Resource$Healthchecks {
-    root: Compute;
-    constructor(root: Compute) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -25553,7 +25424,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$HealthChecksAggregatedList>(
@@ -25625,7 +25496,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'healthCheck'],
         pathParams: ['healthCheck', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -25691,7 +25562,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'healthCheck'],
         pathParams: ['healthCheck', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$HealthCheck>(parameters, callback);
@@ -25762,7 +25633,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -25834,7 +25705,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$HealthCheckList>(parameters, callback);
@@ -25907,7 +25778,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'healthCheck'],
         pathParams: ['healthCheck', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -25980,7 +25851,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -26053,7 +25924,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'healthCheck'],
         pathParams: ['healthCheck', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -26339,15 +26210,7 @@ export namespace compute_alpha {
 
 
   export class Resource$Httphealthchecks {
-    root: Compute;
-    constructor(root: Compute) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -26411,7 +26274,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'httpHealthCheck'],
         pathParams: ['httpHealthCheck', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -26478,7 +26341,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'httpHealthCheck'],
         pathParams: ['httpHealthCheck', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$HttpHealthCheck>(parameters, callback);
@@ -26549,7 +26412,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -26622,7 +26485,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$HttpHealthCheckList>(parameters, callback);
@@ -26696,7 +26559,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'httpHealthCheck'],
         pathParams: ['httpHealthCheck', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -26769,7 +26632,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -26842,7 +26705,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'httpHealthCheck'],
         pathParams: ['httpHealthCheck', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -27074,15 +26937,7 @@ export namespace compute_alpha {
 
 
   export class Resource$Httpshealthchecks {
-    root: Compute;
-    constructor(root: Compute) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -27146,7 +27001,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'httpsHealthCheck'],
         pathParams: ['httpsHealthCheck', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -27213,7 +27068,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'httpsHealthCheck'],
         pathParams: ['httpsHealthCheck', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$HttpsHealthCheck>(parameters, callback);
@@ -27285,7 +27140,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -27360,7 +27215,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$HttpsHealthCheckList>(parameters, callback);
@@ -27434,7 +27289,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'httpsHealthCheck'],
         pathParams: ['httpsHealthCheck', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -27507,7 +27362,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -27580,7 +27435,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'httpsHealthCheck'],
         pathParams: ['httpsHealthCheck', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -27812,15 +27667,7 @@ export namespace compute_alpha {
 
 
   export class Resource$Images {
-    root: Compute;
-    constructor(root: Compute) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -27881,7 +27728,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'image'],
         pathParams: ['image', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -27953,7 +27800,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'image'],
         pathParams: ['image', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -28017,7 +27864,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'image'],
         pathParams: ['image', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Image>(parameters, callback);
@@ -28087,7 +27934,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'family'],
         pathParams: ['family', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Image>(parameters, callback);
@@ -28157,7 +28004,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -28226,7 +28073,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -28300,7 +28147,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ImageList>(parameters, callback);
@@ -28371,7 +28218,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -28442,7 +28289,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -28515,7 +28362,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -28785,15 +28632,7 @@ export namespace compute_alpha {
 
 
   export class Resource$Instancegroupmanagers {
-    root: Compute;
-    constructor(root: Compute) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -28872,7 +28711,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'instanceGroupManager'],
         pathParams: ['instanceGroupManager', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -28956,7 +28795,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$InstanceGroupManagerAggregatedList>(
@@ -29034,7 +28873,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'instanceGroupManager'],
         pathParams: ['instanceGroupManager', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -29108,7 +28947,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'instanceGroupManager'],
         pathParams: ['instanceGroupManager', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -29192,7 +29031,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'instanceGroupManager'],
         pathParams: ['instanceGroupManager', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -29268,7 +29107,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'instanceGroupManager'],
         pathParams: ['instanceGroupManager', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -29338,7 +29177,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'instanceGroupManager'],
         pathParams: ['instanceGroupManager', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$InstanceGroupManager>(parameters, callback);
@@ -29417,7 +29256,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone'],
         pathParams: ['project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -29493,7 +29332,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone'],
         pathParams: ['project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$InstanceGroupManagerList>(parameters, callback);
@@ -29583,7 +29422,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'instanceGroupManager'],
         pathParams: ['instanceGroupManager', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<
@@ -29673,7 +29512,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'instanceGroupManager'],
         pathParams: ['instanceGroupManager', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<
@@ -29755,7 +29594,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'instanceGroupManager'],
         pathParams: ['instanceGroupManager', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -29838,7 +29677,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'instanceGroupManager'],
         pathParams: ['instanceGroupManager', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -29925,7 +29764,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'instanceGroupManager', 'size'],
         pathParams: ['instanceGroupManager', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -30009,7 +29848,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'instanceGroupManager'],
         pathParams: ['instanceGroupManager', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -30085,7 +29924,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'instanceGroupManager'],
         pathParams: ['instanceGroupManager', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -30162,7 +30001,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'instanceGroupManager'],
         pathParams: ['instanceGroupManager', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -30240,7 +30079,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'instanceGroupManager'],
         pathParams: ['instanceGroupManager', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -30315,7 +30154,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'resource'],
         pathParams: ['project', 'resource', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -30392,7 +30231,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'instanceGroupManager'],
         pathParams: ['instanceGroupManager', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -30470,7 +30309,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'instanceGroupManager'],
         pathParams: ['instanceGroupManager', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -31309,15 +31148,7 @@ export namespace compute_alpha {
 
 
   export class Resource$Instancegroups {
-    root: Compute;
-    constructor(root: Compute) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -31385,7 +31216,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'instanceGroup'],
         pathParams: ['instanceGroup', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -31464,7 +31295,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$InstanceGroupAggregatedList>(
@@ -31539,7 +31370,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'instanceGroup'],
         pathParams: ['instanceGroup', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -31607,7 +31438,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'instanceGroup'],
         pathParams: ['instanceGroup', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$InstanceGroup>(parameters, callback);
@@ -31680,7 +31511,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone'],
         pathParams: ['project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -31754,7 +31585,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone'],
         pathParams: ['project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$InstanceGroupList>(parameters, callback);
@@ -31836,7 +31667,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'instanceGroup'],
         pathParams: ['instanceGroup', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$InstanceGroupsListInstances>(
@@ -31914,7 +31745,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'instanceGroup'],
         pathParams: ['instanceGroup', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -31987,7 +31818,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'instanceGroup'],
         pathParams: ['instanceGroup', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -32061,7 +31892,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'resource'],
         pathParams: ['project', 'resource', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -32484,15 +32315,7 @@ export namespace compute_alpha {
 
 
   export class Resource$Instances {
-    root: Compute;
-    constructor(root: Compute) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -32559,7 +32382,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'instance', 'networkInterface'],
         pathParams: ['instance', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -32634,7 +32457,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'instance'],
         pathParams: ['instance', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -32709,7 +32532,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$InstanceAggregatedList>(parameters, callback);
@@ -32786,7 +32609,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'instance'],
         pathParams: ['instance', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -32857,7 +32680,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'instance'],
         pathParams: ['instance', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -32932,7 +32755,7 @@ export namespace compute_alpha {
         requiredParams:
             ['project', 'zone', 'instance', 'accessConfig', 'networkInterface'],
         pathParams: ['instance', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -33005,7 +32828,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'instance', 'deviceName'],
         pathParams: ['instance', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -33071,7 +32894,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'instance'],
         pathParams: ['instance', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Instance>(parameters, callback);
@@ -33145,7 +32968,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'instance'],
         pathParams: ['instance', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GuestAttributes>(parameters, callback);
@@ -33216,7 +33039,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'resource'],
         pathParams: ['project', 'resource', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -33291,7 +33114,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'instance'],
         pathParams: ['instance', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$SerialPortOutput>(parameters, callback);
@@ -33363,7 +33186,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'instance'],
         pathParams: ['instance', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ShieldedVmIdentity>(parameters, callback);
@@ -33435,7 +33258,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone'],
         pathParams: ['project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -33507,7 +33330,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone'],
         pathParams: ['project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$InstanceList>(parameters, callback);
@@ -33586,7 +33409,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'instance'],
         pathParams: ['instance', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$InstanceListReferrers>(parameters, callback);
@@ -33660,7 +33483,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'instance'],
         pathParams: ['instance', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -33731,7 +33554,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'instance'],
         pathParams: ['instance', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -33803,7 +33626,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'instance'],
         pathParams: ['instance', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -33877,7 +33700,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'resource'],
         pathParams: ['project', 'resource', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -33952,7 +33775,7 @@ export namespace compute_alpha {
         requiredParams:
             ['project', 'zone', 'instance', 'autoDelete', 'deviceName'],
         pathParams: ['instance', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -34024,7 +33847,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'resource'],
         pathParams: ['project', 'resource', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -34098,7 +33921,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'instance'],
         pathParams: ['instance', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -34172,7 +33995,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'instance'],
         pathParams: ['instance', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -34246,7 +34069,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'instance'],
         pathParams: ['instance', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -34320,7 +34143,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'instance'],
         pathParams: ['instance', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -34395,7 +34218,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'instance'],
         pathParams: ['instance', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -34468,7 +34291,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'instance'],
         pathParams: ['instance', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -34542,7 +34365,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'instance'],
         pathParams: ['instance', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -34619,7 +34442,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'instance'],
         pathParams: ['instance', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -34693,7 +34516,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'instance'],
         pathParams: ['instance', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -34765,7 +34588,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'instance'],
         pathParams: ['instance', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -34836,7 +34659,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'instance'],
         pathParams: ['instance', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -34911,7 +34734,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'instance'],
         pathParams: ['instance', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -34987,7 +34810,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'instance'],
         pathParams: ['instance', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -35065,7 +34888,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'instance'],
         pathParams: ['instance', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -35139,7 +34962,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'resource'],
         pathParams: ['project', 'resource', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -35216,7 +35039,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'instance', 'networkInterface'],
         pathParams: ['instance', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -35292,7 +35115,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'instance', 'networkInterface'],
         pathParams: ['instance', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -35368,7 +35191,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'instance'],
         pathParams: ['instance', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -36825,15 +36648,7 @@ export namespace compute_alpha {
 
 
   export class Resource$Instancetemplates {
-    root: Compute;
-    constructor(root: Compute) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -36899,7 +36714,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'instanceTemplate'],
         pathParams: ['instanceTemplate', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -36966,7 +36781,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'instanceTemplate'],
         pathParams: ['instanceTemplate', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$InstanceTemplate>(parameters, callback);
@@ -37036,7 +36851,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -37111,7 +36926,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -37186,7 +37001,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$InstanceTemplateList>(parameters, callback);
@@ -37257,7 +37072,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -37330,7 +37145,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -37531,15 +37346,7 @@ export namespace compute_alpha {
 
 
   export class Resource$Interconnectattachments {
-    root: Compute;
-    constructor(root: Compute) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -37616,7 +37423,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$InterconnectAttachmentAggregatedList>(
@@ -37690,7 +37497,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'interconnectAttachment'],
         pathParams: ['interconnectAttachment', 'project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -37758,7 +37565,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'interconnectAttachment'],
         pathParams: ['interconnectAttachment', 'project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$InterconnectAttachment>(parameters, callback);
@@ -37829,7 +37636,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'resource'],
         pathParams: ['project', 'region', 'resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -37902,7 +37709,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -37982,7 +37789,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$InterconnectAttachmentList>(
@@ -38058,7 +37865,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'interconnectAttachment'],
         pathParams: ['interconnectAttachment', 'project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -38130,7 +37937,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'resource'],
         pathParams: ['project', 'region', 'resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -38204,7 +38011,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'resource'],
         pathParams: ['project', 'region', 'resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -38280,7 +38087,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'resource'],
         pathParams: ['project', 'region', 'resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -38640,15 +38447,7 @@ export namespace compute_alpha {
 
 
   export class Resource$Interconnectlocations {
-    root: Compute;
-    constructor(root: Compute) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -38709,7 +38508,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'interconnectLocation'],
         pathParams: ['interconnectLocation', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$InterconnectLocation>(parameters, callback);
@@ -38784,7 +38583,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$InterconnectLocationList>(parameters, callback);
@@ -38858,7 +38657,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -38963,15 +38762,7 @@ export namespace compute_alpha {
 
 
   export class Resource$Interconnects {
-    root: Compute;
-    constructor(root: Compute) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -39035,7 +38826,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'interconnect'],
         pathParams: ['interconnect', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -39102,7 +38893,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'interconnect'],
         pathParams: ['interconnect', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Interconnect>(parameters, callback);
@@ -39182,7 +38973,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'interconnect'],
         pathParams: ['interconnect', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$InterconnectsGetDiagnosticsResponse>(
@@ -39254,7 +39045,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -39325,7 +39116,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -39397,7 +39188,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$InterconnectList>(parameters, callback);
@@ -39471,7 +39262,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'interconnect'],
         pathParams: ['interconnect', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -39542,7 +39333,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -39614,7 +39405,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -39687,7 +39478,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -39959,15 +39750,7 @@ export namespace compute_alpha {
 
 
   export class Resource$Licensecodes {
-    root: Compute;
-    constructor(root: Compute) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -40026,7 +39809,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'licenseCode'],
         pathParams: ['licenseCode', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$LicenseCode>(parameters, callback);
@@ -40096,7 +39879,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -40167,7 +39950,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -40240,7 +40023,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -40326,15 +40109,7 @@ export namespace compute_alpha {
 
 
   export class Resource$Licenses {
-    root: Compute;
-    constructor(root: Compute) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -40396,7 +40171,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'license'],
         pathParams: ['license', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -40460,7 +40235,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'license'],
         pathParams: ['license', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$License>(parameters, callback);
@@ -40530,7 +40305,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -40598,7 +40373,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -40674,7 +40449,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$LicensesListResponse>(parameters, callback);
@@ -40745,7 +40520,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -40818,7 +40593,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -41015,15 +40790,7 @@ export namespace compute_alpha {
 
 
   export class Resource$Machineimages {
-    root: Compute;
-    constructor(root: Compute) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -41088,7 +40855,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'machineImage'],
         pathParams: ['machineImage', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -41155,7 +40922,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'machineImage'],
         pathParams: ['machineImage', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$MachineImage>(parameters, callback);
@@ -41225,7 +40992,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -41300,7 +41067,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -41372,7 +41139,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$MachineImageList>(parameters, callback);
@@ -41443,7 +41210,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -41516,7 +41283,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -41721,15 +41488,7 @@ export namespace compute_alpha {
 
 
   export class Resource$Machinetypes {
-    root: Compute;
-    constructor(root: Compute) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -41797,7 +41556,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$MachineTypeAggregatedList>(
@@ -41865,7 +41624,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'machineType'],
         pathParams: ['machineType', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$MachineType>(parameters, callback);
@@ -41939,7 +41698,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone'],
         pathParams: ['project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$MachineTypeList>(parameters, callback);
@@ -42085,15 +41844,7 @@ export namespace compute_alpha {
 
 
   export class Resource$Networkendpointgroups {
-    root: Compute;
-    constructor(root: Compute) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -42170,7 +41921,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$NetworkEndpointGroupAggregatedList>(
@@ -42249,7 +42000,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'networkEndpointGroup'],
         pathParams: ['networkEndpointGroup', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -42324,7 +42075,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'networkEndpointGroup'],
         pathParams: ['networkEndpointGroup', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -42401,7 +42152,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'networkEndpointGroup'],
         pathParams: ['networkEndpointGroup', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -42470,7 +42221,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'networkEndpointGroup'],
         pathParams: ['networkEndpointGroup', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$NetworkEndpointGroup>(parameters, callback);
@@ -42543,7 +42294,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone'],
         pathParams: ['project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -42619,7 +42370,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone'],
         pathParams: ['project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$NetworkEndpointGroupList>(parameters, callback);
@@ -42705,7 +42456,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'networkEndpointGroup'],
         pathParams: ['networkEndpointGroup', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$NetworkEndpointGroupsListNetworkEndpoints>(
@@ -42782,7 +42533,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'resource'],
         pathParams: ['project', 'resource', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -43176,15 +42927,7 @@ export namespace compute_alpha {
 
 
   export class Resource$Networks {
-    root: Compute;
-    constructor(root: Compute) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -43249,7 +42992,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'network'],
         pathParams: ['network', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -43318,7 +43061,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'network'],
         pathParams: ['network', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -43383,7 +43126,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'network'],
         pathParams: ['network', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Network>(parameters, callback);
@@ -43452,7 +43195,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -43522,7 +43265,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$NetworkList>(parameters, callback);
@@ -43598,7 +43341,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'network'],
         pathParams: ['network', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$IpAddressesList>(parameters, callback);
@@ -43677,7 +43420,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'network'],
         pathParams: ['network', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$IpOwnerList>(parameters, callback);
@@ -43760,7 +43503,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'network'],
         pathParams: ['network', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ExchangedPeeringRoutesList>(
@@ -43833,7 +43576,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'network'],
         pathParams: ['network', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -43905,7 +43648,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'network'],
         pathParams: ['network', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -43977,7 +43720,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'network'],
         pathParams: ['network', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -44050,7 +43793,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -44125,7 +43868,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'network'],
         pathParams: ['network', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -44665,15 +44408,7 @@ export namespace compute_alpha {
 
 
   export class Resource$Nodegroups {
-    root: Compute;
-    constructor(root: Compute) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -44739,7 +44474,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'nodeGroup'],
         pathParams: ['nodeGroup', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -44814,7 +44549,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$NodeGroupAggregatedList>(parameters, callback);
@@ -44885,7 +44620,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'nodeGroup'],
         pathParams: ['nodeGroup', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -44958,7 +44693,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'nodeGroup'],
         pathParams: ['nodeGroup', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -45026,7 +44761,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'nodeGroup'],
         pathParams: ['nodeGroup', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$NodeGroup>(parameters, callback);
@@ -45097,7 +44832,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'resource'],
         pathParams: ['project', 'resource', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -45169,7 +44904,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'initialNodeCount'],
         pathParams: ['project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -45241,7 +44976,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone'],
         pathParams: ['project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$NodeGroupList>(parameters, callback);
@@ -45316,7 +45051,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'nodeGroup'],
         pathParams: ['nodeGroup', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$NodeGroupsListNodes>(parameters, callback);
@@ -45388,7 +45123,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'resource'],
         pathParams: ['project', 'resource', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -45461,7 +45196,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'nodeGroup'],
         pathParams: ['nodeGroup', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -45535,7 +45270,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'resource'],
         pathParams: ['project', 'resource', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -45998,15 +45733,7 @@ export namespace compute_alpha {
 
 
   export class Resource$Nodetemplates {
-    root: Compute;
-    constructor(root: Compute) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -46078,7 +45805,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$NodeTemplateAggregatedList>(
@@ -46151,7 +45878,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'nodeTemplate'],
         pathParams: ['nodeTemplate', 'project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -46219,7 +45946,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'nodeTemplate'],
         pathParams: ['nodeTemplate', 'project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$NodeTemplate>(parameters, callback);
@@ -46290,7 +46017,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'resource'],
         pathParams: ['project', 'region', 'resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -46363,7 +46090,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -46437,7 +46164,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$NodeTemplateList>(parameters, callback);
@@ -46509,7 +46236,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'resource'],
         pathParams: ['project', 'region', 'resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -46583,7 +46310,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'resource'],
         pathParams: ['project', 'region', 'resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -46867,15 +46594,7 @@ export namespace compute_alpha {
 
 
   export class Resource$Nodetypes {
-    root: Compute;
-    constructor(root: Compute) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -46942,7 +46661,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$NodeTypeAggregatedList>(parameters, callback);
@@ -47008,7 +46727,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'nodeType'],
         pathParams: ['nodeType', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$NodeType>(parameters, callback);
@@ -47079,7 +46798,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone'],
         pathParams: ['project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$NodeTypeList>(parameters, callback);
@@ -47224,15 +46943,7 @@ export namespace compute_alpha {
 
 
   export class Resource$Projects {
-    root: Compute;
-    constructor(root: Compute) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -47294,7 +47005,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -47365,7 +47076,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -47433,7 +47144,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -47505,7 +47216,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -47566,7 +47277,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Project>(parameters, callback);
@@ -47633,7 +47344,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Project>(parameters, callback);
@@ -47708,7 +47419,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ProjectsGetXpnResources>(parameters, callback);
@@ -47781,7 +47492,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$XpnHostList>(parameters, callback);
@@ -47850,7 +47561,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -47920,7 +47631,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -47993,7 +47704,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -48066,7 +47777,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -48140,7 +47851,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -48213,7 +47924,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -48654,15 +48365,7 @@ export namespace compute_alpha {
 
 
   export class Resource$Regionautoscalers {
-    root: Compute;
-    constructor(root: Compute) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -48727,7 +48430,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'autoscaler'],
         pathParams: ['autoscaler', 'project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -48794,7 +48497,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'autoscaler'],
         pathParams: ['autoscaler', 'project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Autoscaler>(parameters, callback);
@@ -48867,7 +48570,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -48943,7 +48646,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$RegionAutoscalerList>(parameters, callback);
@@ -49018,7 +48721,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -49092,7 +48795,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'resource'],
         pathParams: ['project', 'region', 'resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -49166,7 +48869,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -49426,15 +49129,7 @@ export namespace compute_alpha {
 
 
   export class Resource$Regionbackendservices {
-    root: Compute;
-    constructor(root: Compute) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -49499,7 +49194,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'backendService'],
         pathParams: ['backendService', 'project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -49566,7 +49261,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'backendService'],
         pathParams: ['backendService', 'project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$BackendService>(parameters, callback);
@@ -49642,7 +49337,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'backendService'],
         pathParams: ['backendService', 'project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$BackendServiceGroupHealth>(
@@ -49718,7 +49413,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -49793,7 +49488,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$BackendServiceList>(parameters, callback);
@@ -49871,7 +49566,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'backendService'],
         pathParams: ['backendService', 'project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -49946,7 +49641,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'resource'],
         pathParams: ['project', 'region', 'resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -50022,7 +49717,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'backendService'],
         pathParams: ['backendService', 'project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -50307,15 +50002,7 @@ export namespace compute_alpha {
 
 
   export class Resource$Regioncommitments {
-    root: Compute;
-    constructor(root: Compute) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -50382,7 +50069,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$CommitmentAggregatedList>(parameters, callback);
@@ -50450,7 +50137,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'commitment'],
         pathParams: ['commitment', 'project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Commitment>(parameters, callback);
@@ -50523,7 +50210,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -50598,7 +50285,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$CommitmentList>(parameters, callback);
@@ -50672,7 +50359,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'resource'],
         pathParams: ['project', 'region', 'resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -50878,15 +50565,7 @@ export namespace compute_alpha {
 
 
   export class Resource$Regiondisks {
-    root: Compute;
-    constructor(root: Compute) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -50954,7 +50633,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'disk'],
         pathParams: ['disk', 'project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -51028,7 +50707,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'disk'],
         pathParams: ['disk', 'project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -51103,7 +50782,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'disk'],
         pathParams: ['disk', 'project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -51168,7 +50847,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'disk'],
         pathParams: ['disk', 'project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Disk>(parameters, callback);
@@ -51241,7 +50920,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -51312,7 +50991,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$DiskList>(parameters, callback);
@@ -51386,7 +51065,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'disk'],
         pathParams: ['disk', 'project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -51459,7 +51138,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'disk'],
         pathParams: ['disk', 'project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -51532,7 +51211,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'resource'],
         pathParams: ['project', 'region', 'resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -51606,7 +51285,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'resource'],
         pathParams: ['project', 'region', 'resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -51986,15 +51665,7 @@ export namespace compute_alpha {
 
 
   export class Resource$Regiondisktypes {
-    root: Compute;
-    constructor(root: Compute) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -52054,7 +51725,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'diskType'],
         pathParams: ['diskType', 'project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$DiskType>(parameters, callback);
@@ -52129,7 +51800,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$RegionDiskTypeList>(parameters, callback);
@@ -52221,15 +51892,7 @@ export namespace compute_alpha {
 
 
   export class Resource$Regionhealthchecks {
-    root: Compute;
-    constructor(root: Compute) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -52294,7 +51957,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'healthCheck'],
         pathParams: ['healthCheck', 'project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -52362,7 +52025,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'healthCheck'],
         pathParams: ['healthCheck', 'project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$HealthCheck>(parameters, callback);
@@ -52435,7 +52098,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -52510,7 +52173,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$HealthCheckList>(parameters, callback);
@@ -52585,7 +52248,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'healthCheck'],
         pathParams: ['healthCheck', 'project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -52660,7 +52323,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'resource'],
         pathParams: ['project', 'region', 'resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -52734,7 +52397,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'healthCheck'],
         pathParams: ['healthCheck', 'project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -52994,15 +52657,7 @@ export namespace compute_alpha {
 
 
   export class Resource$Regioninstancegroupmanagers {
-    root: Compute;
-    constructor(root: Compute) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -53082,7 +52737,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'instanceGroupManager'],
         pathParams: ['instanceGroupManager', 'project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -53160,7 +52815,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'instanceGroupManager'],
         pathParams: ['instanceGroupManager', 'project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -53233,7 +52888,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'instanceGroupManager'],
         pathParams: ['instanceGroupManager', 'project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -53319,7 +52974,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'instanceGroupManager'],
         pathParams: ['instanceGroupManager', 'project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -53398,7 +53053,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'instanceGroupManager'],
         pathParams: ['instanceGroupManager', 'project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -53467,7 +53122,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'instanceGroupManager'],
         pathParams: ['instanceGroupManager', 'project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$InstanceGroupManager>(parameters, callback);
@@ -53545,7 +53200,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -53625,7 +53280,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$RegionInstanceGroupManagerList>(
@@ -53717,7 +53372,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'instanceGroupManager'],
         pathParams: ['instanceGroupManager', 'project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<
@@ -53811,7 +53466,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'instanceGroupManager'],
         pathParams: ['instanceGroupManager', 'project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<
@@ -53894,7 +53549,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'instanceGroupManager'],
         pathParams: ['instanceGroupManager', 'project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -53978,7 +53633,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'instanceGroupManager'],
         pathParams: ['instanceGroupManager', 'project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -54060,7 +53715,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'instanceGroupManager', 'size'],
         pathParams: ['instanceGroupManager', 'project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -54140,7 +53795,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'instanceGroupManager'],
         pathParams: ['instanceGroupManager', 'project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -54217,7 +53872,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'instanceGroupManager'],
         pathParams: ['instanceGroupManager', 'project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -54293,7 +53948,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'instanceGroupManager'],
         pathParams: ['instanceGroupManager', 'project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -54369,7 +54024,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'resource'],
         pathParams: ['project', 'region', 'resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -54446,7 +54101,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'instanceGroupManager'],
         pathParams: ['instanceGroupManager', 'project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -54527,7 +54182,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'instanceGroupManager'],
         pathParams: ['instanceGroupManager', 'project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -55266,15 +54921,7 @@ export namespace compute_alpha {
 
 
   export class Resource$Regioninstancegroups {
-    root: Compute;
-    constructor(root: Compute) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -55334,7 +54981,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'instanceGroup'],
         pathParams: ['instanceGroup', 'project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$InstanceGroup>(parameters, callback);
@@ -55410,7 +55057,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$RegionInstanceGroupList>(parameters, callback);
@@ -55499,7 +55146,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'instanceGroup'],
         pathParams: ['instanceGroup', 'project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$RegionInstanceGroupsListInstances>(
@@ -55574,7 +55221,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'instanceGroup'],
         pathParams: ['instanceGroup', 'project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -55649,7 +55296,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'resource'],
         pathParams: ['project', 'region', 'resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -55874,15 +55521,7 @@ export namespace compute_alpha {
 
 
   export class Resource$Regionoperations {
-    root: Compute;
-    constructor(root: Compute) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -55944,7 +55583,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'operation'],
         pathParams: ['operation', 'project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -56011,7 +55650,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'operation'],
         pathParams: ['operation', 'project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -56086,7 +55725,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$OperationList>(parameters, callback);
@@ -56166,7 +55805,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'operation'],
         pathParams: ['operation', 'project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -56298,15 +55937,7 @@ export namespace compute_alpha {
 
 
   export class Resource$Regions {
-    root: Compute;
-    constructor(root: Compute) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -56363,7 +55994,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Region>(parameters, callback);
@@ -56433,7 +56064,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$RegionList>(parameters, callback);
@@ -56515,15 +56146,7 @@ export namespace compute_alpha {
 
 
   export class Resource$Regionsslcertificates {
-    root: Compute;
-    constructor(root: Compute) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -56588,7 +56211,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'sslCertificate'],
         pathParams: ['project', 'region', 'sslCertificate'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -56657,7 +56280,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'sslCertificate'],
         pathParams: ['project', 'region', 'sslCertificate'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$SslCertificate>(parameters, callback);
@@ -56730,7 +56353,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -56805,7 +56428,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$SslCertificateList>(parameters, callback);
@@ -56881,7 +56504,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'resource'],
         pathParams: ['project', 'region', 'resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -57065,15 +56688,7 @@ export namespace compute_alpha {
 
 
   export class Resource$Regiontargethttpproxies {
-    root: Compute;
-    constructor(root: Compute) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -57138,7 +56753,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'targetHttpProxy'],
         pathParams: ['project', 'region', 'targetHttpProxy'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -57207,7 +56822,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'targetHttpProxy'],
         pathParams: ['project', 'region', 'targetHttpProxy'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TargetHttpProxy>(parameters, callback);
@@ -57280,7 +56895,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -57355,7 +56970,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TargetHttpProxyList>(parameters, callback);
@@ -57428,7 +57043,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'targetHttpProxy'],
         pathParams: ['project', 'region', 'targetHttpProxy'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -57504,7 +57119,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'resource'],
         pathParams: ['project', 'region', 'resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -57726,15 +57341,7 @@ export namespace compute_alpha {
 
 
   export class Resource$Regiontargethttpsproxies {
-    root: Compute;
-    constructor(root: Compute) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -57799,7 +57406,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'targetHttpsProxy'],
         pathParams: ['project', 'region', 'targetHttpsProxy'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -57868,7 +57475,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'targetHttpsProxy'],
         pathParams: ['project', 'region', 'targetHttpsProxy'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TargetHttpsProxy>(parameters, callback);
@@ -57941,7 +57548,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -58017,7 +57624,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TargetHttpsProxyList>(parameters, callback);
@@ -58092,7 +57699,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'targetHttpsProxy'],
         pathParams: ['project', 'region', 'targetHttpsProxy'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -58165,7 +57772,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'targetHttpsProxy'],
         pathParams: ['project', 'region', 'targetHttpsProxy'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -58241,7 +57848,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'resource'],
         pathParams: ['project', 'region', 'resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -58502,15 +58109,7 @@ export namespace compute_alpha {
 
 
   export class Resource$Regionurlmaps {
-    root: Compute;
-    constructor(root: Compute) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -58575,7 +58174,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'urlMap'],
         pathParams: ['project', 'region', 'urlMap'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -58642,7 +58241,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'urlMap'],
         pathParams: ['project', 'region', 'urlMap'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$UrlMap>(parameters, callback);
@@ -58715,7 +58314,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -58789,7 +58388,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'urlMap'],
         pathParams: ['project', 'region', 'urlMap'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -58863,7 +58462,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$UrlMapList>(parameters, callback);
@@ -58938,7 +58537,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'urlMap'],
         pathParams: ['project', 'region', 'urlMap'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -59012,7 +58611,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'resource'],
         pathParams: ['project', 'region', 'resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -59086,7 +58685,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'urlMap'],
         pathParams: ['project', 'region', 'urlMap'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -59162,7 +58761,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'urlMap'],
         pathParams: ['project', 'region', 'urlMap'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$UrlMapsValidateResponse>(parameters, callback);
@@ -59445,15 +59044,7 @@ export namespace compute_alpha {
 
 
   export class Resource$Resourcepolicies {
-    root: Compute;
-    constructor(root: Compute) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -59525,7 +59116,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ResourcePolicyAggregatedList>(
@@ -59599,7 +59190,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'resourcePolicy'],
         pathParams: ['project', 'region', 'resourcePolicy'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -59666,7 +59257,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'resourcePolicy'],
         pathParams: ['project', 'region', 'resourcePolicy'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ResourcePolicy>(parameters, callback);
@@ -59737,7 +59328,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'resource'],
         pathParams: ['project', 'region', 'resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -59809,7 +59400,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -59884,7 +59475,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ResourcePolicyList>(parameters, callback);
@@ -59956,7 +59547,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'resource'],
         pathParams: ['project', 'region', 'resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -60030,7 +59621,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'resource'],
         pathParams: ['project', 'region', 'resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -60314,15 +59905,7 @@ export namespace compute_alpha {
 
 
   export class Resource$Routers {
-    root: Compute;
-    constructor(root: Compute) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -60389,7 +59972,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$RouterAggregatedList>(parameters, callback);
@@ -60459,7 +60042,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'router'],
         pathParams: ['project', 'region', 'router'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -60525,7 +60108,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'router'],
         pathParams: ['project', 'region', 'router'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Router>(parameters, callback);
@@ -60603,7 +60186,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'router'],
         pathParams: ['project', 'region', 'router'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$VmEndpointNatMappingsList>(
@@ -60677,7 +60260,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'router'],
         pathParams: ['project', 'region', 'router'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$RouterStatusResponse>(parameters, callback);
@@ -60748,7 +60331,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -60821,7 +60404,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$RouterList>(parameters, callback);
@@ -60894,7 +60477,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'router'],
         pathParams: ['project', 'region', 'router'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -60967,7 +60550,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'router'],
         pathParams: ['project', 'region', 'router'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$RoutersPreviewResponse>(parameters, callback);
@@ -61041,7 +60624,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'resource'],
         pathParams: ['project', 'region', 'resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -61113,7 +60696,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'router'],
         pathParams: ['project', 'region', 'router'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -61530,15 +61113,7 @@ export namespace compute_alpha {
 
 
   export class Resource$Routes {
-    root: Compute;
-    constructor(root: Compute) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -61599,7 +61174,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'route'],
         pathParams: ['project', 'route'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -61663,7 +61238,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'route'],
         pathParams: ['project', 'route'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Route>(parameters, callback);
@@ -61731,7 +61306,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -61801,7 +61376,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$RouteList>(parameters, callback);
@@ -61874,7 +61449,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -62034,15 +61609,7 @@ export namespace compute_alpha {
 
 
   export class Resource$Securitypolicies {
-    root: Compute;
-    constructor(root: Compute) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -62107,7 +61674,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'securityPolicy'],
         pathParams: ['project', 'securityPolicy'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -62178,7 +61745,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'securityPolicy'],
         pathParams: ['project', 'securityPolicy'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -62244,7 +61811,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'securityPolicy'],
         pathParams: ['project', 'securityPolicy'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$SecurityPolicy>(parameters, callback);
@@ -62315,7 +61882,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'securityPolicy'],
         pathParams: ['project', 'securityPolicy'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$SecurityPolicyRule>(parameters, callback);
@@ -62387,7 +61954,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -62460,7 +62027,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$SecurityPolicyList>(parameters, callback);
@@ -62552,7 +62119,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<
@@ -62628,7 +62195,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'securityPolicy'],
         pathParams: ['project', 'securityPolicy'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -62701,7 +62268,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'securityPolicy'],
         pathParams: ['project', 'securityPolicy'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -62772,7 +62339,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'securityPolicy'],
         pathParams: ['project', 'securityPolicy'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -62844,7 +62411,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -62917,7 +62484,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -63289,15 +62856,7 @@ export namespace compute_alpha {
 
 
   export class Resource$Snapshots {
-    root: Compute;
-    constructor(root: Compute) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -63363,7 +62922,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'snapshot'],
         pathParams: ['project', 'snapshot'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -63428,7 +62987,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'snapshot'],
         pathParams: ['project', 'snapshot'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Snapshot>(parameters, callback);
@@ -63498,7 +63057,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -63569,7 +63128,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$SnapshotList>(parameters, callback);
@@ -63640,7 +63199,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -63712,7 +63271,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -63785,7 +63344,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -63974,15 +63533,7 @@ export namespace compute_alpha {
 
 
   export class Resource$Sslcertificates {
-    root: Compute;
-    constructor(root: Compute) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -64055,7 +63606,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$SslCertificateAggregatedList>(
@@ -64128,7 +63679,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'sslCertificate'],
         pathParams: ['project', 'sslCertificate'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -64195,7 +63746,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'sslCertificate'],
         pathParams: ['project', 'sslCertificate'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$SslCertificate>(parameters, callback);
@@ -64266,7 +63817,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -64339,7 +63890,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$SslCertificateList>(parameters, callback);
@@ -64412,7 +63963,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -64631,15 +64182,7 @@ export namespace compute_alpha {
 
 
   export class Resource$Sslpolicies {
-    root: Compute;
-    constructor(root: Compute) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -64705,7 +64248,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'sslPolicy'],
         pathParams: ['project', 'sslPolicy'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -64771,7 +64314,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'sslPolicy'],
         pathParams: ['project', 'sslPolicy'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$SslPolicy>(parameters, callback);
@@ -64842,7 +64385,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -64913,7 +64456,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$SslPoliciesList>(parameters, callback);
@@ -64994,7 +64537,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$SslPoliciesListAvailableFeaturesResponse>(
@@ -65068,7 +64611,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'sslPolicy'],
         pathParams: ['project', 'sslPolicy'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -65141,7 +64684,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -65395,15 +64938,7 @@ export namespace compute_alpha {
 
 
   export class Resource$Subnetworks {
-    root: Compute;
-    constructor(root: Compute) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -65470,7 +65005,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$SubnetworkAggregatedList>(parameters, callback);
@@ -65542,7 +65077,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'subnetwork'],
         pathParams: ['project', 'region', 'subnetwork'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -65615,7 +65150,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'subnetwork'],
         pathParams: ['project', 'region', 'subnetwork'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -65682,7 +65217,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'subnetwork'],
         pathParams: ['project', 'region', 'subnetwork'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Subnetwork>(parameters, callback);
@@ -65753,7 +65288,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'resource'],
         pathParams: ['project', 'region', 'resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -65826,7 +65361,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -65898,7 +65433,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$SubnetworkList>(parameters, callback);
@@ -65978,7 +65513,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$UsableSubnetworksAggregatedList>(
@@ -66057,7 +65592,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'subnetwork'],
         pathParams: ['project', 'region', 'subnetwork'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -66129,7 +65664,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'resource'],
         pathParams: ['project', 'region', 'resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -66204,7 +65739,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'subnetwork'],
         pathParams: ['project', 'region', 'subnetwork'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -66278,7 +65813,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'resource'],
         pathParams: ['project', 'region', 'resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -66740,15 +66275,7 @@ export namespace compute_alpha {
 
 
   export class Resource$Targethttpproxies {
-    root: Compute;
-    constructor(root: Compute) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -66821,7 +66348,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TargetHttpProxyAggregatedList>(
@@ -66894,7 +66421,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'targetHttpProxy'],
         pathParams: ['project', 'targetHttpProxy'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -66961,7 +66488,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'targetHttpProxy'],
         pathParams: ['project', 'targetHttpProxy'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TargetHttpProxy>(parameters, callback);
@@ -67033,7 +66560,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -67107,7 +66634,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TargetHttpProxyList>(parameters, callback);
@@ -67179,7 +66706,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'targetHttpProxy'],
         pathParams: ['project', 'targetHttpProxy'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -67252,7 +66779,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -67505,15 +67032,7 @@ export namespace compute_alpha {
 
 
   export class Resource$Targethttpsproxies {
-    root: Compute;
-    constructor(root: Compute) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -67586,7 +67105,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TargetHttpsProxyAggregatedList>(
@@ -67659,7 +67178,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'targetHttpsProxy'],
         pathParams: ['project', 'targetHttpsProxy'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -67726,7 +67245,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'targetHttpsProxy'],
         pathParams: ['project', 'targetHttpsProxy'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TargetHttpsProxy>(parameters, callback);
@@ -67798,7 +67317,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -67873,7 +67392,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TargetHttpsProxyList>(parameters, callback);
@@ -67945,7 +67464,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'targetHttpsProxy'],
         pathParams: ['project', 'targetHttpsProxy'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -68018,7 +67537,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'targetHttpsProxy'],
         pathParams: ['project', 'targetHttpsProxy'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -68093,7 +67612,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'targetHttpsProxy'],
         pathParams: ['project', 'targetHttpsProxy'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -68165,7 +67684,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'targetHttpsProxy'],
         pathParams: ['project', 'targetHttpsProxy'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -68239,7 +67758,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -68597,15 +68116,7 @@ export namespace compute_alpha {
 
 
   export class Resource$Targetinstances {
-    root: Compute;
-    constructor(root: Compute) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -68677,7 +68188,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TargetInstanceAggregatedList>(
@@ -68751,7 +68262,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'targetInstance'],
         pathParams: ['project', 'targetInstance', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -68819,7 +68330,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'targetInstance'],
         pathParams: ['project', 'targetInstance', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TargetInstance>(parameters, callback);
@@ -68892,7 +68403,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone'],
         pathParams: ['project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -68967,7 +68478,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone'],
         pathParams: ['project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TargetInstanceList>(parameters, callback);
@@ -69041,7 +68552,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'resource'],
         pathParams: ['project', 'resource', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -69280,15 +68791,7 @@ export namespace compute_alpha {
 
 
   export class Resource$Targetpools {
-    root: Compute;
-    constructor(root: Compute) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -69354,7 +68857,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'targetPool'],
         pathParams: ['project', 'region', 'targetPool'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -69427,7 +68930,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'targetPool'],
         pathParams: ['project', 'region', 'targetPool'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -69501,7 +69004,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TargetPoolAggregatedList>(parameters, callback);
@@ -69573,7 +69076,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'targetPool'],
         pathParams: ['project', 'region', 'targetPool'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -69640,7 +69143,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'targetPool'],
         pathParams: ['project', 'region', 'targetPool'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TargetPool>(parameters, callback);
@@ -69715,7 +69218,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'targetPool'],
         pathParams: ['project', 'region', 'targetPool'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TargetPoolInstanceHealth>(parameters, callback);
@@ -69788,7 +69291,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -69861,7 +69364,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TargetPoolList>(parameters, callback);
@@ -69934,7 +69437,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'targetPool'],
         pathParams: ['project', 'region', 'targetPool'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -70007,7 +69510,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'targetPool'],
         pathParams: ['project', 'region', 'targetPool'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -70081,7 +69584,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'targetPool'],
         pathParams: ['project', 'region', 'targetPool'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -70155,7 +69658,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'resource'],
         pathParams: ['project', 'region', 'resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -70611,15 +70114,7 @@ export namespace compute_alpha {
 
 
   export class Resource$Targetsslproxies {
-    root: Compute;
-    constructor(root: Compute) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -70683,7 +70178,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'targetSslProxy'],
         pathParams: ['project', 'targetSslProxy'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -70750,7 +70245,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'targetSslProxy'],
         pathParams: ['project', 'targetSslProxy'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TargetSslProxy>(parameters, callback);
@@ -70821,7 +70316,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -70894,7 +70389,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TargetSslProxyList>(parameters, callback);
@@ -70966,7 +70461,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'targetSslProxy'],
         pathParams: ['project', 'targetSslProxy'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -71038,7 +70533,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'targetSslProxy'],
         pathParams: ['project', 'targetSslProxy'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -71110,7 +70605,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'targetSslProxy'],
         pathParams: ['project', 'targetSslProxy'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -71185,7 +70680,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'targetSslProxy'],
         pathParams: ['project', 'targetSslProxy'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -71258,7 +70753,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -71561,15 +71056,7 @@ export namespace compute_alpha {
 
 
   export class Resource$Targettcpproxies {
-    root: Compute;
-    constructor(root: Compute) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -71633,7 +71120,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'targetTcpProxy'],
         pathParams: ['project', 'targetTcpProxy'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -71700,7 +71187,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'targetTcpProxy'],
         pathParams: ['project', 'targetTcpProxy'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TargetTcpProxy>(parameters, callback);
@@ -71771,7 +71258,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -71844,7 +71331,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TargetTcpProxyList>(parameters, callback);
@@ -71916,7 +71403,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'targetTcpProxy'],
         pathParams: ['project', 'targetTcpProxy'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -71988,7 +71475,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'targetTcpProxy'],
         pathParams: ['project', 'targetTcpProxy'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -72061,7 +71548,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -72294,15 +71781,7 @@ export namespace compute_alpha {
 
 
   export class Resource$Targetvpngateways {
-    root: Compute;
-    constructor(root: Compute) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -72374,7 +71853,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TargetVpnGatewayAggregatedList>(
@@ -72448,7 +71927,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'targetVpnGateway'],
         pathParams: ['project', 'region', 'targetVpnGateway'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -72516,7 +71995,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'targetVpnGateway'],
         pathParams: ['project', 'region', 'targetVpnGateway'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TargetVpnGateway>(parameters, callback);
@@ -72589,7 +72068,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -72665,7 +72144,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TargetVpnGatewayList>(parameters, callback);
@@ -72739,7 +72218,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'resource'],
         pathParams: ['project', 'region', 'resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -72813,7 +72292,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'resource'],
         pathParams: ['project', 'region', 'resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -73090,15 +72569,7 @@ export namespace compute_alpha {
 
 
   export class Resource$Urlmaps {
-    root: Compute;
-    constructor(root: Compute) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -73166,7 +72637,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$UrlMapsAggregatedList>(parameters, callback);
@@ -73234,7 +72705,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'urlMap'],
         pathParams: ['project', 'urlMap'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -73298,7 +72769,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'urlMap'],
         pathParams: ['project', 'urlMap'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$UrlMap>(parameters, callback);
@@ -73367,7 +72838,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -73440,7 +72911,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'urlMap'],
         pathParams: ['project', 'urlMap'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -73511,7 +72982,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$UrlMapList>(parameters, callback);
@@ -73582,7 +73053,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'urlMap'],
         pathParams: ['project', 'urlMap'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -73655,7 +73126,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -73725,7 +73196,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'urlMap'],
         pathParams: ['project', 'urlMap'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -73799,7 +73270,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'urlMap'],
         pathParams: ['project', 'urlMap'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$UrlMapsValidateResponse>(parameters, callback);
@@ -74134,15 +73605,7 @@ export namespace compute_alpha {
 
 
   export class Resource$Vpngateways {
-    root: Compute;
-    constructor(root: Compute) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -74209,7 +73672,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$VpnGatewayAggregatedList>(parameters, callback);
@@ -74281,7 +73744,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'vpnGateway'],
         pathParams: ['project', 'region', 'vpnGateway'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -74348,7 +73811,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'vpnGateway'],
         pathParams: ['project', 'region', 'vpnGateway'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$VpnGateway>(parameters, callback);
@@ -74421,7 +73884,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -74494,7 +73957,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$VpnGatewayList>(parameters, callback);
@@ -74568,7 +74031,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'resource'],
         pathParams: ['project', 'region', 'resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -74642,7 +74105,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'resource'],
         pathParams: ['project', 'region', 'resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -74917,15 +74380,7 @@ export namespace compute_alpha {
 
 
   export class Resource$Vpntunnels {
-    root: Compute;
-    constructor(root: Compute) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -74992,7 +74447,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$VpnTunnelAggregatedList>(parameters, callback);
@@ -75063,7 +74518,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'vpnTunnel'],
         pathParams: ['project', 'region', 'vpnTunnel'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -75130,7 +74585,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'vpnTunnel'],
         pathParams: ['project', 'region', 'vpnTunnel'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$VpnTunnel>(parameters, callback);
@@ -75202,7 +74657,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -75275,7 +74730,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$VpnTunnelList>(parameters, callback);
@@ -75349,7 +74804,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'resource'],
         pathParams: ['project', 'region', 'resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -75423,7 +74878,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'resource'],
         pathParams: ['project', 'region', 'resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -75698,15 +75153,7 @@ export namespace compute_alpha {
 
 
   export class Resource$Zoneoperations {
-    root: Compute;
-    constructor(root: Compute) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -75768,7 +75215,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'operation'],
         pathParams: ['operation', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -75835,7 +75282,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'operation'],
         pathParams: ['operation', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -75908,7 +75355,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone'],
         pathParams: ['project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$OperationList>(parameters, callback);
@@ -75986,7 +75433,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'operation'],
         pathParams: ['operation', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -76118,15 +75565,7 @@ export namespace compute_alpha {
 
 
   export class Resource$Zones {
-    root: Compute;
-    constructor(root: Compute) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -76182,7 +75621,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone'],
         pathParams: ['project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Zone>(parameters, callback);
@@ -76251,7 +75690,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ZoneList>(parameters, callback);

--- a/src/apis/compute/beta.ts
+++ b/src/apis/compute/beta.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace compute_beta {
   export interface Options extends GlobalOptions {
     version: 'beta';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -79,10 +81,6 @@ export namespace compute_beta {
    * @param {object=} options Options for Compute
    */
   export class Compute {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     acceleratorTypes: Resource$Acceleratortypes;
     addresses: Resource$Addresses;
     autoscalers: Resource$Autoscalers;
@@ -145,75 +143,69 @@ export namespace compute_beta {
     zones: Resource$Zones;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.acceleratorTypes = new Resource$Acceleratortypes(this);
-      this.addresses = new Resource$Addresses(this);
-      this.autoscalers = new Resource$Autoscalers(this);
-      this.backendBuckets = new Resource$Backendbuckets(this);
-      this.backendServices = new Resource$Backendservices(this);
-      this.disks = new Resource$Disks(this);
-      this.diskTypes = new Resource$Disktypes(this);
-      this.firewalls = new Resource$Firewalls(this);
-      this.forwardingRules = new Resource$Forwardingrules(this);
-      this.globalAddresses = new Resource$Globaladdresses(this);
-      this.globalForwardingRules = new Resource$Globalforwardingrules(this);
-      this.globalOperations = new Resource$Globaloperations(this);
-      this.healthChecks = new Resource$Healthchecks(this);
-      this.httpHealthChecks = new Resource$Httphealthchecks(this);
-      this.httpsHealthChecks = new Resource$Httpshealthchecks(this);
-      this.images = new Resource$Images(this);
-      this.instanceGroupManagers = new Resource$Instancegroupmanagers(this);
-      this.instanceGroups = new Resource$Instancegroups(this);
-      this.instances = new Resource$Instances(this);
-      this.instanceTemplates = new Resource$Instancetemplates(this);
-      this.interconnectAttachments = new Resource$Interconnectattachments(this);
-      this.interconnectLocations = new Resource$Interconnectlocations(this);
-      this.interconnects = new Resource$Interconnects(this);
-      this.licenseCodes = new Resource$Licensecodes(this);
-      this.licenses = new Resource$Licenses(this);
-      this.machineTypes = new Resource$Machinetypes(this);
-      this.networkEndpointGroups = new Resource$Networkendpointgroups(this);
-      this.networks = new Resource$Networks(this);
-      this.nodeGroups = new Resource$Nodegroups(this);
-      this.nodeTemplates = new Resource$Nodetemplates(this);
-      this.nodeTypes = new Resource$Nodetypes(this);
-      this.projects = new Resource$Projects(this);
-      this.regionAutoscalers = new Resource$Regionautoscalers(this);
-      this.regionBackendServices = new Resource$Regionbackendservices(this);
-      this.regionCommitments = new Resource$Regioncommitments(this);
-      this.regionDisks = new Resource$Regiondisks(this);
-      this.regionDiskTypes = new Resource$Regiondisktypes(this);
+      this.acceleratorTypes = new Resource$Acceleratortypes();
+      this.addresses = new Resource$Addresses();
+      this.autoscalers = new Resource$Autoscalers();
+      this.backendBuckets = new Resource$Backendbuckets();
+      this.backendServices = new Resource$Backendservices();
+      this.disks = new Resource$Disks();
+      this.diskTypes = new Resource$Disktypes();
+      this.firewalls = new Resource$Firewalls();
+      this.forwardingRules = new Resource$Forwardingrules();
+      this.globalAddresses = new Resource$Globaladdresses();
+      this.globalForwardingRules = new Resource$Globalforwardingrules();
+      this.globalOperations = new Resource$Globaloperations();
+      this.healthChecks = new Resource$Healthchecks();
+      this.httpHealthChecks = new Resource$Httphealthchecks();
+      this.httpsHealthChecks = new Resource$Httpshealthchecks();
+      this.images = new Resource$Images();
+      this.instanceGroupManagers = new Resource$Instancegroupmanagers();
+      this.instanceGroups = new Resource$Instancegroups();
+      this.instances = new Resource$Instances();
+      this.instanceTemplates = new Resource$Instancetemplates();
+      this.interconnectAttachments = new Resource$Interconnectattachments();
+      this.interconnectLocations = new Resource$Interconnectlocations();
+      this.interconnects = new Resource$Interconnects();
+      this.licenseCodes = new Resource$Licensecodes();
+      this.licenses = new Resource$Licenses();
+      this.machineTypes = new Resource$Machinetypes();
+      this.networkEndpointGroups = new Resource$Networkendpointgroups();
+      this.networks = new Resource$Networks();
+      this.nodeGroups = new Resource$Nodegroups();
+      this.nodeTemplates = new Resource$Nodetemplates();
+      this.nodeTypes = new Resource$Nodetypes();
+      this.projects = new Resource$Projects();
+      this.regionAutoscalers = new Resource$Regionautoscalers();
+      this.regionBackendServices = new Resource$Regionbackendservices();
+      this.regionCommitments = new Resource$Regioncommitments();
+      this.regionDisks = new Resource$Regiondisks();
+      this.regionDiskTypes = new Resource$Regiondisktypes();
       this.regionInstanceGroupManagers =
-          new Resource$Regioninstancegroupmanagers(this);
-      this.regionInstanceGroups = new Resource$Regioninstancegroups(this);
-      this.regionOperations = new Resource$Regionoperations(this);
-      this.regions = new Resource$Regions(this);
-      this.resourcePolicies = new Resource$Resourcepolicies(this);
-      this.routers = new Resource$Routers(this);
-      this.routes = new Resource$Routes(this);
-      this.securityPolicies = new Resource$Securitypolicies(this);
-      this.snapshots = new Resource$Snapshots(this);
-      this.sslCertificates = new Resource$Sslcertificates(this);
-      this.sslPolicies = new Resource$Sslpolicies(this);
-      this.subnetworks = new Resource$Subnetworks(this);
-      this.targetHttpProxies = new Resource$Targethttpproxies(this);
-      this.targetHttpsProxies = new Resource$Targethttpsproxies(this);
-      this.targetInstances = new Resource$Targetinstances(this);
-      this.targetPools = new Resource$Targetpools(this);
-      this.targetSslProxies = new Resource$Targetsslproxies(this);
-      this.targetTcpProxies = new Resource$Targettcpproxies(this);
-      this.targetVpnGateways = new Resource$Targetvpngateways(this);
-      this.urlMaps = new Resource$Urlmaps(this);
-      this.vpnTunnels = new Resource$Vpntunnels(this);
-      this.zoneOperations = new Resource$Zoneoperations(this);
-      this.zones = new Resource$Zones(this);
-    }
-
-    getRoot() {
-      return this.root;
+          new Resource$Regioninstancegroupmanagers();
+      this.regionInstanceGroups = new Resource$Regioninstancegroups();
+      this.regionOperations = new Resource$Regionoperations();
+      this.regions = new Resource$Regions();
+      this.resourcePolicies = new Resource$Resourcepolicies();
+      this.routers = new Resource$Routers();
+      this.routes = new Resource$Routes();
+      this.securityPolicies = new Resource$Securitypolicies();
+      this.snapshots = new Resource$Snapshots();
+      this.sslCertificates = new Resource$Sslcertificates();
+      this.sslPolicies = new Resource$Sslpolicies();
+      this.subnetworks = new Resource$Subnetworks();
+      this.targetHttpProxies = new Resource$Targethttpproxies();
+      this.targetHttpsProxies = new Resource$Targethttpsproxies();
+      this.targetInstances = new Resource$Targetinstances();
+      this.targetPools = new Resource$Targetpools();
+      this.targetSslProxies = new Resource$Targetsslproxies();
+      this.targetTcpProxies = new Resource$Targettcpproxies();
+      this.targetVpnGateways = new Resource$Targetvpngateways();
+      this.urlMaps = new Resource$Urlmaps();
+      this.vpnTunnels = new Resource$Vpntunnels();
+      this.zoneOperations = new Resource$Zoneoperations();
+      this.zones = new Resource$Zones();
     }
   }
 
@@ -12139,15 +12131,7 @@ export namespace compute_beta {
 
 
   export class Resource$Acceleratortypes {
-    root: Compute;
-    constructor(root: Compute) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -12286,7 +12270,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$AcceleratorTypeAggregatedList>(
@@ -12415,7 +12399,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone', 'acceleratorType'],
         pathParams: ['acceleratorType', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$AcceleratorType>(parameters, callback);
@@ -12559,7 +12543,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone'],
         pathParams: ['project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$AcceleratorTypeList>(parameters, callback);
@@ -12706,15 +12690,7 @@ export namespace compute_beta {
 
 
   export class Resource$Addresses {
-    root: Compute;
-    constructor(root: Compute) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -12848,7 +12824,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$AddressAggregatedList>(parameters, callback);
@@ -12977,7 +12953,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region', 'address'],
         pathParams: ['address', 'project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -13101,7 +13077,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region', 'address'],
         pathParams: ['address', 'project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Address>(parameters, callback);
@@ -13232,7 +13208,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -13374,7 +13350,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$AddressList>(parameters, callback);
@@ -13511,7 +13487,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region', 'resource'],
         pathParams: ['project', 'region', 'resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -13648,7 +13624,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region', 'resource'],
         pathParams: ['project', 'region', 'resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -13921,15 +13897,7 @@ export namespace compute_beta {
 
 
   export class Resource$Autoscalers {
-    root: Compute;
-    constructor(root: Compute) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -14063,7 +14031,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$AutoscalerAggregatedList>(parameters, callback);
@@ -14194,7 +14162,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone', 'autoscaler'],
         pathParams: ['autoscaler', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -14320,7 +14288,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone', 'autoscaler'],
         pathParams: ['autoscaler', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Autoscaler>(parameters, callback);
@@ -14452,7 +14420,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone'],
         pathParams: ['project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -14593,7 +14561,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone'],
         pathParams: ['project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$AutoscalerList>(parameters, callback);
@@ -14728,7 +14696,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone'],
         pathParams: ['project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -14863,7 +14831,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone', 'resource'],
         pathParams: ['project', 'resource', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -14998,7 +14966,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone'],
         pathParams: ['project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -15311,15 +15279,7 @@ export namespace compute_beta {
 
 
   export class Resource$Backendbuckets {
-    root: Compute;
-    constructor(root: Compute) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -15385,7 +15345,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'backendBucket'],
         pathParams: ['backendBucket', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -15513,7 +15473,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'backendBucket'],
         pathParams: ['backendBucket', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -15586,7 +15546,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'backendBucket', 'keyName'],
         pathParams: ['backendBucket', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -15710,7 +15670,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'backendBucket'],
         pathParams: ['backendBucket', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$BackendBucket>(parameters, callback);
@@ -15838,7 +15798,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -15976,7 +15936,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$BackendBucketList>(parameters, callback);
@@ -16113,7 +16073,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'backendBucket'],
         pathParams: ['backendBucket', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -16249,7 +16209,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'backendBucket'],
         pathParams: ['backendBucket', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -16529,15 +16489,7 @@ export namespace compute_beta {
 
 
   export class Resource$Backendservices {
-    root: Compute;
-    constructor(root: Compute) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -16603,7 +16555,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'backendService'],
         pathParams: ['backendService', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -16750,7 +16702,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$BackendServiceAggregatedList>(
@@ -16880,7 +16832,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'backendService'],
         pathParams: ['backendService', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -16953,7 +16905,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'backendService', 'keyName'],
         pathParams: ['backendService', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -17077,7 +17029,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'backendService'],
         pathParams: ['backendService', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$BackendService>(parameters, callback);
@@ -17211,7 +17163,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'backendService'],
         pathParams: ['backendService', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$BackendServiceGroupHealth>(
@@ -17342,7 +17294,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -17481,7 +17433,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$BackendServiceList>(parameters, callback);
@@ -17620,7 +17572,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'backendService'],
         pathParams: ['backendService', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -17753,7 +17705,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'backendService'],
         pathParams: ['backendService', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -17884,7 +17836,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -18022,7 +17974,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'backendService'],
         pathParams: ['backendService', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -18435,15 +18387,7 @@ export namespace compute_beta {
 
 
   export class Resource$Disks {
-    root: Compute;
-    constructor(root: Compute) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -18511,7 +18455,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone', 'disk'],
         pathParams: ['disk', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -18651,7 +18595,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$DiskAggregatedList>(parameters, callback);
@@ -18788,7 +18732,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone', 'disk'],
         pathParams: ['disk', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -18920,7 +18864,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone', 'disk'],
         pathParams: ['disk', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -19045,7 +18989,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone', 'disk'],
         pathParams: ['disk', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Disk>(parameters, callback);
@@ -19116,7 +19060,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone', 'resource'],
         pathParams: ['project', 'resource', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -19250,7 +19194,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone'],
         pathParams: ['project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -19390,7 +19334,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone'],
         pathParams: ['project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$DiskList>(parameters, callback);
@@ -19464,7 +19408,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone', 'disk'],
         pathParams: ['disk', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -19599,7 +19543,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone', 'disk'],
         pathParams: ['disk', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -19671,7 +19615,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone', 'resource'],
         pathParams: ['project', 'resource', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -19807,7 +19751,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone', 'resource'],
         pathParams: ['project', 'resource', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -19944,7 +19888,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone', 'resource'],
         pathParams: ['project', 'resource', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -20420,15 +20364,7 @@ export namespace compute_beta {
 
 
   export class Resource$Disktypes {
-    root: Compute;
-    constructor(root: Compute) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -20562,7 +20498,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$DiskTypeAggregatedList>(parameters, callback);
@@ -20687,7 +20623,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone', 'diskType'],
         pathParams: ['diskType', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$DiskType>(parameters, callback);
@@ -20827,7 +20763,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone'],
         pathParams: ['project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$DiskTypeList>(parameters, callback);
@@ -20972,15 +20908,7 @@ export namespace compute_beta {
 
 
   export class Resource$Firewalls {
-    root: Compute;
-    constructor(root: Compute) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -21098,7 +21026,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'firewall'],
         pathParams: ['firewall', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -21218,7 +21146,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'firewall'],
         pathParams: ['firewall', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Firewall>(parameters, callback);
@@ -21344,7 +21272,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -21481,7 +21409,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$FirewallList>(parameters, callback);
@@ -21615,7 +21543,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'firewall'],
         pathParams: ['firewall', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -21748,7 +21676,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -21882,7 +21810,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'firewall'],
         pathParams: ['firewall', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -22108,15 +22036,7 @@ export namespace compute_beta {
 
 
   export class Resource$Forwardingrules {
-    root: Compute;
-    constructor(root: Compute) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -22255,7 +22175,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ForwardingRuleAggregatedList>(
@@ -22389,7 +22309,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region', 'forwardingRule'],
         pathParams: ['forwardingRule', 'project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -22516,7 +22436,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region', 'forwardingRule'],
         pathParams: ['forwardingRule', 'project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ForwardingRule>(parameters, callback);
@@ -22649,7 +22569,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -22793,7 +22713,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ForwardingRuleList>(parameters, callback);
@@ -22930,7 +22850,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region', 'resource'],
         pathParams: ['project', 'region', 'resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -23068,7 +22988,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region', 'forwardingRule'],
         pathParams: ['forwardingRule', 'project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -23203,7 +23123,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region', 'resource'],
         pathParams: ['project', 'region', 'resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -23518,15 +23438,7 @@ export namespace compute_beta {
 
 
   export class Resource$Globaladdresses {
-    root: Compute;
-    constructor(root: Compute) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -23646,7 +23558,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'address'],
         pathParams: ['address', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -23768,7 +23680,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'address'],
         pathParams: ['address', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Address>(parameters, callback);
@@ -23896,7 +23808,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -24034,7 +23946,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$AddressList>(parameters, callback);
@@ -24166,7 +24078,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -24297,7 +24209,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -24482,15 +24394,7 @@ export namespace compute_beta {
 
 
   export class Resource$Globalforwardingrules {
-    root: Compute;
-    constructor(root: Compute) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -24611,7 +24515,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'forwardingRule'],
         pathParams: ['forwardingRule', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -24735,7 +24639,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'forwardingRule'],
         pathParams: ['forwardingRule', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ForwardingRule>(parameters, callback);
@@ -24863,7 +24767,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -25002,7 +24906,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ForwardingRuleList>(parameters, callback);
@@ -25132,7 +25036,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -25264,7 +25168,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'forwardingRule'],
         pathParams: ['forwardingRule', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -25396,7 +25300,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -25615,15 +25519,7 @@ export namespace compute_beta {
 
 
   export class Resource$Globaloperations {
-    root: Compute;
-    constructor(root: Compute) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -25757,7 +25653,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$OperationAggregatedList>(parameters, callback);
@@ -25878,7 +25774,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'operation'],
         pathParams: ['operation', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -26001,7 +25897,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'operation'],
         pathParams: ['operation', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -26140,7 +26036,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$OperationList>(parameters, callback);
@@ -26295,15 +26191,7 @@ export namespace compute_beta {
 
 
   export class Resource$Healthchecks {
-    root: Compute;
-    constructor(root: Compute) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -26423,7 +26311,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'healthCheck'],
         pathParams: ['healthCheck', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -26545,7 +26433,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'healthCheck'],
         pathParams: ['healthCheck', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$HealthCheck>(parameters, callback);
@@ -26673,7 +26561,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -26811,7 +26699,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$HealthCheckList>(parameters, callback);
@@ -26946,7 +26834,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'healthCheck'],
         pathParams: ['healthCheck', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -27077,7 +26965,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -27212,7 +27100,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'healthCheck'],
         pathParams: ['healthCheck', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -27443,15 +27331,7 @@ export namespace compute_beta {
 
 
   export class Resource$Httphealthchecks {
-    root: Compute;
-    constructor(root: Compute) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -27572,7 +27452,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'httpHealthCheck'],
         pathParams: ['httpHealthCheck', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -27696,7 +27576,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'httpHealthCheck'],
         pathParams: ['httpHealthCheck', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$HttpHealthCheck>(parameters, callback);
@@ -27824,7 +27704,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -27963,7 +27843,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$HttpHealthCheckList>(parameters, callback);
@@ -28100,7 +27980,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'httpHealthCheck'],
         pathParams: ['httpHealthCheck', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -28231,7 +28111,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -28367,7 +28247,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'httpHealthCheck'],
         pathParams: ['httpHealthCheck', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -28599,15 +28479,7 @@ export namespace compute_beta {
 
 
   export class Resource$Httpshealthchecks {
-    root: Compute;
-    constructor(root: Compute) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -28728,7 +28600,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'httpsHealthCheck'],
         pathParams: ['httpsHealthCheck', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -28852,7 +28724,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'httpsHealthCheck'],
         pathParams: ['httpsHealthCheck', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$HttpsHealthCheck>(parameters, callback);
@@ -28980,7 +28852,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -29120,7 +28992,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$HttpsHealthCheckList>(parameters, callback);
@@ -29257,7 +29129,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'httpsHealthCheck'],
         pathParams: ['httpsHealthCheck', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -29388,7 +29260,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -29524,7 +29396,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'httpsHealthCheck'],
         pathParams: ['httpsHealthCheck', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -29756,15 +29628,7 @@ export namespace compute_beta {
 
 
   export class Resource$Images {
-    root: Compute;
-    constructor(root: Compute) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -29881,7 +29745,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'image'],
         pathParams: ['image', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -30013,7 +29877,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'image'],
         pathParams: ['image', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -30133,7 +29997,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'image'],
         pathParams: ['image', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Image>(parameters, callback);
@@ -30259,7 +30123,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'family'],
         pathParams: ['family', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Image>(parameters, callback);
@@ -30329,7 +30193,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -30455,7 +30319,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -30595,7 +30459,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ImageList>(parameters, callback);
@@ -30666,7 +30530,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -30797,7 +30661,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -30930,7 +30794,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -31200,15 +31064,7 @@ export namespace compute_beta {
 
 
   export class Resource$Instancegroupmanagers {
-    root: Compute;
-    constructor(root: Compute) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -31349,7 +31205,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone', 'instanceGroupManager'],
         pathParams: ['instanceGroupManager', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -31500,7 +31356,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$InstanceGroupManagerAggregatedList>(
@@ -31636,7 +31492,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone', 'instanceGroupManager'],
         pathParams: ['instanceGroupManager', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -31782,7 +31638,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone', 'instanceGroupManager'],
         pathParams: ['instanceGroupManager', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -31912,7 +31768,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone', 'instanceGroupManager'],
         pathParams: ['instanceGroupManager', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$InstanceGroupManager>(parameters, callback);
@@ -32051,7 +31907,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone'],
         pathParams: ['project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -32196,7 +32052,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone'],
         pathParams: ['project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$InstanceGroupManagerList>(parameters, callback);
@@ -32362,7 +32218,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone', 'instanceGroupManager'],
         pathParams: ['instanceGroupManager', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<
@@ -32511,7 +32367,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone', 'instanceGroupManager'],
         pathParams: ['instanceGroupManager', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -32656,7 +32512,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone', 'instanceGroupManager'],
         pathParams: ['instanceGroupManager', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -32810,7 +32666,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone', 'instanceGroupManager', 'size'],
         pathParams: ['instanceGroupManager', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -32956,7 +32812,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone', 'instanceGroupManager'],
         pathParams: ['instanceGroupManager', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -33094,7 +32950,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone', 'instanceGroupManager'],
         pathParams: ['instanceGroupManager', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -33233,7 +33089,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone', 'instanceGroupManager'],
         pathParams: ['instanceGroupManager', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -33373,7 +33229,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone', 'instanceGroupManager'],
         pathParams: ['instanceGroupManager', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -33509,7 +33365,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone', 'resource'],
         pathParams: ['project', 'resource', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -33652,7 +33508,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone', 'instanceGroupManager'],
         pathParams: ['instanceGroupManager', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -34336,15 +34192,7 @@ export namespace compute_beta {
 
 
   export class Resource$Instancegroups {
-    root: Compute;
-    constructor(root: Compute) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -34476,7 +34324,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone', 'instanceGroup'],
         pathParams: ['instanceGroup', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -34622,7 +34470,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$InstanceGroupAggregatedList>(
@@ -34757,7 +34605,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone', 'instanceGroup'],
         pathParams: ['instanceGroup', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -34885,7 +34733,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone', 'instanceGroup'],
         pathParams: ['instanceGroup', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$InstanceGroup>(parameters, callback);
@@ -35018,7 +34866,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone'],
         pathParams: ['project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -35161,7 +35009,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone'],
         pathParams: ['project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$InstanceGroupList>(parameters, callback);
@@ -35320,7 +35168,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone', 'instanceGroup'],
         pathParams: ['instanceGroup', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$InstanceGroupsListInstances>(
@@ -35460,7 +35308,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone', 'instanceGroup'],
         pathParams: ['instanceGroup', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -35597,7 +35445,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone', 'instanceGroup'],
         pathParams: ['instanceGroup', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -35732,7 +35580,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone', 'resource'],
         pathParams: ['project', 'resource', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -36155,15 +36003,7 @@ export namespace compute_beta {
 
 
   export class Resource$Instances {
-    root: Compute;
-    constructor(root: Compute) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -36296,7 +36136,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone', 'instance', 'networkInterface'],
         pathParams: ['instance', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -36438,7 +36278,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$InstanceAggregatedList>(parameters, callback);
@@ -36578,7 +36418,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone', 'instance'],
         pathParams: ['instance', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -36708,7 +36548,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone', 'instance'],
         pathParams: ['instance', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -36848,7 +36688,7 @@ export namespace compute_beta {
         requiredParams:
             ['project', 'zone', 'instance', 'accessConfig', 'networkInterface'],
         pathParams: ['instance', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -36983,7 +36823,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone', 'instance', 'deviceName'],
         pathParams: ['instance', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -37108,7 +36948,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone', 'instance'],
         pathParams: ['instance', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Instance>(parameters, callback);
@@ -37182,7 +37022,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone', 'instance'],
         pathParams: ['instance', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GuestAttributes>(parameters, callback);
@@ -37253,7 +37093,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone', 'resource'],
         pathParams: ['project', 'resource', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -37385,7 +37225,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone', 'instance'],
         pathParams: ['instance', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$SerialPortOutput>(parameters, callback);
@@ -37457,7 +37297,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone', 'instance'],
         pathParams: ['instance', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ShieldedVmIdentity>(parameters, callback);
@@ -37588,7 +37428,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone'],
         pathParams: ['project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -37729,7 +37569,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone'],
         pathParams: ['project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$InstanceList>(parameters, callback);
@@ -37882,7 +37722,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone', 'instance'],
         pathParams: ['instance', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$InstanceListReferrers>(parameters, callback);
@@ -38012,7 +37852,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone', 'instance'],
         pathParams: ['instance', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -38084,7 +37924,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone', 'instance'],
         pathParams: ['instance', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -38215,7 +38055,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone', 'resource'],
         pathParams: ['project', 'resource', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -38355,7 +38195,7 @@ export namespace compute_beta {
         requiredParams:
             ['project', 'zone', 'instance', 'autoDelete', 'deviceName'],
         pathParams: ['instance', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -38427,7 +38267,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone', 'resource'],
         pathParams: ['project', 'resource', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -38564,7 +38404,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone', 'instance'],
         pathParams: ['instance', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -38699,7 +38539,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone', 'instance'],
         pathParams: ['instance', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -38836,7 +38676,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone', 'instance'],
         pathParams: ['instance', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -38973,7 +38813,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone', 'instance'],
         pathParams: ['instance', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -39111,7 +38951,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone', 'instance'],
         pathParams: ['instance', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -39247,7 +39087,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone', 'instance'],
         pathParams: ['instance', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -39384,7 +39224,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone', 'instance'],
         pathParams: ['instance', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -39461,7 +39301,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone', 'instance'],
         pathParams: ['instance', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -39598,7 +39438,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone', 'instance'],
         pathParams: ['instance', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -39670,7 +39510,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone', 'instance'],
         pathParams: ['instance', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -39800,7 +39640,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone', 'instance'],
         pathParams: ['instance', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -39936,7 +39776,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone', 'instance'],
         pathParams: ['instance', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -40070,7 +39910,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone', 'instance'],
         pathParams: ['instance', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -40148,7 +39988,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone', 'instance'],
         pathParams: ['instance', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -40285,7 +40125,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone', 'resource'],
         pathParams: ['project', 'resource', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -40428,7 +40268,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone', 'instance', 'networkInterface'],
         pathParams: ['instance', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -40570,7 +40410,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone', 'instance', 'networkInterface'],
         pathParams: ['instance', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -40646,7 +40486,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone', 'instance'],
         pathParams: ['instance', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -42013,15 +41853,7 @@ export namespace compute_beta {
 
 
   export class Resource$Instancetemplates {
-    root: Compute;
-    constructor(root: Compute) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -42144,7 +41976,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'instanceTemplate'],
         pathParams: ['instanceTemplate', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -42268,7 +42100,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'instanceTemplate'],
         pathParams: ['instanceTemplate', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$InstanceTemplate>(parameters, callback);
@@ -42338,7 +42170,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -42469,7 +42301,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -42609,7 +42441,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$InstanceTemplateList>(parameters, callback);
@@ -42680,7 +42512,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -42811,7 +42643,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -43012,15 +42844,7 @@ export namespace compute_beta {
 
 
   export class Resource$Interconnectattachments {
-    root: Compute;
-    constructor(root: Compute) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -43165,7 +42989,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$InterconnectAttachmentAggregatedList>(
@@ -43297,7 +43121,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region', 'interconnectAttachment'],
         pathParams: ['interconnectAttachment', 'project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -43425,7 +43249,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region', 'interconnectAttachment'],
         pathParams: ['interconnectAttachment', 'project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$InterconnectAttachment>(parameters, callback);
@@ -43556,7 +43380,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -43705,7 +43529,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$InterconnectAttachmentList>(
@@ -43781,7 +43605,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region', 'interconnectAttachment'],
         pathParams: ['interconnectAttachment', 'project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -43855,7 +43679,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region', 'resource'],
         pathParams: ['project', 'region', 'resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -43992,7 +43816,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region', 'resource'],
         pathParams: ['project', 'region', 'resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -44307,15 +44131,7 @@ export namespace compute_beta {
 
 
   export class Resource$Interconnectlocations {
-    root: Compute;
-    constructor(root: Compute) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -44433,7 +44249,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'interconnectLocation'],
         pathParams: ['interconnectLocation', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$InterconnectLocation>(parameters, callback);
@@ -44574,7 +44390,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$InterconnectLocationList>(parameters, callback);
@@ -44658,15 +44474,7 @@ export namespace compute_beta {
 
 
   export class Resource$Interconnects {
-    root: Compute;
-    constructor(root: Compute) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -44786,7 +44594,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'interconnect'],
         pathParams: ['interconnect', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -44909,7 +44717,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'interconnect'],
         pathParams: ['interconnect', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Interconnect>(parameters, callback);
@@ -44989,7 +44797,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'interconnect'],
         pathParams: ['interconnect', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$InterconnectsGetDiagnosticsResponse>(
@@ -45119,7 +44927,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -45257,7 +45065,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$InterconnectList>(parameters, callback);
@@ -45393,7 +45201,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'interconnect'],
         pathParams: ['interconnect', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -45465,7 +45273,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -45596,7 +45404,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -45831,15 +45639,7 @@ export namespace compute_beta {
 
 
   export class Resource$Licensecodes {
-    root: Compute;
-    constructor(root: Compute) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -45898,7 +45698,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'licenseCode'],
         pathParams: ['licenseCode', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$LicenseCode>(parameters, callback);
@@ -45926,15 +45726,7 @@ export namespace compute_beta {
 
 
   export class Resource$Licenses {
-    root: Compute;
-    constructor(root: Compute) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -45996,7 +45788,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'license'],
         pathParams: ['license', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -46116,7 +45908,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'license'],
         pathParams: ['license', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$License>(parameters, callback);
@@ -46184,7 +45976,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -46260,7 +46052,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$LicensesListResponse>(parameters, callback);
@@ -46399,15 +46191,7 @@ export namespace compute_beta {
 
 
   export class Resource$Machinetypes {
-    root: Compute;
-    constructor(root: Compute) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -46542,7 +46326,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$MachineTypeAggregatedList>(
@@ -46669,7 +46453,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone', 'machineType'],
         pathParams: ['machineType', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$MachineType>(parameters, callback);
@@ -46812,7 +46596,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone'],
         pathParams: ['project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$MachineTypeList>(parameters, callback);
@@ -46958,15 +46742,7 @@ export namespace compute_beta {
 
 
   export class Resource$Networkendpointgroups {
-    root: Compute;
-    constructor(root: Compute) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -47043,7 +46819,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$NetworkEndpointGroupAggregatedList>(
@@ -47122,7 +46898,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone', 'networkEndpointGroup'],
         pathParams: ['networkEndpointGroup', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -47197,7 +46973,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone', 'networkEndpointGroup'],
         pathParams: ['networkEndpointGroup', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -47274,7 +47050,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone', 'networkEndpointGroup'],
         pathParams: ['networkEndpointGroup', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -47343,7 +47119,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone', 'networkEndpointGroup'],
         pathParams: ['networkEndpointGroup', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$NetworkEndpointGroup>(parameters, callback);
@@ -47416,7 +47192,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone'],
         pathParams: ['project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -47492,7 +47268,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone'],
         pathParams: ['project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$NetworkEndpointGroupList>(parameters, callback);
@@ -47578,7 +47354,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone', 'networkEndpointGroup'],
         pathParams: ['networkEndpointGroup', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$NetworkEndpointGroupsListNetworkEndpoints>(
@@ -47655,7 +47431,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone', 'resource'],
         pathParams: ['project', 'resource', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -48049,15 +47825,7 @@ export namespace compute_beta {
 
 
   export class Resource$Networks {
-    root: Compute;
-    constructor(root: Compute) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -48182,7 +47950,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'network'],
         pathParams: ['network', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -48307,7 +48075,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'network'],
         pathParams: ['network', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -48428,7 +48196,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'network'],
         pathParams: ['network', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Network>(parameters, callback);
@@ -48554,7 +48322,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -48690,7 +48458,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$NetworkList>(parameters, callback);
@@ -48824,7 +48592,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'network'],
         pathParams: ['network', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -48956,7 +48724,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'network'],
         pathParams: ['network', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -49084,7 +48852,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'network'],
         pathParams: ['network', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -49217,7 +48985,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -49507,15 +49275,7 @@ export namespace compute_beta {
 
 
   export class Resource$Nodegroups {
-    root: Compute;
-    constructor(root: Compute) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -49581,7 +49341,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone', 'nodeGroup'],
         pathParams: ['nodeGroup', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -49656,7 +49416,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$NodeGroupAggregatedList>(parameters, callback);
@@ -49727,7 +49487,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone', 'nodeGroup'],
         pathParams: ['nodeGroup', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -49800,7 +49560,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone', 'nodeGroup'],
         pathParams: ['nodeGroup', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -49868,7 +49628,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone', 'nodeGroup'],
         pathParams: ['nodeGroup', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$NodeGroup>(parameters, callback);
@@ -49939,7 +49699,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone', 'resource'],
         pathParams: ['project', 'resource', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -50011,7 +49771,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone', 'initialNodeCount'],
         pathParams: ['project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -50083,7 +49843,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone'],
         pathParams: ['project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$NodeGroupList>(parameters, callback);
@@ -50158,7 +49918,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone', 'nodeGroup'],
         pathParams: ['nodeGroup', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$NodeGroupsListNodes>(parameters, callback);
@@ -50230,7 +49990,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone', 'resource'],
         pathParams: ['project', 'resource', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -50303,7 +50063,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone', 'nodeGroup'],
         pathParams: ['nodeGroup', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -50377,7 +50137,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone', 'resource'],
         pathParams: ['project', 'resource', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -50840,15 +50600,7 @@ export namespace compute_beta {
 
 
   export class Resource$Nodetemplates {
-    root: Compute;
-    constructor(root: Compute) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -50919,7 +50671,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$NodeTemplateAggregatedList>(
@@ -50992,7 +50744,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region', 'nodeTemplate'],
         pathParams: ['nodeTemplate', 'project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -51060,7 +50812,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region', 'nodeTemplate'],
         pathParams: ['nodeTemplate', 'project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$NodeTemplate>(parameters, callback);
@@ -51131,7 +50883,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region', 'resource'],
         pathParams: ['project', 'region', 'resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -51204,7 +50956,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -51278,7 +51030,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$NodeTemplateList>(parameters, callback);
@@ -51350,7 +51102,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region', 'resource'],
         pathParams: ['project', 'region', 'resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -51424,7 +51176,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region', 'resource'],
         pathParams: ['project', 'region', 'resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -51708,15 +51460,7 @@ export namespace compute_beta {
 
 
   export class Resource$Nodetypes {
-    root: Compute;
-    constructor(root: Compute) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -51783,7 +51527,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$NodeTypeAggregatedList>(parameters, callback);
@@ -51849,7 +51593,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone', 'nodeType'],
         pathParams: ['nodeType', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$NodeType>(parameters, callback);
@@ -51920,7 +51664,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone'],
         pathParams: ['project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$NodeTypeList>(parameters, callback);
@@ -52065,15 +51809,7 @@ export namespace compute_beta {
 
 
   export class Resource$Projects {
-    root: Compute;
-    constructor(root: Compute) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -52187,7 +51923,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -52315,7 +52051,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -52436,7 +52172,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -52565,7 +52301,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -52679,7 +52415,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Project>(parameters, callback);
@@ -52799,7 +52535,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Project>(parameters, callback);
@@ -52940,7 +52676,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ProjectsGetXpnResources>(parameters, callback);
@@ -53083,7 +52819,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$XpnHostList>(parameters, callback);
@@ -53209,7 +52945,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -53336,7 +53072,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -53464,7 +53200,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -53537,7 +53273,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -53665,7 +53401,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -54076,15 +53812,7 @@ export namespace compute_beta {
 
 
   export class Resource$Regionautoscalers {
-    root: Compute;
-    constructor(root: Compute) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -54208,7 +53936,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region', 'autoscaler'],
         pathParams: ['autoscaler', 'project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -54334,7 +54062,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region', 'autoscaler'],
         pathParams: ['autoscaler', 'project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Autoscaler>(parameters, callback);
@@ -54467,7 +54195,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -54612,7 +54340,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$RegionAutoscalerList>(parameters, callback);
@@ -54749,7 +54477,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -54884,7 +54612,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region', 'resource'],
         pathParams: ['project', 'region', 'resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -55020,7 +54748,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -55280,15 +55008,7 @@ export namespace compute_beta {
 
 
   export class Resource$Regionbackendservices {
-    root: Compute;
-    constructor(root: Compute) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -55413,7 +55133,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region', 'backendService'],
         pathParams: ['backendService', 'project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -55540,7 +55260,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region', 'backendService'],
         pathParams: ['backendService', 'project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$BackendService>(parameters, callback);
@@ -55677,7 +55397,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region', 'backendService'],
         pathParams: ['backendService', 'project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$BackendServiceGroupHealth>(
@@ -55813,7 +55533,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -55957,7 +55677,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$BackendServiceList>(parameters, callback);
@@ -56101,7 +55821,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region', 'backendService'],
         pathParams: ['backendService', 'project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -56237,7 +55957,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region', 'resource'],
         pathParams: ['project', 'region', 'resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -56379,7 +56099,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region', 'backendService'],
         pathParams: ['backendService', 'project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -56664,15 +56384,7 @@ export namespace compute_beta {
 
 
   export class Resource$Regioncommitments {
-    root: Compute;
-    constructor(root: Compute) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -56806,7 +56518,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$CommitmentAggregatedList>(parameters, callback);
@@ -56933,7 +56645,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region', 'commitment'],
         pathParams: ['commitment', 'project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Commitment>(parameters, callback);
@@ -57066,7 +56778,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -57210,7 +56922,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$CommitmentList>(parameters, callback);
@@ -57391,15 +57103,7 @@ export namespace compute_beta {
 
 
   export class Resource$Regiondisks {
-    root: Compute;
-    constructor(root: Compute) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -57467,7 +57171,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region', 'disk'],
         pathParams: ['disk', 'project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -57540,7 +57244,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region', 'disk'],
         pathParams: ['disk', 'project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -57615,7 +57319,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region', 'disk'],
         pathParams: ['disk', 'project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -57680,7 +57384,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region', 'disk'],
         pathParams: ['disk', 'project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Disk>(parameters, callback);
@@ -57753,7 +57457,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -57824,7 +57528,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$DiskList>(parameters, callback);
@@ -57898,7 +57602,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region', 'disk'],
         pathParams: ['disk', 'project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -57971,7 +57675,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region', 'disk'],
         pathParams: ['disk', 'project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -58044,7 +57748,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region', 'resource'],
         pathParams: ['project', 'region', 'resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -58118,7 +57822,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region', 'resource'],
         pathParams: ['project', 'region', 'resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -58494,15 +58198,7 @@ export namespace compute_beta {
 
 
   export class Resource$Regiondisktypes {
-    root: Compute;
-    constructor(root: Compute) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -58562,7 +58258,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region', 'diskType'],
         pathParams: ['diskType', 'project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$DiskType>(parameters, callback);
@@ -58637,7 +58333,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$RegionDiskTypeList>(parameters, callback);
@@ -58729,15 +58425,7 @@ export namespace compute_beta {
 
 
   export class Resource$Regioninstancegroupmanagers {
-    root: Compute;
-    constructor(root: Compute) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -58879,7 +58567,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region', 'instanceGroupManager'],
         pathParams: ['instanceGroupManager', 'project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -59010,7 +58698,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region', 'instanceGroupManager'],
         pathParams: ['instanceGroupManager', 'project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -59158,7 +58846,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region', 'instanceGroupManager'],
         pathParams: ['instanceGroupManager', 'project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -59285,7 +58973,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region', 'instanceGroupManager'],
         pathParams: ['instanceGroupManager', 'project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$InstanceGroupManager>(parameters, callback);
@@ -59421,7 +59109,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -59570,7 +59258,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$RegionInstanceGroupManagerList>(
@@ -59738,7 +59426,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region', 'instanceGroupManager'],
         pathParams: ['instanceGroupManager', 'project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<
@@ -59885,7 +59573,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region', 'instanceGroupManager'],
         pathParams: ['instanceGroupManager', 'project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -60031,7 +59719,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region', 'instanceGroupManager'],
         pathParams: ['instanceGroupManager', 'project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -60174,7 +59862,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region', 'instanceGroupManager', 'size'],
         pathParams: ['instanceGroupManager', 'project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -60316,7 +60004,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region', 'instanceGroupManager'],
         pathParams: ['instanceGroupManager', 'project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -60455,7 +60143,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region', 'instanceGroupManager'],
         pathParams: ['instanceGroupManager', 'project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -60593,7 +60281,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region', 'instanceGroupManager'],
         pathParams: ['instanceGroupManager', 'project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -60730,7 +60418,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region', 'resource'],
         pathParams: ['project', 'region', 'resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -60871,7 +60559,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region', 'instanceGroupManager'],
         pathParams: ['instanceGroupManager', 'project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -61459,15 +61147,7 @@ export namespace compute_beta {
 
 
   export class Resource$Regioninstancegroups {
-    root: Compute;
-    constructor(root: Compute) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -61587,7 +61267,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region', 'instanceGroup'],
         pathParams: ['instanceGroup', 'project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$InstanceGroup>(parameters, callback);
@@ -61732,7 +61412,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$RegionInstanceGroupList>(parameters, callback);
@@ -61898,7 +61578,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region', 'instanceGroup'],
         pathParams: ['instanceGroup', 'project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$RegionInstanceGroupsListInstances>(
@@ -62035,7 +61715,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region', 'instanceGroup'],
         pathParams: ['instanceGroup', 'project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -62171,7 +61851,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region', 'resource'],
         pathParams: ['project', 'region', 'resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -62396,15 +62076,7 @@ export namespace compute_beta {
 
 
   export class Resource$Regionoperations {
-    root: Compute;
-    constructor(root: Compute) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -62522,7 +62194,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region', 'operation'],
         pathParams: ['operation', 'project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -62648,7 +62320,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region', 'operation'],
         pathParams: ['operation', 'project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -62792,7 +62464,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$OperationList>(parameters, callback);
@@ -62904,15 +62576,7 @@ export namespace compute_beta {
 
 
   export class Resource$Regions {
-    root: Compute;
-    constructor(root: Compute) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -63025,7 +62689,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Region>(parameters, callback);
@@ -63161,7 +62825,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$RegionList>(parameters, callback);
@@ -63243,15 +62907,7 @@ export namespace compute_beta {
 
 
   export class Resource$Resourcepolicies {
-    root: Compute;
-    constructor(root: Compute) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -63323,7 +62979,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ResourcePolicyAggregatedList>(
@@ -63397,7 +63053,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region', 'resourcePolicy'],
         pathParams: ['project', 'region', 'resourcePolicy'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -63464,7 +63120,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region', 'resourcePolicy'],
         pathParams: ['project', 'region', 'resourcePolicy'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ResourcePolicy>(parameters, callback);
@@ -63536,7 +63192,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -63611,7 +63267,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ResourcePolicyList>(parameters, callback);
@@ -63685,7 +63341,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region', 'resource'],
         pathParams: ['project', 'region', 'resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -63924,15 +63580,7 @@ export namespace compute_beta {
 
 
   export class Resource$Routers {
-    root: Compute;
-    constructor(root: Compute) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -64066,7 +63714,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$RouterAggregatedList>(parameters, callback);
@@ -64195,7 +63843,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region', 'router'],
         pathParams: ['project', 'region', 'router'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -64320,7 +63968,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region', 'router'],
         pathParams: ['project', 'region', 'router'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Router>(parameters, callback);
@@ -64398,7 +64046,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region', 'router'],
         pathParams: ['project', 'region', 'router'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$VmEndpointNatMappingsList>(
@@ -64531,7 +64179,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region', 'router'],
         pathParams: ['project', 'region', 'router'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$RouterStatusResponse>(parameters, callback);
@@ -64661,7 +64309,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -64802,7 +64450,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$RouterList>(parameters, callback);
@@ -64940,7 +64588,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region', 'router'],
         pathParams: ['project', 'region', 'router'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -65076,7 +64724,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region', 'router'],
         pathParams: ['project', 'region', 'router'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$RoutersPreviewResponse>(parameters, callback);
@@ -65213,7 +64861,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region', 'resource'],
         pathParams: ['project', 'region', 'resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -65350,7 +64998,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region', 'router'],
         pathParams: ['project', 'region', 'router'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -65767,15 +65415,7 @@ export namespace compute_beta {
 
 
   export class Resource$Routes {
-    root: Compute;
-    constructor(root: Compute) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -65892,7 +65532,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'route'],
         pathParams: ['project', 'route'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -66012,7 +65652,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'route'],
         pathParams: ['project', 'route'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Route>(parameters, callback);
@@ -66137,7 +65777,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -66273,7 +65913,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$RouteList>(parameters, callback);
@@ -66406,7 +66046,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -66566,15 +66206,7 @@ export namespace compute_beta {
 
 
   export class Resource$Securitypolicies {
-    root: Compute;
-    constructor(root: Compute) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -66639,7 +66271,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'securityPolicy'],
         pathParams: ['project', 'securityPolicy'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -66767,7 +66399,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'securityPolicy'],
         pathParams: ['project', 'securityPolicy'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -66890,7 +66522,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'securityPolicy'],
         pathParams: ['project', 'securityPolicy'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$SecurityPolicy>(parameters, callback);
@@ -66961,7 +66593,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'securityPolicy'],
         pathParams: ['project', 'securityPolicy'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$SecurityPolicyRule>(parameters, callback);
@@ -67090,7 +66722,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -67229,7 +66861,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$SecurityPolicyList>(parameters, callback);
@@ -67321,7 +66953,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<
@@ -67460,7 +67092,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'securityPolicy'],
         pathParams: ['project', 'securityPolicy'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -67533,7 +67165,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'securityPolicy'],
         pathParams: ['project', 'securityPolicy'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -67604,7 +67236,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'securityPolicy'],
         pathParams: ['project', 'securityPolicy'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -67676,7 +67308,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -67807,7 +67439,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -68179,15 +67811,7 @@ export namespace compute_beta {
 
 
   export class Resource$Snapshots {
-    root: Compute;
-    constructor(root: Compute) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -68309,7 +67933,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'snapshot'],
         pathParams: ['project', 'snapshot'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -68430,7 +68054,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'snapshot'],
         pathParams: ['project', 'snapshot'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Snapshot>(parameters, callback);
@@ -68500,7 +68124,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -68637,7 +68261,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$SnapshotList>(parameters, callback);
@@ -68708,7 +68332,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -68840,7 +68464,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -68973,7 +68597,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -69162,15 +68786,7 @@ export namespace compute_beta {
 
 
   export class Resource$Sslcertificates {
-    root: Compute;
-    constructor(root: Compute) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -69291,7 +68907,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'sslCertificate'],
         pathParams: ['project', 'sslCertificate'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -69415,7 +69031,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'sslCertificate'],
         pathParams: ['project', 'sslCertificate'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$SslCertificate>(parameters, callback);
@@ -69543,7 +69159,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -69682,7 +69298,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$SslCertificateList>(parameters, callback);
@@ -69813,7 +69429,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -69977,15 +69593,7 @@ export namespace compute_beta {
 
 
   export class Resource$Sslpolicies {
-    root: Compute;
-    constructor(root: Compute) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -70051,7 +69659,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'sslPolicy'],
         pathParams: ['project', 'sslPolicy'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -70117,7 +69725,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'sslPolicy'],
         pathParams: ['project', 'sslPolicy'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$SslPolicy>(parameters, callback);
@@ -70188,7 +69796,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -70259,7 +69867,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$SslPoliciesList>(parameters, callback);
@@ -70340,7 +69948,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$SslPoliciesListAvailableFeaturesResponse>(
@@ -70414,7 +70022,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'sslPolicy'],
         pathParams: ['project', 'sslPolicy'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -70487,7 +70095,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -70741,15 +70349,7 @@ export namespace compute_beta {
 
 
   export class Resource$Subnetworks {
-    root: Compute;
-    constructor(root: Compute) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -70883,7 +70483,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$SubnetworkAggregatedList>(parameters, callback);
@@ -71014,7 +70614,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region', 'subnetwork'],
         pathParams: ['project', 'region', 'subnetwork'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -71148,7 +70748,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region', 'subnetwork'],
         pathParams: ['project', 'region', 'subnetwork'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -71274,7 +70874,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region', 'subnetwork'],
         pathParams: ['project', 'region', 'subnetwork'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Subnetwork>(parameters, callback);
@@ -71404,7 +71004,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region', 'resource'],
         pathParams: ['project', 'region', 'resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -71537,7 +71137,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -71678,7 +71278,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$SubnetworkList>(parameters, callback);
@@ -71758,7 +71358,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$UsableSubnetworksAggregatedList>(
@@ -71901,7 +71501,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region', 'subnetwork'],
         pathParams: ['project', 'region', 'subnetwork'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -72036,7 +71636,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region', 'resource'],
         pathParams: ['project', 'region', 'resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -72172,7 +71772,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region', 'subnetwork'],
         pathParams: ['project', 'region', 'subnetwork'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -72307,7 +71907,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region', 'resource'],
         pathParams: ['project', 'region', 'resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -72758,15 +72358,7 @@ export namespace compute_beta {
 
 
   export class Resource$Targethttpproxies {
-    root: Compute;
-    constructor(root: Compute) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -72887,7 +72479,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'targetHttpProxy'],
         pathParams: ['project', 'targetHttpProxy'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -73011,7 +72603,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'targetHttpProxy'],
         pathParams: ['project', 'targetHttpProxy'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TargetHttpProxy>(parameters, callback);
@@ -73139,7 +72731,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -73278,7 +72870,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TargetHttpProxyList>(parameters, callback);
@@ -73411,7 +73003,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'targetHttpProxy'],
         pathParams: ['project', 'targetHttpProxy'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -73542,7 +73134,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -73740,15 +73332,7 @@ export namespace compute_beta {
 
 
   export class Resource$Targethttpsproxies {
-    root: Compute;
-    constructor(root: Compute) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -73869,7 +73453,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'targetHttpsProxy'],
         pathParams: ['project', 'targetHttpsProxy'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -73993,7 +73577,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'targetHttpsProxy'],
         pathParams: ['project', 'targetHttpsProxy'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TargetHttpsProxy>(parameters, callback);
@@ -74122,7 +73706,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -74263,7 +73847,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TargetHttpsProxyList>(parameters, callback);
@@ -74335,7 +73919,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'targetHttpsProxy'],
         pathParams: ['project', 'targetHttpsProxy'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -74467,7 +74051,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'targetHttpsProxy'],
         pathParams: ['project', 'targetHttpsProxy'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -74542,7 +74126,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'targetHttpsProxy'],
         pathParams: ['project', 'targetHttpsProxy'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -74675,7 +74259,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'targetHttpsProxy'],
         pathParams: ['project', 'targetHttpsProxy'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -74807,7 +74391,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -75110,15 +74694,7 @@ export namespace compute_beta {
 
 
   export class Resource$Targetinstances {
-    root: Compute;
-    constructor(root: Compute) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -75257,7 +74833,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TargetInstanceAggregatedList>(
@@ -75391,7 +74967,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone', 'targetInstance'],
         pathParams: ['project', 'targetInstance', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -75519,7 +75095,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone', 'targetInstance'],
         pathParams: ['project', 'targetInstance', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TargetInstance>(parameters, callback);
@@ -75652,7 +75228,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone'],
         pathParams: ['project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -75796,7 +75372,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone'],
         pathParams: ['project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TargetInstanceList>(parameters, callback);
@@ -75931,7 +75507,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone', 'resource'],
         pathParams: ['project', 'resource', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -76170,15 +75746,7 @@ export namespace compute_beta {
 
 
   export class Resource$Targetpools {
-    root: Compute;
-    constructor(root: Compute) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -76307,7 +75875,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region', 'targetPool'],
         pathParams: ['project', 'region', 'targetPool'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -76443,7 +76011,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region', 'targetPool'],
         pathParams: ['project', 'region', 'targetPool'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -76584,7 +76152,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TargetPoolAggregatedList>(parameters, callback);
@@ -76715,7 +76283,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region', 'targetPool'],
         pathParams: ['project', 'region', 'targetPool'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -76841,7 +76409,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region', 'targetPool'],
         pathParams: ['project', 'region', 'targetPool'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TargetPool>(parameters, callback);
@@ -76980,7 +76548,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region', 'targetPool'],
         pathParams: ['project', 'region', 'targetPool'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TargetPoolInstanceHealth>(parameters, callback);
@@ -77113,7 +76681,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -77255,7 +76823,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TargetPoolList>(parameters, callback);
@@ -77389,7 +76957,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region', 'targetPool'],
         pathParams: ['project', 'region', 'targetPool'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -77525,7 +77093,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region', 'targetPool'],
         pathParams: ['project', 'region', 'targetPool'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -77662,7 +77230,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region', 'targetPool'],
         pathParams: ['project', 'region', 'targetPool'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -77797,7 +77365,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region', 'resource'],
         pathParams: ['project', 'region', 'resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -78253,15 +77821,7 @@ export namespace compute_beta {
 
 
   export class Resource$Targetsslproxies {
-    root: Compute;
-    constructor(root: Compute) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -78382,7 +77942,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'targetSslProxy'],
         pathParams: ['project', 'targetSslProxy'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -78506,7 +78066,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'targetSslProxy'],
         pathParams: ['project', 'targetSslProxy'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TargetSslProxy>(parameters, callback);
@@ -78634,7 +78194,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -78773,7 +78333,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TargetSslProxyList>(parameters, callback);
@@ -78904,7 +78464,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'targetSslProxy'],
         pathParams: ['project', 'targetSslProxy'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -79035,7 +78595,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'targetSslProxy'],
         pathParams: ['project', 'targetSslProxy'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -79166,7 +78726,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'targetSslProxy'],
         pathParams: ['project', 'targetSslProxy'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -79241,7 +78801,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'targetSslProxy'],
         pathParams: ['project', 'targetSslProxy'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -79372,7 +78932,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -79675,15 +79235,7 @@ export namespace compute_beta {
 
 
   export class Resource$Targettcpproxies {
-    root: Compute;
-    constructor(root: Compute) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -79804,7 +79356,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'targetTcpProxy'],
         pathParams: ['project', 'targetTcpProxy'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -79928,7 +79480,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'targetTcpProxy'],
         pathParams: ['project', 'targetTcpProxy'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TargetTcpProxy>(parameters, callback);
@@ -80056,7 +79608,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -80195,7 +79747,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TargetTcpProxyList>(parameters, callback);
@@ -80326,7 +79878,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'targetTcpProxy'],
         pathParams: ['project', 'targetTcpProxy'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -80457,7 +80009,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'targetTcpProxy'],
         pathParams: ['project', 'targetTcpProxy'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -80669,15 +80221,7 @@ export namespace compute_beta {
 
 
   export class Resource$Targetvpngateways {
-    root: Compute;
-    constructor(root: Compute) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -80816,7 +80360,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TargetVpnGatewayAggregatedList>(
@@ -80950,7 +80494,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region', 'targetVpnGateway'],
         pathParams: ['project', 'region', 'targetVpnGateway'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -81078,7 +80622,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region', 'targetVpnGateway'],
         pathParams: ['project', 'region', 'targetVpnGateway'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TargetVpnGateway>(parameters, callback);
@@ -81211,7 +80755,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -81356,7 +80900,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TargetVpnGatewayList>(parameters, callback);
@@ -81430,7 +80974,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region', 'resource'],
         pathParams: ['project', 'region', 'resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -81565,7 +81109,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region', 'resource'],
         pathParams: ['project', 'region', 'resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -81842,15 +81386,7 @@ export namespace compute_beta {
 
 
   export class Resource$Urlmaps {
-    root: Compute;
-    constructor(root: Compute) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -81967,7 +81503,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'urlMap'],
         pathParams: ['project', 'urlMap'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -82087,7 +81623,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'urlMap'],
         pathParams: ['project', 'urlMap'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$UrlMap>(parameters, callback);
@@ -82212,7 +81748,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -82345,7 +81881,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'urlMap'],
         pathParams: ['project', 'urlMap'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -82481,7 +82017,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$UrlMapList>(parameters, callback);
@@ -82614,7 +82150,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'urlMap'],
         pathParams: ['project', 'urlMap'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -82747,7 +82283,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -82879,7 +82415,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'urlMap'],
         pathParams: ['project', 'urlMap'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -83013,7 +82549,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'urlMap'],
         pathParams: ['project', 'urlMap'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$UrlMapsValidateResponse>(parameters, callback);
@@ -83293,15 +82829,7 @@ export namespace compute_beta {
 
 
   export class Resource$Vpntunnels {
-    root: Compute;
-    constructor(root: Compute) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -83435,7 +82963,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$VpnTunnelAggregatedList>(parameters, callback);
@@ -83565,7 +83093,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region', 'vpnTunnel'],
         pathParams: ['project', 'region', 'vpnTunnel'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -83691,7 +83219,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region', 'vpnTunnel'],
         pathParams: ['project', 'region', 'vpnTunnel'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$VpnTunnel>(parameters, callback);
@@ -83823,7 +83351,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -83965,7 +83493,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$VpnTunnelList>(parameters, callback);
@@ -84039,7 +83567,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region', 'resource'],
         pathParams: ['project', 'region', 'resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -84174,7 +83702,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region', 'resource'],
         pathParams: ['project', 'region', 'resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -84449,15 +83977,7 @@ export namespace compute_beta {
 
 
   export class Resource$Zoneoperations {
-    root: Compute;
-    constructor(root: Compute) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -84575,7 +84095,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone', 'operation'],
         pathParams: ['operation', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -84701,7 +84221,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone', 'operation'],
         pathParams: ['operation', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -84843,7 +84363,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone'],
         pathParams: ['project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$OperationList>(parameters, callback);
@@ -84955,15 +84475,7 @@ export namespace compute_beta {
 
 
   export class Resource$Zones {
-    root: Compute;
-    constructor(root: Compute) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -85075,7 +84587,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone'],
         pathParams: ['project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Zone>(parameters, callback);
@@ -85210,7 +84722,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ZoneList>(parameters, callback);

--- a/src/apis/compute/v1.ts
+++ b/src/apis/compute/v1.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace compute_v1 {
   export interface Options extends GlobalOptions {
     version: 'v1';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -79,10 +81,6 @@ export namespace compute_v1 {
    * @param {object=} options Options for Compute
    */
   export class Compute {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     acceleratorTypes: Resource$Acceleratortypes;
     addresses: Resource$Addresses;
     autoscalers: Resource$Autoscalers;
@@ -143,73 +141,67 @@ export namespace compute_v1 {
     zones: Resource$Zones;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.acceleratorTypes = new Resource$Acceleratortypes(this);
-      this.addresses = new Resource$Addresses(this);
-      this.autoscalers = new Resource$Autoscalers(this);
-      this.backendBuckets = new Resource$Backendbuckets(this);
-      this.backendServices = new Resource$Backendservices(this);
-      this.disks = new Resource$Disks(this);
-      this.diskTypes = new Resource$Disktypes(this);
-      this.firewalls = new Resource$Firewalls(this);
-      this.forwardingRules = new Resource$Forwardingrules(this);
-      this.globalAddresses = new Resource$Globaladdresses(this);
-      this.globalForwardingRules = new Resource$Globalforwardingrules(this);
-      this.globalOperations = new Resource$Globaloperations(this);
-      this.healthChecks = new Resource$Healthchecks(this);
-      this.httpHealthChecks = new Resource$Httphealthchecks(this);
-      this.httpsHealthChecks = new Resource$Httpshealthchecks(this);
-      this.images = new Resource$Images(this);
-      this.instanceGroupManagers = new Resource$Instancegroupmanagers(this);
-      this.instanceGroups = new Resource$Instancegroups(this);
-      this.instances = new Resource$Instances(this);
-      this.instanceTemplates = new Resource$Instancetemplates(this);
-      this.interconnectAttachments = new Resource$Interconnectattachments(this);
-      this.interconnectLocations = new Resource$Interconnectlocations(this);
-      this.interconnects = new Resource$Interconnects(this);
-      this.licenseCodes = new Resource$Licensecodes(this);
-      this.licenses = new Resource$Licenses(this);
-      this.machineTypes = new Resource$Machinetypes(this);
-      this.networks = new Resource$Networks(this);
-      this.nodeGroups = new Resource$Nodegroups(this);
-      this.nodeTemplates = new Resource$Nodetemplates(this);
-      this.nodeTypes = new Resource$Nodetypes(this);
-      this.projects = new Resource$Projects(this);
-      this.regionAutoscalers = new Resource$Regionautoscalers(this);
-      this.regionBackendServices = new Resource$Regionbackendservices(this);
-      this.regionCommitments = new Resource$Regioncommitments(this);
-      this.regionDisks = new Resource$Regiondisks(this);
-      this.regionDiskTypes = new Resource$Regiondisktypes(this);
+      this.acceleratorTypes = new Resource$Acceleratortypes();
+      this.addresses = new Resource$Addresses();
+      this.autoscalers = new Resource$Autoscalers();
+      this.backendBuckets = new Resource$Backendbuckets();
+      this.backendServices = new Resource$Backendservices();
+      this.disks = new Resource$Disks();
+      this.diskTypes = new Resource$Disktypes();
+      this.firewalls = new Resource$Firewalls();
+      this.forwardingRules = new Resource$Forwardingrules();
+      this.globalAddresses = new Resource$Globaladdresses();
+      this.globalForwardingRules = new Resource$Globalforwardingrules();
+      this.globalOperations = new Resource$Globaloperations();
+      this.healthChecks = new Resource$Healthchecks();
+      this.httpHealthChecks = new Resource$Httphealthchecks();
+      this.httpsHealthChecks = new Resource$Httpshealthchecks();
+      this.images = new Resource$Images();
+      this.instanceGroupManagers = new Resource$Instancegroupmanagers();
+      this.instanceGroups = new Resource$Instancegroups();
+      this.instances = new Resource$Instances();
+      this.instanceTemplates = new Resource$Instancetemplates();
+      this.interconnectAttachments = new Resource$Interconnectattachments();
+      this.interconnectLocations = new Resource$Interconnectlocations();
+      this.interconnects = new Resource$Interconnects();
+      this.licenseCodes = new Resource$Licensecodes();
+      this.licenses = new Resource$Licenses();
+      this.machineTypes = new Resource$Machinetypes();
+      this.networks = new Resource$Networks();
+      this.nodeGroups = new Resource$Nodegroups();
+      this.nodeTemplates = new Resource$Nodetemplates();
+      this.nodeTypes = new Resource$Nodetypes();
+      this.projects = new Resource$Projects();
+      this.regionAutoscalers = new Resource$Regionautoscalers();
+      this.regionBackendServices = new Resource$Regionbackendservices();
+      this.regionCommitments = new Resource$Regioncommitments();
+      this.regionDisks = new Resource$Regiondisks();
+      this.regionDiskTypes = new Resource$Regiondisktypes();
       this.regionInstanceGroupManagers =
-          new Resource$Regioninstancegroupmanagers(this);
-      this.regionInstanceGroups = new Resource$Regioninstancegroups(this);
-      this.regionOperations = new Resource$Regionoperations(this);
-      this.regions = new Resource$Regions(this);
-      this.routers = new Resource$Routers(this);
-      this.routes = new Resource$Routes(this);
-      this.securityPolicies = new Resource$Securitypolicies(this);
-      this.snapshots = new Resource$Snapshots(this);
-      this.sslCertificates = new Resource$Sslcertificates(this);
-      this.sslPolicies = new Resource$Sslpolicies(this);
-      this.subnetworks = new Resource$Subnetworks(this);
-      this.targetHttpProxies = new Resource$Targethttpproxies(this);
-      this.targetHttpsProxies = new Resource$Targethttpsproxies(this);
-      this.targetInstances = new Resource$Targetinstances(this);
-      this.targetPools = new Resource$Targetpools(this);
-      this.targetSslProxies = new Resource$Targetsslproxies(this);
-      this.targetTcpProxies = new Resource$Targettcpproxies(this);
-      this.targetVpnGateways = new Resource$Targetvpngateways(this);
-      this.urlMaps = new Resource$Urlmaps(this);
-      this.vpnTunnels = new Resource$Vpntunnels(this);
-      this.zoneOperations = new Resource$Zoneoperations(this);
-      this.zones = new Resource$Zones(this);
-    }
-
-    getRoot() {
-      return this.root;
+          new Resource$Regioninstancegroupmanagers();
+      this.regionInstanceGroups = new Resource$Regioninstancegroups();
+      this.regionOperations = new Resource$Regionoperations();
+      this.regions = new Resource$Regions();
+      this.routers = new Resource$Routers();
+      this.routes = new Resource$Routes();
+      this.securityPolicies = new Resource$Securitypolicies();
+      this.snapshots = new Resource$Snapshots();
+      this.sslCertificates = new Resource$Sslcertificates();
+      this.sslPolicies = new Resource$Sslpolicies();
+      this.subnetworks = new Resource$Subnetworks();
+      this.targetHttpProxies = new Resource$Targethttpproxies();
+      this.targetHttpsProxies = new Resource$Targethttpsproxies();
+      this.targetInstances = new Resource$Targetinstances();
+      this.targetPools = new Resource$Targetpools();
+      this.targetSslProxies = new Resource$Targetsslproxies();
+      this.targetTcpProxies = new Resource$Targettcpproxies();
+      this.targetVpnGateways = new Resource$Targetvpngateways();
+      this.urlMaps = new Resource$Urlmaps();
+      this.vpnTunnels = new Resource$Vpntunnels();
+      this.zoneOperations = new Resource$Zoneoperations();
+      this.zones = new Resource$Zones();
     }
   }
 
@@ -10362,15 +10354,7 @@ export namespace compute_v1 {
 
 
   export class Resource$Acceleratortypes {
-    root: Compute;
-    constructor(root: Compute) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -10509,7 +10493,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$AcceleratorTypeAggregatedList>(
@@ -10638,7 +10622,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'zone', 'acceleratorType'],
         pathParams: ['acceleratorType', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$AcceleratorType>(parameters, callback);
@@ -10782,7 +10766,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'zone'],
         pathParams: ['project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$AcceleratorTypeList>(parameters, callback);
@@ -10929,15 +10913,7 @@ export namespace compute_v1 {
 
 
   export class Resource$Addresses {
-    root: Compute;
-    constructor(root: Compute) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -11071,7 +11047,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$AddressAggregatedList>(parameters, callback);
@@ -11200,7 +11176,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region', 'address'],
         pathParams: ['address', 'project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -11324,7 +11300,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region', 'address'],
         pathParams: ['address', 'project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Address>(parameters, callback);
@@ -11454,7 +11430,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -11595,7 +11571,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$AddressList>(parameters, callback);
@@ -11805,15 +11781,7 @@ export namespace compute_v1 {
 
 
   export class Resource$Autoscalers {
-    root: Compute;
-    constructor(root: Compute) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -11947,7 +11915,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$AutoscalerAggregatedList>(parameters, callback);
@@ -12078,7 +12046,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'zone', 'autoscaler'],
         pathParams: ['autoscaler', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -12204,7 +12172,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'zone', 'autoscaler'],
         pathParams: ['autoscaler', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Autoscaler>(parameters, callback);
@@ -12336,7 +12304,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'zone'],
         pathParams: ['project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -12477,7 +12445,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'zone'],
         pathParams: ['project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$AutoscalerList>(parameters, callback);
@@ -12612,7 +12580,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'zone'],
         pathParams: ['project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -12747,7 +12715,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'zone'],
         pathParams: ['project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -13035,15 +13003,7 @@ export namespace compute_v1 {
 
 
   export class Resource$Backendbuckets {
-    root: Compute;
-    constructor(root: Compute) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -13109,7 +13069,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'backendBucket'],
         pathParams: ['backendBucket', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -13237,7 +13197,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'backendBucket'],
         pathParams: ['backendBucket', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -13310,7 +13270,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'backendBucket', 'keyName'],
         pathParams: ['backendBucket', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -13434,7 +13394,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'backendBucket'],
         pathParams: ['backendBucket', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$BackendBucket>(parameters, callback);
@@ -13562,7 +13522,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -13700,7 +13660,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$BackendBucketList>(parameters, callback);
@@ -13837,7 +13797,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'backendBucket'],
         pathParams: ['backendBucket', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -13973,7 +13933,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'backendBucket'],
         pathParams: ['backendBucket', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -14253,15 +14213,7 @@ export namespace compute_v1 {
 
 
   export class Resource$Backendservices {
-    root: Compute;
-    constructor(root: Compute) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -14327,7 +14279,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'backendService'],
         pathParams: ['backendService', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -14473,7 +14425,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$BackendServiceAggregatedList>(
@@ -14603,7 +14555,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'backendService'],
         pathParams: ['backendService', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -14676,7 +14628,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'backendService', 'keyName'],
         pathParams: ['backendService', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -14800,7 +14752,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'backendService'],
         pathParams: ['backendService', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$BackendService>(parameters, callback);
@@ -14934,7 +14886,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'backendService'],
         pathParams: ['backendService', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$BackendServiceGroupHealth>(
@@ -15065,7 +15017,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -15204,7 +15156,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$BackendServiceList>(parameters, callback);
@@ -15343,7 +15295,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'backendService'],
         pathParams: ['backendService', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -15415,7 +15367,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'backendService'],
         pathParams: ['backendService', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -15553,7 +15505,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'backendService'],
         pathParams: ['backendService', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -15945,15 +15897,7 @@ export namespace compute_v1 {
 
 
   export class Resource$Disks {
-    root: Compute;
-    constructor(root: Compute) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -16085,7 +16029,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$DiskAggregatedList>(parameters, callback);
@@ -16222,7 +16166,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'zone', 'disk'],
         pathParams: ['disk', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -16353,7 +16297,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'zone', 'disk'],
         pathParams: ['disk', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -16477,7 +16421,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'zone', 'disk'],
         pathParams: ['disk', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Disk>(parameters, callback);
@@ -16611,7 +16555,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'zone'],
         pathParams: ['project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -16751,7 +16695,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'zone'],
         pathParams: ['project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$DiskList>(parameters, callback);
@@ -16886,7 +16830,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'zone', 'disk'],
         pathParams: ['disk', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -17022,7 +16966,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'zone', 'resource'],
         pathParams: ['project', 'resource', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -17352,15 +17296,7 @@ export namespace compute_v1 {
 
 
   export class Resource$Disktypes {
-    root: Compute;
-    constructor(root: Compute) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -17494,7 +17430,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$DiskTypeAggregatedList>(parameters, callback);
@@ -17619,7 +17555,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'zone', 'diskType'],
         pathParams: ['diskType', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$DiskType>(parameters, callback);
@@ -17759,7 +17695,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'zone'],
         pathParams: ['project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$DiskTypeList>(parameters, callback);
@@ -17904,15 +17840,7 @@ export namespace compute_v1 {
 
 
   export class Resource$Firewalls {
-    root: Compute;
-    constructor(root: Compute) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -18030,7 +17958,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'firewall'],
         pathParams: ['firewall', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -18150,7 +18078,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'firewall'],
         pathParams: ['firewall', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Firewall>(parameters, callback);
@@ -18275,7 +18203,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -18411,7 +18339,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$FirewallList>(parameters, callback);
@@ -18545,7 +18473,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'firewall'],
         pathParams: ['firewall', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -18679,7 +18607,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'firewall'],
         pathParams: ['firewall', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -18884,15 +18812,7 @@ export namespace compute_v1 {
 
 
   export class Resource$Forwardingrules {
-    root: Compute;
-    constructor(root: Compute) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -19030,7 +18950,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ForwardingRuleAggregatedList>(
@@ -19164,7 +19084,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region', 'forwardingRule'],
         pathParams: ['forwardingRule', 'project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -19291,7 +19211,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region', 'forwardingRule'],
         pathParams: ['forwardingRule', 'project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ForwardingRule>(parameters, callback);
@@ -19424,7 +19344,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -19568,7 +19488,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ForwardingRuleList>(parameters, callback);
@@ -19706,7 +19626,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region', 'forwardingRule'],
         pathParams: ['forwardingRule', 'project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -19958,15 +19878,7 @@ export namespace compute_v1 {
 
 
   export class Resource$Globaladdresses {
-    root: Compute;
-    constructor(root: Compute) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -20085,7 +19997,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'address'],
         pathParams: ['address', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -20206,7 +20118,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'address'],
         pathParams: ['address', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Address>(parameters, callback);
@@ -20333,7 +20245,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -20470,7 +20382,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$AddressList>(parameters, callback);
@@ -20613,15 +20525,7 @@ export namespace compute_v1 {
 
 
   export class Resource$Globalforwardingrules {
-    root: Compute;
-    constructor(root: Compute) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -20742,7 +20646,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'forwardingRule'],
         pathParams: ['forwardingRule', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -20866,7 +20770,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'forwardingRule'],
         pathParams: ['forwardingRule', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ForwardingRule>(parameters, callback);
@@ -20994,7 +20898,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -21133,7 +21037,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ForwardingRuleList>(parameters, callback);
@@ -21265,7 +21169,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'forwardingRule'],
         pathParams: ['forwardingRule', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -21442,15 +21346,7 @@ export namespace compute_v1 {
 
 
   export class Resource$Globaloperations {
-    root: Compute;
-    constructor(root: Compute) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -21584,7 +21480,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$OperationAggregatedList>(parameters, callback);
@@ -21705,7 +21601,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'operation'],
         pathParams: ['operation', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -21828,7 +21724,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'operation'],
         pathParams: ['operation', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -21967,7 +21863,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$OperationList>(parameters, callback);
@@ -22122,15 +22018,7 @@ export namespace compute_v1 {
 
 
   export class Resource$Healthchecks {
-    root: Compute;
-    constructor(root: Compute) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -22250,7 +22138,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'healthCheck'],
         pathParams: ['healthCheck', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -22372,7 +22260,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'healthCheck'],
         pathParams: ['healthCheck', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$HealthCheck>(parameters, callback);
@@ -22500,7 +22388,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -22638,7 +22526,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$HealthCheckList>(parameters, callback);
@@ -22773,7 +22661,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'healthCheck'],
         pathParams: ['healthCheck', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -22908,7 +22796,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'healthCheck'],
         pathParams: ['healthCheck', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -23118,15 +23006,7 @@ export namespace compute_v1 {
 
 
   export class Resource$Httphealthchecks {
-    root: Compute;
-    constructor(root: Compute) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -23247,7 +23127,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'httpHealthCheck'],
         pathParams: ['httpHealthCheck', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -23371,7 +23251,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'httpHealthCheck'],
         pathParams: ['httpHealthCheck', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$HttpHealthCheck>(parameters, callback);
@@ -23499,7 +23379,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -23638,7 +23518,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$HttpHealthCheckList>(parameters, callback);
@@ -23775,7 +23655,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'httpHealthCheck'],
         pathParams: ['httpHealthCheck', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -23911,7 +23791,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'httpHealthCheck'],
         pathParams: ['httpHealthCheck', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -24122,15 +24002,7 @@ export namespace compute_v1 {
 
 
   export class Resource$Httpshealthchecks {
-    root: Compute;
-    constructor(root: Compute) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -24251,7 +24123,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'httpsHealthCheck'],
         pathParams: ['httpsHealthCheck', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -24375,7 +24247,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'httpsHealthCheck'],
         pathParams: ['httpsHealthCheck', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$HttpsHealthCheck>(parameters, callback);
@@ -24503,7 +24375,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -24643,7 +24515,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$HttpsHealthCheckList>(parameters, callback);
@@ -24780,7 +24652,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'httpsHealthCheck'],
         pathParams: ['httpsHealthCheck', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -24916,7 +24788,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'httpsHealthCheck'],
         pathParams: ['httpsHealthCheck', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -25127,15 +24999,7 @@ export namespace compute_v1 {
 
 
   export class Resource$Images {
-    root: Compute;
-    constructor(root: Compute) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -25252,7 +25116,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'image'],
         pathParams: ['image', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -25384,7 +25248,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'image'],
         pathParams: ['image', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -25504,7 +25368,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'image'],
         pathParams: ['image', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Image>(parameters, callback);
@@ -25630,7 +25494,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'family'],
         pathParams: ['family', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Image>(parameters, callback);
@@ -25756,7 +25620,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -25896,7 +25760,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ImageList>(parameters, callback);
@@ -26027,7 +25891,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -26239,15 +26103,7 @@ export namespace compute_v1 {
 
 
   export class Resource$Instancegroupmanagers {
-    root: Compute;
-    constructor(root: Compute) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -26388,7 +26244,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'zone', 'instanceGroupManager'],
         pathParams: ['instanceGroupManager', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -26539,7 +26395,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$InstanceGroupManagerAggregatedList>(
@@ -26675,7 +26531,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'zone', 'instanceGroupManager'],
         pathParams: ['instanceGroupManager', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -26821,7 +26677,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'zone', 'instanceGroupManager'],
         pathParams: ['instanceGroupManager', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -26951,7 +26807,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'zone', 'instanceGroupManager'],
         pathParams: ['instanceGroupManager', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$InstanceGroupManager>(parameters, callback);
@@ -27090,7 +26946,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'zone'],
         pathParams: ['project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -27235,7 +27091,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'zone'],
         pathParams: ['project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$InstanceGroupManagerList>(parameters, callback);
@@ -27383,7 +27239,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'zone', 'instanceGroupManager'],
         pathParams: ['instanceGroupManager', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<
@@ -27532,7 +27388,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'zone', 'instanceGroupManager'],
         pathParams: ['instanceGroupManager', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -27686,7 +27542,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'zone', 'instanceGroupManager', 'size'],
         pathParams: ['instanceGroupManager', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -27825,7 +27681,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'zone', 'instanceGroupManager'],
         pathParams: ['instanceGroupManager', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -27965,7 +27821,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'zone', 'instanceGroupManager'],
         pathParams: ['instanceGroupManager', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -28472,15 +28328,7 @@ export namespace compute_v1 {
 
 
   export class Resource$Instancegroups {
-    root: Compute;
-    constructor(root: Compute) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -28612,7 +28460,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'zone', 'instanceGroup'],
         pathParams: ['instanceGroup', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -28757,7 +28605,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$InstanceGroupAggregatedList>(
@@ -28892,7 +28740,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'zone', 'instanceGroup'],
         pathParams: ['instanceGroup', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -29020,7 +28868,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'zone', 'instanceGroup'],
         pathParams: ['instanceGroup', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$InstanceGroup>(parameters, callback);
@@ -29153,7 +29001,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'zone'],
         pathParams: ['project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -29296,7 +29144,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'zone'],
         pathParams: ['project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$InstanceGroupList>(parameters, callback);
@@ -29455,7 +29303,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'zone', 'instanceGroup'],
         pathParams: ['instanceGroup', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$InstanceGroupsListInstances>(
@@ -29595,7 +29443,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'zone', 'instanceGroup'],
         pathParams: ['instanceGroup', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -29732,7 +29580,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'zone', 'instanceGroup'],
         pathParams: ['instanceGroup', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -30130,15 +29978,7 @@ export namespace compute_v1 {
 
 
   export class Resource$Instances {
-    root: Compute;
-    constructor(root: Compute) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -30271,7 +30111,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'zone', 'instance', 'networkInterface'],
         pathParams: ['instance', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -30413,7 +30253,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$InstanceAggregatedList>(parameters, callback);
@@ -30553,7 +30393,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'zone', 'instance'],
         pathParams: ['instance', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -30683,7 +30523,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'zone', 'instance'],
         pathParams: ['instance', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -30823,7 +30663,7 @@ export namespace compute_v1 {
         requiredParams:
             ['project', 'zone', 'instance', 'accessConfig', 'networkInterface'],
         pathParams: ['instance', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -30958,7 +30798,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'zone', 'instance', 'deviceName'],
         pathParams: ['instance', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -31083,7 +30923,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'zone', 'instance'],
         pathParams: ['instance', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Instance>(parameters, callback);
@@ -31215,7 +31055,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'zone', 'instance'],
         pathParams: ['instance', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$SerialPortOutput>(parameters, callback);
@@ -31346,7 +31186,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'zone'],
         pathParams: ['project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -31487,7 +31327,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'zone'],
         pathParams: ['project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$InstanceList>(parameters, callback);
@@ -31566,7 +31406,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'zone', 'instance'],
         pathParams: ['instance', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$InstanceListReferrers>(parameters, callback);
@@ -31696,7 +31536,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'zone', 'instance'],
         pathParams: ['instance', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -31827,7 +31667,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'zone', 'resource'],
         pathParams: ['project', 'resource', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -31967,7 +31807,7 @@ export namespace compute_v1 {
         requiredParams:
             ['project', 'zone', 'instance', 'autoDelete', 'deviceName'],
         pathParams: ['instance', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -32104,7 +31944,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'zone', 'instance'],
         pathParams: ['instance', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -32239,7 +32079,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'zone', 'instance'],
         pathParams: ['instance', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -32376,7 +32216,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'zone', 'instance'],
         pathParams: ['instance', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -32513,7 +32353,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'zone', 'instance'],
         pathParams: ['instance', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -32651,7 +32491,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'zone', 'instance'],
         pathParams: ['instance', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -32787,7 +32627,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'zone', 'instance'],
         pathParams: ['instance', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -32924,7 +32764,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'zone', 'instance'],
         pathParams: ['instance', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -33061,7 +32901,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'zone', 'instance'],
         pathParams: ['instance', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -33133,7 +32973,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'zone', 'instance'],
         pathParams: ['instance', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -33263,7 +33103,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'zone', 'instance'],
         pathParams: ['instance', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -33399,7 +33239,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'zone', 'instance'],
         pathParams: ['instance', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -33533,7 +33373,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'zone', 'instance'],
         pathParams: ['instance', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -33610,7 +33450,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'zone', 'instance', 'networkInterface'],
         pathParams: ['instance', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -33686,7 +33526,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'zone', 'instance', 'networkInterface'],
         pathParams: ['instance', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -34784,15 +34624,7 @@ export namespace compute_v1 {
 
 
   export class Resource$Instancetemplates {
-    root: Compute;
-    constructor(root: Compute) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -34915,7 +34747,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'instanceTemplate'],
         pathParams: ['instanceTemplate', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -35039,7 +34871,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'instanceTemplate'],
         pathParams: ['instanceTemplate', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$InstanceTemplate>(parameters, callback);
@@ -35170,7 +35002,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -35310,7 +35142,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$InstanceTemplateList>(parameters, callback);
@@ -35453,15 +35285,7 @@ export namespace compute_v1 {
 
 
   export class Resource$Interconnectattachments {
-    root: Compute;
-    constructor(root: Compute) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -35606,7 +35430,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$InterconnectAttachmentAggregatedList>(
@@ -35738,7 +35562,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region', 'interconnectAttachment'],
         pathParams: ['interconnectAttachment', 'project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -35866,7 +35690,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region', 'interconnectAttachment'],
         pathParams: ['interconnectAttachment', 'project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$InterconnectAttachment>(parameters, callback);
@@ -35997,7 +35821,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -36146,7 +35970,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$InterconnectAttachmentList>(
@@ -36222,7 +36046,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region', 'interconnectAttachment'],
         pathParams: ['interconnectAttachment', 'project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -36474,15 +36298,7 @@ export namespace compute_v1 {
 
 
   export class Resource$Interconnectlocations {
-    root: Compute;
-    constructor(root: Compute) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -36600,7 +36416,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'interconnectLocation'],
         pathParams: ['interconnectLocation', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$InterconnectLocation>(parameters, callback);
@@ -36741,7 +36557,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$InterconnectLocationList>(parameters, callback);
@@ -36825,15 +36641,7 @@ export namespace compute_v1 {
 
 
   export class Resource$Interconnects {
-    root: Compute;
-    constructor(root: Compute) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -36953,7 +36761,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'interconnect'],
         pathParams: ['interconnect', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -37076,7 +36884,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'interconnect'],
         pathParams: ['interconnect', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Interconnect>(parameters, callback);
@@ -37156,7 +36964,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'interconnect'],
         pathParams: ['interconnect', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$InterconnectsGetDiagnosticsResponse>(
@@ -37286,7 +37094,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -37424,7 +37232,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$InterconnectList>(parameters, callback);
@@ -37560,7 +37368,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'interconnect'],
         pathParams: ['interconnect', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -37753,15 +37561,7 @@ export namespace compute_v1 {
 
 
   export class Resource$Licensecodes {
-    root: Compute;
-    constructor(root: Compute) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -37820,7 +37620,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'licenseCode'],
         pathParams: ['licenseCode', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$LicenseCode>(parameters, callback);
@@ -37893,7 +37693,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -37942,15 +37742,7 @@ export namespace compute_v1 {
 
 
   export class Resource$Licenses {
-    root: Compute;
-    constructor(root: Compute) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -38011,7 +37803,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'license'],
         pathParams: ['license', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -38130,7 +37922,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'license'],
         pathParams: ['license', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$License>(parameters, callback);
@@ -38197,7 +37989,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -38272,7 +38064,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$LicensesListResponse>(parameters, callback);
@@ -38345,7 +38137,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -38505,15 +38297,7 @@ export namespace compute_v1 {
 
 
   export class Resource$Machinetypes {
-    root: Compute;
-    constructor(root: Compute) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -38648,7 +38432,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$MachineTypeAggregatedList>(
@@ -38775,7 +38559,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'zone', 'machineType'],
         pathParams: ['machineType', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$MachineType>(parameters, callback);
@@ -38917,7 +38701,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'zone'],
         pathParams: ['project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$MachineTypeList>(parameters, callback);
@@ -39063,15 +38847,7 @@ export namespace compute_v1 {
 
 
   export class Resource$Networks {
-    root: Compute;
-    constructor(root: Compute) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -39196,7 +38972,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'network'],
         pathParams: ['network', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -39320,7 +39096,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'network'],
         pathParams: ['network', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -39440,7 +39216,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'network'],
         pathParams: ['network', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Network>(parameters, callback);
@@ -39565,7 +39341,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -39700,7 +39476,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$NetworkList>(parameters, callback);
@@ -39833,7 +39609,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'network'],
         pathParams: ['network', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -39965,7 +39741,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'network'],
         pathParams: ['network', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -40093,7 +39869,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'network'],
         pathParams: ['network', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -40362,15 +40138,7 @@ export namespace compute_v1 {
 
 
   export class Resource$Nodegroups {
-    root: Compute;
-    constructor(root: Compute) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -40436,7 +40204,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'zone', 'nodeGroup'],
         pathParams: ['nodeGroup', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -40511,7 +40279,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$NodeGroupAggregatedList>(parameters, callback);
@@ -40582,7 +40350,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'zone', 'nodeGroup'],
         pathParams: ['nodeGroup', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -40655,7 +40423,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'zone', 'nodeGroup'],
         pathParams: ['nodeGroup', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -40723,7 +40491,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'zone', 'nodeGroup'],
         pathParams: ['nodeGroup', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$NodeGroup>(parameters, callback);
@@ -40795,7 +40563,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'zone', 'initialNodeCount'],
         pathParams: ['project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -40867,7 +40635,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'zone'],
         pathParams: ['project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$NodeGroupList>(parameters, callback);
@@ -40942,7 +40710,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'zone', 'nodeGroup'],
         pathParams: ['nodeGroup', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$NodeGroupsListNodes>(parameters, callback);
@@ -41015,7 +40783,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'zone', 'nodeGroup'],
         pathParams: ['nodeGroup', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -41408,15 +41176,7 @@ export namespace compute_v1 {
 
 
   export class Resource$Nodetemplates {
-    root: Compute;
-    constructor(root: Compute) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -41487,7 +41247,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$NodeTemplateAggregatedList>(
@@ -41560,7 +41320,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region', 'nodeTemplate'],
         pathParams: ['nodeTemplate', 'project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -41628,7 +41388,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region', 'nodeTemplate'],
         pathParams: ['nodeTemplate', 'project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$NodeTemplate>(parameters, callback);
@@ -41701,7 +41461,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -41775,7 +41535,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$NodeTemplateList>(parameters, callback);
@@ -41989,15 +41749,7 @@ export namespace compute_v1 {
 
 
   export class Resource$Nodetypes {
-    root: Compute;
-    constructor(root: Compute) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -42064,7 +41816,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$NodeTypeAggregatedList>(parameters, callback);
@@ -42130,7 +41882,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'zone', 'nodeType'],
         pathParams: ['nodeType', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$NodeType>(parameters, callback);
@@ -42201,7 +41953,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'zone'],
         pathParams: ['project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$NodeTypeList>(parameters, callback);
@@ -42346,15 +42098,7 @@ export namespace compute_v1 {
 
 
   export class Resource$Projects {
-    root: Compute;
-    constructor(root: Compute) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -42468,7 +42212,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -42596,7 +42340,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -42717,7 +42461,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -42846,7 +42590,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -42960,7 +42704,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Project>(parameters, callback);
@@ -43080,7 +42824,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Project>(parameters, callback);
@@ -43220,7 +42964,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ProjectsGetXpnResources>(parameters, callback);
@@ -43363,7 +43107,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$XpnHostList>(parameters, callback);
@@ -43489,7 +43233,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -43616,7 +43360,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -43743,7 +43487,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -43816,7 +43560,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -43944,7 +43688,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -44355,15 +44099,7 @@ export namespace compute_v1 {
 
 
   export class Resource$Regionautoscalers {
-    root: Compute;
-    constructor(root: Compute) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -44487,7 +44223,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region', 'autoscaler'],
         pathParams: ['autoscaler', 'project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -44613,7 +44349,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region', 'autoscaler'],
         pathParams: ['autoscaler', 'project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Autoscaler>(parameters, callback);
@@ -44746,7 +44482,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -44891,7 +44627,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$RegionAutoscalerList>(parameters, callback);
@@ -45028,7 +44764,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -45164,7 +44900,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -45399,15 +45135,7 @@ export namespace compute_v1 {
 
 
   export class Resource$Regionbackendservices {
-    root: Compute;
-    constructor(root: Compute) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -45532,7 +45260,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region', 'backendService'],
         pathParams: ['backendService', 'project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -45659,7 +45387,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region', 'backendService'],
         pathParams: ['backendService', 'project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$BackendService>(parameters, callback);
@@ -45796,7 +45524,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region', 'backendService'],
         pathParams: ['backendService', 'project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$BackendServiceGroupHealth>(
@@ -45932,7 +45660,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -46076,7 +45804,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$BackendServiceList>(parameters, callback);
@@ -46220,7 +45948,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region', 'backendService'],
         pathParams: ['backendService', 'project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -46362,7 +46090,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region', 'backendService'],
         pathParams: ['backendService', 'project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -46622,15 +46350,7 @@ export namespace compute_v1 {
 
 
   export class Resource$Regioncommitments {
-    root: Compute;
-    constructor(root: Compute) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -46764,7 +46484,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$CommitmentAggregatedList>(parameters, callback);
@@ -46891,7 +46611,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region', 'commitment'],
         pathParams: ['commitment', 'project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Commitment>(parameters, callback);
@@ -47024,7 +46744,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -47168,7 +46888,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$CommitmentList>(parameters, callback);
@@ -47349,15 +47069,7 @@ export namespace compute_v1 {
 
 
   export class Resource$Regiondisks {
-    root: Compute;
-    constructor(root: Compute) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -47423,7 +47135,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region', 'disk'],
         pathParams: ['disk', 'project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -47498,7 +47210,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region', 'disk'],
         pathParams: ['disk', 'project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -47563,7 +47275,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region', 'disk'],
         pathParams: ['disk', 'project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Disk>(parameters, callback);
@@ -47636,7 +47348,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -47707,7 +47419,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$DiskList>(parameters, callback);
@@ -47780,7 +47492,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region', 'disk'],
         pathParams: ['disk', 'project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -47853,7 +47565,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region', 'resource'],
         pathParams: ['project', 'region', 'resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -47927,7 +47639,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region', 'resource'],
         pathParams: ['project', 'region', 'resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -48227,15 +47939,7 @@ export namespace compute_v1 {
 
 
   export class Resource$Regiondisktypes {
-    root: Compute;
-    constructor(root: Compute) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -48295,7 +47999,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region', 'diskType'],
         pathParams: ['diskType', 'project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$DiskType>(parameters, callback);
@@ -48369,7 +48073,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$RegionDiskTypeList>(parameters, callback);
@@ -48461,15 +48165,7 @@ export namespace compute_v1 {
 
 
   export class Resource$Regioninstancegroupmanagers {
-    root: Compute;
-    constructor(root: Compute) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -48611,7 +48307,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region', 'instanceGroupManager'],
         pathParams: ['instanceGroupManager', 'project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -48742,7 +48438,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region', 'instanceGroupManager'],
         pathParams: ['instanceGroupManager', 'project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -48890,7 +48586,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region', 'instanceGroupManager'],
         pathParams: ['instanceGroupManager', 'project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -49017,7 +48713,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region', 'instanceGroupManager'],
         pathParams: ['instanceGroupManager', 'project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$InstanceGroupManager>(parameters, callback);
@@ -49153,7 +48849,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -49302,7 +48998,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$RegionInstanceGroupManagerList>(
@@ -49452,7 +49148,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region', 'instanceGroupManager'],
         pathParams: ['instanceGroupManager', 'project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<
@@ -49602,7 +49298,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region', 'instanceGroupManager'],
         pathParams: ['instanceGroupManager', 'project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -49745,7 +49441,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region', 'instanceGroupManager', 'size'],
         pathParams: ['instanceGroupManager', 'project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -49884,7 +49580,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region', 'instanceGroupManager'],
         pathParams: ['instanceGroupManager', 'project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -50022,7 +49718,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region', 'instanceGroupManager'],
         pathParams: ['instanceGroupManager', 'project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -50471,15 +50167,7 @@ export namespace compute_v1 {
 
 
   export class Resource$Regioninstancegroups {
-    root: Compute;
-    constructor(root: Compute) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -50599,7 +50287,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region', 'instanceGroup'],
         pathParams: ['instanceGroup', 'project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$InstanceGroup>(parameters, callback);
@@ -50744,7 +50432,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$RegionInstanceGroupList>(parameters, callback);
@@ -50910,7 +50598,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region', 'instanceGroup'],
         pathParams: ['instanceGroup', 'project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$RegionInstanceGroupsListInstances>(
@@ -51047,7 +50735,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region', 'instanceGroup'],
         pathParams: ['instanceGroup', 'project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -51247,15 +50935,7 @@ export namespace compute_v1 {
 
 
   export class Resource$Regionoperations {
-    root: Compute;
-    constructor(root: Compute) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -51373,7 +51053,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region', 'operation'],
         pathParams: ['operation', 'project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -51499,7 +51179,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region', 'operation'],
         pathParams: ['operation', 'project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -51643,7 +51323,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$OperationList>(parameters, callback);
@@ -51755,15 +51435,7 @@ export namespace compute_v1 {
 
 
   export class Resource$Regions {
-    root: Compute;
-    constructor(root: Compute) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -51875,7 +51547,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Region>(parameters, callback);
@@ -52011,7 +51683,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$RegionList>(parameters, callback);
@@ -52093,15 +51765,7 @@ export namespace compute_v1 {
 
 
   export class Resource$Routers {
-    root: Compute;
-    constructor(root: Compute) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -52235,7 +51899,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$RouterAggregatedList>(parameters, callback);
@@ -52364,7 +52028,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region', 'router'],
         pathParams: ['project', 'region', 'router'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -52489,7 +52153,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region', 'router'],
         pathParams: ['project', 'region', 'router'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Router>(parameters, callback);
@@ -52567,7 +52231,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region', 'router'],
         pathParams: ['project', 'region', 'router'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$VmEndpointNatMappingsList>(
@@ -52700,7 +52364,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region', 'router'],
         pathParams: ['project', 'region', 'router'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$RouterStatusResponse>(parameters, callback);
@@ -52830,7 +52494,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -52971,7 +52635,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$RouterList>(parameters, callback);
@@ -53109,7 +52773,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region', 'router'],
         pathParams: ['project', 'region', 'router'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -53245,7 +52909,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region', 'router'],
         pathParams: ['project', 'region', 'router'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$RoutersPreviewResponse>(parameters, callback);
@@ -53382,7 +53046,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region', 'router'],
         pathParams: ['project', 'region', 'router'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -53774,15 +53438,7 @@ export namespace compute_v1 {
 
 
   export class Resource$Routes {
-    root: Compute;
-    constructor(root: Compute) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -53899,7 +53555,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'route'],
         pathParams: ['project', 'route'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -54019,7 +53675,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'route'],
         pathParams: ['project', 'route'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Route>(parameters, callback);
@@ -54144,7 +53800,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -54280,7 +53936,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$RouteList>(parameters, callback);
@@ -54419,15 +54075,7 @@ export namespace compute_v1 {
 
 
   export class Resource$Securitypolicies {
-    root: Compute;
-    constructor(root: Compute) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -54491,7 +54139,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'securityPolicy'],
         pathParams: ['project', 'securityPolicy'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -54562,7 +54210,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'securityPolicy'],
         pathParams: ['project', 'securityPolicy'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -54628,7 +54276,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'securityPolicy'],
         pathParams: ['project', 'securityPolicy'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$SecurityPolicy>(parameters, callback);
@@ -54699,7 +54347,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'securityPolicy'],
         pathParams: ['project', 'securityPolicy'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$SecurityPolicyRule>(parameters, callback);
@@ -54770,7 +54418,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -54843,7 +54491,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$SecurityPolicyList>(parameters, callback);
@@ -54915,7 +54563,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'securityPolicy'],
         pathParams: ['project', 'securityPolicy'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -54987,7 +54635,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'securityPolicy'],
         pathParams: ['project', 'securityPolicy'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -55058,7 +54706,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'securityPolicy'],
         pathParams: ['project', 'securityPolicy'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -55321,15 +54969,7 @@ export namespace compute_v1 {
 
 
   export class Resource$Snapshots {
-    root: Compute;
-    constructor(root: Compute) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -55451,7 +55091,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'snapshot'],
         pathParams: ['project', 'snapshot'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -55572,7 +55212,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'snapshot'],
         pathParams: ['project', 'snapshot'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Snapshot>(parameters, callback);
@@ -55708,7 +55348,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$SnapshotList>(parameters, callback);
@@ -55840,7 +55480,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -55971,15 +55611,7 @@ export namespace compute_v1 {
 
 
   export class Resource$Sslcertificates {
-    root: Compute;
-    constructor(root: Compute) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -56100,7 +55732,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'sslCertificate'],
         pathParams: ['project', 'sslCertificate'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -56224,7 +55856,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'sslCertificate'],
         pathParams: ['project', 'sslCertificate'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$SslCertificate>(parameters, callback);
@@ -56352,7 +55984,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -56491,7 +56123,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$SslCertificateList>(parameters, callback);
@@ -56634,15 +56266,7 @@ export namespace compute_v1 {
 
 
   export class Resource$Sslpolicies {
-    root: Compute;
-    constructor(root: Compute) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -56708,7 +56332,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'sslPolicy'],
         pathParams: ['project', 'sslPolicy'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -56774,7 +56398,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'sslPolicy'],
         pathParams: ['project', 'sslPolicy'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$SslPolicy>(parameters, callback);
@@ -56845,7 +56469,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -56916,7 +56540,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$SslPoliciesList>(parameters, callback);
@@ -56997,7 +56621,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$SslPoliciesListAvailableFeaturesResponse>(
@@ -57071,7 +56695,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'sslPolicy'],
         pathParams: ['project', 'sslPolicy'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -57304,15 +56928,7 @@ export namespace compute_v1 {
 
 
   export class Resource$Subnetworks {
-    root: Compute;
-    constructor(root: Compute) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -57446,7 +57062,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$SubnetworkAggregatedList>(parameters, callback);
@@ -57577,7 +57193,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region', 'subnetwork'],
         pathParams: ['project', 'region', 'subnetwork'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -57711,7 +57327,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region', 'subnetwork'],
         pathParams: ['project', 'region', 'subnetwork'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -57837,7 +57453,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region', 'subnetwork'],
         pathParams: ['project', 'region', 'subnetwork'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Subnetwork>(parameters, callback);
@@ -57970,7 +57586,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -58111,7 +57727,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$SubnetworkList>(parameters, callback);
@@ -58191,7 +57807,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$UsableSubnetworksAggregatedList>(
@@ -58269,7 +57885,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region', 'subnetwork'],
         pathParams: ['project', 'region', 'subnetwork'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -58405,7 +58021,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region', 'subnetwork'],
         pathParams: ['project', 'region', 'subnetwork'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -58786,15 +58402,7 @@ export namespace compute_v1 {
 
 
   export class Resource$Targethttpproxies {
-    root: Compute;
-    constructor(root: Compute) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -58915,7 +58523,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'targetHttpProxy'],
         pathParams: ['project', 'targetHttpProxy'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -59039,7 +58647,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'targetHttpProxy'],
         pathParams: ['project', 'targetHttpProxy'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TargetHttpProxy>(parameters, callback);
@@ -59167,7 +58775,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -59306,7 +58914,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TargetHttpProxyList>(parameters, callback);
@@ -59439,7 +59047,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'targetHttpProxy'],
         pathParams: ['project', 'targetHttpProxy'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -59616,15 +59224,7 @@ export namespace compute_v1 {
 
 
   export class Resource$Targethttpsproxies {
-    root: Compute;
-    constructor(root: Compute) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -59745,7 +59345,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'targetHttpsProxy'],
         pathParams: ['project', 'targetHttpsProxy'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -59869,7 +59469,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'targetHttpsProxy'],
         pathParams: ['project', 'targetHttpsProxy'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TargetHttpsProxy>(parameters, callback);
@@ -59997,7 +59597,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -60137,7 +59737,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TargetHttpsProxyList>(parameters, callback);
@@ -60209,7 +59809,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'targetHttpsProxy'],
         pathParams: ['project', 'targetHttpsProxy'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -60341,7 +59941,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'targetHttpsProxy'],
         pathParams: ['project', 'targetHttpsProxy'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -60416,7 +60016,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'targetHttpsProxy'],
         pathParams: ['project', 'targetHttpsProxy'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -60549,7 +60149,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'targetHttpsProxy'],
         pathParams: ['project', 'targetHttpsProxy'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -60831,15 +60431,7 @@ export namespace compute_v1 {
 
 
   export class Resource$Targetinstances {
-    root: Compute;
-    constructor(root: Compute) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -60977,7 +60569,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TargetInstanceAggregatedList>(
@@ -61111,7 +60703,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'zone', 'targetInstance'],
         pathParams: ['project', 'targetInstance', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -61239,7 +60831,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'zone', 'targetInstance'],
         pathParams: ['project', 'targetInstance', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TargetInstance>(parameters, callback);
@@ -61372,7 +60964,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'zone'],
         pathParams: ['project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -61516,7 +61108,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'zone'],
         pathParams: ['project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TargetInstanceList>(parameters, callback);
@@ -61730,15 +61322,7 @@ export namespace compute_v1 {
 
 
   export class Resource$Targetpools {
-    root: Compute;
-    constructor(root: Compute) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -61867,7 +61451,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region', 'targetPool'],
         pathParams: ['project', 'region', 'targetPool'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -62003,7 +61587,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region', 'targetPool'],
         pathParams: ['project', 'region', 'targetPool'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -62144,7 +61728,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TargetPoolAggregatedList>(parameters, callback);
@@ -62275,7 +61859,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region', 'targetPool'],
         pathParams: ['project', 'region', 'targetPool'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -62401,7 +61985,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region', 'targetPool'],
         pathParams: ['project', 'region', 'targetPool'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TargetPool>(parameters, callback);
@@ -62540,7 +62124,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region', 'targetPool'],
         pathParams: ['project', 'region', 'targetPool'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TargetPoolInstanceHealth>(parameters, callback);
@@ -62673,7 +62257,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -62815,7 +62399,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TargetPoolList>(parameters, callback);
@@ -62949,7 +62533,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region', 'targetPool'],
         pathParams: ['project', 'region', 'targetPool'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -63085,7 +62669,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region', 'targetPool'],
         pathParams: ['project', 'region', 'targetPool'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -63222,7 +62806,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region', 'targetPool'],
         pathParams: ['project', 'region', 'targetPool'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -63653,15 +63237,7 @@ export namespace compute_v1 {
 
 
   export class Resource$Targetsslproxies {
-    root: Compute;
-    constructor(root: Compute) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -63782,7 +63358,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'targetSslProxy'],
         pathParams: ['project', 'targetSslProxy'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -63906,7 +63482,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'targetSslProxy'],
         pathParams: ['project', 'targetSslProxy'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TargetSslProxy>(parameters, callback);
@@ -64034,7 +63610,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -64173,7 +63749,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TargetSslProxyList>(parameters, callback);
@@ -64304,7 +63880,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'targetSslProxy'],
         pathParams: ['project', 'targetSslProxy'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -64435,7 +64011,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'targetSslProxy'],
         pathParams: ['project', 'targetSslProxy'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -64566,7 +64142,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'targetSslProxy'],
         pathParams: ['project', 'targetSslProxy'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -64641,7 +64217,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'targetSslProxy'],
         pathParams: ['project', 'targetSslProxy'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -64923,15 +64499,7 @@ export namespace compute_v1 {
 
 
   export class Resource$Targettcpproxies {
-    root: Compute;
-    constructor(root: Compute) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -65052,7 +64620,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'targetTcpProxy'],
         pathParams: ['project', 'targetTcpProxy'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -65176,7 +64744,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'targetTcpProxy'],
         pathParams: ['project', 'targetTcpProxy'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TargetTcpProxy>(parameters, callback);
@@ -65304,7 +64872,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -65443,7 +65011,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TargetTcpProxyList>(parameters, callback);
@@ -65574,7 +65142,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'targetTcpProxy'],
         pathParams: ['project', 'targetTcpProxy'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -65705,7 +65273,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'targetTcpProxy'],
         pathParams: ['project', 'targetTcpProxy'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -65917,15 +65485,7 @@ export namespace compute_v1 {
 
 
   export class Resource$Targetvpngateways {
-    root: Compute;
-    constructor(root: Compute) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -66064,7 +65624,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TargetVpnGatewayAggregatedList>(
@@ -66198,7 +65758,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region', 'targetVpnGateway'],
         pathParams: ['project', 'region', 'targetVpnGateway'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -66326,7 +65886,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region', 'targetVpnGateway'],
         pathParams: ['project', 'region', 'targetVpnGateway'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TargetVpnGateway>(parameters, callback);
@@ -66459,7 +66019,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -66604,7 +66164,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TargetVpnGatewayList>(parameters, callback);
@@ -66818,15 +66378,7 @@ export namespace compute_v1 {
 
 
   export class Resource$Urlmaps {
-    root: Compute;
-    constructor(root: Compute) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -66943,7 +66495,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'urlMap'],
         pathParams: ['project', 'urlMap'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -67063,7 +66615,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'urlMap'],
         pathParams: ['project', 'urlMap'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$UrlMap>(parameters, callback);
@@ -67188,7 +66740,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -67321,7 +66873,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'urlMap'],
         pathParams: ['project', 'urlMap'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -67457,7 +67009,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$UrlMapList>(parameters, callback);
@@ -67590,7 +67142,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'urlMap'],
         pathParams: ['project', 'urlMap'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -67722,7 +67274,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'urlMap'],
         pathParams: ['project', 'urlMap'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -67856,7 +67408,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'urlMap'],
         pathParams: ['project', 'urlMap'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$UrlMapsValidateResponse>(parameters, callback);
@@ -68115,15 +67667,7 @@ export namespace compute_v1 {
 
 
   export class Resource$Vpntunnels {
-    root: Compute;
-    constructor(root: Compute) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -68257,7 +67801,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$VpnTunnelAggregatedList>(parameters, callback);
@@ -68387,7 +67931,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region', 'vpnTunnel'],
         pathParams: ['project', 'region', 'vpnTunnel'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -68513,7 +68057,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region', 'vpnTunnel'],
         pathParams: ['project', 'region', 'vpnTunnel'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$VpnTunnel>(parameters, callback);
@@ -68645,7 +68189,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -68787,7 +68331,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$VpnTunnelList>(parameters, callback);
@@ -68999,15 +68543,7 @@ export namespace compute_v1 {
 
 
   export class Resource$Zoneoperations {
-    root: Compute;
-    constructor(root: Compute) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -69125,7 +68661,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'zone', 'operation'],
         pathParams: ['operation', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -69251,7 +68787,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'zone', 'operation'],
         pathParams: ['operation', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -69393,7 +68929,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'zone'],
         pathParams: ['project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$OperationList>(parameters, callback);
@@ -69505,15 +69041,7 @@ export namespace compute_v1 {
 
 
   export class Resource$Zones {
-    root: Compute;
-    constructor(root: Compute) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -69625,7 +69153,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'zone'],
         pathParams: ['project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Zone>(parameters, callback);
@@ -69760,7 +69288,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ZoneList>(parameters, callback);

--- a/src/apis/container/v1.ts
+++ b/src/apis/container/v1.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace container_v1 {
   export interface Options extends GlobalOptions {
     version: 'v1';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -97,22 +99,12 @@ export namespace container_v1 {
    * @param {object=} options Options for Container
    */
   export class Container {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     projects: Resource$Projects;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.projects = new Resource$Projects(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.projects = new Resource$Projects();
     }
   }
 
@@ -1926,35 +1918,21 @@ export namespace container_v1 {
 
 
   export class Resource$Projects {
-    root: Container;
     locations: Resource$Projects$Locations;
     zones: Resource$Projects$Zones;
-    constructor(root: Container) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.locations = new Resource$Projects$Locations(root);
-      this.zones = new Resource$Projects$Zones(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.locations = new Resource$Projects$Locations();
+      this.zones = new Resource$Projects$Zones();
     }
   }
 
 
   export class Resource$Projects$Locations {
-    root: Container;
     clusters: Resource$Projects$Locations$Clusters;
     operations: Resource$Projects$Locations$Operations;
-    constructor(root: Container) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.clusters = new Resource$Projects$Locations$Clusters(root);
-      this.operations = new Resource$Projects$Locations$Operations(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.clusters = new Resource$Projects$Locations$Clusters();
+      this.operations = new Resource$Projects$Locations$Operations();
     }
 
 
@@ -2017,7 +1995,7 @@ export namespace container_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ServerConfig>(parameters, callback);
@@ -2054,16 +2032,9 @@ export namespace container_v1 {
   }
 
   export class Resource$Projects$Locations$Clusters {
-    root: Container;
     nodePools: Resource$Projects$Locations$Clusters$Nodepools;
-    constructor(root: Container) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.nodePools = new Resource$Projects$Locations$Clusters$Nodepools(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.nodePools = new Resource$Projects$Locations$Clusters$Nodepools();
     }
 
 
@@ -2127,7 +2098,7 @@ export namespace container_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -2203,7 +2174,7 @@ export namespace container_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -2276,7 +2247,7 @@ export namespace container_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -2340,7 +2311,7 @@ export namespace container_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Cluster>(parameters, callback);
@@ -2411,7 +2382,7 @@ export namespace container_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListClustersResponse>(parameters, callback);
@@ -2480,7 +2451,7 @@ export namespace container_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -2550,7 +2521,7 @@ export namespace container_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -2619,7 +2590,7 @@ export namespace container_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -2688,7 +2659,7 @@ export namespace container_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -2762,7 +2733,7 @@ export namespace container_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -2834,7 +2805,7 @@ export namespace container_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -2904,7 +2875,7 @@ export namespace container_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -2974,7 +2945,7 @@ export namespace container_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -3044,7 +3015,7 @@ export namespace container_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -3114,7 +3085,7 @@ export namespace container_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -3181,7 +3152,7 @@ export namespace container_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -3250,7 +3221,7 @@ export namespace container_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -3602,15 +3573,7 @@ export namespace container_v1 {
   }
 
   export class Resource$Projects$Locations$Clusters$Nodepools {
-    root: Container;
-    constructor(root: Container) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -3673,7 +3636,7 @@ export namespace container_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -3745,7 +3708,7 @@ export namespace container_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -3812,7 +3775,7 @@ export namespace container_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$NodePool>(parameters, callback);
@@ -3885,7 +3848,7 @@ export namespace container_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListNodePoolsResponse>(parameters, callback);
@@ -3956,7 +3919,7 @@ export namespace container_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -4029,7 +3992,7 @@ export namespace container_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -4102,7 +4065,7 @@ export namespace container_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -4172,7 +4135,7 @@ export namespace container_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -4241,7 +4204,7 @@ export namespace container_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -4470,15 +4433,7 @@ export namespace container_v1 {
 
 
   export class Resource$Projects$Locations$Operations {
-    root: Container;
-    constructor(root: Container) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -4538,7 +4493,7 @@ export namespace container_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -4603,7 +4558,7 @@ export namespace container_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -4673,7 +4628,7 @@ export namespace container_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListOperationsResponse>(parameters, callback);
@@ -4762,18 +4717,11 @@ export namespace container_v1 {
 
 
   export class Resource$Projects$Zones {
-    root: Container;
     clusters: Resource$Projects$Zones$Clusters;
     operations: Resource$Projects$Zones$Operations;
-    constructor(root: Container) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.clusters = new Resource$Projects$Zones$Clusters(root);
-      this.operations = new Resource$Projects$Zones$Operations(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.clusters = new Resource$Projects$Zones$Clusters();
+      this.operations = new Resource$Projects$Zones$Operations();
     }
 
 
@@ -4894,7 +4842,7 @@ export namespace container_v1 {
         params,
         requiredParams: ['projectId', 'zone'],
         pathParams: ['projectId', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ServerConfig>(parameters, callback);
@@ -4931,16 +4879,9 @@ export namespace container_v1 {
   }
 
   export class Resource$Projects$Zones$Clusters {
-    root: Container;
     nodePools: Resource$Projects$Zones$Clusters$Nodepools;
-    constructor(root: Container) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.nodePools = new Resource$Projects$Zones$Clusters$Nodepools(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.nodePools = new Resource$Projects$Zones$Clusters$Nodepools();
     }
 
 
@@ -5070,7 +5011,7 @@ export namespace container_v1 {
         params,
         requiredParams: ['projectId', 'zone', 'clusterId'],
         pathParams: ['clusterId', 'projectId', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -5209,7 +5150,7 @@ export namespace container_v1 {
         params,
         requiredParams: ['projectId', 'zone', 'clusterId'],
         pathParams: ['clusterId', 'projectId', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -5347,7 +5288,7 @@ export namespace container_v1 {
         params,
         requiredParams: ['projectId', 'zone'],
         pathParams: ['projectId', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -5483,7 +5424,7 @@ export namespace container_v1 {
         params,
         requiredParams: ['projectId', 'zone', 'clusterId'],
         pathParams: ['clusterId', 'projectId', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -5610,7 +5551,7 @@ export namespace container_v1 {
         params,
         requiredParams: ['projectId', 'zone', 'clusterId'],
         pathParams: ['clusterId', 'projectId', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Cluster>(parameters, callback);
@@ -5746,7 +5687,7 @@ export namespace container_v1 {
         params,
         requiredParams: ['projectId', 'zone', 'clusterId'],
         pathParams: ['clusterId', 'projectId', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -5874,7 +5815,7 @@ export namespace container_v1 {
         params,
         requiredParams: ['projectId', 'zone'],
         pathParams: ['projectId', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListClustersResponse>(parameters, callback);
@@ -6010,7 +5951,7 @@ export namespace container_v1 {
         params,
         requiredParams: ['projectId', 'zone', 'clusterId'],
         pathParams: ['clusterId', 'projectId', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -6146,7 +6087,7 @@ export namespace container_v1 {
         params,
         requiredParams: ['projectId', 'zone', 'clusterId'],
         pathParams: ['clusterId', 'projectId', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -6282,7 +6223,7 @@ export namespace container_v1 {
         params,
         requiredParams: ['projectId', 'zone', 'clusterId'],
         pathParams: ['clusterId', 'projectId', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -6418,7 +6359,7 @@ export namespace container_v1 {
         params,
         requiredParams: ['projectId', 'zone', 'clusterId'],
         pathParams: ['clusterId', 'projectId', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -6556,7 +6497,7 @@ export namespace container_v1 {
         params,
         requiredParams: ['projectId', 'zone', 'clusterId'],
         pathParams: ['clusterId', 'projectId', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -6695,7 +6636,7 @@ export namespace container_v1 {
         params,
         requiredParams: ['projectId', 'zone', 'clusterId'],
         pathParams: ['clusterId', 'projectId', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -6834,7 +6775,7 @@ export namespace container_v1 {
         params,
         requiredParams: ['projectId', 'zone', 'clusterId'],
         pathParams: ['clusterId', 'projectId', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -6972,7 +6913,7 @@ export namespace container_v1 {
         params,
         requiredParams: ['projectId', 'zone', 'clusterId'],
         pathParams: ['clusterId', 'projectId', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -7110,7 +7051,7 @@ export namespace container_v1 {
         params,
         requiredParams: ['projectId', 'zone', 'clusterId'],
         pathParams: ['clusterId', 'projectId', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -7248,7 +7189,7 @@ export namespace container_v1 {
         params,
         requiredParams: ['projectId', 'zone', 'clusterId'],
         pathParams: ['clusterId', 'projectId', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -7759,15 +7700,7 @@ export namespace container_v1 {
   }
 
   export class Resource$Projects$Zones$Clusters$Nodepools {
-    root: Container;
-    constructor(root: Container) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -7902,7 +7835,7 @@ export namespace container_v1 {
         params,
         requiredParams: ['projectId', 'zone', 'clusterId', 'nodePoolId'],
         pathParams: ['clusterId', 'nodePoolId', 'projectId', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -8040,7 +7973,7 @@ export namespace container_v1 {
         params,
         requiredParams: ['projectId', 'zone', 'clusterId'],
         pathParams: ['clusterId', 'projectId', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -8178,7 +8111,7 @@ export namespace container_v1 {
         params,
         requiredParams: ['projectId', 'zone', 'clusterId', 'nodePoolId'],
         pathParams: ['clusterId', 'nodePoolId', 'projectId', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -8311,7 +8244,7 @@ export namespace container_v1 {
         params,
         requiredParams: ['projectId', 'zone', 'clusterId', 'nodePoolId'],
         pathParams: ['clusterId', 'nodePoolId', 'projectId', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$NodePool>(parameters, callback);
@@ -8446,7 +8379,7 @@ export namespace container_v1 {
         params,
         requiredParams: ['projectId', 'zone', 'clusterId'],
         pathParams: ['clusterId', 'projectId', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListNodePoolsResponse>(parameters, callback);
@@ -8589,7 +8522,7 @@ export namespace container_v1 {
         params,
         requiredParams: ['projectId', 'zone', 'clusterId', 'nodePoolId'],
         pathParams: ['clusterId', 'nodePoolId', 'projectId', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -8732,7 +8665,7 @@ export namespace container_v1 {
         params,
         requiredParams: ['projectId', 'zone', 'clusterId', 'nodePoolId'],
         pathParams: ['clusterId', 'nodePoolId', 'projectId', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -8874,7 +8807,7 @@ export namespace container_v1 {
         params,
         requiredParams: ['projectId', 'zone', 'clusterId', 'nodePoolId'],
         pathParams: ['clusterId', 'nodePoolId', 'projectId', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -9015,7 +8948,7 @@ export namespace container_v1 {
         params,
         requiredParams: ['projectId', 'zone', 'clusterId', 'nodePoolId'],
         pathParams: ['clusterId', 'nodePoolId', 'projectId', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -9336,15 +9269,7 @@ export namespace container_v1 {
 
 
   export class Resource$Projects$Zones$Operations {
-    root: Container;
-    constructor(root: Container) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -9470,7 +9395,7 @@ export namespace container_v1 {
         params,
         requiredParams: ['projectId', 'zone', 'operationId'],
         pathParams: ['operationId', 'projectId', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -9598,7 +9523,7 @@ export namespace container_v1 {
         params,
         requiredParams: ['projectId', 'zone', 'operationId'],
         pathParams: ['operationId', 'projectId', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -9726,7 +9651,7 @@ export namespace container_v1 {
         params,
         requiredParams: ['projectId', 'zone'],
         pathParams: ['projectId', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListOperationsResponse>(parameters, callback);

--- a/src/apis/container/v1beta1.ts
+++ b/src/apis/container/v1beta1.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace container_v1beta1 {
   export interface Options extends GlobalOptions {
     version: 'v1beta1';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -97,22 +99,12 @@ export namespace container_v1beta1 {
    * @param {object=} options Options for Container
    */
   export class Container {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     projects: Resource$Projects;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.projects = new Resource$Projects(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.projects = new Resource$Projects();
     }
   }
 
@@ -2272,50 +2264,28 @@ export namespace container_v1beta1 {
 
 
   export class Resource$Projects {
-    root: Container;
     aggregated: Resource$Projects$Aggregated;
     locations: Resource$Projects$Locations;
     zones: Resource$Projects$Zones;
-    constructor(root: Container) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.aggregated = new Resource$Projects$Aggregated(root);
-      this.locations = new Resource$Projects$Locations(root);
-      this.zones = new Resource$Projects$Zones(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.aggregated = new Resource$Projects$Aggregated();
+      this.locations = new Resource$Projects$Locations();
+      this.zones = new Resource$Projects$Zones();
     }
   }
 
 
   export class Resource$Projects$Aggregated {
-    root: Container;
     usableSubnetworks: Resource$Projects$Aggregated$Usablesubnetworks;
-    constructor(root: Container) {
-      this.root = root;
-      this.getRoot.bind(this);
+    constructor() {
       this.usableSubnetworks =
-          new Resource$Projects$Aggregated$Usablesubnetworks(root);
-    }
-
-    getRoot() {
-      return this.root;
+          new Resource$Projects$Aggregated$Usablesubnetworks();
     }
   }
 
 
   export class Resource$Projects$Aggregated$Usablesubnetworks {
-    root: Container;
-    constructor(root: Container) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -2386,7 +2356,7 @@ export namespace container_v1beta1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListUsableSubnetworksResponse>(
@@ -2434,18 +2404,11 @@ export namespace container_v1beta1 {
 
 
   export class Resource$Projects$Locations {
-    root: Container;
     clusters: Resource$Projects$Locations$Clusters;
     operations: Resource$Projects$Locations$Operations;
-    constructor(root: Container) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.clusters = new Resource$Projects$Locations$Clusters(root);
-      this.operations = new Resource$Projects$Locations$Operations(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.clusters = new Resource$Projects$Locations$Clusters();
+      this.operations = new Resource$Projects$Locations$Operations();
     }
 
 
@@ -2508,7 +2471,7 @@ export namespace container_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ServerConfig>(parameters, callback);
@@ -2575,7 +2538,7 @@ export namespace container_v1beta1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListLocationsResponse>(parameters, callback);
@@ -2625,16 +2588,9 @@ export namespace container_v1beta1 {
   }
 
   export class Resource$Projects$Locations$Clusters {
-    root: Container;
     nodePools: Resource$Projects$Locations$Clusters$Nodepools;
-    constructor(root: Container) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.nodePools = new Resource$Projects$Locations$Clusters$Nodepools(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.nodePools = new Resource$Projects$Locations$Clusters$Nodepools();
     }
 
 
@@ -2698,7 +2654,7 @@ export namespace container_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -2774,7 +2730,7 @@ export namespace container_v1beta1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -2847,7 +2803,7 @@ export namespace container_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -2911,7 +2867,7 @@ export namespace container_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Cluster>(parameters, callback);
@@ -2982,7 +2938,7 @@ export namespace container_v1beta1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListClustersResponse>(parameters, callback);
@@ -3051,7 +3007,7 @@ export namespace container_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -3121,7 +3077,7 @@ export namespace container_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -3190,7 +3146,7 @@ export namespace container_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -3259,7 +3215,7 @@ export namespace container_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -3333,7 +3289,7 @@ export namespace container_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -3406,7 +3362,7 @@ export namespace container_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -3476,7 +3432,7 @@ export namespace container_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -3546,7 +3502,7 @@ export namespace container_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -3616,7 +3572,7 @@ export namespace container_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -3686,7 +3642,7 @@ export namespace container_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -3753,7 +3709,7 @@ export namespace container_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -3822,7 +3778,7 @@ export namespace container_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -4174,15 +4130,7 @@ export namespace container_v1beta1 {
   }
 
   export class Resource$Projects$Locations$Clusters$Nodepools {
-    root: Container;
-    constructor(root: Container) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -4245,7 +4193,7 @@ export namespace container_v1beta1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -4317,7 +4265,7 @@ export namespace container_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -4384,7 +4332,7 @@ export namespace container_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$NodePool>(parameters, callback);
@@ -4457,7 +4405,7 @@ export namespace container_v1beta1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListNodePoolsResponse>(parameters, callback);
@@ -4528,7 +4476,7 @@ export namespace container_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -4601,7 +4549,7 @@ export namespace container_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -4674,7 +4622,7 @@ export namespace container_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -4744,7 +4692,7 @@ export namespace container_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -4813,7 +4761,7 @@ export namespace container_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -5042,15 +4990,7 @@ export namespace container_v1beta1 {
 
 
   export class Resource$Projects$Locations$Operations {
-    root: Container;
-    constructor(root: Container) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -5110,7 +5050,7 @@ export namespace container_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -5175,7 +5115,7 @@ export namespace container_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -5245,7 +5185,7 @@ export namespace container_v1beta1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListOperationsResponse>(parameters, callback);
@@ -5334,18 +5274,11 @@ export namespace container_v1beta1 {
 
 
   export class Resource$Projects$Zones {
-    root: Container;
     clusters: Resource$Projects$Zones$Clusters;
     operations: Resource$Projects$Zones$Operations;
-    constructor(root: Container) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.clusters = new Resource$Projects$Zones$Clusters(root);
-      this.operations = new Resource$Projects$Zones$Operations(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.clusters = new Resource$Projects$Zones$Clusters();
+      this.operations = new Resource$Projects$Zones$Operations();
     }
 
 
@@ -5409,7 +5342,7 @@ export namespace container_v1beta1 {
         params,
         requiredParams: ['projectId', 'zone'],
         pathParams: ['projectId', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ServerConfig>(parameters, callback);
@@ -5446,16 +5379,9 @@ export namespace container_v1beta1 {
   }
 
   export class Resource$Projects$Zones$Clusters {
-    root: Container;
     nodePools: Resource$Projects$Zones$Clusters$Nodepools;
-    constructor(root: Container) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.nodePools = new Resource$Projects$Zones$Clusters$Nodepools(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.nodePools = new Resource$Projects$Zones$Clusters$Nodepools();
     }
 
 
@@ -5521,7 +5447,7 @@ export namespace container_v1beta1 {
         params,
         requiredParams: ['projectId', 'zone', 'clusterId'],
         pathParams: ['clusterId', 'projectId', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -5595,7 +5521,7 @@ export namespace container_v1beta1 {
         params,
         requiredParams: ['projectId', 'zone', 'clusterId'],
         pathParams: ['clusterId', 'projectId', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -5673,7 +5599,7 @@ export namespace container_v1beta1 {
         params,
         requiredParams: ['projectId', 'zone'],
         pathParams: ['projectId', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -5749,7 +5675,7 @@ export namespace container_v1beta1 {
         params,
         requiredParams: ['projectId', 'zone', 'clusterId'],
         pathParams: ['clusterId', 'projectId', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -5816,7 +5742,7 @@ export namespace container_v1beta1 {
         params,
         requiredParams: ['projectId', 'zone', 'clusterId'],
         pathParams: ['clusterId', 'projectId', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Cluster>(parameters, callback);
@@ -5888,7 +5814,7 @@ export namespace container_v1beta1 {
         params,
         requiredParams: ['projectId', 'zone', 'clusterId'],
         pathParams: ['clusterId', 'projectId', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -5960,7 +5886,7 @@ export namespace container_v1beta1 {
         params,
         requiredParams: ['projectId', 'zone'],
         pathParams: ['projectId', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListClustersResponse>(parameters, callback);
@@ -6032,7 +5958,7 @@ export namespace container_v1beta1 {
         params,
         requiredParams: ['projectId', 'zone', 'clusterId'],
         pathParams: ['clusterId', 'projectId', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -6104,7 +6030,7 @@ export namespace container_v1beta1 {
         params,
         requiredParams: ['projectId', 'zone', 'clusterId'],
         pathParams: ['clusterId', 'projectId', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -6176,7 +6102,7 @@ export namespace container_v1beta1 {
         params,
         requiredParams: ['projectId', 'zone', 'clusterId'],
         pathParams: ['clusterId', 'projectId', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -6248,7 +6174,7 @@ export namespace container_v1beta1 {
         params,
         requiredParams: ['projectId', 'zone', 'clusterId'],
         pathParams: ['clusterId', 'projectId', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -6321,7 +6247,7 @@ export namespace container_v1beta1 {
         params,
         requiredParams: ['projectId', 'zone', 'clusterId'],
         pathParams: ['clusterId', 'projectId', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -6396,7 +6322,7 @@ export namespace container_v1beta1 {
         params,
         requiredParams: ['projectId', 'zone', 'clusterId'],
         pathParams: ['clusterId', 'projectId', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -6472,7 +6398,7 @@ export namespace container_v1beta1 {
         params,
         requiredParams: ['projectId', 'zone', 'clusterId'],
         pathParams: ['clusterId', 'projectId', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -6545,7 +6471,7 @@ export namespace container_v1beta1 {
         params,
         requiredParams: ['projectId', 'zone', 'clusterId'],
         pathParams: ['clusterId', 'projectId', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -6618,7 +6544,7 @@ export namespace container_v1beta1 {
         params,
         requiredParams: ['projectId', 'zone', 'clusterId'],
         pathParams: ['clusterId', 'projectId', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -6690,7 +6616,7 @@ export namespace container_v1beta1 {
         params,
         requiredParams: ['projectId', 'zone', 'clusterId'],
         pathParams: ['clusterId', 'projectId', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -7201,15 +7127,7 @@ export namespace container_v1beta1 {
   }
 
   export class Resource$Projects$Zones$Clusters$Nodepools {
-    root: Container;
-    constructor(root: Container) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -7277,7 +7195,7 @@ export namespace container_v1beta1 {
         params,
         requiredParams: ['projectId', 'zone', 'clusterId', 'nodePoolId'],
         pathParams: ['clusterId', 'nodePoolId', 'projectId', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -7350,7 +7268,7 @@ export namespace container_v1beta1 {
         params,
         requiredParams: ['projectId', 'zone', 'clusterId'],
         pathParams: ['clusterId', 'projectId', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -7424,7 +7342,7 @@ export namespace container_v1beta1 {
         params,
         requiredParams: ['projectId', 'zone', 'clusterId', 'nodePoolId'],
         pathParams: ['clusterId', 'nodePoolId', 'projectId', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -7493,7 +7411,7 @@ export namespace container_v1beta1 {
         params,
         requiredParams: ['projectId', 'zone', 'clusterId', 'nodePoolId'],
         pathParams: ['clusterId', 'nodePoolId', 'projectId', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$NodePool>(parameters, callback);
@@ -7567,7 +7485,7 @@ export namespace container_v1beta1 {
         params,
         requiredParams: ['projectId', 'zone', 'clusterId'],
         pathParams: ['clusterId', 'projectId', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListNodePoolsResponse>(parameters, callback);
@@ -7643,7 +7561,7 @@ export namespace container_v1beta1 {
         params,
         requiredParams: ['projectId', 'zone', 'clusterId', 'nodePoolId'],
         pathParams: ['clusterId', 'nodePoolId', 'projectId', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -7719,7 +7637,7 @@ export namespace container_v1beta1 {
         params,
         requiredParams: ['projectId', 'zone', 'clusterId', 'nodePoolId'],
         pathParams: ['clusterId', 'nodePoolId', 'projectId', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -7794,7 +7712,7 @@ export namespace container_v1beta1 {
         params,
         requiredParams: ['projectId', 'zone', 'clusterId', 'nodePoolId'],
         pathParams: ['clusterId', 'nodePoolId', 'projectId', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -7868,7 +7786,7 @@ export namespace container_v1beta1 {
         params,
         requiredParams: ['projectId', 'zone', 'clusterId', 'nodePoolId'],
         pathParams: ['clusterId', 'nodePoolId', 'projectId', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -8189,15 +8107,7 @@ export namespace container_v1beta1 {
 
 
   export class Resource$Projects$Zones$Operations {
-    root: Container;
-    constructor(root: Container) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -8261,7 +8171,7 @@ export namespace container_v1beta1 {
         params,
         requiredParams: ['projectId', 'zone', 'operationId'],
         pathParams: ['operationId', 'projectId', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -8329,7 +8239,7 @@ export namespace container_v1beta1 {
         params,
         requiredParams: ['projectId', 'zone', 'operationId'],
         pathParams: ['operationId', 'projectId', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -8400,7 +8310,7 @@ export namespace container_v1beta1 {
         params,
         requiredParams: ['projectId', 'zone'],
         pathParams: ['projectId', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListOperationsResponse>(parameters, callback);

--- a/src/apis/content/v2.ts
+++ b/src/apis/content/v2.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace content_v2 {
   export interface Options extends GlobalOptions {
     version: 'v2';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -80,10 +82,6 @@ export namespace content_v2 {
    * @param {object=} options Options for Content
    */
   export class Content {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     accounts: Resource$Accounts;
     accountstatuses: Resource$Accountstatuses;
     accounttax: Resource$Accounttax;
@@ -102,30 +100,24 @@ export namespace content_v2 {
     shippingsettings: Resource$Shippingsettings;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.accounts = new Resource$Accounts(this);
-      this.accountstatuses = new Resource$Accountstatuses(this);
-      this.accounttax = new Resource$Accounttax(this);
-      this.datafeeds = new Resource$Datafeeds(this);
-      this.datafeedstatuses = new Resource$Datafeedstatuses(this);
-      this.inventory = new Resource$Inventory(this);
-      this.liasettings = new Resource$Liasettings(this);
-      this.orderinvoices = new Resource$Orderinvoices(this);
-      this.orderpayments = new Resource$Orderpayments(this);
-      this.orderreports = new Resource$Orderreports(this);
-      this.orderreturns = new Resource$Orderreturns(this);
-      this.orders = new Resource$Orders(this);
-      this.pos = new Resource$Pos(this);
-      this.products = new Resource$Products(this);
-      this.productstatuses = new Resource$Productstatuses(this);
-      this.shippingsettings = new Resource$Shippingsettings(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.accounts = new Resource$Accounts();
+      this.accountstatuses = new Resource$Accountstatuses();
+      this.accounttax = new Resource$Accounttax();
+      this.datafeeds = new Resource$Datafeeds();
+      this.datafeedstatuses = new Resource$Datafeedstatuses();
+      this.inventory = new Resource$Inventory();
+      this.liasettings = new Resource$Liasettings();
+      this.orderinvoices = new Resource$Orderinvoices();
+      this.orderpayments = new Resource$Orderpayments();
+      this.orderreports = new Resource$Orderreports();
+      this.orderreturns = new Resource$Orderreturns();
+      this.orders = new Resource$Orders();
+      this.pos = new Resource$Pos();
+      this.products = new Resource$Products();
+      this.productstatuses = new Resource$Productstatuses();
+      this.shippingsettings = new Resource$Shippingsettings();
     }
   }
 
@@ -5783,15 +5775,7 @@ export namespace content_v2 {
 
 
   export class Resource$Accounts {
-    root: Content;
-    constructor(root: Content) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -5852,7 +5836,7 @@ export namespace content_v2 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$AccountsAuthInfoResponse>(parameters, callback);
@@ -5929,7 +5913,7 @@ export namespace content_v2 {
         params,
         requiredParams: ['merchantId', 'accountId'],
         pathParams: ['accountId', 'merchantId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$AccountsClaimWebsiteResponse>(
@@ -6005,7 +5989,7 @@ export namespace content_v2 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$AccountsCustomBatchResponse>(
@@ -6072,7 +6056,7 @@ export namespace content_v2 {
         params,
         requiredParams: ['merchantId', 'accountId'],
         pathParams: ['accountId', 'merchantId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -6134,7 +6118,7 @@ export namespace content_v2 {
         params,
         requiredParams: ['merchantId', 'accountId'],
         pathParams: ['accountId', 'merchantId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Account>(parameters, callback);
@@ -6200,7 +6184,7 @@ export namespace content_v2 {
         params,
         requiredParams: ['merchantId'],
         pathParams: ['merchantId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Account>(parameters, callback);
@@ -6270,7 +6254,7 @@ export namespace content_v2 {
         params,
         requiredParams: ['merchantId', 'accountId'],
         pathParams: ['accountId', 'merchantId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$AccountsLinkResponse>(parameters, callback);
@@ -6338,7 +6322,7 @@ export namespace content_v2 {
         params,
         requiredParams: ['merchantId'],
         pathParams: ['merchantId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$AccountsListResponse>(parameters, callback);
@@ -6406,7 +6390,7 @@ export namespace content_v2 {
         params,
         requiredParams: ['merchantId', 'accountId'],
         pathParams: ['accountId', 'merchantId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Account>(parameters, callback);
@@ -6473,7 +6457,7 @@ export namespace content_v2 {
         params,
         requiredParams: ['merchantId', 'accountId'],
         pathParams: ['accountId', 'merchantId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Account>(parameters, callback);
@@ -6689,15 +6673,7 @@ export namespace content_v2 {
 
 
   export class Resource$Accountstatuses {
-    root: Content;
-    constructor(root: Content) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -6766,7 +6742,7 @@ export namespace content_v2 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$AccountstatusesCustomBatchResponse>(
@@ -6835,7 +6811,7 @@ export namespace content_v2 {
         params,
         requiredParams: ['merchantId', 'accountId'],
         pathParams: ['accountId', 'merchantId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$AccountStatus>(parameters, callback);
@@ -6910,7 +6886,7 @@ export namespace content_v2 {
         params,
         requiredParams: ['merchantId'],
         pathParams: ['merchantId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$AccountstatusesListResponse>(
@@ -6986,15 +6962,7 @@ export namespace content_v2 {
 
 
   export class Resource$Accounttax {
-    root: Content;
-    constructor(root: Content) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -7062,7 +7030,7 @@ export namespace content_v2 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$AccounttaxCustomBatchResponse>(
@@ -7127,7 +7095,7 @@ export namespace content_v2 {
         params,
         requiredParams: ['merchantId', 'accountId'],
         pathParams: ['accountId', 'merchantId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$AccountTax>(parameters, callback);
@@ -7196,7 +7164,7 @@ export namespace content_v2 {
         params,
         requiredParams: ['merchantId'],
         pathParams: ['merchantId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$AccounttaxListResponse>(parameters, callback);
@@ -7265,7 +7233,7 @@ export namespace content_v2 {
         params,
         requiredParams: ['merchantId', 'accountId'],
         pathParams: ['accountId', 'merchantId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$AccountTax>(parameters, callback);
@@ -7334,7 +7302,7 @@ export namespace content_v2 {
         params,
         requiredParams: ['merchantId', 'accountId'],
         pathParams: ['accountId', 'merchantId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$AccountTax>(parameters, callback);
@@ -7454,15 +7422,7 @@ export namespace content_v2 {
 
 
   export class Resource$Datafeeds {
-    root: Content;
-    constructor(root: Content) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -7528,7 +7488,7 @@ export namespace content_v2 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$DatafeedsCustomBatchResponse>(
@@ -7595,7 +7555,7 @@ export namespace content_v2 {
         params,
         requiredParams: ['merchantId', 'datafeedId'],
         pathParams: ['datafeedId', 'merchantId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -7667,7 +7627,7 @@ export namespace content_v2 {
         params,
         requiredParams: ['merchantId', 'datafeedId'],
         pathParams: ['datafeedId', 'merchantId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$DatafeedsFetchNowResponse>(
@@ -7731,7 +7691,7 @@ export namespace content_v2 {
         params,
         requiredParams: ['merchantId', 'datafeedId'],
         pathParams: ['datafeedId', 'merchantId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Datafeed>(parameters, callback);
@@ -7798,7 +7758,7 @@ export namespace content_v2 {
         params,
         requiredParams: ['merchantId'],
         pathParams: ['merchantId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Datafeed>(parameters, callback);
@@ -7867,7 +7827,7 @@ export namespace content_v2 {
         params,
         requiredParams: ['merchantId'],
         pathParams: ['merchantId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$DatafeedsListResponse>(parameters, callback);
@@ -7935,7 +7895,7 @@ export namespace content_v2 {
         params,
         requiredParams: ['merchantId', 'datafeedId'],
         pathParams: ['datafeedId', 'merchantId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Datafeed>(parameters, callback);
@@ -8002,7 +7962,7 @@ export namespace content_v2 {
         params,
         requiredParams: ['merchantId', 'datafeedId'],
         pathParams: ['datafeedId', 'merchantId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Datafeed>(parameters, callback);
@@ -8181,15 +8141,7 @@ export namespace content_v2 {
 
 
   export class Resource$Datafeedstatuses {
-    root: Content;
-    constructor(root: Content) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -8258,7 +8210,7 @@ export namespace content_v2 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$DatafeedstatusesCustomBatchResponse>(
@@ -8328,7 +8280,7 @@ export namespace content_v2 {
         params,
         requiredParams: ['merchantId', 'datafeedId'],
         pathParams: ['datafeedId', 'merchantId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$DatafeedStatus>(parameters, callback);
@@ -8403,7 +8355,7 @@ export namespace content_v2 {
         params,
         requiredParams: ['merchantId'],
         pathParams: ['merchantId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$DatafeedstatusesListResponse>(
@@ -8484,15 +8436,7 @@ export namespace content_v2 {
 
 
   export class Resource$Inventory {
-    root: Content;
-    constructor(root: Content) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -8561,7 +8505,7 @@ export namespace content_v2 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$InventoryCustomBatchResponse>(
@@ -8633,7 +8577,7 @@ export namespace content_v2 {
         params,
         requiredParams: ['merchantId', 'storeCode', 'productId'],
         pathParams: ['merchantId', 'productId', 'storeCode'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$InventorySetResponse>(parameters, callback);
@@ -8693,15 +8637,7 @@ export namespace content_v2 {
 
 
   export class Resource$Liasettings {
-    root: Content;
-    constructor(root: Content) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -8769,7 +8705,7 @@ export namespace content_v2 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$LiasettingsCustomBatchResponse>(
@@ -8835,7 +8771,7 @@ export namespace content_v2 {
         params,
         requiredParams: ['merchantId', 'accountId'],
         pathParams: ['accountId', 'merchantId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$LiaSettings>(parameters, callback);
@@ -8913,7 +8849,7 @@ export namespace content_v2 {
         params,
         requiredParams: ['merchantId', 'accountId'],
         pathParams: ['accountId', 'merchantId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$LiasettingsGetAccessibleGmbAccountsResponse>(
@@ -8984,7 +8920,7 @@ export namespace content_v2 {
         params,
         requiredParams: ['merchantId'],
         pathParams: ['merchantId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$LiasettingsListResponse>(parameters, callback);
@@ -9057,7 +8993,7 @@ export namespace content_v2 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$LiasettingsListPosDataProvidersResponse>(
@@ -9130,7 +9066,7 @@ export namespace content_v2 {
         params,
         requiredParams: ['merchantId', 'accountId'],
         pathParams: ['accountId', 'merchantId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$LiaSettings>(parameters, callback);
@@ -9211,7 +9147,7 @@ export namespace content_v2 {
         params,
         requiredParams: ['merchantId', 'accountId', 'gmbEmail'],
         pathParams: ['accountId', 'merchantId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$LiasettingsRequestGmbAccessResponse>(
@@ -9293,7 +9229,7 @@ export namespace content_v2 {
         params,
         requiredParams: ['merchantId', 'accountId', 'country'],
         pathParams: ['accountId', 'country', 'merchantId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<
@@ -9384,7 +9320,7 @@ export namespace content_v2 {
           'language'
         ],
         pathParams: ['accountId', 'merchantId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<
@@ -9471,7 +9407,7 @@ export namespace content_v2 {
         params,
         requiredParams: ['merchantId', 'accountId', 'country'],
         pathParams: ['accountId', 'merchantId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$LiasettingsSetPosDataProviderResponse>(
@@ -9544,7 +9480,7 @@ export namespace content_v2 {
         params,
         requiredParams: ['merchantId', 'accountId'],
         pathParams: ['accountId', 'merchantId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$LiaSettings>(parameters, callback);
@@ -9802,15 +9738,7 @@ export namespace content_v2 {
 
 
   export class Resource$Orderinvoices {
-    root: Content;
-    constructor(root: Content) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -9881,7 +9809,7 @@ export namespace content_v2 {
         params,
         requiredParams: ['merchantId', 'orderId'],
         pathParams: ['merchantId', 'orderId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$OrderinvoicesCreateChargeInvoiceResponse>(
@@ -9964,7 +9892,7 @@ export namespace content_v2 {
         params,
         requiredParams: ['merchantId', 'orderId'],
         pathParams: ['merchantId', 'orderId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$OrderinvoicesCreateRefundInvoiceResponse>(
@@ -10023,15 +9951,7 @@ export namespace content_v2 {
 
 
   export class Resource$Orderpayments {
-    root: Content;
-    constructor(root: Content) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -10102,7 +10022,7 @@ export namespace content_v2 {
         params,
         requiredParams: ['merchantId', 'orderId'],
         pathParams: ['merchantId', 'orderId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$OrderpaymentsNotifyAuthApprovedResponse>(
@@ -10181,7 +10101,7 @@ export namespace content_v2 {
         params,
         requiredParams: ['merchantId', 'orderId'],
         pathParams: ['merchantId', 'orderId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$OrderpaymentsNotifyAuthDeclinedResponse>(
@@ -10264,7 +10184,7 @@ export namespace content_v2 {
         params,
         requiredParams: ['merchantId', 'orderId'],
         pathParams: ['merchantId', 'orderId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$OrderpaymentsNotifyChargeResponse>(
@@ -10347,7 +10267,7 @@ export namespace content_v2 {
         params,
         requiredParams: ['merchantId', 'orderId'],
         pathParams: ['merchantId', 'orderId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$OrderpaymentsNotifyRefundResponse>(
@@ -10450,15 +10370,7 @@ export namespace content_v2 {
 
 
   export class Resource$Orderreports {
-    root: Content;
-    constructor(root: Content) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -10534,7 +10446,7 @@ export namespace content_v2 {
         params,
         requiredParams: ['merchantId', 'disbursementStartDate'],
         pathParams: ['merchantId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$OrderreportsListDisbursementsResponse>(
@@ -10622,7 +10534,7 @@ export namespace content_v2 {
         requiredParams:
             ['merchantId', 'disbursementId', 'transactionStartDate'],
         pathParams: ['disbursementId', 'merchantId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$OrderreportsListTransactionsResponse>(
@@ -10703,15 +10615,7 @@ export namespace content_v2 {
 
 
   export class Resource$Orderreturns {
-    root: Content;
-    constructor(root: Content) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -10768,7 +10672,7 @@ export namespace content_v2 {
         params,
         requiredParams: ['merchantId', 'returnId'],
         pathParams: ['merchantId', 'returnId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$MerchantOrderReturn>(parameters, callback);
@@ -10840,7 +10744,7 @@ export namespace content_v2 {
         params,
         requiredParams: ['merchantId'],
         pathParams: ['merchantId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$OrderreturnsListResponse>(parameters, callback);
@@ -10906,15 +10810,7 @@ export namespace content_v2 {
 
 
   export class Resource$Orders {
-    root: Content;
-    constructor(root: Content) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -10979,7 +10875,7 @@ export namespace content_v2 {
         params,
         requiredParams: ['merchantId', 'orderId'],
         pathParams: ['merchantId', 'orderId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$OrdersAcknowledgeResponse>(
@@ -11056,7 +10952,7 @@ export namespace content_v2 {
         params,
         requiredParams: ['merchantId', 'orderId'],
         pathParams: ['merchantId', 'orderId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$OrdersAdvanceTestOrderResponse>(
@@ -11127,7 +11023,7 @@ export namespace content_v2 {
         params,
         requiredParams: ['merchantId', 'orderId'],
         pathParams: ['merchantId', 'orderId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$OrdersCancelResponse>(parameters, callback);
@@ -11203,7 +11099,7 @@ export namespace content_v2 {
         params,
         requiredParams: ['merchantId', 'orderId'],
         pathParams: ['merchantId', 'orderId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$OrdersCancelLineItemResponse>(
@@ -11284,7 +11180,7 @@ export namespace content_v2 {
         params,
         requiredParams: ['merchantId', 'orderId'],
         pathParams: ['merchantId', 'orderId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$OrdersCancelTestOrderByCustomerResponse>(
@@ -11360,7 +11256,7 @@ export namespace content_v2 {
         params,
         requiredParams: ['merchantId'],
         pathParams: ['merchantId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$OrdersCreateTestOrderResponse>(
@@ -11438,7 +11334,7 @@ export namespace content_v2 {
         params,
         requiredParams: ['merchantId', 'orderId'],
         pathParams: ['merchantId', 'orderId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$OrdersCreateTestReturnResponse>(
@@ -11509,7 +11405,7 @@ export namespace content_v2 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$OrdersCustomBatchResponse>(
@@ -11572,7 +11468,7 @@ export namespace content_v2 {
         params,
         requiredParams: ['merchantId', 'orderId'],
         pathParams: ['merchantId', 'orderId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Order>(parameters, callback);
@@ -11652,7 +11548,7 @@ export namespace content_v2 {
         params,
         requiredParams: ['merchantId', 'merchantOrderId'],
         pathParams: ['merchantId', 'merchantOrderId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$OrdersGetByMerchantOrderIdResponse>(
@@ -11736,7 +11632,7 @@ export namespace content_v2 {
         params,
         requiredParams: ['merchantId', 'templateName'],
         pathParams: ['merchantId', 'templateName'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$OrdersGetTestOrderTemplateResponse>(
@@ -11821,7 +11717,7 @@ export namespace content_v2 {
         params,
         requiredParams: ['merchantId', 'orderId'],
         pathParams: ['merchantId', 'orderId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$OrdersInStoreRefundLineItemResponse>(
@@ -11895,7 +11791,7 @@ export namespace content_v2 {
         params,
         requiredParams: ['merchantId'],
         pathParams: ['merchantId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$OrdersListResponse>(parameters, callback);
@@ -11964,7 +11860,7 @@ export namespace content_v2 {
         params,
         requiredParams: ['merchantId', 'orderId'],
         pathParams: ['merchantId', 'orderId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$OrdersRefundResponse>(parameters, callback);
@@ -12045,7 +11941,7 @@ export namespace content_v2 {
         params,
         requiredParams: ['merchantId', 'orderId'],
         pathParams: ['merchantId', 'orderId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$OrdersRejectReturnLineItemResponse>(
@@ -12123,7 +12019,7 @@ export namespace content_v2 {
         params,
         requiredParams: ['merchantId', 'orderId'],
         pathParams: ['merchantId', 'orderId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$OrdersReturnLineItemResponse>(
@@ -12207,7 +12103,7 @@ export namespace content_v2 {
         params,
         requiredParams: ['merchantId', 'orderId'],
         pathParams: ['merchantId', 'orderId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$OrdersReturnRefundLineItemResponse>(
@@ -12290,7 +12186,7 @@ export namespace content_v2 {
         params,
         requiredParams: ['merchantId', 'orderId'],
         pathParams: ['merchantId', 'orderId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$OrdersSetLineItemMetadataResponse>(
@@ -12367,7 +12263,7 @@ export namespace content_v2 {
         params,
         requiredParams: ['merchantId', 'orderId'],
         pathParams: ['merchantId', 'orderId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$OrdersShipLineItemsResponse>(
@@ -12447,7 +12343,7 @@ export namespace content_v2 {
         params,
         requiredParams: ['merchantId', 'orderId'],
         pathParams: ['merchantId', 'orderId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$OrdersUpdateLineItemShippingDetailsResponse>(
@@ -12530,7 +12426,7 @@ export namespace content_v2 {
         params,
         requiredParams: ['merchantId', 'orderId'],
         pathParams: ['merchantId', 'orderId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$OrdersUpdateMerchantOrderIdResponse>(
@@ -12608,7 +12504,7 @@ export namespace content_v2 {
         params,
         requiredParams: ['merchantId', 'orderId'],
         pathParams: ['merchantId', 'orderId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$OrdersUpdateShipmentResponse>(
@@ -13109,15 +13005,7 @@ export namespace content_v2 {
 
 
   export class Resource$Pos {
-    root: Content;
-    constructor(root: Content) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -13179,7 +13067,7 @@ export namespace content_v2 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$PosCustomBatchResponse>(parameters, callback);
@@ -13247,7 +13135,7 @@ export namespace content_v2 {
         params,
         requiredParams: ['merchantId', 'targetMerchantId', 'storeCode'],
         pathParams: ['merchantId', 'storeCode', 'targetMerchantId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -13312,7 +13200,7 @@ export namespace content_v2 {
         params,
         requiredParams: ['merchantId', 'targetMerchantId', 'storeCode'],
         pathParams: ['merchantId', 'storeCode', 'targetMerchantId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$PosStore>(parameters, callback);
@@ -13380,7 +13268,7 @@ export namespace content_v2 {
         params,
         requiredParams: ['merchantId', 'targetMerchantId'],
         pathParams: ['merchantId', 'targetMerchantId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$PosStore>(parameters, callback);
@@ -13451,7 +13339,7 @@ export namespace content_v2 {
         params,
         requiredParams: ['merchantId', 'targetMerchantId'],
         pathParams: ['merchantId', 'targetMerchantId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$PosInventoryResponse>(parameters, callback);
@@ -13518,7 +13406,7 @@ export namespace content_v2 {
         params,
         requiredParams: ['merchantId', 'targetMerchantId'],
         pathParams: ['merchantId', 'targetMerchantId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$PosListResponse>(parameters, callback);
@@ -13587,7 +13475,7 @@ export namespace content_v2 {
         params,
         requiredParams: ['merchantId', 'targetMerchantId'],
         pathParams: ['merchantId', 'targetMerchantId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$PosSaleResponse>(parameters, callback);
@@ -13745,15 +13633,7 @@ export namespace content_v2 {
 
 
   export class Resource$Products {
-    root: Content;
-    constructor(root: Content) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -13820,7 +13700,7 @@ export namespace content_v2 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ProductsCustomBatchResponse>(
@@ -13886,7 +13766,7 @@ export namespace content_v2 {
         params,
         requiredParams: ['merchantId', 'productId'],
         pathParams: ['merchantId', 'productId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -13948,7 +13828,7 @@ export namespace content_v2 {
         params,
         requiredParams: ['merchantId', 'productId'],
         pathParams: ['merchantId', 'productId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Product>(parameters, callback);
@@ -14016,7 +13896,7 @@ export namespace content_v2 {
         params,
         requiredParams: ['merchantId'],
         pathParams: ['merchantId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Product>(parameters, callback);
@@ -14085,7 +13965,7 @@ export namespace content_v2 {
         params,
         requiredParams: ['merchantId'],
         pathParams: ['merchantId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ProductsListResponse>(parameters, callback);
@@ -14199,15 +14079,7 @@ export namespace content_v2 {
 
 
   export class Resource$Productstatuses {
-    root: Content;
-    constructor(root: Content) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -14278,7 +14150,7 @@ export namespace content_v2 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ProductstatusesCustomBatchResponse>(
@@ -14347,7 +14219,7 @@ export namespace content_v2 {
         params,
         requiredParams: ['merchantId', 'productId'],
         pathParams: ['merchantId', 'productId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ProductStatus>(parameters, callback);
@@ -14423,7 +14295,7 @@ export namespace content_v2 {
         params,
         requiredParams: ['merchantId'],
         pathParams: ['merchantId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ProductstatusesListResponse>(
@@ -14520,15 +14392,7 @@ export namespace content_v2 {
 
 
   export class Resource$Shippingsettings {
-    root: Content;
-    constructor(root: Content) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -14600,7 +14464,7 @@ export namespace content_v2 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ShippingsettingsCustomBatchResponse>(
@@ -14667,7 +14531,7 @@ export namespace content_v2 {
         params,
         requiredParams: ['merchantId', 'accountId'],
         pathParams: ['accountId', 'merchantId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ShippingSettings>(parameters, callback);
@@ -14743,7 +14607,7 @@ export namespace content_v2 {
         params,
         requiredParams: ['merchantId'],
         pathParams: ['merchantId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ShippingsettingsGetSupportedCarriersResponse>(
@@ -14821,7 +14685,7 @@ export namespace content_v2 {
         params,
         requiredParams: ['merchantId'],
         pathParams: ['merchantId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ShippingsettingsGetSupportedHolidaysResponse>(
@@ -14898,7 +14762,7 @@ export namespace content_v2 {
         params,
         requiredParams: ['merchantId'],
         pathParams: ['merchantId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ShippingsettingsListResponse>(
@@ -14972,7 +14836,7 @@ export namespace content_v2 {
         params,
         requiredParams: ['merchantId', 'accountId'],
         pathParams: ['accountId', 'merchantId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ShippingSettings>(parameters, callback);
@@ -15043,7 +14907,7 @@ export namespace content_v2 {
         params,
         requiredParams: ['merchantId', 'accountId'],
         pathParams: ['accountId', 'merchantId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ShippingSettings>(parameters, callback);

--- a/src/apis/customsearch/v1.ts
+++ b/src/apis/customsearch/v1.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace customsearch_v1 {
   export interface Options extends GlobalOptions {
     version: 'v1';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -79,22 +81,12 @@ export namespace customsearch_v1 {
    * @param {object=} options Options for Customsearch
    */
   export class Customsearch {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     cse: Resource$Cse;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.cse = new Resource$Cse(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.cse = new Resource$Cse();
     }
   }
 
@@ -194,16 +186,9 @@ export namespace customsearch_v1 {
 
 
   export class Resource$Cse {
-    root: Customsearch;
     siterestrict: Resource$Cse$Siterestrict;
-    constructor(root: Customsearch) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.siterestrict = new Resource$Cse$Siterestrict(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.siterestrict = new Resource$Cse$Siterestrict();
     }
 
 
@@ -291,7 +276,7 @@ export namespace customsearch_v1 {
         params,
         requiredParams: ['q'],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Search>(parameters, callback);
@@ -449,15 +434,7 @@ export namespace customsearch_v1 {
   }
 
   export class Resource$Cse$Siterestrict {
-    root: Customsearch;
-    constructor(root: Customsearch) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -548,7 +525,7 @@ export namespace customsearch_v1 {
         params,
         requiredParams: ['q'],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Search>(parameters, callback);

--- a/src/apis/dataflow/v1b3.ts
+++ b/src/apis/dataflow/v1b3.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace dataflow_v1b3 {
   export interface Options extends GlobalOptions {
     version: 'v1b3';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -96,22 +98,12 @@ export namespace dataflow_v1b3 {
    * @param {object=} options Options for Dataflow
    */
   export class Dataflow {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     projects: Resource$Projects;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.projects = new Resource$Projects(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.projects = new Resource$Projects();
     }
   }
 
@@ -3524,20 +3516,13 @@ export namespace dataflow_v1b3 {
 
 
   export class Resource$Projects {
-    root: Dataflow;
     jobs: Resource$Projects$Jobs;
     locations: Resource$Projects$Locations;
     templates: Resource$Projects$Templates;
-    constructor(root: Dataflow) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.jobs = new Resource$Projects$Jobs(root);
-      this.locations = new Resource$Projects$Locations(root);
-      this.templates = new Resource$Projects$Templates(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.jobs = new Resource$Projects$Jobs();
+      this.locations = new Resource$Projects$Locations();
+      this.templates = new Resource$Projects$Templates();
     }
 
 
@@ -3605,7 +3590,7 @@ export namespace dataflow_v1b3 {
         params,
         requiredParams: ['projectId'],
         pathParams: ['projectId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$SendWorkerMessagesResponse>(
@@ -3635,20 +3620,13 @@ export namespace dataflow_v1b3 {
   }
 
   export class Resource$Projects$Jobs {
-    root: Dataflow;
     debug: Resource$Projects$Jobs$Debug;
     messages: Resource$Projects$Jobs$Messages;
     workItems: Resource$Projects$Jobs$Workitems;
-    constructor(root: Dataflow) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.debug = new Resource$Projects$Jobs$Debug(root);
-      this.messages = new Resource$Projects$Jobs$Messages(root);
-      this.workItems = new Resource$Projects$Jobs$Workitems(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.debug = new Resource$Projects$Jobs$Debug();
+      this.messages = new Resource$Projects$Jobs$Messages();
+      this.workItems = new Resource$Projects$Jobs$Workitems();
     }
 
 
@@ -3714,7 +3692,7 @@ export namespace dataflow_v1b3 {
         params,
         requiredParams: ['projectId'],
         pathParams: ['projectId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListJobsResponse>(parameters, callback);
@@ -3784,7 +3762,7 @@ export namespace dataflow_v1b3 {
         params,
         requiredParams: ['projectId'],
         pathParams: ['projectId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Job>(parameters, callback);
@@ -3849,7 +3827,7 @@ export namespace dataflow_v1b3 {
         params,
         requiredParams: ['projectId', 'jobId'],
         pathParams: ['jobId', 'projectId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Job>(parameters, callback);
@@ -3919,7 +3897,7 @@ export namespace dataflow_v1b3 {
         params,
         requiredParams: ['projectId', 'jobId'],
         pathParams: ['jobId', 'projectId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$JobMetrics>(parameters, callback);
@@ -3990,7 +3968,7 @@ export namespace dataflow_v1b3 {
         params,
         requiredParams: ['projectId'],
         pathParams: ['projectId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListJobsResponse>(parameters, callback);
@@ -4059,7 +4037,7 @@ export namespace dataflow_v1b3 {
         params,
         requiredParams: ['projectId', 'jobId'],
         pathParams: ['jobId', 'projectId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Snapshot>(parameters, callback);
@@ -4128,7 +4106,7 @@ export namespace dataflow_v1b3 {
         params,
         requiredParams: ['projectId', 'jobId'],
         pathParams: ['jobId', 'projectId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Job>(parameters, callback);
@@ -4336,15 +4314,7 @@ export namespace dataflow_v1b3 {
   }
 
   export class Resource$Projects$Jobs$Debug {
-    root: Dataflow;
-    constructor(root: Dataflow) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -4409,7 +4379,7 @@ export namespace dataflow_v1b3 {
         params,
         requiredParams: ['projectId', 'jobId'],
         pathParams: ['jobId', 'projectId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GetDebugConfigResponse>(parameters, callback);
@@ -4481,7 +4451,7 @@ export namespace dataflow_v1b3 {
         params,
         requiredParams: ['projectId', 'jobId'],
         pathParams: ['jobId', 'projectId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$SendDebugCaptureResponse>(parameters, callback);
@@ -4536,15 +4506,7 @@ export namespace dataflow_v1b3 {
 
 
   export class Resource$Projects$Jobs$Messages {
-    root: Dataflow;
-    constructor(root: Dataflow) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -4613,7 +4575,7 @@ export namespace dataflow_v1b3 {
         params,
         requiredParams: ['projectId', 'jobId'],
         pathParams: ['jobId', 'projectId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListJobMessagesResponse>(parameters, callback);
@@ -4671,15 +4633,7 @@ export namespace dataflow_v1b3 {
 
 
   export class Resource$Projects$Jobs$Workitems {
-    root: Dataflow;
-    constructor(root: Dataflow) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -4743,7 +4697,7 @@ export namespace dataflow_v1b3 {
         params,
         requiredParams: ['projectId', 'jobId'],
         pathParams: ['jobId', 'projectId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$LeaseWorkItemResponse>(parameters, callback);
@@ -4820,7 +4774,7 @@ export namespace dataflow_v1b3 {
         params,
         requiredParams: ['projectId', 'jobId'],
         pathParams: ['jobId', 'projectId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ReportWorkItemStatusResponse>(
@@ -4878,18 +4832,11 @@ export namespace dataflow_v1b3 {
 
 
   export class Resource$Projects$Locations {
-    root: Dataflow;
     jobs: Resource$Projects$Locations$Jobs;
     templates: Resource$Projects$Locations$Templates;
-    constructor(root: Dataflow) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.jobs = new Resource$Projects$Locations$Jobs(root);
-      this.templates = new Resource$Projects$Locations$Templates(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.jobs = new Resource$Projects$Locations$Jobs();
+      this.templates = new Resource$Projects$Locations$Templates();
     }
 
 
@@ -4960,7 +4907,7 @@ export namespace dataflow_v1b3 {
         params,
         requiredParams: ['projectId', 'location'],
         pathParams: ['location', 'projectId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$SendWorkerMessagesResponse>(
@@ -4994,20 +4941,13 @@ export namespace dataflow_v1b3 {
   }
 
   export class Resource$Projects$Locations$Jobs {
-    root: Dataflow;
     debug: Resource$Projects$Locations$Jobs$Debug;
     messages: Resource$Projects$Locations$Jobs$Messages;
     workItems: Resource$Projects$Locations$Jobs$Workitems;
-    constructor(root: Dataflow) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.debug = new Resource$Projects$Locations$Jobs$Debug(root);
-      this.messages = new Resource$Projects$Locations$Jobs$Messages(root);
-      this.workItems = new Resource$Projects$Locations$Jobs$Workitems(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.debug = new Resource$Projects$Locations$Jobs$Debug();
+      this.messages = new Resource$Projects$Locations$Jobs$Messages();
+      this.workItems = new Resource$Projects$Locations$Jobs$Workitems();
     }
 
 
@@ -5072,7 +5012,7 @@ export namespace dataflow_v1b3 {
         params,
         requiredParams: ['projectId', 'location'],
         pathParams: ['location', 'projectId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Job>(parameters, callback);
@@ -5139,7 +5079,7 @@ export namespace dataflow_v1b3 {
         params,
         requiredParams: ['projectId', 'location', 'jobId'],
         pathParams: ['jobId', 'location', 'projectId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Job>(parameters, callback);
@@ -5211,7 +5151,7 @@ export namespace dataflow_v1b3 {
         params,
         requiredParams: ['projectId', 'location', 'jobId'],
         pathParams: ['jobId', 'location', 'projectId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$JobMetrics>(parameters, callback);
@@ -5284,7 +5224,7 @@ export namespace dataflow_v1b3 {
         params,
         requiredParams: ['projectId', 'location'],
         pathParams: ['location', 'projectId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListJobsResponse>(parameters, callback);
@@ -5355,7 +5295,7 @@ export namespace dataflow_v1b3 {
         params,
         requiredParams: ['projectId', 'location', 'jobId'],
         pathParams: ['jobId', 'location', 'projectId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Snapshot>(parameters, callback);
@@ -5426,7 +5366,7 @@ export namespace dataflow_v1b3 {
         params,
         requiredParams: ['projectId', 'location', 'jobId'],
         pathParams: ['jobId', 'location', 'projectId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Job>(parameters, callback);
@@ -5602,15 +5542,7 @@ export namespace dataflow_v1b3 {
   }
 
   export class Resource$Projects$Locations$Jobs$Debug {
-    root: Dataflow;
-    constructor(root: Dataflow) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -5678,7 +5610,7 @@ export namespace dataflow_v1b3 {
         params,
         requiredParams: ['projectId', 'location', 'jobId'],
         pathParams: ['jobId', 'location', 'projectId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GetDebugConfigResponse>(parameters, callback);
@@ -5754,7 +5686,7 @@ export namespace dataflow_v1b3 {
         params,
         requiredParams: ['projectId', 'location', 'jobId'],
         pathParams: ['jobId', 'location', 'projectId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$SendDebugCaptureResponse>(parameters, callback);
@@ -5817,15 +5749,7 @@ export namespace dataflow_v1b3 {
 
 
   export class Resource$Projects$Locations$Jobs$Messages {
-    root: Dataflow;
-    constructor(root: Dataflow) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -5896,7 +5820,7 @@ export namespace dataflow_v1b3 {
         params,
         requiredParams: ['projectId', 'location', 'jobId'],
         pathParams: ['jobId', 'location', 'projectId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListJobMessagesResponse>(parameters, callback);
@@ -5954,15 +5878,7 @@ export namespace dataflow_v1b3 {
 
 
   export class Resource$Projects$Locations$Jobs$Workitems {
-    root: Dataflow;
-    constructor(root: Dataflow) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -6029,7 +5945,7 @@ export namespace dataflow_v1b3 {
         params,
         requiredParams: ['projectId', 'location', 'jobId'],
         pathParams: ['jobId', 'location', 'projectId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$LeaseWorkItemResponse>(parameters, callback);
@@ -6109,7 +6025,7 @@ export namespace dataflow_v1b3 {
         params,
         requiredParams: ['projectId', 'location', 'jobId'],
         pathParams: ['jobId', 'location', 'projectId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ReportWorkItemStatusResponse>(
@@ -6175,15 +6091,7 @@ export namespace dataflow_v1b3 {
 
 
   export class Resource$Projects$Locations$Templates {
-    root: Dataflow;
-    constructor(root: Dataflow) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -6245,7 +6153,7 @@ export namespace dataflow_v1b3 {
         params,
         requiredParams: ['projectId', 'location'],
         pathParams: ['location', 'projectId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Job>(parameters, callback);
@@ -6313,7 +6221,7 @@ export namespace dataflow_v1b3 {
         params,
         requiredParams: ['projectId', 'location'],
         pathParams: ['location', 'projectId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GetTemplateResponse>(parameters, callback);
@@ -6389,7 +6297,7 @@ export namespace dataflow_v1b3 {
         params,
         requiredParams: ['projectId', 'location'],
         pathParams: ['location', 'projectId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$LaunchTemplateResponse>(parameters, callback);
@@ -6490,15 +6398,7 @@ export namespace dataflow_v1b3 {
 
 
   export class Resource$Projects$Templates {
-    root: Dataflow;
-    constructor(root: Dataflow) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -6558,7 +6458,7 @@ export namespace dataflow_v1b3 {
         params,
         requiredParams: ['projectId'],
         pathParams: ['projectId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Job>(parameters, callback);
@@ -6624,7 +6524,7 @@ export namespace dataflow_v1b3 {
         params,
         requiredParams: ['projectId'],
         pathParams: ['projectId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GetTemplateResponse>(parameters, callback);
@@ -6698,7 +6598,7 @@ export namespace dataflow_v1b3 {
         params,
         requiredParams: ['projectId'],
         pathParams: ['projectId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$LaunchTemplateResponse>(parameters, callback);

--- a/src/apis/dataproc/v1.ts
+++ b/src/apis/dataproc/v1.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace dataproc_v1 {
   export interface Options extends GlobalOptions {
     version: 'v1';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -96,22 +98,12 @@ export namespace dataproc_v1 {
    * @param {object=} options Options for Dataproc
    */
   export class Dataproc {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     projects: Resource$Projects;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.projects = new Resource$Projects(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.projects = new Resource$Projects();
     }
   }
 
@@ -1744,48 +1736,26 @@ export namespace dataproc_v1 {
 
 
   export class Resource$Projects {
-    root: Dataproc;
     locations: Resource$Projects$Locations;
     regions: Resource$Projects$Regions;
-    constructor(root: Dataproc) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.locations = new Resource$Projects$Locations(root);
-      this.regions = new Resource$Projects$Regions(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.locations = new Resource$Projects$Locations();
+      this.regions = new Resource$Projects$Regions();
     }
   }
 
 
   export class Resource$Projects$Locations {
-    root: Dataproc;
     workflowTemplates: Resource$Projects$Locations$Workflowtemplates;
-    constructor(root: Dataproc) {
-      this.root = root;
-      this.getRoot.bind(this);
+    constructor() {
       this.workflowTemplates =
-          new Resource$Projects$Locations$Workflowtemplates(root);
-    }
-
-    getRoot() {
-      return this.root;
+          new Resource$Projects$Locations$Workflowtemplates();
     }
   }
 
 
   export class Resource$Projects$Locations$Workflowtemplates {
-    root: Dataproc;
-    constructor(root: Dataproc) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -1848,7 +1818,7 @@ export namespace dataproc_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$WorkflowTemplate>(parameters, callback);
@@ -1917,7 +1887,7 @@ export namespace dataproc_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -1982,7 +1952,7 @@ export namespace dataproc_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$WorkflowTemplate>(parameters, callback);
@@ -2055,7 +2025,7 @@ export namespace dataproc_v1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -2134,7 +2104,7 @@ export namespace dataproc_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -2217,7 +2187,7 @@ export namespace dataproc_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -2293,7 +2263,7 @@ export namespace dataproc_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListWorkflowTemplatesResponse>(
@@ -2368,7 +2338,7 @@ export namespace dataproc_v1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -2451,7 +2421,7 @@ export namespace dataproc_v1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TestIamPermissionsResponse>(
@@ -2522,7 +2492,7 @@ export namespace dataproc_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$WorkflowTemplate>(parameters, callback);
@@ -2738,37 +2708,22 @@ export namespace dataproc_v1 {
 
 
   export class Resource$Projects$Regions {
-    root: Dataproc;
     clusters: Resource$Projects$Regions$Clusters;
     jobs: Resource$Projects$Regions$Jobs;
     operations: Resource$Projects$Regions$Operations;
     workflowTemplates: Resource$Projects$Regions$Workflowtemplates;
-    constructor(root: Dataproc) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.clusters = new Resource$Projects$Regions$Clusters(root);
-      this.jobs = new Resource$Projects$Regions$Jobs(root);
-      this.operations = new Resource$Projects$Regions$Operations(root);
+    constructor() {
+      this.clusters = new Resource$Projects$Regions$Clusters();
+      this.jobs = new Resource$Projects$Regions$Jobs();
+      this.operations = new Resource$Projects$Regions$Operations();
       this.workflowTemplates =
-          new Resource$Projects$Regions$Workflowtemplates(root);
-    }
-
-    getRoot() {
-      return this.root;
+          new Resource$Projects$Regions$Workflowtemplates();
     }
   }
 
 
   export class Resource$Projects$Regions$Clusters {
-    root: Dataproc;
-    constructor(root: Dataproc) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -2891,7 +2846,7 @@ export namespace dataproc_v1 {
         params,
         requiredParams: ['projectId', 'region'],
         pathParams: ['projectId', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -3022,7 +2977,7 @@ export namespace dataproc_v1 {
         params,
         requiredParams: ['projectId', 'region', 'clusterName'],
         pathParams: ['clusterName', 'projectId', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -3157,7 +3112,7 @@ export namespace dataproc_v1 {
         params,
         requiredParams: ['projectId', 'region', 'clusterName'],
         pathParams: ['clusterName', 'projectId', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -3281,7 +3236,7 @@ export namespace dataproc_v1 {
         params,
         requiredParams: ['projectId', 'region', 'clusterName'],
         pathParams: ['clusterName', 'projectId', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Cluster>(parameters, callback);
@@ -3350,7 +3305,7 @@ export namespace dataproc_v1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -3493,7 +3448,7 @@ export namespace dataproc_v1 {
         params,
         requiredParams: ['projectId', 'region'],
         pathParams: ['projectId', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListClustersResponse>(parameters, callback);
@@ -3632,7 +3587,7 @@ export namespace dataproc_v1 {
         params,
         requiredParams: ['projectId', 'region', 'clusterName'],
         pathParams: ['clusterName', 'projectId', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -3701,7 +3656,7 @@ export namespace dataproc_v1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -3781,7 +3736,7 @@ export namespace dataproc_v1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TestIamPermissionsResponse>(
@@ -4074,15 +4029,7 @@ export namespace dataproc_v1 {
 
 
   export class Resource$Projects$Regions$Jobs {
-    root: Dataproc;
-    constructor(root: Dataproc) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -4210,7 +4157,7 @@ export namespace dataproc_v1 {
         params,
         requiredParams: ['projectId', 'region', 'jobId'],
         pathParams: ['jobId', 'projectId', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Job>(parameters, callback);
@@ -4337,7 +4284,7 @@ export namespace dataproc_v1 {
         params,
         requiredParams: ['projectId', 'region', 'jobId'],
         pathParams: ['jobId', 'projectId', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -4462,7 +4409,7 @@ export namespace dataproc_v1 {
         params,
         requiredParams: ['projectId', 'region', 'jobId'],
         pathParams: ['jobId', 'projectId', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Job>(parameters, callback);
@@ -4530,7 +4477,7 @@ export namespace dataproc_v1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -4673,7 +4620,7 @@ export namespace dataproc_v1 {
         params,
         requiredParams: ['projectId', 'region'],
         pathParams: ['projectId', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListJobsResponse>(parameters, callback);
@@ -4810,7 +4757,7 @@ export namespace dataproc_v1 {
         params,
         requiredParams: ['projectId', 'region', 'jobId'],
         pathParams: ['jobId', 'projectId', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Job>(parameters, callback);
@@ -4878,7 +4825,7 @@ export namespace dataproc_v1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -5006,7 +4953,7 @@ export namespace dataproc_v1 {
         params,
         requiredParams: ['projectId', 'region'],
         pathParams: ['projectId', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Job>(parameters, callback);
@@ -5085,7 +5032,7 @@ export namespace dataproc_v1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TestIamPermissionsResponse>(
@@ -5325,15 +5272,7 @@ export namespace dataproc_v1 {
 
 
   export class Resource$Projects$Regions$Operations {
-    root: Dataproc;
-    constructor(root: Dataproc) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -5452,7 +5391,7 @@ export namespace dataproc_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -5572,7 +5511,7 @@ export namespace dataproc_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -5689,7 +5628,7 @@ export namespace dataproc_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -5758,7 +5697,7 @@ export namespace dataproc_v1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -5904,7 +5843,7 @@ export namespace dataproc_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListOperationsResponse>(parameters, callback);
@@ -5973,7 +5912,7 @@ export namespace dataproc_v1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -6053,7 +5992,7 @@ export namespace dataproc_v1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TestIamPermissionsResponse>(
@@ -6181,15 +6120,7 @@ export namespace dataproc_v1 {
 
 
   export class Resource$Projects$Regions$Workflowtemplates {
-    root: Dataproc;
-    constructor(root: Dataproc) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -6252,7 +6183,7 @@ export namespace dataproc_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$WorkflowTemplate>(parameters, callback);
@@ -6321,7 +6252,7 @@ export namespace dataproc_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -6386,7 +6317,7 @@ export namespace dataproc_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$WorkflowTemplate>(parameters, callback);
@@ -6457,7 +6388,7 @@ export namespace dataproc_v1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -6533,7 +6464,7 @@ export namespace dataproc_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -6616,7 +6547,7 @@ export namespace dataproc_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -6691,7 +6622,7 @@ export namespace dataproc_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListWorkflowTemplatesResponse>(
@@ -6764,7 +6695,7 @@ export namespace dataproc_v1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -6847,7 +6778,7 @@ export namespace dataproc_v1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TestIamPermissionsResponse>(
@@ -6918,7 +6849,7 @@ export namespace dataproc_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$WorkflowTemplate>(parameters, callback);

--- a/src/apis/dataproc/v1beta2.ts
+++ b/src/apis/dataproc/v1beta2.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace dataproc_v1beta2 {
   export interface Options extends GlobalOptions {
     version: 'v1beta2';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -96,22 +98,12 @@ export namespace dataproc_v1beta2 {
    * @param {object=} options Options for Dataproc
    */
   export class Dataproc {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     projects: Resource$Projects;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.projects = new Resource$Projects(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.projects = new Resource$Projects();
     }
   }
 
@@ -1852,48 +1844,26 @@ export namespace dataproc_v1beta2 {
 
 
   export class Resource$Projects {
-    root: Dataproc;
     locations: Resource$Projects$Locations;
     regions: Resource$Projects$Regions;
-    constructor(root: Dataproc) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.locations = new Resource$Projects$Locations(root);
-      this.regions = new Resource$Projects$Regions(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.locations = new Resource$Projects$Locations();
+      this.regions = new Resource$Projects$Regions();
     }
   }
 
 
   export class Resource$Projects$Locations {
-    root: Dataproc;
     workflowTemplates: Resource$Projects$Locations$Workflowtemplates;
-    constructor(root: Dataproc) {
-      this.root = root;
-      this.getRoot.bind(this);
+    constructor() {
       this.workflowTemplates =
-          new Resource$Projects$Locations$Workflowtemplates(root);
-    }
-
-    getRoot() {
-      return this.root;
+          new Resource$Projects$Locations$Workflowtemplates();
     }
   }
 
 
   export class Resource$Projects$Locations$Workflowtemplates {
-    root: Dataproc;
-    constructor(root: Dataproc) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -1956,7 +1926,7 @@ export namespace dataproc_v1beta2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$WorkflowTemplate>(parameters, callback);
@@ -2025,7 +1995,7 @@ export namespace dataproc_v1beta2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -2090,7 +2060,7 @@ export namespace dataproc_v1beta2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$WorkflowTemplate>(parameters, callback);
@@ -2162,7 +2132,7 @@ export namespace dataproc_v1beta2 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -2241,7 +2211,7 @@ export namespace dataproc_v1beta2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -2325,7 +2295,7 @@ export namespace dataproc_v1beta2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -2401,7 +2371,7 @@ export namespace dataproc_v1beta2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListWorkflowTemplatesResponse>(
@@ -2476,7 +2446,7 @@ export namespace dataproc_v1beta2 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -2559,7 +2529,7 @@ export namespace dataproc_v1beta2 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TestIamPermissionsResponse>(
@@ -2630,7 +2600,7 @@ export namespace dataproc_v1beta2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$WorkflowTemplate>(parameters, callback);
@@ -2845,37 +2815,22 @@ export namespace dataproc_v1beta2 {
 
 
   export class Resource$Projects$Regions {
-    root: Dataproc;
     clusters: Resource$Projects$Regions$Clusters;
     jobs: Resource$Projects$Regions$Jobs;
     operations: Resource$Projects$Regions$Operations;
     workflowTemplates: Resource$Projects$Regions$Workflowtemplates;
-    constructor(root: Dataproc) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.clusters = new Resource$Projects$Regions$Clusters(root);
-      this.jobs = new Resource$Projects$Regions$Jobs(root);
-      this.operations = new Resource$Projects$Regions$Operations(root);
+    constructor() {
+      this.clusters = new Resource$Projects$Regions$Clusters();
+      this.jobs = new Resource$Projects$Regions$Jobs();
+      this.operations = new Resource$Projects$Regions$Operations();
       this.workflowTemplates =
-          new Resource$Projects$Regions$Workflowtemplates(root);
-    }
-
-    getRoot() {
-      return this.root;
+          new Resource$Projects$Regions$Workflowtemplates();
     }
   }
 
 
   export class Resource$Projects$Regions$Clusters {
-    root: Dataproc;
-    constructor(root: Dataproc) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -2939,7 +2894,7 @@ export namespace dataproc_v1beta2 {
         params,
         requiredParams: ['projectId', 'region'],
         pathParams: ['projectId', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -3012,7 +2967,7 @@ export namespace dataproc_v1beta2 {
         params,
         requiredParams: ['projectId', 'region', 'clusterName'],
         pathParams: ['clusterName', 'projectId', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -3085,7 +3040,7 @@ export namespace dataproc_v1beta2 {
         params,
         requiredParams: ['projectId', 'region', 'clusterName'],
         pathParams: ['clusterName', 'projectId', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -3151,7 +3106,7 @@ export namespace dataproc_v1beta2 {
         params,
         requiredParams: ['projectId', 'region', 'clusterName'],
         pathParams: ['clusterName', 'projectId', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Cluster>(parameters, callback);
@@ -3219,7 +3174,7 @@ export namespace dataproc_v1beta2 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -3292,7 +3247,7 @@ export namespace dataproc_v1beta2 {
         params,
         requiredParams: ['projectId', 'region'],
         pathParams: ['projectId', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListClustersResponse>(parameters, callback);
@@ -3367,7 +3322,7 @@ export namespace dataproc_v1beta2 {
         params,
         requiredParams: ['projectId', 'region', 'clusterName'],
         pathParams: ['clusterName', 'projectId', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -3436,7 +3391,7 @@ export namespace dataproc_v1beta2 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -3516,7 +3471,7 @@ export namespace dataproc_v1beta2 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TestIamPermissionsResponse>(
@@ -3809,15 +3764,7 @@ export namespace dataproc_v1beta2 {
 
 
   export class Resource$Projects$Regions$Jobs {
-    root: Dataproc;
-    constructor(root: Dataproc) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -3883,7 +3830,7 @@ export namespace dataproc_v1beta2 {
         params,
         requiredParams: ['projectId', 'region', 'jobId'],
         pathParams: ['jobId', 'projectId', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Job>(parameters, callback);
@@ -3954,7 +3901,7 @@ export namespace dataproc_v1beta2 {
         params,
         requiredParams: ['projectId', 'region', 'jobId'],
         pathParams: ['jobId', 'projectId', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -4020,7 +3967,7 @@ export namespace dataproc_v1beta2 {
         params,
         requiredParams: ['projectId', 'region', 'jobId'],
         pathParams: ['jobId', 'projectId', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Job>(parameters, callback);
@@ -4087,7 +4034,7 @@ export namespace dataproc_v1beta2 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -4161,7 +4108,7 @@ export namespace dataproc_v1beta2 {
         params,
         requiredParams: ['projectId', 'region'],
         pathParams: ['projectId', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListJobsResponse>(parameters, callback);
@@ -4233,7 +4180,7 @@ export namespace dataproc_v1beta2 {
         params,
         requiredParams: ['projectId', 'region', 'jobId'],
         pathParams: ['jobId', 'projectId', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Job>(parameters, callback);
@@ -4301,7 +4248,7 @@ export namespace dataproc_v1beta2 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -4371,7 +4318,7 @@ export namespace dataproc_v1beta2 {
         params,
         requiredParams: ['projectId', 'region'],
         pathParams: ['projectId', 'region'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Job>(parameters, callback);
@@ -4450,7 +4397,7 @@ export namespace dataproc_v1beta2 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TestIamPermissionsResponse>(
@@ -4685,15 +4632,7 @@ export namespace dataproc_v1beta2 {
 
 
   export class Resource$Projects$Regions$Operations {
-    root: Dataproc;
-    constructor(root: Dataproc) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -4760,7 +4699,7 @@ export namespace dataproc_v1beta2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -4828,7 +4767,7 @@ export namespace dataproc_v1beta2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -4892,7 +4831,7 @@ export namespace dataproc_v1beta2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -4960,7 +4899,7 @@ export namespace dataproc_v1beta2 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -5038,7 +4977,7 @@ export namespace dataproc_v1beta2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListOperationsResponse>(parameters, callback);
@@ -5107,7 +5046,7 @@ export namespace dataproc_v1beta2 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -5187,7 +5126,7 @@ export namespace dataproc_v1beta2 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TestIamPermissionsResponse>(
@@ -5310,15 +5249,7 @@ export namespace dataproc_v1beta2 {
 
 
   export class Resource$Projects$Regions$Workflowtemplates {
-    root: Dataproc;
-    constructor(root: Dataproc) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -5381,7 +5312,7 @@ export namespace dataproc_v1beta2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$WorkflowTemplate>(parameters, callback);
@@ -5450,7 +5381,7 @@ export namespace dataproc_v1beta2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -5515,7 +5446,7 @@ export namespace dataproc_v1beta2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$WorkflowTemplate>(parameters, callback);
@@ -5585,7 +5516,7 @@ export namespace dataproc_v1beta2 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -5661,7 +5592,7 @@ export namespace dataproc_v1beta2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -5745,7 +5676,7 @@ export namespace dataproc_v1beta2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -5820,7 +5751,7 @@ export namespace dataproc_v1beta2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListWorkflowTemplatesResponse>(
@@ -5893,7 +5824,7 @@ export namespace dataproc_v1beta2 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -5976,7 +5907,7 @@ export namespace dataproc_v1beta2 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TestIamPermissionsResponse>(
@@ -6047,7 +5978,7 @@ export namespace dataproc_v1beta2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$WorkflowTemplate>(parameters, callback);

--- a/src/apis/datastore/v1.ts
+++ b/src/apis/datastore/v1.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace datastore_v1 {
   export interface Options extends GlobalOptions {
     version: 'v1';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -97,22 +99,12 @@ export namespace datastore_v1 {
    * @param {object=} options Options for Datastore
    */
   export class Datastore {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     projects: Resource$Projects;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.projects = new Resource$Projects(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.projects = new Resource$Projects();
     }
   }
 
@@ -1350,18 +1342,11 @@ export namespace datastore_v1 {
 
 
   export class Resource$Projects {
-    root: Datastore;
     indexes: Resource$Projects$Indexes;
     operations: Resource$Projects$Operations;
-    constructor(root: Datastore) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.indexes = new Resource$Projects$Indexes(root);
-      this.operations = new Resource$Projects$Operations(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.indexes = new Resource$Projects$Indexes();
+      this.operations = new Resource$Projects$Operations();
     }
 
 
@@ -1425,7 +1410,7 @@ export namespace datastore_v1 {
         params,
         requiredParams: ['projectId'],
         pathParams: ['projectId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$AllocateIdsResponse>(parameters, callback);
@@ -1495,7 +1480,7 @@ export namespace datastore_v1 {
         params,
         requiredParams: ['projectId'],
         pathParams: ['projectId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$BeginTransactionResponse>(parameters, callback);
@@ -1562,7 +1547,7 @@ export namespace datastore_v1 {
         params,
         requiredParams: ['projectId'],
         pathParams: ['projectId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$CommitResponse>(parameters, callback);
@@ -1639,7 +1624,7 @@ export namespace datastore_v1 {
         params,
         requiredParams: ['projectId'],
         pathParams: ['projectId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleLongrunningOperation>(
@@ -1684,7 +1669,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Import|BodyResponseCallback<S
     options = {};
                                                                                                                                                                                                                                                                                                                                              }
 
-                                                                                                                                                                                                                                                                                                                                             const rootUrl = options.rootUrl || 'https://datastore.googleapis.com/'; const parameters = {options: Object.assign({url: (rootUrl + '/v1/projects/{projectId}:import').replace(/([^:]\/)\/+/g, '$1'), method: 'POST'}, options), params, requiredParams: ['projectId'], pathParams: ['projectId'], context: this.getRoot()}; if(callback) {
+                                                                                                                                                                                                                                                                                                                                             const rootUrl = options.rootUrl || 'https://datastore.googleapis.com/'; const parameters = {options: Object.assign({url: (rootUrl + '/v1/projects/{projectId}:import').replace(/([^:]\/)\/+/g, '$1'), method: 'POST'}, options), params, requiredParams: ['projectId'], pathParams: ['projectId'], context}; if(callback) {
     createAPIRequest<Schema$GoogleLongrunningOperation>(parameters, callback);
                                                                                                                                                                                                                                                                                                                                              } else {
     return createAPIRequest<Schema$GoogleLongrunningOperation>(parameters);
@@ -1746,7 +1731,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Import|BodyResponseCallback<S
         params,
         requiredParams: ['projectId'],
         pathParams: ['projectId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$LookupResponse>(parameters, callback);
@@ -1815,7 +1800,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Import|BodyResponseCallback<S
         params,
         requiredParams: ['projectId'],
         pathParams: ['projectId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ReserveIdsResponse>(parameters, callback);
@@ -1883,7 +1868,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Import|BodyResponseCallback<S
         params,
         requiredParams: ['projectId'],
         pathParams: ['projectId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$RollbackResponse>(parameters, callback);
@@ -1951,7 +1936,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Import|BodyResponseCallback<S
         params,
         requiredParams: ['projectId'],
         pathParams: ['projectId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$RunQueryResponse>(parameters, callback);
@@ -2112,15 +2097,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Import|BodyResponseCallback<S
   }
 
   export class Resource$Projects$Indexes {
-    root: Datastore;
-    constructor(root: Datastore) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -2181,7 +2158,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Import|BodyResponseCallback<S
         params,
         requiredParams: ['projectId', 'indexId'],
         pathParams: ['indexId', 'projectId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleDatastoreAdminV1Index>(
@@ -2260,7 +2237,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Import|BodyResponseCallback<S
         params,
         requiredParams: ['projectId'],
         pathParams: ['projectId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleDatastoreAdminV1ListIndexesResponse>(
@@ -2316,15 +2293,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Import|BodyResponseCallback<S
 
 
   export class Resource$Projects$Operations {
-    root: Datastore;
-    constructor(root: Datastore) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -2391,7 +2360,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Import|BodyResponseCallback<S
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -2459,7 +2428,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Import|BodyResponseCallback<S
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -2528,7 +2497,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Import|BodyResponseCallback<S
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleLongrunningOperation>(
@@ -2613,7 +2582,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Import|BodyResponseCallback<S
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleLongrunningListOperationsResponse>(

--- a/src/apis/datastore/v1beta1.ts
+++ b/src/apis/datastore/v1beta1.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace datastore_v1beta1 {
   export interface Options extends GlobalOptions {
     version: 'v1beta1';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -97,22 +99,12 @@ export namespace datastore_v1beta1 {
    * @param {object=} options Options for Datastore
    */
   export class Datastore {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     projects: Resource$Projects;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.projects = new Resource$Projects(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.projects = new Resource$Projects();
     }
   }
 
@@ -562,15 +554,7 @@ export namespace datastore_v1beta1 {
 
 
   export class Resource$Projects {
-    root: Datastore;
-    constructor(root: Datastore) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -640,7 +624,7 @@ export namespace datastore_v1beta1 {
         params,
         requiredParams: ['projectId'],
         pathParams: ['projectId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleLongrunningOperation>(
@@ -696,7 +680,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Import|BodyResponseCallback<S
     params,
         requiredParams: ['projectId'],
     pathParams: ['projectId'],
-    context: this.getRoot()
+    context
   };
     if (callback) {
       createAPIRequest<Schema$GoogleLongrunningOperation>(parameters, callback);

--- a/src/apis/datastore/v1beta3.ts
+++ b/src/apis/datastore/v1beta3.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace datastore_v1beta3 {
   export interface Options extends GlobalOptions {
     version: 'v1beta3';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -97,22 +99,12 @@ export namespace datastore_v1beta3 {
    * @param {object=} options Options for Datastore
    */
   export class Datastore {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     projects: Resource$Projects;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.projects = new Resource$Projects(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.projects = new Resource$Projects();
     }
   }
 
@@ -1119,15 +1111,7 @@ export namespace datastore_v1beta3 {
 
 
   export class Resource$Projects {
-    root: Datastore;
-    constructor(root: Datastore) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -1190,7 +1174,7 @@ export namespace datastore_v1beta3 {
         params,
         requiredParams: ['projectId'],
         pathParams: ['projectId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$AllocateIdsResponse>(parameters, callback);
@@ -1260,7 +1244,7 @@ export namespace datastore_v1beta3 {
         params,
         requiredParams: ['projectId'],
         pathParams: ['projectId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$BeginTransactionResponse>(parameters, callback);
@@ -1327,7 +1311,7 @@ export namespace datastore_v1beta3 {
         params,
         requiredParams: ['projectId'],
         pathParams: ['projectId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$CommitResponse>(parameters, callback);
@@ -1393,7 +1377,7 @@ export namespace datastore_v1beta3 {
         params,
         requiredParams: ['projectId'],
         pathParams: ['projectId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$LookupResponse>(parameters, callback);
@@ -1462,7 +1446,7 @@ export namespace datastore_v1beta3 {
         params,
         requiredParams: ['projectId'],
         pathParams: ['projectId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ReserveIdsResponse>(parameters, callback);
@@ -1530,7 +1514,7 @@ export namespace datastore_v1beta3 {
         params,
         requiredParams: ['projectId'],
         pathParams: ['projectId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$RollbackResponse>(parameters, callback);
@@ -1598,7 +1582,7 @@ export namespace datastore_v1beta3 {
         params,
         requiredParams: ['projectId'],
         pathParams: ['projectId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$RunQueryResponse>(parameters, callback);

--- a/src/apis/deploymentmanager/alpha.ts
+++ b/src/apis/deploymentmanager/alpha.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace deploymentmanager_alpha {
   export interface Options extends GlobalOptions {
     version: 'alpha';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -80,10 +82,6 @@ export namespace deploymentmanager_alpha {
    * @param {object=} options Options for Deploymentmanager
    */
   export class Deploymentmanager {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     compositeTypes: Resource$Compositetypes;
     deployments: Resource$Deployments;
     manifests: Resource$Manifests;
@@ -93,21 +91,15 @@ export namespace deploymentmanager_alpha {
     types: Resource$Types;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.compositeTypes = new Resource$Compositetypes(this);
-      this.deployments = new Resource$Deployments(this);
-      this.manifests = new Resource$Manifests(this);
-      this.operations = new Resource$Operations(this);
-      this.resources = new Resource$Resources(this);
-      this.typeProviders = new Resource$Typeproviders(this);
-      this.types = new Resource$Types(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.compositeTypes = new Resource$Compositetypes();
+      this.deployments = new Resource$Deployments();
+      this.manifests = new Resource$Manifests();
+      this.operations = new Resource$Operations();
+      this.resources = new Resource$Resources();
+      this.typeProviders = new Resource$Typeproviders();
+      this.types = new Resource$Types();
     }
   }
 
@@ -1512,15 +1504,7 @@ export namespace deploymentmanager_alpha {
 
 
   export class Resource$Compositetypes {
-    root: Deploymentmanager;
-    constructor(root: Deploymentmanager) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -1583,7 +1567,7 @@ export namespace deploymentmanager_alpha {
         params,
         requiredParams: ['project', 'compositeType'],
         pathParams: ['compositeType', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -1649,7 +1633,7 @@ export namespace deploymentmanager_alpha {
         params,
         requiredParams: ['project', 'compositeType'],
         pathParams: ['compositeType', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$CompositeType>(parameters, callback);
@@ -1719,7 +1703,7 @@ export namespace deploymentmanager_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -1795,7 +1779,7 @@ export namespace deploymentmanager_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$CompositeTypesListResponse>(
@@ -1867,7 +1851,7 @@ export namespace deploymentmanager_alpha {
         params,
         requiredParams: ['project', 'compositeType'],
         pathParams: ['compositeType', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -1938,7 +1922,7 @@ export namespace deploymentmanager_alpha {
         params,
         requiredParams: ['project', 'compositeType'],
         pathParams: ['compositeType', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -2097,15 +2081,7 @@ export namespace deploymentmanager_alpha {
 
 
   export class Resource$Deployments {
-    root: Deploymentmanager;
-    constructor(root: Deploymentmanager) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -2170,7 +2146,7 @@ export namespace deploymentmanager_alpha {
         params,
         requiredParams: ['project', 'deployment'],
         pathParams: ['deployment', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -2241,7 +2217,7 @@ export namespace deploymentmanager_alpha {
         params,
         requiredParams: ['project', 'deployment'],
         pathParams: ['deployment', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -2306,7 +2282,7 @@ export namespace deploymentmanager_alpha {
         params,
         requiredParams: ['project', 'deployment'],
         pathParams: ['deployment', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Deployment>(parameters, callback);
@@ -2376,7 +2352,7 @@ export namespace deploymentmanager_alpha {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -2449,7 +2425,7 @@ export namespace deploymentmanager_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -2521,7 +2497,7 @@ export namespace deploymentmanager_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$DeploymentsListResponse>(parameters, callback);
@@ -2595,7 +2571,7 @@ export namespace deploymentmanager_alpha {
         params,
         requiredParams: ['project', 'deployment'],
         pathParams: ['deployment', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -2666,7 +2642,7 @@ export namespace deploymentmanager_alpha {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -2736,7 +2712,7 @@ export namespace deploymentmanager_alpha {
         params,
         requiredParams: ['project', 'deployment'],
         pathParams: ['deployment', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -2809,7 +2785,7 @@ export namespace deploymentmanager_alpha {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -2884,7 +2860,7 @@ export namespace deploymentmanager_alpha {
         params,
         requiredParams: ['project', 'deployment'],
         pathParams: ['deployment', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -3200,15 +3176,7 @@ export namespace deploymentmanager_alpha {
 
 
   export class Resource$Manifests {
-    root: Deploymentmanager;
-    constructor(root: Deploymentmanager) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -3266,7 +3234,7 @@ export namespace deploymentmanager_alpha {
         params,
         requiredParams: ['project', 'deployment', 'manifest'],
         pathParams: ['deployment', 'manifest', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Manifest>(parameters, callback);
@@ -3339,7 +3307,7 @@ export namespace deploymentmanager_alpha {
         params,
         requiredParams: ['project', 'deployment'],
         pathParams: ['deployment', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ManifestsListResponse>(parameters, callback);
@@ -3429,15 +3397,7 @@ export namespace deploymentmanager_alpha {
 
 
   export class Resource$Operations {
-    root: Deploymentmanager;
-    constructor(root: Deploymentmanager) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -3495,7 +3455,7 @@ export namespace deploymentmanager_alpha {
         params,
         requiredParams: ['project', 'operation'],
         pathParams: ['operation', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -3567,7 +3527,7 @@ export namespace deploymentmanager_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$OperationsListResponse>(parameters, callback);
@@ -3649,15 +3609,7 @@ export namespace deploymentmanager_alpha {
 
 
   export class Resource$Resources {
-    root: Deploymentmanager;
-    constructor(root: Deploymentmanager) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -3715,7 +3667,7 @@ export namespace deploymentmanager_alpha {
         params,
         requiredParams: ['project', 'deployment', 'resource'],
         pathParams: ['deployment', 'project', 'resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Resource>(parameters, callback);
@@ -3788,7 +3740,7 @@ export namespace deploymentmanager_alpha {
         params,
         requiredParams: ['project', 'deployment'],
         pathParams: ['deployment', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ResourcesListResponse>(parameters, callback);
@@ -3878,15 +3830,7 @@ export namespace deploymentmanager_alpha {
 
 
   export class Resource$Typeproviders {
-    root: Deploymentmanager;
-    constructor(root: Deploymentmanager) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -3949,7 +3893,7 @@ export namespace deploymentmanager_alpha {
         params,
         requiredParams: ['project', 'typeProvider'],
         pathParams: ['project', 'typeProvider'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -4015,7 +3959,7 @@ export namespace deploymentmanager_alpha {
         params,
         requiredParams: ['project', 'typeProvider'],
         pathParams: ['project', 'typeProvider'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TypeProvider>(parameters, callback);
@@ -4085,7 +4029,7 @@ export namespace deploymentmanager_alpha {
         params,
         requiredParams: ['project', 'typeProvider', 'type'],
         pathParams: ['project', 'type', 'typeProvider'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TypeInfo>(parameters, callback);
@@ -4155,7 +4099,7 @@ export namespace deploymentmanager_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -4229,7 +4173,7 @@ export namespace deploymentmanager_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TypeProvidersListResponse>(
@@ -4310,7 +4254,7 @@ export namespace deploymentmanager_alpha {
         params,
         requiredParams: ['project', 'typeProvider'],
         pathParams: ['project', 'typeProvider'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TypeProvidersListTypesResponse>(
@@ -4383,7 +4327,7 @@ export namespace deploymentmanager_alpha {
         params,
         requiredParams: ['project', 'typeProvider'],
         pathParams: ['project', 'typeProvider'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -4454,7 +4398,7 @@ export namespace deploymentmanager_alpha {
         params,
         requiredParams: ['project', 'typeProvider'],
         pathParams: ['project', 'typeProvider'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -4692,15 +4636,7 @@ export namespace deploymentmanager_alpha {
 
 
   export class Resource$Types {
-    root: Deploymentmanager;
-    constructor(root: Deploymentmanager) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -4761,7 +4697,7 @@ export namespace deploymentmanager_alpha {
         params,
         requiredParams: ['project', 'type'],
         pathParams: ['project', 'type'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -4825,7 +4761,7 @@ export namespace deploymentmanager_alpha {
         params,
         requiredParams: ['project', 'type'],
         pathParams: ['project', 'type'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Type>(parameters, callback);
@@ -4892,7 +4828,7 @@ export namespace deploymentmanager_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -4962,7 +4898,7 @@ export namespace deploymentmanager_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TypesListResponse>(parameters, callback);
@@ -5031,7 +4967,7 @@ export namespace deploymentmanager_alpha {
         params,
         requiredParams: ['project', 'type'],
         pathParams: ['project', 'type'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -5100,7 +5036,7 @@ export namespace deploymentmanager_alpha {
         params,
         requiredParams: ['project', 'type'],
         pathParams: ['project', 'type'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);

--- a/src/apis/deploymentmanager/v2.ts
+++ b/src/apis/deploymentmanager/v2.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace deploymentmanager_v2 {
   export interface Options extends GlobalOptions {
     version: 'v2';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -80,10 +82,6 @@ export namespace deploymentmanager_v2 {
    * @param {object=} options Options for Deploymentmanager
    */
   export class Deploymentmanager {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     deployments: Resource$Deployments;
     manifests: Resource$Manifests;
     operations: Resource$Operations;
@@ -91,19 +89,13 @@ export namespace deploymentmanager_v2 {
     types: Resource$Types;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.deployments = new Resource$Deployments(this);
-      this.manifests = new Resource$Manifests(this);
-      this.operations = new Resource$Operations(this);
-      this.resources = new Resource$Resources(this);
-      this.types = new Resource$Types(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.deployments = new Resource$Deployments();
+      this.manifests = new Resource$Manifests();
+      this.operations = new Resource$Operations();
+      this.resources = new Resource$Resources();
+      this.types = new Resource$Types();
     }
   }
 
@@ -1003,15 +995,7 @@ export namespace deploymentmanager_v2 {
 
 
   export class Resource$Deployments {
-    root: Deploymentmanager;
-    constructor(root: Deploymentmanager) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -1134,7 +1118,7 @@ export namespace deploymentmanager_v2 {
         params,
         requiredParams: ['project', 'deployment'],
         pathParams: ['deployment', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -1261,7 +1245,7 @@ export namespace deploymentmanager_v2 {
         params,
         requiredParams: ['project', 'deployment'],
         pathParams: ['deployment', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -1382,7 +1366,7 @@ export namespace deploymentmanager_v2 {
         params,
         requiredParams: ['project', 'deployment'],
         pathParams: ['deployment', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Deployment>(parameters, callback);
@@ -1506,7 +1490,7 @@ export namespace deploymentmanager_v2 {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -1636,7 +1620,7 @@ export namespace deploymentmanager_v2 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -1775,7 +1759,7 @@ export namespace deploymentmanager_v2 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$DeploymentsListResponse>(parameters, callback);
@@ -1911,7 +1895,7 @@ export namespace deploymentmanager_v2 {
         params,
         requiredParams: ['project', 'deployment'],
         pathParams: ['deployment', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -2040,7 +2024,7 @@ export namespace deploymentmanager_v2 {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -2170,7 +2154,7 @@ export namespace deploymentmanager_v2 {
         params,
         requiredParams: ['project', 'deployment'],
         pathParams: ['deployment', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -2301,7 +2285,7 @@ export namespace deploymentmanager_v2 {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -2438,7 +2422,7 @@ export namespace deploymentmanager_v2 {
         params,
         requiredParams: ['project', 'deployment'],
         pathParams: ['deployment', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -2754,15 +2738,7 @@ export namespace deploymentmanager_v2 {
 
 
   export class Resource$Manifests {
-    root: Deploymentmanager;
-    constructor(root: Deploymentmanager) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -2879,7 +2855,7 @@ export namespace deploymentmanager_v2 {
         params,
         requiredParams: ['project', 'deployment', 'manifest'],
         pathParams: ['deployment', 'manifest', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Manifest>(parameters, callback);
@@ -3021,7 +2997,7 @@ export namespace deploymentmanager_v2 {
         params,
         requiredParams: ['project', 'deployment'],
         pathParams: ['deployment', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ManifestsListResponse>(parameters, callback);
@@ -3111,15 +3087,7 @@ export namespace deploymentmanager_v2 {
 
 
   export class Resource$Operations {
-    root: Deploymentmanager;
-    constructor(root: Deploymentmanager) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -3233,7 +3201,7 @@ export namespace deploymentmanager_v2 {
         params,
         requiredParams: ['project', 'operation'],
         pathParams: ['operation', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -3372,7 +3340,7 @@ export namespace deploymentmanager_v2 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$OperationsListResponse>(parameters, callback);
@@ -3454,15 +3422,7 @@ export namespace deploymentmanager_v2 {
 
 
   export class Resource$Resources {
-    root: Deploymentmanager;
-    constructor(root: Deploymentmanager) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -3579,7 +3539,7 @@ export namespace deploymentmanager_v2 {
         params,
         requiredParams: ['project', 'deployment', 'resource'],
         pathParams: ['deployment', 'project', 'resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Resource>(parameters, callback);
@@ -3721,7 +3681,7 @@ export namespace deploymentmanager_v2 {
         params,
         requiredParams: ['project', 'deployment'],
         pathParams: ['deployment', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ResourcesListResponse>(parameters, callback);
@@ -3811,15 +3771,7 @@ export namespace deploymentmanager_v2 {
 
 
   export class Resource$Types {
-    root: Deploymentmanager;
-    constructor(root: Deploymentmanager) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -3948,7 +3900,7 @@ export namespace deploymentmanager_v2 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TypesListResponse>(parameters, callback);

--- a/src/apis/deploymentmanager/v2beta.ts
+++ b/src/apis/deploymentmanager/v2beta.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace deploymentmanager_v2beta {
   export interface Options extends GlobalOptions {
     version: 'v2beta';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -80,10 +82,6 @@ export namespace deploymentmanager_v2beta {
    * @param {object=} options Options for Deploymentmanager
    */
   export class Deploymentmanager {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     compositeTypes: Resource$Compositetypes;
     deployments: Resource$Deployments;
     manifests: Resource$Manifests;
@@ -93,21 +91,15 @@ export namespace deploymentmanager_v2beta {
     types: Resource$Types;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.compositeTypes = new Resource$Compositetypes(this);
-      this.deployments = new Resource$Deployments(this);
-      this.manifests = new Resource$Manifests(this);
-      this.operations = new Resource$Operations(this);
-      this.resources = new Resource$Resources(this);
-      this.typeProviders = new Resource$Typeproviders(this);
-      this.types = new Resource$Types(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.compositeTypes = new Resource$Compositetypes();
+      this.deployments = new Resource$Deployments();
+      this.manifests = new Resource$Manifests();
+      this.operations = new Resource$Operations();
+      this.resources = new Resource$Resources();
+      this.typeProviders = new Resource$Typeproviders();
+      this.types = new Resource$Types();
     }
   }
 
@@ -1444,15 +1436,7 @@ export namespace deploymentmanager_v2beta {
 
 
   export class Resource$Compositetypes {
-    root: Deploymentmanager;
-    constructor(root: Deploymentmanager) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -1515,7 +1499,7 @@ export namespace deploymentmanager_v2beta {
         params,
         requiredParams: ['project', 'compositeType'],
         pathParams: ['compositeType', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -1581,7 +1565,7 @@ export namespace deploymentmanager_v2beta {
         params,
         requiredParams: ['project', 'compositeType'],
         pathParams: ['compositeType', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$CompositeType>(parameters, callback);
@@ -1651,7 +1635,7 @@ export namespace deploymentmanager_v2beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -1727,7 +1711,7 @@ export namespace deploymentmanager_v2beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$CompositeTypesListResponse>(
@@ -1799,7 +1783,7 @@ export namespace deploymentmanager_v2beta {
         params,
         requiredParams: ['project', 'compositeType'],
         pathParams: ['compositeType', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -1870,7 +1854,7 @@ export namespace deploymentmanager_v2beta {
         params,
         requiredParams: ['project', 'compositeType'],
         pathParams: ['compositeType', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -2029,15 +2013,7 @@ export namespace deploymentmanager_v2beta {
 
 
   export class Resource$Deployments {
-    root: Deploymentmanager;
-    constructor(root: Deploymentmanager) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -2102,7 +2078,7 @@ export namespace deploymentmanager_v2beta {
         params,
         requiredParams: ['project', 'deployment'],
         pathParams: ['deployment', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -2173,7 +2149,7 @@ export namespace deploymentmanager_v2beta {
         params,
         requiredParams: ['project', 'deployment'],
         pathParams: ['deployment', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -2238,7 +2214,7 @@ export namespace deploymentmanager_v2beta {
         params,
         requiredParams: ['project', 'deployment'],
         pathParams: ['deployment', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Deployment>(parameters, callback);
@@ -2308,7 +2284,7 @@ export namespace deploymentmanager_v2beta {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -2381,7 +2357,7 @@ export namespace deploymentmanager_v2beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -2453,7 +2429,7 @@ export namespace deploymentmanager_v2beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$DeploymentsListResponse>(parameters, callback);
@@ -2527,7 +2503,7 @@ export namespace deploymentmanager_v2beta {
         params,
         requiredParams: ['project', 'deployment'],
         pathParams: ['deployment', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -2598,7 +2574,7 @@ export namespace deploymentmanager_v2beta {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -2668,7 +2644,7 @@ export namespace deploymentmanager_v2beta {
         params,
         requiredParams: ['project', 'deployment'],
         pathParams: ['deployment', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -2741,7 +2717,7 @@ export namespace deploymentmanager_v2beta {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -2816,7 +2792,7 @@ export namespace deploymentmanager_v2beta {
         params,
         requiredParams: ['project', 'deployment'],
         pathParams: ['deployment', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -3132,15 +3108,7 @@ export namespace deploymentmanager_v2beta {
 
 
   export class Resource$Manifests {
-    root: Deploymentmanager;
-    constructor(root: Deploymentmanager) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -3198,7 +3166,7 @@ export namespace deploymentmanager_v2beta {
         params,
         requiredParams: ['project', 'deployment', 'manifest'],
         pathParams: ['deployment', 'manifest', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Manifest>(parameters, callback);
@@ -3271,7 +3239,7 @@ export namespace deploymentmanager_v2beta {
         params,
         requiredParams: ['project', 'deployment'],
         pathParams: ['deployment', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ManifestsListResponse>(parameters, callback);
@@ -3361,15 +3329,7 @@ export namespace deploymentmanager_v2beta {
 
 
   export class Resource$Operations {
-    root: Deploymentmanager;
-    constructor(root: Deploymentmanager) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -3427,7 +3387,7 @@ export namespace deploymentmanager_v2beta {
         params,
         requiredParams: ['project', 'operation'],
         pathParams: ['operation', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -3499,7 +3459,7 @@ export namespace deploymentmanager_v2beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$OperationsListResponse>(parameters, callback);
@@ -3581,15 +3541,7 @@ export namespace deploymentmanager_v2beta {
 
 
   export class Resource$Resources {
-    root: Deploymentmanager;
-    constructor(root: Deploymentmanager) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -3647,7 +3599,7 @@ export namespace deploymentmanager_v2beta {
         params,
         requiredParams: ['project', 'deployment', 'resource'],
         pathParams: ['deployment', 'project', 'resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Resource>(parameters, callback);
@@ -3720,7 +3672,7 @@ export namespace deploymentmanager_v2beta {
         params,
         requiredParams: ['project', 'deployment'],
         pathParams: ['deployment', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ResourcesListResponse>(parameters, callback);
@@ -3810,15 +3762,7 @@ export namespace deploymentmanager_v2beta {
 
 
   export class Resource$Typeproviders {
-    root: Deploymentmanager;
-    constructor(root: Deploymentmanager) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -3881,7 +3825,7 @@ export namespace deploymentmanager_v2beta {
         params,
         requiredParams: ['project', 'typeProvider'],
         pathParams: ['project', 'typeProvider'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -3947,7 +3891,7 @@ export namespace deploymentmanager_v2beta {
         params,
         requiredParams: ['project', 'typeProvider'],
         pathParams: ['project', 'typeProvider'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TypeProvider>(parameters, callback);
@@ -4017,7 +3961,7 @@ export namespace deploymentmanager_v2beta {
         params,
         requiredParams: ['project', 'typeProvider', 'type'],
         pathParams: ['project', 'type', 'typeProvider'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TypeInfo>(parameters, callback);
@@ -4087,7 +4031,7 @@ export namespace deploymentmanager_v2beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -4161,7 +4105,7 @@ export namespace deploymentmanager_v2beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TypeProvidersListResponse>(
@@ -4242,7 +4186,7 @@ export namespace deploymentmanager_v2beta {
         params,
         requiredParams: ['project', 'typeProvider'],
         pathParams: ['project', 'typeProvider'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TypeProvidersListTypesResponse>(
@@ -4315,7 +4259,7 @@ export namespace deploymentmanager_v2beta {
         params,
         requiredParams: ['project', 'typeProvider'],
         pathParams: ['project', 'typeProvider'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -4386,7 +4330,7 @@ export namespace deploymentmanager_v2beta {
         params,
         requiredParams: ['project', 'typeProvider'],
         pathParams: ['project', 'typeProvider'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -4624,15 +4568,7 @@ export namespace deploymentmanager_v2beta {
 
 
   export class Resource$Types {
-    root: Deploymentmanager;
-    constructor(root: Deploymentmanager) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -4695,7 +4631,7 @@ export namespace deploymentmanager_v2beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TypesListResponse>(parameters, callback);

--- a/src/apis/dfareporting/v3.1.ts
+++ b/src/apis/dfareporting/v3.1.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace dfareporting_v3_1 {
   export interface Options extends GlobalOptions {
     version: 'v3_1';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -79,10 +81,6 @@ export namespace dfareporting_v3_1 {
    * @param {object=} options Options for Dfareporting
    */
   export class Dfareporting {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     accountActiveAdSummaries: Resource$Accountactiveadsummaries;
     accountPermissionGroups: Resource$Accountpermissiongroups;
     accountPermissions: Resource$Accountpermissions;
@@ -146,81 +144,71 @@ export namespace dfareporting_v3_1 {
     videoFormats: Resource$Videoformats;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.accountActiveAdSummaries =
-          new Resource$Accountactiveadsummaries(this);
-      this.accountPermissionGroups = new Resource$Accountpermissiongroups(this);
-      this.accountPermissions = new Resource$Accountpermissions(this);
-      this.accounts = new Resource$Accounts(this);
-      this.accountUserProfiles = new Resource$Accountuserprofiles(this);
-      this.ads = new Resource$Ads(this);
-      this.advertiserGroups = new Resource$Advertisergroups(this);
-      this.advertiserLandingPages = new Resource$Advertiserlandingpages(this);
-      this.advertisers = new Resource$Advertisers(this);
-      this.browsers = new Resource$Browsers(this);
+      this.accountActiveAdSummaries = new Resource$Accountactiveadsummaries();
+      this.accountPermissionGroups = new Resource$Accountpermissiongroups();
+      this.accountPermissions = new Resource$Accountpermissions();
+      this.accounts = new Resource$Accounts();
+      this.accountUserProfiles = new Resource$Accountuserprofiles();
+      this.ads = new Resource$Ads();
+      this.advertiserGroups = new Resource$Advertisergroups();
+      this.advertiserLandingPages = new Resource$Advertiserlandingpages();
+      this.advertisers = new Resource$Advertisers();
+      this.browsers = new Resource$Browsers();
       this.campaignCreativeAssociations =
-          new Resource$Campaigncreativeassociations(this);
-      this.campaigns = new Resource$Campaigns(this);
-      this.changeLogs = new Resource$Changelogs(this);
-      this.cities = new Resource$Cities(this);
-      this.connectionTypes = new Resource$Connectiontypes(this);
-      this.contentCategories = new Resource$Contentcategories(this);
-      this.conversions = new Resource$Conversions(this);
-      this.countries = new Resource$Countries(this);
-      this.creativeAssets = new Resource$Creativeassets(this);
-      this.creativeFields = new Resource$Creativefields(this);
-      this.creativeFieldValues = new Resource$Creativefieldvalues(this);
-      this.creativeGroups = new Resource$Creativegroups(this);
-      this.creatives = new Resource$Creatives(this);
-      this.dimensionValues = new Resource$Dimensionvalues(this);
-      this.directorySiteContacts = new Resource$Directorysitecontacts(this);
-      this.directorySites = new Resource$Directorysites(this);
-      this.dynamicTargetingKeys = new Resource$Dynamictargetingkeys(this);
-      this.eventTags = new Resource$Eventtags(this);
-      this.files = new Resource$Files(this);
-      this.floodlightActivities = new Resource$Floodlightactivities(this);
-      this.floodlightActivityGroups =
-          new Resource$Floodlightactivitygroups(this);
-      this.floodlightConfigurations =
-          new Resource$Floodlightconfigurations(this);
-      this.inventoryItems = new Resource$Inventoryitems(this);
-      this.languages = new Resource$Languages(this);
-      this.metros = new Resource$Metros(this);
-      this.mobileApps = new Resource$Mobileapps(this);
-      this.mobileCarriers = new Resource$Mobilecarriers(this);
-      this.operatingSystems = new Resource$Operatingsystems(this);
-      this.operatingSystemVersions = new Resource$Operatingsystemversions(this);
-      this.orderDocuments = new Resource$Orderdocuments(this);
-      this.orders = new Resource$Orders(this);
-      this.placementGroups = new Resource$Placementgroups(this);
-      this.placements = new Resource$Placements(this);
-      this.placementStrategies = new Resource$Placementstrategies(this);
-      this.platformTypes = new Resource$Platformtypes(this);
-      this.postalCodes = new Resource$Postalcodes(this);
-      this.projects = new Resource$Projects(this);
-      this.regions = new Resource$Regions(this);
-      this.remarketingLists = new Resource$Remarketinglists(this);
-      this.remarketingListShares = new Resource$Remarketinglistshares(this);
-      this.reports = new Resource$Reports(this);
-      this.sites = new Resource$Sites(this);
-      this.sizes = new Resource$Sizes(this);
-      this.subaccounts = new Resource$Subaccounts(this);
+          new Resource$Campaigncreativeassociations();
+      this.campaigns = new Resource$Campaigns();
+      this.changeLogs = new Resource$Changelogs();
+      this.cities = new Resource$Cities();
+      this.connectionTypes = new Resource$Connectiontypes();
+      this.contentCategories = new Resource$Contentcategories();
+      this.conversions = new Resource$Conversions();
+      this.countries = new Resource$Countries();
+      this.creativeAssets = new Resource$Creativeassets();
+      this.creativeFields = new Resource$Creativefields();
+      this.creativeFieldValues = new Resource$Creativefieldvalues();
+      this.creativeGroups = new Resource$Creativegroups();
+      this.creatives = new Resource$Creatives();
+      this.dimensionValues = new Resource$Dimensionvalues();
+      this.directorySiteContacts = new Resource$Directorysitecontacts();
+      this.directorySites = new Resource$Directorysites();
+      this.dynamicTargetingKeys = new Resource$Dynamictargetingkeys();
+      this.eventTags = new Resource$Eventtags();
+      this.files = new Resource$Files();
+      this.floodlightActivities = new Resource$Floodlightactivities();
+      this.floodlightActivityGroups = new Resource$Floodlightactivitygroups();
+      this.floodlightConfigurations = new Resource$Floodlightconfigurations();
+      this.inventoryItems = new Resource$Inventoryitems();
+      this.languages = new Resource$Languages();
+      this.metros = new Resource$Metros();
+      this.mobileApps = new Resource$Mobileapps();
+      this.mobileCarriers = new Resource$Mobilecarriers();
+      this.operatingSystems = new Resource$Operatingsystems();
+      this.operatingSystemVersions = new Resource$Operatingsystemversions();
+      this.orderDocuments = new Resource$Orderdocuments();
+      this.orders = new Resource$Orders();
+      this.placementGroups = new Resource$Placementgroups();
+      this.placements = new Resource$Placements();
+      this.placementStrategies = new Resource$Placementstrategies();
+      this.platformTypes = new Resource$Platformtypes();
+      this.postalCodes = new Resource$Postalcodes();
+      this.projects = new Resource$Projects();
+      this.regions = new Resource$Regions();
+      this.remarketingLists = new Resource$Remarketinglists();
+      this.remarketingListShares = new Resource$Remarketinglistshares();
+      this.reports = new Resource$Reports();
+      this.sites = new Resource$Sites();
+      this.sizes = new Resource$Sizes();
+      this.subaccounts = new Resource$Subaccounts();
       this.targetableRemarketingLists =
-          new Resource$Targetableremarketinglists(this);
-      this.targetingTemplates = new Resource$Targetingtemplates(this);
-      this.userProfiles = new Resource$Userprofiles(this);
-      this.userRolePermissionGroups =
-          new Resource$Userrolepermissiongroups(this);
-      this.userRolePermissions = new Resource$Userrolepermissions(this);
-      this.userRoles = new Resource$Userroles(this);
-      this.videoFormats = new Resource$Videoformats(this);
-    }
-
-    getRoot() {
-      return this.root;
+          new Resource$Targetableremarketinglists();
+      this.targetingTemplates = new Resource$Targetingtemplates();
+      this.userProfiles = new Resource$Userprofiles();
+      this.userRolePermissionGroups = new Resource$Userrolepermissiongroups();
+      this.userRolePermissions = new Resource$Userrolepermissions();
+      this.userRoles = new Resource$Userroles();
+      this.videoFormats = new Resource$Videoformats();
     }
   }
 
@@ -7719,15 +7707,7 @@ export namespace dfareporting_v3_1 {
 
 
   export class Resource$Accountactiveadsummaries {
-    root: Dfareporting;
-    constructor(root: Dfareporting) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -7787,7 +7767,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId', 'summaryAccountId'],
         pathParams: ['profileId', 'summaryAccountId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$AccountActiveAdSummary>(parameters, callback);
@@ -7816,15 +7796,7 @@ export namespace dfareporting_v3_1 {
 
 
   export class Resource$Accountpermissiongroups {
-    root: Dfareporting;
-    constructor(root: Dfareporting) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -7884,7 +7856,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$AccountPermissionGroup>(parameters, callback);
@@ -7962,7 +7934,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$AccountPermissionGroupsListResponse>(
@@ -8005,15 +7977,7 @@ export namespace dfareporting_v3_1 {
 
 
   export class Resource$Accountpermissions {
-    root: Dfareporting;
-    constructor(root: Dfareporting) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -8072,7 +8036,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$AccountPermission>(parameters, callback);
@@ -8146,7 +8110,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$AccountPermissionsListResponse>(
@@ -8189,15 +8153,7 @@ export namespace dfareporting_v3_1 {
 
 
   export class Resource$Accounts {
-    root: Dfareporting;
-    constructor(root: Dfareporting) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -8253,7 +8209,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Account>(parameters, callback);
@@ -8328,7 +8284,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$AccountsListResponse>(parameters, callback);
@@ -8395,7 +8351,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Account>(parameters, callback);
@@ -8461,7 +8417,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Account>(parameters, callback);
@@ -8570,15 +8526,7 @@ export namespace dfareporting_v3_1 {
 
 
   export class Resource$Accountuserprofiles {
-    root: Dfareporting;
-    constructor(root: Dfareporting) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -8637,7 +8585,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$AccountUserProfile>(parameters, callback);
@@ -8707,7 +8655,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$AccountUserProfile>(parameters, callback);
@@ -8793,7 +8741,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$AccountUserProfilesListResponse>(
@@ -8867,7 +8815,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$AccountUserProfile>(parameters, callback);
@@ -8937,7 +8885,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$AccountUserProfile>(parameters, callback);
@@ -9075,15 +9023,7 @@ export namespace dfareporting_v3_1 {
 
 
   export class Resource$Ads {
-    root: Dfareporting;
-    constructor(root: Dfareporting) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -9139,7 +9079,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Ad>(parameters, callback);
@@ -9204,7 +9144,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Ad>(parameters, callback);
@@ -9293,7 +9233,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$AdsListResponse>(parameters, callback);
@@ -9359,7 +9299,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Ad>(parameters, callback);
@@ -9424,7 +9364,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Ad>(parameters, callback);
@@ -9620,15 +9560,7 @@ export namespace dfareporting_v3_1 {
 
 
   export class Resource$Advertisergroups {
-    root: Dfareporting;
-    constructor(root: Dfareporting) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -9689,7 +9621,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -9755,7 +9687,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$AdvertiserGroup>(parameters, callback);
@@ -9825,7 +9757,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$AdvertiserGroup>(parameters, callback);
@@ -9906,7 +9838,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$AdvertiserGroupsListResponse>(
@@ -9980,7 +9912,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$AdvertiserGroup>(parameters, callback);
@@ -10050,7 +9982,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$AdvertiserGroup>(parameters, callback);
@@ -10192,15 +10124,7 @@ export namespace dfareporting_v3_1 {
 
 
   export class Resource$Advertiserlandingpages {
-    root: Dfareporting;
-    constructor(root: Dfareporting) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -10259,7 +10183,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$LandingPage>(parameters, callback);
@@ -10329,7 +10253,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$LandingPage>(parameters, callback);
@@ -10416,7 +10340,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$AdvertiserLandingPagesListResponse>(
@@ -10490,7 +10414,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$LandingPage>(parameters, callback);
@@ -10560,7 +10484,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$LandingPage>(parameters, callback);
@@ -10699,15 +10623,7 @@ export namespace dfareporting_v3_1 {
 
 
   export class Resource$Advertisers {
-    root: Dfareporting;
-    constructor(root: Dfareporting) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -10765,7 +10681,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Advertiser>(parameters, callback);
@@ -10834,7 +10750,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Advertiser>(parameters, callback);
@@ -10914,7 +10830,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$AdvertisersListResponse>(parameters, callback);
@@ -10984,7 +10900,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Advertiser>(parameters, callback);
@@ -11053,7 +10969,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Advertiser>(parameters, callback);
@@ -11202,15 +11118,7 @@ export namespace dfareporting_v3_1 {
 
 
   export class Resource$Browsers {
-    root: Dfareporting;
-    constructor(root: Dfareporting) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -11270,7 +11178,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$BrowsersListResponse>(parameters, callback);
@@ -11294,15 +11202,7 @@ export namespace dfareporting_v3_1 {
 
 
   export class Resource$Campaigncreativeassociations {
-    root: Dfareporting;
-    constructor(root: Dfareporting) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -11373,7 +11273,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId', 'campaignId'],
         pathParams: ['campaignId', 'profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$CampaignCreativeAssociation>(
@@ -11454,7 +11354,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId', 'campaignId'],
         pathParams: ['campaignId', 'profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$CampaignCreativeAssociationsListResponse>(
@@ -11518,15 +11418,7 @@ export namespace dfareporting_v3_1 {
 
 
   export class Resource$Campaigns {
-    root: Dfareporting;
-    constructor(root: Dfareporting) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -11583,7 +11475,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Campaign>(parameters, callback);
@@ -11649,7 +11541,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Campaign>(parameters, callback);
@@ -11730,7 +11622,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$CampaignsListResponse>(parameters, callback);
@@ -11797,7 +11689,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Campaign>(parameters, callback);
@@ -11863,7 +11755,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Campaign>(parameters, callback);
@@ -12014,15 +11906,7 @@ export namespace dfareporting_v3_1 {
 
 
   export class Resource$Changelogs {
-    root: Dfareporting;
-    constructor(root: Dfareporting) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -12080,7 +11964,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ChangeLog>(parameters, callback);
@@ -12157,7 +12041,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ChangeLogsListResponse>(parameters, callback);
@@ -12247,15 +12131,7 @@ export namespace dfareporting_v3_1 {
 
 
   export class Resource$Cities {
-    root: Dfareporting;
-    constructor(root: Dfareporting) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -12318,7 +12194,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$CitiesListResponse>(parameters, callback);
@@ -12358,15 +12234,7 @@ export namespace dfareporting_v3_1 {
 
 
   export class Resource$Connectiontypes {
-    root: Dfareporting;
-    constructor(root: Dfareporting) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -12425,7 +12293,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ConnectionType>(parameters, callback);
@@ -12498,7 +12366,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ConnectionTypesListResponse>(
@@ -12540,15 +12408,7 @@ export namespace dfareporting_v3_1 {
 
 
   export class Resource$Contentcategories {
-    root: Dfareporting;
-    constructor(root: Dfareporting) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -12609,7 +12469,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -12675,7 +12535,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ContentCategory>(parameters, callback);
@@ -12745,7 +12605,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ContentCategory>(parameters, callback);
@@ -12826,7 +12686,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ContentCategoriesListResponse>(
@@ -12900,7 +12760,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ContentCategory>(parameters, callback);
@@ -12970,7 +12830,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ContentCategory>(parameters, callback);
@@ -13112,15 +12972,7 @@ export namespace dfareporting_v3_1 {
 
 
   export class Resource$Conversions {
-    root: Dfareporting;
-    constructor(root: Dfareporting) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -13189,7 +13041,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ConversionsBatchInsertResponse>(
@@ -13267,7 +13119,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ConversionsBatchUpdateResponse>(
@@ -13316,15 +13168,7 @@ export namespace dfareporting_v3_1 {
 
 
   export class Resource$Countries {
-    root: Dfareporting;
-    constructor(root: Dfareporting) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -13381,7 +13225,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId', 'dartId'],
         pathParams: ['dartId', 'profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Country>(parameters, callback);
@@ -13448,7 +13292,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$CountriesListResponse>(parameters, callback);
@@ -13487,15 +13331,7 @@ export namespace dfareporting_v3_1 {
 
 
   export class Resource$Creativeassets {
-    root: Dfareporting;
-    constructor(root: Dfareporting) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -13567,7 +13403,7 @@ export namespace dfareporting_v3_1 {
                 .replace(/([^:]\/)\/+/g, '$1'),
         requiredParams: ['profileId', 'advertiserId'],
         pathParams: ['advertiserId', 'profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$CreativeAssetMetadata>(parameters, callback);
@@ -13616,15 +13452,7 @@ export namespace dfareporting_v3_1 {
 
 
   export class Resource$Creativefields {
-    root: Dfareporting;
-    constructor(root: Dfareporting) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -13685,7 +13513,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -13751,7 +13579,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$CreativeField>(parameters, callback);
@@ -13821,7 +13649,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$CreativeField>(parameters, callback);
@@ -13901,7 +13729,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$CreativeFieldsListResponse>(
@@ -13974,7 +13802,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$CreativeField>(parameters, callback);
@@ -14044,7 +13872,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$CreativeField>(parameters, callback);
@@ -14190,15 +14018,7 @@ export namespace dfareporting_v3_1 {
 
 
   export class Resource$Creativefieldvalues {
-    root: Dfareporting;
-    constructor(root: Dfareporting) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -14260,7 +14080,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId', 'creativeFieldId', 'id'],
         pathParams: ['creativeFieldId', 'id', 'profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -14327,7 +14147,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId', 'creativeFieldId', 'id'],
         pathParams: ['creativeFieldId', 'id', 'profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$CreativeFieldValue>(parameters, callback);
@@ -14398,7 +14218,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId', 'creativeFieldId'],
         pathParams: ['creativeFieldId', 'profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$CreativeFieldValue>(parameters, callback);
@@ -14482,7 +14302,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId', 'creativeFieldId'],
         pathParams: ['creativeFieldId', 'profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$CreativeFieldValuesListResponse>(
@@ -14557,7 +14377,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId', 'creativeFieldId', 'id'],
         pathParams: ['creativeFieldId', 'profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$CreativeFieldValue>(parameters, callback);
@@ -14628,7 +14448,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId', 'creativeFieldId'],
         pathParams: ['creativeFieldId', 'profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$CreativeFieldValue>(parameters, callback);
@@ -14789,15 +14609,7 @@ export namespace dfareporting_v3_1 {
 
 
   export class Resource$Creativegroups {
-    root: Dfareporting;
-    constructor(root: Dfareporting) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -14856,7 +14668,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$CreativeGroup>(parameters, callback);
@@ -14926,7 +14738,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$CreativeGroup>(parameters, callback);
@@ -15007,7 +14819,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$CreativeGroupsListResponse>(
@@ -15080,7 +14892,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$CreativeGroup>(parameters, callback);
@@ -15150,7 +14962,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$CreativeGroup>(parameters, callback);
@@ -15284,15 +15096,7 @@ export namespace dfareporting_v3_1 {
 
 
   export class Resource$Creatives {
-    root: Dfareporting;
-    constructor(root: Dfareporting) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -15349,7 +15153,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Creative>(parameters, callback);
@@ -15415,7 +15219,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Creative>(parameters, callback);
@@ -15499,7 +15303,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$CreativesListResponse>(parameters, callback);
@@ -15566,7 +15370,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Creative>(parameters, callback);
@@ -15632,7 +15436,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Creative>(parameters, callback);
@@ -15795,15 +15599,7 @@ export namespace dfareporting_v3_1 {
 
 
   export class Resource$Dimensionvalues {
-    root: Dfareporting;
-    constructor(root: Dfareporting) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -15868,7 +15664,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$DimensionValueList>(parameters, callback);
@@ -15906,15 +15702,7 @@ export namespace dfareporting_v3_1 {
 
 
   export class Resource$Directorysitecontacts {
-    root: Dfareporting;
-    constructor(root: Dfareporting) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -15974,7 +15762,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$DirectorySiteContact>(parameters, callback);
@@ -16060,7 +15848,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$DirectorySiteContactsListResponse>(
@@ -16139,15 +15927,7 @@ export namespace dfareporting_v3_1 {
 
 
   export class Resource$Directorysites {
-    root: Dfareporting;
-    constructor(root: Dfareporting) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -16206,7 +15986,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$DirectorySite>(parameters, callback);
@@ -16276,7 +16056,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$DirectorySite>(parameters, callback);
@@ -16362,7 +16142,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$DirectorySitesListResponse>(
@@ -16483,15 +16263,7 @@ export namespace dfareporting_v3_1 {
 
 
   export class Resource$Dynamictargetingkeys {
-    root: Dfareporting;
-    constructor(root: Dfareporting) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -16554,7 +16326,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId', 'objectId', 'name', 'objectType'],
         pathParams: ['objectId', 'profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -16628,7 +16400,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$DynamicTargetingKey>(parameters, callback);
@@ -16710,7 +16482,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$DynamicTargetingKeysListResponse>(
@@ -16797,15 +16569,7 @@ export namespace dfareporting_v3_1 {
 
 
   export class Resource$Eventtags {
-    root: Dfareporting;
-    constructor(root: Dfareporting) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -16864,7 +16628,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -16928,7 +16692,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$EventTag>(parameters, callback);
@@ -16994,7 +16758,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$EventTag>(parameters, callback);
@@ -17071,7 +16835,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$EventTagsListResponse>(parameters, callback);
@@ -17139,7 +16903,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$EventTag>(parameters, callback);
@@ -17205,7 +16969,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$EventTag>(parameters, callback);
@@ -17371,15 +17135,7 @@ export namespace dfareporting_v3_1 {
 
 
   export class Resource$Files {
-    root: Dfareporting;
-    constructor(root: Dfareporting) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -17436,7 +17192,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['reportId', 'fileId'],
         pathParams: ['fileId', 'reportId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$File>(parameters, callback);
@@ -17506,7 +17262,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$FileList>(parameters, callback);
@@ -17565,15 +17321,7 @@ export namespace dfareporting_v3_1 {
 
 
   export class Resource$Floodlightactivities {
-    root: Dfareporting;
-    constructor(root: Dfareporting) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -17634,7 +17382,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -17710,7 +17458,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$FloodlightActivitiesGenerateTagResponse>(
@@ -17778,7 +17526,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$FloodlightActivity>(parameters, callback);
@@ -17848,7 +17596,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$FloodlightActivity>(parameters, callback);
@@ -17940,7 +17688,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$FloodlightActivitiesListResponse>(
@@ -18014,7 +17762,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$FloodlightActivity>(parameters, callback);
@@ -18084,7 +17832,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$FloodlightActivity>(parameters, callback);
@@ -18281,15 +18029,7 @@ export namespace dfareporting_v3_1 {
 
 
   export class Resource$Floodlightactivitygroups {
-    root: Dfareporting;
-    constructor(root: Dfareporting) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -18349,7 +18089,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$FloodlightActivityGroup>(parameters, callback);
@@ -18421,7 +18161,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$FloodlightActivityGroup>(parameters, callback);
@@ -18509,7 +18249,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$FloodlightActivityGroupsListResponse>(
@@ -18584,7 +18324,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$FloodlightActivityGroup>(parameters, callback);
@@ -18656,7 +18396,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$FloodlightActivityGroup>(parameters, callback);
@@ -18802,15 +18542,7 @@ export namespace dfareporting_v3_1 {
 
 
   export class Resource$Floodlightconfigurations {
-    root: Dfareporting;
-    constructor(root: Dfareporting) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -18870,7 +18602,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$FloodlightConfiguration>(parameters, callback);
@@ -18949,7 +18681,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$FloodlightConfigurationsListResponse>(
@@ -19024,7 +18756,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$FloodlightConfiguration>(parameters, callback);
@@ -19096,7 +18828,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$FloodlightConfiguration>(parameters, callback);
@@ -19180,15 +18912,7 @@ export namespace dfareporting_v3_1 {
 
 
   export class Resource$Inventoryitems {
-    root: Dfareporting;
-    constructor(root: Dfareporting) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -19248,7 +18972,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId', 'projectId', 'id'],
         pathParams: ['id', 'profileId', 'projectId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$InventoryItem>(parameters, callback);
@@ -19331,7 +19055,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId', 'projectId'],
         pathParams: ['profileId', 'projectId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$InventoryItemsListResponse>(
@@ -19417,15 +19141,7 @@ export namespace dfareporting_v3_1 {
 
 
   export class Resource$Languages {
-    root: Dfareporting;
-    constructor(root: Dfareporting) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -19485,7 +19201,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$LanguagesListResponse>(parameters, callback);
@@ -19509,15 +19225,7 @@ export namespace dfareporting_v3_1 {
 
 
   export class Resource$Metros {
-    root: Dfareporting;
-    constructor(root: Dfareporting) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -19576,7 +19284,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$MetrosListResponse>(parameters, callback);
@@ -19600,15 +19308,7 @@ export namespace dfareporting_v3_1 {
 
 
   export class Resource$Mobileapps {
-    root: Dfareporting;
-    constructor(root: Dfareporting) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -19666,7 +19366,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$MobileApp>(parameters, callback);
@@ -19738,7 +19438,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$MobileAppsListResponse>(parameters, callback);
@@ -19802,15 +19502,7 @@ export namespace dfareporting_v3_1 {
 
 
   export class Resource$Mobilecarriers {
-    root: Dfareporting;
-    constructor(root: Dfareporting) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -19869,7 +19561,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$MobileCarrier>(parameters, callback);
@@ -19941,7 +19633,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$MobileCarriersListResponse>(
@@ -19983,15 +19675,7 @@ export namespace dfareporting_v3_1 {
 
 
   export class Resource$Operatingsystems {
-    root: Dfareporting;
-    constructor(root: Dfareporting) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -20050,7 +19734,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId', 'dartId'],
         pathParams: ['dartId', 'profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$OperatingSystem>(parameters, callback);
@@ -20124,7 +19808,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$OperatingSystemsListResponse>(
@@ -20167,15 +19851,7 @@ export namespace dfareporting_v3_1 {
 
 
   export class Resource$Operatingsystemversions {
-    root: Dfareporting;
-    constructor(root: Dfareporting) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -20235,7 +19911,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$OperatingSystemVersion>(parameters, callback);
@@ -20313,7 +19989,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$OperatingSystemVersionsListResponse>(
@@ -20356,15 +20032,7 @@ export namespace dfareporting_v3_1 {
 
 
   export class Resource$Orderdocuments {
-    root: Dfareporting;
-    constructor(root: Dfareporting) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -20424,7 +20092,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId', 'projectId', 'id'],
         pathParams: ['id', 'profileId', 'projectId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$OrderDocument>(parameters, callback);
@@ -20507,7 +20175,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId', 'projectId'],
         pathParams: ['profileId', 'projectId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$OrderDocumentsListResponse>(
@@ -20599,15 +20267,7 @@ export namespace dfareporting_v3_1 {
 
 
   export class Resource$Orders {
-    root: Dfareporting;
-    constructor(root: Dfareporting) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -20665,7 +20325,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId', 'projectId', 'id'],
         pathParams: ['id', 'profileId', 'projectId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Order>(parameters, callback);
@@ -20741,7 +20401,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId', 'projectId'],
         pathParams: ['profileId', 'projectId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$OrdersListResponse>(parameters, callback);
@@ -20821,15 +20481,7 @@ export namespace dfareporting_v3_1 {
 
 
   export class Resource$Placementgroups {
-    root: Dfareporting;
-    constructor(root: Dfareporting) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -20888,7 +20540,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$PlacementGroup>(parameters, callback);
@@ -20958,7 +20610,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$PlacementGroup>(parameters, callback);
@@ -21051,7 +20703,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$PlacementGroupsListResponse>(
@@ -21124,7 +20776,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$PlacementGroup>(parameters, callback);
@@ -21194,7 +20846,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$PlacementGroup>(parameters, callback);
@@ -21387,15 +21039,7 @@ export namespace dfareporting_v3_1 {
 
 
   export class Resource$Placements {
-    root: Dfareporting;
-    constructor(root: Dfareporting) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -21466,7 +21110,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$PlacementsGenerateTagsResponse>(
@@ -21533,7 +21177,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Placement>(parameters, callback);
@@ -21601,7 +21245,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Placement>(parameters, callback);
@@ -21691,7 +21335,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$PlacementsListResponse>(parameters, callback);
@@ -21760,7 +21404,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Placement>(parameters, callback);
@@ -21828,7 +21472,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Placement>(parameters, callback);
@@ -22052,15 +21696,7 @@ export namespace dfareporting_v3_1 {
 
 
   export class Resource$Placementstrategies {
-    root: Dfareporting;
-    constructor(root: Dfareporting) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -22121,7 +21757,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -22187,7 +21823,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$PlacementStrategy>(parameters, callback);
@@ -22257,7 +21893,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$PlacementStrategy>(parameters, callback);
@@ -22340,7 +21976,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$PlacementStrategiesListResponse>(
@@ -22414,7 +22050,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$PlacementStrategy>(parameters, callback);
@@ -22484,7 +22120,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$PlacementStrategy>(parameters, callback);
@@ -22627,15 +22263,7 @@ export namespace dfareporting_v3_1 {
 
 
   export class Resource$Platformtypes {
-    root: Dfareporting;
-    constructor(root: Dfareporting) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -22694,7 +22322,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$PlatformType>(parameters, callback);
@@ -22763,7 +22391,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$PlatformTypesListResponse>(
@@ -22805,15 +22433,7 @@ export namespace dfareporting_v3_1 {
 
 
   export class Resource$Postalcodes {
-    root: Dfareporting;
-    constructor(root: Dfareporting) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -22871,7 +22491,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId', 'code'],
         pathParams: ['code', 'profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$PostalCode>(parameters, callback);
@@ -22938,7 +22558,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$PostalCodesListResponse>(parameters, callback);
@@ -22977,15 +22597,7 @@ export namespace dfareporting_v3_1 {
 
 
   export class Resource$Projects {
-    root: Dfareporting;
-    constructor(root: Dfareporting) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -23041,7 +22653,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Project>(parameters, callback);
@@ -23116,7 +22728,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ProjectsListResponse>(parameters, callback);
@@ -23188,15 +22800,7 @@ export namespace dfareporting_v3_1 {
 
 
   export class Resource$Regions {
-    root: Dfareporting;
-    constructor(root: Dfareporting) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -23255,7 +22859,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$RegionsListResponse>(parameters, callback);
@@ -23279,15 +22883,7 @@ export namespace dfareporting_v3_1 {
 
 
   export class Resource$Remarketinglists {
-    root: Dfareporting;
-    constructor(root: Dfareporting) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -23346,7 +22942,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$RemarketingList>(parameters, callback);
@@ -23416,7 +23012,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$RemarketingList>(parameters, callback);
@@ -23499,7 +23095,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId', 'advertiserId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$RemarketingListsListResponse>(
@@ -23573,7 +23169,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$RemarketingList>(parameters, callback);
@@ -23643,7 +23239,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$RemarketingList>(parameters, callback);
@@ -23777,15 +23373,7 @@ export namespace dfareporting_v3_1 {
 
 
   export class Resource$Remarketinglistshares {
-    root: Dfareporting;
-    constructor(root: Dfareporting) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -23845,7 +23433,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId', 'remarketingListId'],
         pathParams: ['profileId', 'remarketingListId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$RemarketingListShare>(parameters, callback);
@@ -23918,7 +23506,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId', 'remarketingListId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$RemarketingListShare>(parameters, callback);
@@ -23989,7 +23577,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$RemarketingListShare>(parameters, callback);
@@ -24056,18 +23644,11 @@ export namespace dfareporting_v3_1 {
 
 
   export class Resource$Reports {
-    root: Dfareporting;
     compatibleFields: Resource$Reports$Compatiblefields;
     files: Resource$Reports$Files;
-    constructor(root: Dfareporting) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.compatibleFields = new Resource$Reports$Compatiblefields(root);
-      this.files = new Resource$Reports$Files(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.compatibleFields = new Resource$Reports$Compatiblefields();
+      this.files = new Resource$Reports$Files();
     }
 
 
@@ -24127,7 +23708,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId', 'reportId'],
         pathParams: ['profileId', 'reportId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -24191,7 +23772,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId', 'reportId'],
         pathParams: ['profileId', 'reportId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Report>(parameters, callback);
@@ -24257,7 +23838,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Report>(parameters, callback);
@@ -24328,7 +23909,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ReportList>(parameters, callback);
@@ -24396,7 +23977,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId', 'reportId'],
         pathParams: ['profileId', 'reportId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Report>(parameters, callback);
@@ -24461,7 +24042,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId', 'reportId'],
         pathParams: ['profileId', 'reportId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$File>(parameters, callback);
@@ -24529,7 +24110,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId', 'reportId'],
         pathParams: ['profileId', 'reportId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Report>(parameters, callback);
@@ -24677,15 +24258,7 @@ export namespace dfareporting_v3_1 {
   }
 
   export class Resource$Reports$Compatiblefields {
-    root: Dfareporting;
-    constructor(root: Dfareporting) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -24750,7 +24323,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$CompatibleFields>(parameters, callback);
@@ -24780,15 +24353,7 @@ export namespace dfareporting_v3_1 {
 
 
   export class Resource$Reports$Files {
-    root: Dfareporting;
-    constructor(root: Dfareporting) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -24847,7 +24412,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId', 'reportId', 'fileId'],
         pathParams: ['fileId', 'profileId', 'reportId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$File>(parameters, callback);
@@ -24919,7 +24484,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId', 'reportId'],
         pathParams: ['profileId', 'reportId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$FileList>(parameters, callback);
@@ -24985,15 +24550,7 @@ export namespace dfareporting_v3_1 {
 
 
   export class Resource$Sites {
-    root: Dfareporting;
-    constructor(root: Dfareporting) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -25049,7 +24606,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Site>(parameters, callback);
@@ -25115,7 +24672,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Site>(parameters, callback);
@@ -25197,7 +24754,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$SitesListResponse>(parameters, callback);
@@ -25264,7 +24821,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Site>(parameters, callback);
@@ -25330,7 +24887,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Site>(parameters, callback);
@@ -25488,15 +25045,7 @@ export namespace dfareporting_v3_1 {
 
 
   export class Resource$Sizes {
-    root: Dfareporting;
-    constructor(root: Dfareporting) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -25552,7 +25101,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Size>(parameters, callback);
@@ -25618,7 +25167,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Size>(parameters, callback);
@@ -25691,7 +25240,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$SizesListResponse>(parameters, callback);
@@ -25762,15 +25311,7 @@ export namespace dfareporting_v3_1 {
 
 
   export class Resource$Subaccounts {
-    root: Dfareporting;
-    constructor(root: Dfareporting) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -25828,7 +25369,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Subaccount>(parameters, callback);
@@ -25897,7 +25438,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Subaccount>(parameters, callback);
@@ -25971,7 +25512,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$SubaccountsListResponse>(parameters, callback);
@@ -26041,7 +25582,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Subaccount>(parameters, callback);
@@ -26110,7 +25651,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Subaccount>(parameters, callback);
@@ -26234,15 +25775,7 @@ export namespace dfareporting_v3_1 {
 
 
   export class Resource$Targetableremarketinglists {
-    root: Dfareporting;
-    constructor(root: Dfareporting) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -26303,7 +25836,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TargetableRemarketingList>(
@@ -26387,7 +25920,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId', 'advertiserId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TargetableRemarketingListsListResponse>(
@@ -26464,15 +25997,7 @@ export namespace dfareporting_v3_1 {
 
 
   export class Resource$Targetingtemplates {
-    root: Dfareporting;
-    constructor(root: Dfareporting) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -26531,7 +26056,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TargetingTemplate>(parameters, callback);
@@ -26601,7 +26126,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TargetingTemplate>(parameters, callback);
@@ -26683,7 +26208,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TargetingTemplatesListResponse>(
@@ -26757,7 +26282,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TargetingTemplate>(parameters, callback);
@@ -26827,7 +26352,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TargetingTemplate>(parameters, callback);
@@ -26957,15 +26482,7 @@ export namespace dfareporting_v3_1 {
 
 
   export class Resource$Userprofiles {
-    root: Dfareporting;
-    constructor(root: Dfareporting) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -27020,7 +26537,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$UserProfile>(parameters, callback);
@@ -27085,7 +26602,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$UserProfileList>(parameters, callback);
@@ -27116,15 +26633,7 @@ export namespace dfareporting_v3_1 {
 
 
   export class Resource$Userrolepermissiongroups {
-    root: Dfareporting;
-    constructor(root: Dfareporting) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -27184,7 +26693,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$UserRolePermissionGroup>(parameters, callback);
@@ -27262,7 +26771,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$UserRolePermissionGroupsListResponse>(
@@ -27305,15 +26814,7 @@ export namespace dfareporting_v3_1 {
 
 
   export class Resource$Userrolepermissions {
-    root: Dfareporting;
-    constructor(root: Dfareporting) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -27372,7 +26873,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$UserRolePermission>(parameters, callback);
@@ -27449,7 +26950,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$UserRolePermissionsListResponse>(
@@ -27496,15 +26997,7 @@ export namespace dfareporting_v3_1 {
 
 
   export class Resource$Userroles {
-    root: Dfareporting;
-    constructor(root: Dfareporting) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -27563,7 +27056,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -27627,7 +27120,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$UserRole>(parameters, callback);
@@ -27693,7 +27186,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$UserRole>(parameters, callback);
@@ -27769,7 +27262,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$UserRolesListResponse>(parameters, callback);
@@ -27837,7 +27330,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$UserRole>(parameters, callback);
@@ -27903,7 +27396,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$UserRole>(parameters, callback);
@@ -28048,15 +27541,7 @@ export namespace dfareporting_v3_1 {
 
 
   export class Resource$Videoformats {
-    root: Dfareporting;
-    constructor(root: Dfareporting) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -28114,7 +27599,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$VideoFormat>(parameters, callback);
@@ -28182,7 +27667,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$VideoFormatsListResponse>(parameters, callback);

--- a/src/apis/dfareporting/v3.2.ts
+++ b/src/apis/dfareporting/v3.2.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace dfareporting_v3_2 {
   export interface Options extends GlobalOptions {
     version: 'v3_2';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -79,10 +81,6 @@ export namespace dfareporting_v3_2 {
    * @param {object=} options Options for Dfareporting
    */
   export class Dfareporting {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     accountActiveAdSummaries: Resource$Accountactiveadsummaries;
     accountPermissionGroups: Resource$Accountpermissiongroups;
     accountPermissions: Resource$Accountpermissions;
@@ -146,81 +144,71 @@ export namespace dfareporting_v3_2 {
     videoFormats: Resource$Videoformats;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.accountActiveAdSummaries =
-          new Resource$Accountactiveadsummaries(this);
-      this.accountPermissionGroups = new Resource$Accountpermissiongroups(this);
-      this.accountPermissions = new Resource$Accountpermissions(this);
-      this.accounts = new Resource$Accounts(this);
-      this.accountUserProfiles = new Resource$Accountuserprofiles(this);
-      this.ads = new Resource$Ads(this);
-      this.advertiserGroups = new Resource$Advertisergroups(this);
-      this.advertiserLandingPages = new Resource$Advertiserlandingpages(this);
-      this.advertisers = new Resource$Advertisers(this);
-      this.browsers = new Resource$Browsers(this);
+      this.accountActiveAdSummaries = new Resource$Accountactiveadsummaries();
+      this.accountPermissionGroups = new Resource$Accountpermissiongroups();
+      this.accountPermissions = new Resource$Accountpermissions();
+      this.accounts = new Resource$Accounts();
+      this.accountUserProfiles = new Resource$Accountuserprofiles();
+      this.ads = new Resource$Ads();
+      this.advertiserGroups = new Resource$Advertisergroups();
+      this.advertiserLandingPages = new Resource$Advertiserlandingpages();
+      this.advertisers = new Resource$Advertisers();
+      this.browsers = new Resource$Browsers();
       this.campaignCreativeAssociations =
-          new Resource$Campaigncreativeassociations(this);
-      this.campaigns = new Resource$Campaigns(this);
-      this.changeLogs = new Resource$Changelogs(this);
-      this.cities = new Resource$Cities(this);
-      this.connectionTypes = new Resource$Connectiontypes(this);
-      this.contentCategories = new Resource$Contentcategories(this);
-      this.conversions = new Resource$Conversions(this);
-      this.countries = new Resource$Countries(this);
-      this.creativeAssets = new Resource$Creativeassets(this);
-      this.creativeFields = new Resource$Creativefields(this);
-      this.creativeFieldValues = new Resource$Creativefieldvalues(this);
-      this.creativeGroups = new Resource$Creativegroups(this);
-      this.creatives = new Resource$Creatives(this);
-      this.dimensionValues = new Resource$Dimensionvalues(this);
-      this.directorySiteContacts = new Resource$Directorysitecontacts(this);
-      this.directorySites = new Resource$Directorysites(this);
-      this.dynamicTargetingKeys = new Resource$Dynamictargetingkeys(this);
-      this.eventTags = new Resource$Eventtags(this);
-      this.files = new Resource$Files(this);
-      this.floodlightActivities = new Resource$Floodlightactivities(this);
-      this.floodlightActivityGroups =
-          new Resource$Floodlightactivitygroups(this);
-      this.floodlightConfigurations =
-          new Resource$Floodlightconfigurations(this);
-      this.inventoryItems = new Resource$Inventoryitems(this);
-      this.languages = new Resource$Languages(this);
-      this.metros = new Resource$Metros(this);
-      this.mobileApps = new Resource$Mobileapps(this);
-      this.mobileCarriers = new Resource$Mobilecarriers(this);
-      this.operatingSystems = new Resource$Operatingsystems(this);
-      this.operatingSystemVersions = new Resource$Operatingsystemversions(this);
-      this.orderDocuments = new Resource$Orderdocuments(this);
-      this.orders = new Resource$Orders(this);
-      this.placementGroups = new Resource$Placementgroups(this);
-      this.placements = new Resource$Placements(this);
-      this.placementStrategies = new Resource$Placementstrategies(this);
-      this.platformTypes = new Resource$Platformtypes(this);
-      this.postalCodes = new Resource$Postalcodes(this);
-      this.projects = new Resource$Projects(this);
-      this.regions = new Resource$Regions(this);
-      this.remarketingLists = new Resource$Remarketinglists(this);
-      this.remarketingListShares = new Resource$Remarketinglistshares(this);
-      this.reports = new Resource$Reports(this);
-      this.sites = new Resource$Sites(this);
-      this.sizes = new Resource$Sizes(this);
-      this.subaccounts = new Resource$Subaccounts(this);
+          new Resource$Campaigncreativeassociations();
+      this.campaigns = new Resource$Campaigns();
+      this.changeLogs = new Resource$Changelogs();
+      this.cities = new Resource$Cities();
+      this.connectionTypes = new Resource$Connectiontypes();
+      this.contentCategories = new Resource$Contentcategories();
+      this.conversions = new Resource$Conversions();
+      this.countries = new Resource$Countries();
+      this.creativeAssets = new Resource$Creativeassets();
+      this.creativeFields = new Resource$Creativefields();
+      this.creativeFieldValues = new Resource$Creativefieldvalues();
+      this.creativeGroups = new Resource$Creativegroups();
+      this.creatives = new Resource$Creatives();
+      this.dimensionValues = new Resource$Dimensionvalues();
+      this.directorySiteContacts = new Resource$Directorysitecontacts();
+      this.directorySites = new Resource$Directorysites();
+      this.dynamicTargetingKeys = new Resource$Dynamictargetingkeys();
+      this.eventTags = new Resource$Eventtags();
+      this.files = new Resource$Files();
+      this.floodlightActivities = new Resource$Floodlightactivities();
+      this.floodlightActivityGroups = new Resource$Floodlightactivitygroups();
+      this.floodlightConfigurations = new Resource$Floodlightconfigurations();
+      this.inventoryItems = new Resource$Inventoryitems();
+      this.languages = new Resource$Languages();
+      this.metros = new Resource$Metros();
+      this.mobileApps = new Resource$Mobileapps();
+      this.mobileCarriers = new Resource$Mobilecarriers();
+      this.operatingSystems = new Resource$Operatingsystems();
+      this.operatingSystemVersions = new Resource$Operatingsystemversions();
+      this.orderDocuments = new Resource$Orderdocuments();
+      this.orders = new Resource$Orders();
+      this.placementGroups = new Resource$Placementgroups();
+      this.placements = new Resource$Placements();
+      this.placementStrategies = new Resource$Placementstrategies();
+      this.platformTypes = new Resource$Platformtypes();
+      this.postalCodes = new Resource$Postalcodes();
+      this.projects = new Resource$Projects();
+      this.regions = new Resource$Regions();
+      this.remarketingLists = new Resource$Remarketinglists();
+      this.remarketingListShares = new Resource$Remarketinglistshares();
+      this.reports = new Resource$Reports();
+      this.sites = new Resource$Sites();
+      this.sizes = new Resource$Sizes();
+      this.subaccounts = new Resource$Subaccounts();
       this.targetableRemarketingLists =
-          new Resource$Targetableremarketinglists(this);
-      this.targetingTemplates = new Resource$Targetingtemplates(this);
-      this.userProfiles = new Resource$Userprofiles(this);
-      this.userRolePermissionGroups =
-          new Resource$Userrolepermissiongroups(this);
-      this.userRolePermissions = new Resource$Userrolepermissions(this);
-      this.userRoles = new Resource$Userroles(this);
-      this.videoFormats = new Resource$Videoformats(this);
-    }
-
-    getRoot() {
-      return this.root;
+          new Resource$Targetableremarketinglists();
+      this.targetingTemplates = new Resource$Targetingtemplates();
+      this.userProfiles = new Resource$Userprofiles();
+      this.userRolePermissionGroups = new Resource$Userrolepermissiongroups();
+      this.userRolePermissions = new Resource$Userrolepermissions();
+      this.userRoles = new Resource$Userroles();
+      this.videoFormats = new Resource$Videoformats();
     }
   }
 
@@ -7748,15 +7736,7 @@ export namespace dfareporting_v3_2 {
 
 
   export class Resource$Accountactiveadsummaries {
-    root: Dfareporting;
-    constructor(root: Dfareporting) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -7816,7 +7796,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId', 'summaryAccountId'],
         pathParams: ['profileId', 'summaryAccountId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$AccountActiveAdSummary>(parameters, callback);
@@ -7845,15 +7825,7 @@ export namespace dfareporting_v3_2 {
 
 
   export class Resource$Accountpermissiongroups {
-    root: Dfareporting;
-    constructor(root: Dfareporting) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -7913,7 +7885,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$AccountPermissionGroup>(parameters, callback);
@@ -7991,7 +7963,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$AccountPermissionGroupsListResponse>(
@@ -8034,15 +8006,7 @@ export namespace dfareporting_v3_2 {
 
 
   export class Resource$Accountpermissions {
-    root: Dfareporting;
-    constructor(root: Dfareporting) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -8101,7 +8065,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$AccountPermission>(parameters, callback);
@@ -8175,7 +8139,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$AccountPermissionsListResponse>(
@@ -8218,15 +8182,7 @@ export namespace dfareporting_v3_2 {
 
 
   export class Resource$Accounts {
-    root: Dfareporting;
-    constructor(root: Dfareporting) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -8282,7 +8238,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Account>(parameters, callback);
@@ -8357,7 +8313,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$AccountsListResponse>(parameters, callback);
@@ -8424,7 +8380,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Account>(parameters, callback);
@@ -8490,7 +8446,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Account>(parameters, callback);
@@ -8599,15 +8555,7 @@ export namespace dfareporting_v3_2 {
 
 
   export class Resource$Accountuserprofiles {
-    root: Dfareporting;
-    constructor(root: Dfareporting) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -8666,7 +8614,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$AccountUserProfile>(parameters, callback);
@@ -8736,7 +8684,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$AccountUserProfile>(parameters, callback);
@@ -8822,7 +8770,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$AccountUserProfilesListResponse>(
@@ -8896,7 +8844,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$AccountUserProfile>(parameters, callback);
@@ -8966,7 +8914,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$AccountUserProfile>(parameters, callback);
@@ -9104,15 +9052,7 @@ export namespace dfareporting_v3_2 {
 
 
   export class Resource$Ads {
-    root: Dfareporting;
-    constructor(root: Dfareporting) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -9168,7 +9108,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Ad>(parameters, callback);
@@ -9233,7 +9173,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Ad>(parameters, callback);
@@ -9322,7 +9262,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$AdsListResponse>(parameters, callback);
@@ -9388,7 +9328,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Ad>(parameters, callback);
@@ -9453,7 +9393,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Ad>(parameters, callback);
@@ -9649,15 +9589,7 @@ export namespace dfareporting_v3_2 {
 
 
   export class Resource$Advertisergroups {
-    root: Dfareporting;
-    constructor(root: Dfareporting) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -9718,7 +9650,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -9784,7 +9716,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$AdvertiserGroup>(parameters, callback);
@@ -9854,7 +9786,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$AdvertiserGroup>(parameters, callback);
@@ -9935,7 +9867,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$AdvertiserGroupsListResponse>(
@@ -10009,7 +9941,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$AdvertiserGroup>(parameters, callback);
@@ -10079,7 +10011,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$AdvertiserGroup>(parameters, callback);
@@ -10221,15 +10153,7 @@ export namespace dfareporting_v3_2 {
 
 
   export class Resource$Advertiserlandingpages {
-    root: Dfareporting;
-    constructor(root: Dfareporting) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -10288,7 +10212,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$LandingPage>(parameters, callback);
@@ -10358,7 +10282,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$LandingPage>(parameters, callback);
@@ -10446,7 +10370,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$AdvertiserLandingPagesListResponse>(
@@ -10520,7 +10444,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$LandingPage>(parameters, callback);
@@ -10590,7 +10514,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$LandingPage>(parameters, callback);
@@ -10733,15 +10657,7 @@ export namespace dfareporting_v3_2 {
 
 
   export class Resource$Advertisers {
-    root: Dfareporting;
-    constructor(root: Dfareporting) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -10799,7 +10715,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Advertiser>(parameters, callback);
@@ -10868,7 +10784,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Advertiser>(parameters, callback);
@@ -10948,7 +10864,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$AdvertisersListResponse>(parameters, callback);
@@ -11018,7 +10934,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Advertiser>(parameters, callback);
@@ -11087,7 +11003,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Advertiser>(parameters, callback);
@@ -11236,15 +11152,7 @@ export namespace dfareporting_v3_2 {
 
 
   export class Resource$Browsers {
-    root: Dfareporting;
-    constructor(root: Dfareporting) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -11304,7 +11212,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$BrowsersListResponse>(parameters, callback);
@@ -11328,15 +11236,7 @@ export namespace dfareporting_v3_2 {
 
 
   export class Resource$Campaigncreativeassociations {
-    root: Dfareporting;
-    constructor(root: Dfareporting) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -11407,7 +11307,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId', 'campaignId'],
         pathParams: ['campaignId', 'profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$CampaignCreativeAssociation>(
@@ -11488,7 +11388,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId', 'campaignId'],
         pathParams: ['campaignId', 'profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$CampaignCreativeAssociationsListResponse>(
@@ -11552,15 +11452,7 @@ export namespace dfareporting_v3_2 {
 
 
   export class Resource$Campaigns {
-    root: Dfareporting;
-    constructor(root: Dfareporting) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -11617,7 +11509,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Campaign>(parameters, callback);
@@ -11683,7 +11575,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Campaign>(parameters, callback);
@@ -11764,7 +11656,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$CampaignsListResponse>(parameters, callback);
@@ -11831,7 +11723,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Campaign>(parameters, callback);
@@ -11897,7 +11789,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Campaign>(parameters, callback);
@@ -12048,15 +11940,7 @@ export namespace dfareporting_v3_2 {
 
 
   export class Resource$Changelogs {
-    root: Dfareporting;
-    constructor(root: Dfareporting) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -12114,7 +11998,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ChangeLog>(parameters, callback);
@@ -12191,7 +12075,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ChangeLogsListResponse>(parameters, callback);
@@ -12281,15 +12165,7 @@ export namespace dfareporting_v3_2 {
 
 
   export class Resource$Cities {
-    root: Dfareporting;
-    constructor(root: Dfareporting) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -12352,7 +12228,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$CitiesListResponse>(parameters, callback);
@@ -12392,15 +12268,7 @@ export namespace dfareporting_v3_2 {
 
 
   export class Resource$Connectiontypes {
-    root: Dfareporting;
-    constructor(root: Dfareporting) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -12459,7 +12327,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ConnectionType>(parameters, callback);
@@ -12532,7 +12400,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ConnectionTypesListResponse>(
@@ -12574,15 +12442,7 @@ export namespace dfareporting_v3_2 {
 
 
   export class Resource$Contentcategories {
-    root: Dfareporting;
-    constructor(root: Dfareporting) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -12643,7 +12503,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -12709,7 +12569,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ContentCategory>(parameters, callback);
@@ -12779,7 +12639,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ContentCategory>(parameters, callback);
@@ -12860,7 +12720,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ContentCategoriesListResponse>(
@@ -12934,7 +12794,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ContentCategory>(parameters, callback);
@@ -13004,7 +12864,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ContentCategory>(parameters, callback);
@@ -13146,15 +13006,7 @@ export namespace dfareporting_v3_2 {
 
 
   export class Resource$Conversions {
-    root: Dfareporting;
-    constructor(root: Dfareporting) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -13223,7 +13075,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ConversionsBatchInsertResponse>(
@@ -13301,7 +13153,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ConversionsBatchUpdateResponse>(
@@ -13350,15 +13202,7 @@ export namespace dfareporting_v3_2 {
 
 
   export class Resource$Countries {
-    root: Dfareporting;
-    constructor(root: Dfareporting) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -13415,7 +13259,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId', 'dartId'],
         pathParams: ['dartId', 'profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Country>(parameters, callback);
@@ -13482,7 +13326,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$CountriesListResponse>(parameters, callback);
@@ -13521,15 +13365,7 @@ export namespace dfareporting_v3_2 {
 
 
   export class Resource$Creativeassets {
-    root: Dfareporting;
-    constructor(root: Dfareporting) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -13601,7 +13437,7 @@ export namespace dfareporting_v3_2 {
                 .replace(/([^:]\/)\/+/g, '$1'),
         requiredParams: ['profileId', 'advertiserId'],
         pathParams: ['advertiserId', 'profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$CreativeAssetMetadata>(parameters, callback);
@@ -13650,15 +13486,7 @@ export namespace dfareporting_v3_2 {
 
 
   export class Resource$Creativefields {
-    root: Dfareporting;
-    constructor(root: Dfareporting) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -13719,7 +13547,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -13785,7 +13613,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$CreativeField>(parameters, callback);
@@ -13855,7 +13683,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$CreativeField>(parameters, callback);
@@ -13935,7 +13763,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$CreativeFieldsListResponse>(
@@ -14008,7 +13836,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$CreativeField>(parameters, callback);
@@ -14078,7 +13906,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$CreativeField>(parameters, callback);
@@ -14224,15 +14052,7 @@ export namespace dfareporting_v3_2 {
 
 
   export class Resource$Creativefieldvalues {
-    root: Dfareporting;
-    constructor(root: Dfareporting) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -14294,7 +14114,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId', 'creativeFieldId', 'id'],
         pathParams: ['creativeFieldId', 'id', 'profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -14361,7 +14181,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId', 'creativeFieldId', 'id'],
         pathParams: ['creativeFieldId', 'id', 'profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$CreativeFieldValue>(parameters, callback);
@@ -14432,7 +14252,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId', 'creativeFieldId'],
         pathParams: ['creativeFieldId', 'profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$CreativeFieldValue>(parameters, callback);
@@ -14516,7 +14336,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId', 'creativeFieldId'],
         pathParams: ['creativeFieldId', 'profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$CreativeFieldValuesListResponse>(
@@ -14591,7 +14411,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId', 'creativeFieldId', 'id'],
         pathParams: ['creativeFieldId', 'profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$CreativeFieldValue>(parameters, callback);
@@ -14662,7 +14482,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId', 'creativeFieldId'],
         pathParams: ['creativeFieldId', 'profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$CreativeFieldValue>(parameters, callback);
@@ -14823,15 +14643,7 @@ export namespace dfareporting_v3_2 {
 
 
   export class Resource$Creativegroups {
-    root: Dfareporting;
-    constructor(root: Dfareporting) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -14890,7 +14702,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$CreativeGroup>(parameters, callback);
@@ -14960,7 +14772,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$CreativeGroup>(parameters, callback);
@@ -15041,7 +14853,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$CreativeGroupsListResponse>(
@@ -15114,7 +14926,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$CreativeGroup>(parameters, callback);
@@ -15184,7 +14996,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$CreativeGroup>(parameters, callback);
@@ -15318,15 +15130,7 @@ export namespace dfareporting_v3_2 {
 
 
   export class Resource$Creatives {
-    root: Dfareporting;
-    constructor(root: Dfareporting) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -15383,7 +15187,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Creative>(parameters, callback);
@@ -15449,7 +15253,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Creative>(parameters, callback);
@@ -15533,7 +15337,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$CreativesListResponse>(parameters, callback);
@@ -15600,7 +15404,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Creative>(parameters, callback);
@@ -15666,7 +15470,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Creative>(parameters, callback);
@@ -15829,15 +15633,7 @@ export namespace dfareporting_v3_2 {
 
 
   export class Resource$Dimensionvalues {
-    root: Dfareporting;
-    constructor(root: Dfareporting) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -15902,7 +15698,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$DimensionValueList>(parameters, callback);
@@ -15940,15 +15736,7 @@ export namespace dfareporting_v3_2 {
 
 
   export class Resource$Directorysitecontacts {
-    root: Dfareporting;
-    constructor(root: Dfareporting) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -16008,7 +15796,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$DirectorySiteContact>(parameters, callback);
@@ -16094,7 +15882,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$DirectorySiteContactsListResponse>(
@@ -16173,15 +15961,7 @@ export namespace dfareporting_v3_2 {
 
 
   export class Resource$Directorysites {
-    root: Dfareporting;
-    constructor(root: Dfareporting) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -16240,7 +16020,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$DirectorySite>(parameters, callback);
@@ -16310,7 +16090,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$DirectorySite>(parameters, callback);
@@ -16396,7 +16176,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$DirectorySitesListResponse>(
@@ -16517,15 +16297,7 @@ export namespace dfareporting_v3_2 {
 
 
   export class Resource$Dynamictargetingkeys {
-    root: Dfareporting;
-    constructor(root: Dfareporting) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -16588,7 +16360,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId', 'objectId', 'name', 'objectType'],
         pathParams: ['objectId', 'profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -16662,7 +16434,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$DynamicTargetingKey>(parameters, callback);
@@ -16744,7 +16516,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$DynamicTargetingKeysListResponse>(
@@ -16831,15 +16603,7 @@ export namespace dfareporting_v3_2 {
 
 
   export class Resource$Eventtags {
-    root: Dfareporting;
-    constructor(root: Dfareporting) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -16898,7 +16662,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -16962,7 +16726,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$EventTag>(parameters, callback);
@@ -17028,7 +16792,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$EventTag>(parameters, callback);
@@ -17105,7 +16869,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$EventTagsListResponse>(parameters, callback);
@@ -17173,7 +16937,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$EventTag>(parameters, callback);
@@ -17239,7 +17003,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$EventTag>(parameters, callback);
@@ -17405,15 +17169,7 @@ export namespace dfareporting_v3_2 {
 
 
   export class Resource$Files {
-    root: Dfareporting;
-    constructor(root: Dfareporting) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -17470,7 +17226,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['reportId', 'fileId'],
         pathParams: ['fileId', 'reportId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$File>(parameters, callback);
@@ -17540,7 +17296,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$FileList>(parameters, callback);
@@ -17599,15 +17355,7 @@ export namespace dfareporting_v3_2 {
 
 
   export class Resource$Floodlightactivities {
-    root: Dfareporting;
-    constructor(root: Dfareporting) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -17668,7 +17416,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -17744,7 +17492,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$FloodlightActivitiesGenerateTagResponse>(
@@ -17812,7 +17560,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$FloodlightActivity>(parameters, callback);
@@ -17882,7 +17630,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$FloodlightActivity>(parameters, callback);
@@ -17974,7 +17722,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$FloodlightActivitiesListResponse>(
@@ -18048,7 +17796,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$FloodlightActivity>(parameters, callback);
@@ -18118,7 +17866,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$FloodlightActivity>(parameters, callback);
@@ -18315,15 +18063,7 @@ export namespace dfareporting_v3_2 {
 
 
   export class Resource$Floodlightactivitygroups {
-    root: Dfareporting;
-    constructor(root: Dfareporting) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -18383,7 +18123,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$FloodlightActivityGroup>(parameters, callback);
@@ -18455,7 +18195,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$FloodlightActivityGroup>(parameters, callback);
@@ -18543,7 +18283,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$FloodlightActivityGroupsListResponse>(
@@ -18618,7 +18358,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$FloodlightActivityGroup>(parameters, callback);
@@ -18690,7 +18430,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$FloodlightActivityGroup>(parameters, callback);
@@ -18836,15 +18576,7 @@ export namespace dfareporting_v3_2 {
 
 
   export class Resource$Floodlightconfigurations {
-    root: Dfareporting;
-    constructor(root: Dfareporting) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -18904,7 +18636,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$FloodlightConfiguration>(parameters, callback);
@@ -18983,7 +18715,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$FloodlightConfigurationsListResponse>(
@@ -19058,7 +18790,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$FloodlightConfiguration>(parameters, callback);
@@ -19130,7 +18862,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$FloodlightConfiguration>(parameters, callback);
@@ -19214,15 +18946,7 @@ export namespace dfareporting_v3_2 {
 
 
   export class Resource$Inventoryitems {
-    root: Dfareporting;
-    constructor(root: Dfareporting) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -19282,7 +19006,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId', 'projectId', 'id'],
         pathParams: ['id', 'profileId', 'projectId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$InventoryItem>(parameters, callback);
@@ -19365,7 +19089,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId', 'projectId'],
         pathParams: ['profileId', 'projectId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$InventoryItemsListResponse>(
@@ -19451,15 +19175,7 @@ export namespace dfareporting_v3_2 {
 
 
   export class Resource$Languages {
-    root: Dfareporting;
-    constructor(root: Dfareporting) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -19519,7 +19235,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$LanguagesListResponse>(parameters, callback);
@@ -19543,15 +19259,7 @@ export namespace dfareporting_v3_2 {
 
 
   export class Resource$Metros {
-    root: Dfareporting;
-    constructor(root: Dfareporting) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -19610,7 +19318,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$MetrosListResponse>(parameters, callback);
@@ -19634,15 +19342,7 @@ export namespace dfareporting_v3_2 {
 
 
   export class Resource$Mobileapps {
-    root: Dfareporting;
-    constructor(root: Dfareporting) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -19700,7 +19400,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$MobileApp>(parameters, callback);
@@ -19772,7 +19472,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$MobileAppsListResponse>(parameters, callback);
@@ -19836,15 +19536,7 @@ export namespace dfareporting_v3_2 {
 
 
   export class Resource$Mobilecarriers {
-    root: Dfareporting;
-    constructor(root: Dfareporting) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -19903,7 +19595,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$MobileCarrier>(parameters, callback);
@@ -19975,7 +19667,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$MobileCarriersListResponse>(
@@ -20017,15 +19709,7 @@ export namespace dfareporting_v3_2 {
 
 
   export class Resource$Operatingsystems {
-    root: Dfareporting;
-    constructor(root: Dfareporting) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -20084,7 +19768,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId', 'dartId'],
         pathParams: ['dartId', 'profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$OperatingSystem>(parameters, callback);
@@ -20158,7 +19842,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$OperatingSystemsListResponse>(
@@ -20201,15 +19885,7 @@ export namespace dfareporting_v3_2 {
 
 
   export class Resource$Operatingsystemversions {
-    root: Dfareporting;
-    constructor(root: Dfareporting) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -20269,7 +19945,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$OperatingSystemVersion>(parameters, callback);
@@ -20347,7 +20023,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$OperatingSystemVersionsListResponse>(
@@ -20390,15 +20066,7 @@ export namespace dfareporting_v3_2 {
 
 
   export class Resource$Orderdocuments {
-    root: Dfareporting;
-    constructor(root: Dfareporting) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -20458,7 +20126,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId', 'projectId', 'id'],
         pathParams: ['id', 'profileId', 'projectId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$OrderDocument>(parameters, callback);
@@ -20541,7 +20209,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId', 'projectId'],
         pathParams: ['profileId', 'projectId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$OrderDocumentsListResponse>(
@@ -20633,15 +20301,7 @@ export namespace dfareporting_v3_2 {
 
 
   export class Resource$Orders {
-    root: Dfareporting;
-    constructor(root: Dfareporting) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -20699,7 +20359,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId', 'projectId', 'id'],
         pathParams: ['id', 'profileId', 'projectId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Order>(parameters, callback);
@@ -20775,7 +20435,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId', 'projectId'],
         pathParams: ['profileId', 'projectId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$OrdersListResponse>(parameters, callback);
@@ -20855,15 +20515,7 @@ export namespace dfareporting_v3_2 {
 
 
   export class Resource$Placementgroups {
-    root: Dfareporting;
-    constructor(root: Dfareporting) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -20922,7 +20574,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$PlacementGroup>(parameters, callback);
@@ -20992,7 +20644,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$PlacementGroup>(parameters, callback);
@@ -21085,7 +20737,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$PlacementGroupsListResponse>(
@@ -21158,7 +20810,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$PlacementGroup>(parameters, callback);
@@ -21228,7 +20880,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$PlacementGroup>(parameters, callback);
@@ -21421,15 +21073,7 @@ export namespace dfareporting_v3_2 {
 
 
   export class Resource$Placements {
-    root: Dfareporting;
-    constructor(root: Dfareporting) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -21500,7 +21144,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$PlacementsGenerateTagsResponse>(
@@ -21567,7 +21211,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Placement>(parameters, callback);
@@ -21635,7 +21279,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Placement>(parameters, callback);
@@ -21725,7 +21369,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$PlacementsListResponse>(parameters, callback);
@@ -21794,7 +21438,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Placement>(parameters, callback);
@@ -21862,7 +21506,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Placement>(parameters, callback);
@@ -22086,15 +21730,7 @@ export namespace dfareporting_v3_2 {
 
 
   export class Resource$Placementstrategies {
-    root: Dfareporting;
-    constructor(root: Dfareporting) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -22155,7 +21791,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -22221,7 +21857,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$PlacementStrategy>(parameters, callback);
@@ -22291,7 +21927,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$PlacementStrategy>(parameters, callback);
@@ -22374,7 +22010,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$PlacementStrategiesListResponse>(
@@ -22448,7 +22084,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$PlacementStrategy>(parameters, callback);
@@ -22518,7 +22154,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$PlacementStrategy>(parameters, callback);
@@ -22661,15 +22297,7 @@ export namespace dfareporting_v3_2 {
 
 
   export class Resource$Platformtypes {
-    root: Dfareporting;
-    constructor(root: Dfareporting) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -22728,7 +22356,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$PlatformType>(parameters, callback);
@@ -22797,7 +22425,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$PlatformTypesListResponse>(
@@ -22839,15 +22467,7 @@ export namespace dfareporting_v3_2 {
 
 
   export class Resource$Postalcodes {
-    root: Dfareporting;
-    constructor(root: Dfareporting) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -22905,7 +22525,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId', 'code'],
         pathParams: ['code', 'profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$PostalCode>(parameters, callback);
@@ -22972,7 +22592,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$PostalCodesListResponse>(parameters, callback);
@@ -23011,15 +22631,7 @@ export namespace dfareporting_v3_2 {
 
 
   export class Resource$Projects {
-    root: Dfareporting;
-    constructor(root: Dfareporting) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -23075,7 +22687,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Project>(parameters, callback);
@@ -23150,7 +22762,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ProjectsListResponse>(parameters, callback);
@@ -23222,15 +22834,7 @@ export namespace dfareporting_v3_2 {
 
 
   export class Resource$Regions {
-    root: Dfareporting;
-    constructor(root: Dfareporting) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -23289,7 +22893,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$RegionsListResponse>(parameters, callback);
@@ -23313,15 +22917,7 @@ export namespace dfareporting_v3_2 {
 
 
   export class Resource$Remarketinglists {
-    root: Dfareporting;
-    constructor(root: Dfareporting) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -23380,7 +22976,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$RemarketingList>(parameters, callback);
@@ -23450,7 +23046,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$RemarketingList>(parameters, callback);
@@ -23533,7 +23129,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId', 'advertiserId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$RemarketingListsListResponse>(
@@ -23607,7 +23203,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$RemarketingList>(parameters, callback);
@@ -23677,7 +23273,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$RemarketingList>(parameters, callback);
@@ -23811,15 +23407,7 @@ export namespace dfareporting_v3_2 {
 
 
   export class Resource$Remarketinglistshares {
-    root: Dfareporting;
-    constructor(root: Dfareporting) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -23879,7 +23467,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId', 'remarketingListId'],
         pathParams: ['profileId', 'remarketingListId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$RemarketingListShare>(parameters, callback);
@@ -23952,7 +23540,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId', 'remarketingListId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$RemarketingListShare>(parameters, callback);
@@ -24023,7 +23611,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$RemarketingListShare>(parameters, callback);
@@ -24090,18 +23678,11 @@ export namespace dfareporting_v3_2 {
 
 
   export class Resource$Reports {
-    root: Dfareporting;
     compatibleFields: Resource$Reports$Compatiblefields;
     files: Resource$Reports$Files;
-    constructor(root: Dfareporting) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.compatibleFields = new Resource$Reports$Compatiblefields(root);
-      this.files = new Resource$Reports$Files(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.compatibleFields = new Resource$Reports$Compatiblefields();
+      this.files = new Resource$Reports$Files();
     }
 
 
@@ -24161,7 +23742,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId', 'reportId'],
         pathParams: ['profileId', 'reportId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -24225,7 +23806,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId', 'reportId'],
         pathParams: ['profileId', 'reportId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Report>(parameters, callback);
@@ -24291,7 +23872,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Report>(parameters, callback);
@@ -24362,7 +23943,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ReportList>(parameters, callback);
@@ -24430,7 +24011,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId', 'reportId'],
         pathParams: ['profileId', 'reportId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Report>(parameters, callback);
@@ -24495,7 +24076,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId', 'reportId'],
         pathParams: ['profileId', 'reportId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$File>(parameters, callback);
@@ -24563,7 +24144,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId', 'reportId'],
         pathParams: ['profileId', 'reportId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Report>(parameters, callback);
@@ -24711,15 +24292,7 @@ export namespace dfareporting_v3_2 {
   }
 
   export class Resource$Reports$Compatiblefields {
-    root: Dfareporting;
-    constructor(root: Dfareporting) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -24784,7 +24357,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$CompatibleFields>(parameters, callback);
@@ -24814,15 +24387,7 @@ export namespace dfareporting_v3_2 {
 
 
   export class Resource$Reports$Files {
-    root: Dfareporting;
-    constructor(root: Dfareporting) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -24881,7 +24446,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId', 'reportId', 'fileId'],
         pathParams: ['fileId', 'profileId', 'reportId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$File>(parameters, callback);
@@ -24953,7 +24518,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId', 'reportId'],
         pathParams: ['profileId', 'reportId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$FileList>(parameters, callback);
@@ -25019,15 +24584,7 @@ export namespace dfareporting_v3_2 {
 
 
   export class Resource$Sites {
-    root: Dfareporting;
-    constructor(root: Dfareporting) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -25083,7 +24640,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Site>(parameters, callback);
@@ -25149,7 +24706,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Site>(parameters, callback);
@@ -25231,7 +24788,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$SitesListResponse>(parameters, callback);
@@ -25298,7 +24855,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Site>(parameters, callback);
@@ -25364,7 +24921,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Site>(parameters, callback);
@@ -25522,15 +25079,7 @@ export namespace dfareporting_v3_2 {
 
 
   export class Resource$Sizes {
-    root: Dfareporting;
-    constructor(root: Dfareporting) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -25586,7 +25135,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Size>(parameters, callback);
@@ -25652,7 +25201,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Size>(parameters, callback);
@@ -25725,7 +25274,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$SizesListResponse>(parameters, callback);
@@ -25796,15 +25345,7 @@ export namespace dfareporting_v3_2 {
 
 
   export class Resource$Subaccounts {
-    root: Dfareporting;
-    constructor(root: Dfareporting) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -25862,7 +25403,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Subaccount>(parameters, callback);
@@ -25931,7 +25472,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Subaccount>(parameters, callback);
@@ -26005,7 +25546,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$SubaccountsListResponse>(parameters, callback);
@@ -26075,7 +25616,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Subaccount>(parameters, callback);
@@ -26144,7 +25685,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Subaccount>(parameters, callback);
@@ -26268,15 +25809,7 @@ export namespace dfareporting_v3_2 {
 
 
   export class Resource$Targetableremarketinglists {
-    root: Dfareporting;
-    constructor(root: Dfareporting) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -26337,7 +25870,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TargetableRemarketingList>(
@@ -26421,7 +25954,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId', 'advertiserId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TargetableRemarketingListsListResponse>(
@@ -26498,15 +26031,7 @@ export namespace dfareporting_v3_2 {
 
 
   export class Resource$Targetingtemplates {
-    root: Dfareporting;
-    constructor(root: Dfareporting) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -26565,7 +26090,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TargetingTemplate>(parameters, callback);
@@ -26635,7 +26160,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TargetingTemplate>(parameters, callback);
@@ -26717,7 +26242,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TargetingTemplatesListResponse>(
@@ -26791,7 +26316,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TargetingTemplate>(parameters, callback);
@@ -26861,7 +26386,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TargetingTemplate>(parameters, callback);
@@ -26991,15 +26516,7 @@ export namespace dfareporting_v3_2 {
 
 
   export class Resource$Userprofiles {
-    root: Dfareporting;
-    constructor(root: Dfareporting) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -27054,7 +26571,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$UserProfile>(parameters, callback);
@@ -27119,7 +26636,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$UserProfileList>(parameters, callback);
@@ -27150,15 +26667,7 @@ export namespace dfareporting_v3_2 {
 
 
   export class Resource$Userrolepermissiongroups {
-    root: Dfareporting;
-    constructor(root: Dfareporting) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -27218,7 +26727,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$UserRolePermissionGroup>(parameters, callback);
@@ -27296,7 +26805,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$UserRolePermissionGroupsListResponse>(
@@ -27339,15 +26848,7 @@ export namespace dfareporting_v3_2 {
 
 
   export class Resource$Userrolepermissions {
-    root: Dfareporting;
-    constructor(root: Dfareporting) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -27406,7 +26907,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$UserRolePermission>(parameters, callback);
@@ -27483,7 +26984,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$UserRolePermissionsListResponse>(
@@ -27530,15 +27031,7 @@ export namespace dfareporting_v3_2 {
 
 
   export class Resource$Userroles {
-    root: Dfareporting;
-    constructor(root: Dfareporting) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -27597,7 +27090,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -27661,7 +27154,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$UserRole>(parameters, callback);
@@ -27727,7 +27220,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$UserRole>(parameters, callback);
@@ -27803,7 +27296,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$UserRolesListResponse>(parameters, callback);
@@ -27871,7 +27364,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$UserRole>(parameters, callback);
@@ -27937,7 +27430,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$UserRole>(parameters, callback);
@@ -28082,15 +27575,7 @@ export namespace dfareporting_v3_2 {
 
 
   export class Resource$Videoformats {
-    root: Dfareporting;
-    constructor(root: Dfareporting) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -28148,7 +27633,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$VideoFormat>(parameters, callback);
@@ -28216,7 +27701,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$VideoFormatsListResponse>(parameters, callback);

--- a/src/apis/dialogflow/v2.ts
+++ b/src/apis/dialogflow/v2.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace dialogflow_v2 {
   export interface Options extends GlobalOptions {
     version: 'v2';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -97,22 +99,12 @@ export namespace dialogflow_v2 {
    * @param {object=} options Options for Dialogflow
    */
   export class Dialogflow {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     projects: Resource$Projects;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.projects = new Resource$Projects(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.projects = new Resource$Projects();
     }
   }
 
@@ -2719,18 +2711,11 @@ export namespace dialogflow_v2 {
 
 
   export class Resource$Projects {
-    root: Dialogflow;
     agent: Resource$Projects$Agent;
     operations: Resource$Projects$Operations;
-    constructor(root: Dialogflow) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.agent = new Resource$Projects$Agent(root);
-      this.operations = new Resource$Projects$Operations(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.agent = new Resource$Projects$Agent();
+      this.operations = new Resource$Projects$Operations();
     }
 
 
@@ -2796,7 +2781,7 @@ export namespace dialogflow_v2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleCloudDialogflowV2Agent>(
@@ -2823,20 +2808,13 @@ export namespace dialogflow_v2 {
   }
 
   export class Resource$Projects$Agent {
-    root: Dialogflow;
     entityTypes: Resource$Projects$Agent$Entitytypes;
     intents: Resource$Projects$Agent$Intents;
     sessions: Resource$Projects$Agent$Sessions;
-    constructor(root: Dialogflow) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.entityTypes = new Resource$Projects$Agent$Entitytypes(root);
-      this.intents = new Resource$Projects$Agent$Intents(root);
-      this.sessions = new Resource$Projects$Agent$Sessions(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.entityTypes = new Resource$Projects$Agent$Entitytypes();
+      this.intents = new Resource$Projects$Agent$Intents();
+      this.sessions = new Resource$Projects$Agent$Sessions();
     }
 
 
@@ -2904,7 +2882,7 @@ export namespace dialogflow_v2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleLongrunningOperation>(
@@ -2949,7 +2927,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
     options = {};
                                                                                                                                                                                                                                                                                                                                                    }
 
-                                                                                                                                                                                                                                                                                                                                                   const rootUrl = options.rootUrl || 'https://dialogflow.googleapis.com/'; const parameters = {options: Object.assign({url: (rootUrl + '/v2/{+parent}/agent:import').replace(/([^:]\/)\/+/g, '$1'), method: 'POST'}, options), params, requiredParams: ['parent'], pathParams: ['parent'], context: this.getRoot()}; if(callback) {
+                                                                                                                                                                                                                                                                                                                                                   const rootUrl = options.rootUrl || 'https://dialogflow.googleapis.com/'; const parameters = {options: Object.assign({url: (rootUrl + '/v2/{+parent}/agent:import').replace(/([^:]\/)\/+/g, '$1'), method: 'POST'}, options), params, requiredParams: ['parent'], pathParams: ['parent'], context}; if(callback) {
     createAPIRequest<Schema$GoogleLongrunningOperation>(parameters, callback);
                                                                                                                                                                                                                                                                                                                                                    } else {
     return createAPIRequest<Schema$GoogleLongrunningOperation>(parameters);
@@ -3016,7 +2994,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleLongrunningOperation>(
@@ -3097,7 +3075,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleCloudDialogflowV2SearchAgentsResponse>(
@@ -3172,7 +3150,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleLongrunningOperation>(
@@ -3280,16 +3258,9 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
   }
 
   export class Resource$Projects$Agent$Entitytypes {
-    root: Dialogflow;
     entities: Resource$Projects$Agent$Entitytypes$Entities;
-    constructor(root: Dialogflow) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.entities = new Resource$Projects$Agent$Entitytypes$Entities(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.entities = new Resource$Projects$Agent$Entitytypes$Entities();
     }
 
 
@@ -3359,7 +3330,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleLongrunningOperation>(
@@ -3437,7 +3408,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleLongrunningOperation>(
@@ -3516,7 +3487,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleCloudDialogflowV2EntityType>(
@@ -3584,7 +3555,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleProtobufEmpty>(parameters, callback);
@@ -3656,7 +3627,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleCloudDialogflowV2EntityType>(
@@ -3735,7 +3706,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleCloudDialogflowV2ListEntityTypesResponse>(
@@ -3815,7 +3786,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleCloudDialogflowV2EntityType>(
@@ -3983,15 +3954,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
   }
 
   export class Resource$Projects$Agent$Entitytypes$Entities {
-    root: Dialogflow;
-    constructor(root: Dialogflow) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -4062,7 +4025,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleLongrunningOperation>(
@@ -4142,7 +4105,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleLongrunningOperation>(
@@ -4223,7 +4186,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleLongrunningOperation>(
@@ -4292,15 +4255,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
 
 
   export class Resource$Projects$Agent$Intents {
-    root: Dialogflow;
-    constructor(root: Dialogflow) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -4368,7 +4323,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleLongrunningOperation>(
@@ -4444,7 +4399,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleLongrunningOperation>(
@@ -4521,7 +4476,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleCloudDialogflowV2Intent>(
@@ -4590,7 +4545,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleProtobufEmpty>(parameters, callback);
@@ -4659,7 +4614,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleCloudDialogflowV2Intent>(
@@ -4738,7 +4693,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleCloudDialogflowV2ListIntentsResponse>(
@@ -4815,7 +4770,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleCloudDialogflowV2Intent>(
@@ -5005,18 +4960,11 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
 
 
   export class Resource$Projects$Agent$Sessions {
-    root: Dialogflow;
     contexts: Resource$Projects$Agent$Sessions$Contexts;
     entityTypes: Resource$Projects$Agent$Sessions$Entitytypes;
-    constructor(root: Dialogflow) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.contexts = new Resource$Projects$Agent$Sessions$Contexts(root);
-      this.entityTypes = new Resource$Projects$Agent$Sessions$Entitytypes(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.contexts = new Resource$Projects$Agent$Sessions$Contexts();
+      this.entityTypes = new Resource$Projects$Agent$Sessions$Entitytypes();
     }
 
 
@@ -5079,7 +5027,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleProtobufEmpty>(parameters, callback);
@@ -5157,7 +5105,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['session'],
         pathParams: ['session'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleCloudDialogflowV2DetectIntentResponse>(
@@ -5205,15 +5153,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
   }
 
   export class Resource$Projects$Agent$Sessions$Contexts {
-    root: Dialogflow;
-    constructor(root: Dialogflow) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -5282,7 +5222,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleCloudDialogflowV2Context>(
@@ -5351,7 +5291,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleProtobufEmpty>(parameters, callback);
@@ -5418,7 +5358,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleCloudDialogflowV2Context>(
@@ -5497,7 +5437,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleCloudDialogflowV2ListContextsResponse>(
@@ -5574,7 +5514,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleCloudDialogflowV2Context>(
@@ -5680,15 +5620,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
 
 
   export class Resource$Projects$Agent$Sessions$Entitytypes {
-    root: Dialogflow;
-    constructor(root: Dialogflow) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -5758,7 +5690,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleCloudDialogflowV2SessionEntityType>(
@@ -5828,7 +5760,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleProtobufEmpty>(parameters, callback);
@@ -5897,7 +5829,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleCloudDialogflowV2SessionEntityType>(
@@ -5981,7 +5913,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<
@@ -6061,7 +5993,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleCloudDialogflowV2SessionEntityType>(
@@ -6170,15 +6102,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
 
 
   export class Resource$Projects$Operations {
-    root: Dialogflow;
-    constructor(root: Dialogflow) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -6240,7 +6164,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleLongrunningOperation>(

--- a/src/apis/dialogflow/v2beta1.ts
+++ b/src/apis/dialogflow/v2beta1.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace dialogflow_v2beta1 {
   export interface Options extends GlobalOptions {
     version: 'v2beta1';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -97,22 +99,12 @@ export namespace dialogflow_v2beta1 {
    * @param {object=} options Options for Dialogflow
    */
   export class Dialogflow {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     projects: Resource$Projects;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.projects = new Resource$Projects(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.projects = new Resource$Projects();
     }
   }
 
@@ -2965,22 +2957,15 @@ export namespace dialogflow_v2beta1 {
 
 
   export class Resource$Projects {
-    root: Dialogflow;
     agent: Resource$Projects$Agent;
     environments: Resource$Projects$Environments;
     knowledgeBases: Resource$Projects$Knowledgebases;
     operations: Resource$Projects$Operations;
-    constructor(root: Dialogflow) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.agent = new Resource$Projects$Agent(root);
-      this.environments = new Resource$Projects$Environments(root);
-      this.knowledgeBases = new Resource$Projects$Knowledgebases(root);
-      this.operations = new Resource$Projects$Operations(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.agent = new Resource$Projects$Agent();
+      this.environments = new Resource$Projects$Environments();
+      this.knowledgeBases = new Resource$Projects$Knowledgebases();
+      this.operations = new Resource$Projects$Operations();
     }
 
 
@@ -3050,7 +3035,7 @@ export namespace dialogflow_v2beta1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleCloudDialogflowV2beta1Agent>(
@@ -3077,24 +3062,17 @@ export namespace dialogflow_v2beta1 {
   }
 
   export class Resource$Projects$Agent {
-    root: Dialogflow;
     entityTypes: Resource$Projects$Agent$Entitytypes;
     environments: Resource$Projects$Agent$Environments;
     intents: Resource$Projects$Agent$Intents;
     knowledgeBases: Resource$Projects$Agent$Knowledgebases;
     sessions: Resource$Projects$Agent$Sessions;
-    constructor(root: Dialogflow) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.entityTypes = new Resource$Projects$Agent$Entitytypes(root);
-      this.environments = new Resource$Projects$Agent$Environments(root);
-      this.intents = new Resource$Projects$Agent$Intents(root);
-      this.knowledgeBases = new Resource$Projects$Agent$Knowledgebases(root);
-      this.sessions = new Resource$Projects$Agent$Sessions(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.entityTypes = new Resource$Projects$Agent$Entitytypes();
+      this.environments = new Resource$Projects$Agent$Environments();
+      this.intents = new Resource$Projects$Agent$Intents();
+      this.knowledgeBases = new Resource$Projects$Agent$Knowledgebases();
+      this.sessions = new Resource$Projects$Agent$Sessions();
     }
 
 
@@ -3162,7 +3140,7 @@ export namespace dialogflow_v2beta1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleLongrunningOperation>(
@@ -3207,7 +3185,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
     options = {};
                                                                                                                                                                                                                                                                                                                                                    }
 
-                                                                                                                                                                                                                                                                                                                                                   const rootUrl = options.rootUrl || 'https://dialogflow.googleapis.com/'; const parameters = {options: Object.assign({url: (rootUrl + '/v2beta1/{+parent}/agent:import').replace(/([^:]\/)\/+/g, '$1'), method: 'POST'}, options), params, requiredParams: ['parent'], pathParams: ['parent'], context: this.getRoot()}; if(callback) {
+                                                                                                                                                                                                                                                                                                                                                   const rootUrl = options.rootUrl || 'https://dialogflow.googleapis.com/'; const parameters = {options: Object.assign({url: (rootUrl + '/v2beta1/{+parent}/agent:import').replace(/([^:]\/)\/+/g, '$1'), method: 'POST'}, options), params, requiredParams: ['parent'], pathParams: ['parent'], context}; if(callback) {
     createAPIRequest<Schema$GoogleLongrunningOperation>(parameters, callback);
                                                                                                                                                                                                                                                                                                                                                    } else {
     return createAPIRequest<Schema$GoogleLongrunningOperation>(parameters);
@@ -3274,7 +3252,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleLongrunningOperation>(
@@ -3355,7 +3333,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<
@@ -3432,7 +3410,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleLongrunningOperation>(
@@ -3540,16 +3518,9 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
   }
 
   export class Resource$Projects$Agent$Entitytypes {
-    root: Dialogflow;
     entities: Resource$Projects$Agent$Entitytypes$Entities;
-    constructor(root: Dialogflow) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.entities = new Resource$Projects$Agent$Entitytypes$Entities(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.entities = new Resource$Projects$Agent$Entitytypes$Entities();
     }
 
 
@@ -3619,7 +3590,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleLongrunningOperation>(
@@ -3697,7 +3668,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleLongrunningOperation>(
@@ -3773,7 +3744,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleCloudDialogflowV2beta1EntityType>(
@@ -3841,7 +3812,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleProtobufEmpty>(parameters, callback);
@@ -3910,7 +3881,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleCloudDialogflowV2beta1EntityType>(
@@ -3991,7 +3962,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<
@@ -4070,7 +4041,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleCloudDialogflowV2beta1EntityType>(
@@ -4240,15 +4211,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
   }
 
   export class Resource$Projects$Agent$Entitytypes$Entities {
-    root: Dialogflow;
-    constructor(root: Dialogflow) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -4319,7 +4282,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleLongrunningOperation>(
@@ -4399,7 +4362,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleLongrunningOperation>(
@@ -4480,7 +4443,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleLongrunningOperation>(
@@ -4549,54 +4512,30 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
 
 
   export class Resource$Projects$Agent$Environments {
-    root: Dialogflow;
     users: Resource$Projects$Agent$Environments$Users;
-    constructor(root: Dialogflow) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.users = new Resource$Projects$Agent$Environments$Users(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.users = new Resource$Projects$Agent$Environments$Users();
     }
   }
 
 
   export class Resource$Projects$Agent$Environments$Users {
-    root: Dialogflow;
     sessions: Resource$Projects$Agent$Environments$Users$Sessions;
-    constructor(root: Dialogflow) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.sessions =
-          new Resource$Projects$Agent$Environments$Users$Sessions(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.sessions = new Resource$Projects$Agent$Environments$Users$Sessions();
     }
   }
 
 
   export class Resource$Projects$Agent$Environments$Users$Sessions {
-    root: Dialogflow;
     contexts: Resource$Projects$Agent$Environments$Users$Sessions$Contexts;
     entityTypes:
         Resource$Projects$Agent$Environments$Users$Sessions$Entitytypes;
-    constructor(root: Dialogflow) {
-      this.root = root;
-      this.getRoot.bind(this);
+    constructor() {
       this.contexts =
-          new Resource$Projects$Agent$Environments$Users$Sessions$Contexts(
-              root);
+          new Resource$Projects$Agent$Environments$Users$Sessions$Contexts();
       this.entityTypes =
-          new Resource$Projects$Agent$Environments$Users$Sessions$Entitytypes(
-              root);
-    }
-
-    getRoot() {
-      return this.root;
+          new Resource$Projects$Agent$Environments$Users$Sessions$Entitytypes();
     }
 
 
@@ -4664,7 +4603,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleProtobufEmpty>(parameters, callback);
@@ -4748,7 +4687,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['session'],
         pathParams: ['session'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<
@@ -4805,15 +4744,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
   }
 
   export class Resource$Projects$Agent$Environments$Users$Sessions$Contexts {
-    root: Dialogflow;
-    constructor(root: Dialogflow) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -4891,7 +4822,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleCloudDialogflowV2beta1Context>(
@@ -4965,7 +4896,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleProtobufEmpty>(parameters, callback);
@@ -5041,7 +4972,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleCloudDialogflowV2beta1Context>(
@@ -5125,7 +5056,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<
@@ -5212,7 +5143,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleCloudDialogflowV2beta1Context>(
@@ -5336,15 +5267,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
 
 
   export class Resource$Projects$Agent$Environments$Users$Sessions$Entitytypes {
-    root: Dialogflow;
-    constructor(root: Dialogflow) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -5419,7 +5342,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleCloudDialogflowV2beta1SessionEntityType>(
@@ -5493,7 +5416,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleProtobufEmpty>(parameters, callback);
@@ -5568,7 +5491,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleCloudDialogflowV2beta1SessionEntityType>(
@@ -5658,7 +5581,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<
@@ -5743,7 +5666,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleCloudDialogflowV2beta1SessionEntityType>(
@@ -5872,15 +5795,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
 
 
   export class Resource$Projects$Agent$Intents {
-    root: Dialogflow;
-    constructor(root: Dialogflow) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -5948,7 +5863,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleLongrunningOperation>(
@@ -6024,7 +5939,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleLongrunningOperation>(
@@ -6104,7 +6019,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleCloudDialogflowV2beta1Intent>(
@@ -6173,7 +6088,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleProtobufEmpty>(parameters, callback);
@@ -6246,7 +6161,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleCloudDialogflowV2beta1Intent>(
@@ -6326,7 +6241,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<
@@ -6408,7 +6323,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleCloudDialogflowV2beta1Intent>(
@@ -6598,17 +6513,9 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
 
 
   export class Resource$Projects$Agent$Knowledgebases {
-    root: Dialogflow;
     documents: Resource$Projects$Agent$Knowledgebases$Documents;
-    constructor(root: Dialogflow) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.documents =
-          new Resource$Projects$Agent$Knowledgebases$Documents(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.documents = new Resource$Projects$Agent$Knowledgebases$Documents();
     }
 
 
@@ -6676,7 +6583,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleCloudDialogflowV2beta1KnowledgeBase>(
@@ -6745,7 +6652,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleProtobufEmpty>(parameters, callback);
@@ -6813,7 +6720,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleCloudDialogflowV2beta1KnowledgeBase>(
@@ -6895,7 +6802,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<
@@ -6973,7 +6880,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleCloudDialogflowV2beta1KnowledgeBase>(
@@ -7084,15 +6991,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
   }
 
   export class Resource$Projects$Agent$Knowledgebases$Documents {
-    root: Dialogflow;
-    constructor(root: Dialogflow) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -7161,7 +7060,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleLongrunningOperation>(
@@ -7236,7 +7135,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleLongrunningOperation>(
@@ -7310,7 +7209,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleCloudDialogflowV2beta1Document>(
@@ -7390,7 +7289,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<
@@ -7470,7 +7369,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleLongrunningOperation>(
@@ -7551,7 +7450,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleLongrunningOperation>(
@@ -7676,18 +7575,11 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
 
 
   export class Resource$Projects$Agent$Sessions {
-    root: Dialogflow;
     contexts: Resource$Projects$Agent$Sessions$Contexts;
     entityTypes: Resource$Projects$Agent$Sessions$Entitytypes;
-    constructor(root: Dialogflow) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.contexts = new Resource$Projects$Agent$Sessions$Contexts(root);
-      this.entityTypes = new Resource$Projects$Agent$Sessions$Entitytypes(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.contexts = new Resource$Projects$Agent$Sessions$Contexts();
+      this.entityTypes = new Resource$Projects$Agent$Sessions$Entitytypes();
     }
 
 
@@ -7750,7 +7642,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleProtobufEmpty>(parameters, callback);
@@ -7829,7 +7721,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['session'],
         pathParams: ['session'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<
@@ -7886,15 +7778,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
   }
 
   export class Resource$Projects$Agent$Sessions$Contexts {
-    root: Dialogflow;
-    constructor(root: Dialogflow) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -7967,7 +7851,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleCloudDialogflowV2beta1Context>(
@@ -8036,7 +7920,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleProtobufEmpty>(parameters, callback);
@@ -8107,7 +7991,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleCloudDialogflowV2beta1Context>(
@@ -8186,7 +8070,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<
@@ -8268,7 +8152,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleCloudDialogflowV2beta1Context>(
@@ -8392,15 +8276,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
 
 
   export class Resource$Projects$Agent$Sessions$Entitytypes {
-    root: Dialogflow;
-    constructor(root: Dialogflow) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -8471,7 +8347,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleCloudDialogflowV2beta1SessionEntityType>(
@@ -8541,7 +8417,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleProtobufEmpty>(parameters, callback);
@@ -8611,7 +8487,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleCloudDialogflowV2beta1SessionEntityType>(
@@ -8696,7 +8572,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<
@@ -8777,7 +8653,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleCloudDialogflowV2beta1SessionEntityType>(
@@ -8906,48 +8782,27 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
 
 
   export class Resource$Projects$Environments {
-    root: Dialogflow;
     users: Resource$Projects$Environments$Users;
-    constructor(root: Dialogflow) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.users = new Resource$Projects$Environments$Users(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.users = new Resource$Projects$Environments$Users();
     }
   }
 
 
   export class Resource$Projects$Environments$Users {
-    root: Dialogflow;
     conversations: Resource$Projects$Environments$Users$Conversations;
-    constructor(root: Dialogflow) {
-      this.root = root;
-      this.getRoot.bind(this);
+    constructor() {
       this.conversations =
-          new Resource$Projects$Environments$Users$Conversations(root);
-    }
-
-    getRoot() {
-      return this.root;
+          new Resource$Projects$Environments$Users$Conversations();
     }
   }
 
 
   export class Resource$Projects$Environments$Users$Conversations {
-    root: Dialogflow;
     contexts: Resource$Projects$Environments$Users$Conversations$Contexts;
-    constructor(root: Dialogflow) {
-      this.root = root;
-      this.getRoot.bind(this);
+    constructor() {
       this.contexts =
-          new Resource$Projects$Environments$Users$Conversations$Contexts(root);
-    }
-
-    getRoot() {
-      return this.root;
+          new Resource$Projects$Environments$Users$Conversations$Contexts();
     }
 
 
@@ -9015,7 +8870,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleProtobufEmpty>(parameters, callback);
@@ -9043,15 +8898,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
   }
 
   export class Resource$Projects$Environments$Users$Conversations$Contexts {
-    root: Dialogflow;
-    constructor(root: Dialogflow) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -9129,7 +8976,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleCloudDialogflowV2beta1Context>(
@@ -9203,7 +9050,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleProtobufEmpty>(parameters, callback);
@@ -9279,7 +9126,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleCloudDialogflowV2beta1Context>(
@@ -9362,7 +9209,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<
@@ -9449,7 +9296,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleCloudDialogflowV2beta1Context>(
@@ -9574,16 +9421,9 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
 
 
   export class Resource$Projects$Knowledgebases {
-    root: Dialogflow;
     documents: Resource$Projects$Knowledgebases$Documents;
-    constructor(root: Dialogflow) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.documents = new Resource$Projects$Knowledgebases$Documents(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.documents = new Resource$Projects$Knowledgebases$Documents();
     }
 
 
@@ -9651,7 +9491,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleCloudDialogflowV2beta1KnowledgeBase>(
@@ -9720,7 +9560,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleProtobufEmpty>(parameters, callback);
@@ -9788,7 +9628,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleCloudDialogflowV2beta1KnowledgeBase>(
@@ -9870,7 +9710,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<
@@ -9948,7 +9788,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleCloudDialogflowV2beta1KnowledgeBase>(
@@ -10059,15 +9899,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
   }
 
   export class Resource$Projects$Knowledgebases$Documents {
-    root: Dialogflow;
-    constructor(root: Dialogflow) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -10135,7 +9967,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleLongrunningOperation>(
@@ -10209,7 +10041,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleLongrunningOperation>(
@@ -10282,7 +10114,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleCloudDialogflowV2beta1Document>(
@@ -10361,7 +10193,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<
@@ -10440,7 +10272,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleLongrunningOperation>(
@@ -10520,7 +10352,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleLongrunningOperation>(
@@ -10645,15 +10477,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
 
 
   export class Resource$Projects$Operations {
-    root: Dialogflow;
-    constructor(root: Dialogflow) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -10715,7 +10539,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleLongrunningOperation>(

--- a/src/apis/digitalassetlinks/v1.ts
+++ b/src/apis/digitalassetlinks/v1.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace digitalassetlinks_v1 {
   export interface Options extends GlobalOptions {
     version: 'v1';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -97,24 +99,14 @@ export namespace digitalassetlinks_v1 {
    * @param {object=} options Options for Digitalassetlinks
    */
   export class Digitalassetlinks {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     assetlinks: Resource$Assetlinks;
     statements: Resource$Statements;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.assetlinks = new Resource$Assetlinks(this);
-      this.statements = new Resource$Statements(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.assetlinks = new Resource$Assetlinks();
+      this.statements = new Resource$Statements();
     }
   }
 
@@ -298,15 +290,7 @@ export namespace digitalassetlinks_v1 {
 
 
   export class Resource$Assetlinks {
-    root: Digitalassetlinks;
-    constructor(root: Digitalassetlinks) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -389,7 +373,7 @@ export namespace digitalassetlinks_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$CheckResponse>(parameters, callback);
@@ -509,15 +493,7 @@ export namespace digitalassetlinks_v1 {
 
 
   export class Resource$Statements {
-    root: Digitalassetlinks;
-    constructor(root: Digitalassetlinks) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -592,7 +568,7 @@ export namespace digitalassetlinks_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListResponse>(parameters, callback);

--- a/src/apis/discovery/v1.ts
+++ b/src/apis/discovery/v1.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace discovery_v1 {
   export interface Options extends GlobalOptions {
     version: 'v1';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -80,22 +82,12 @@ export namespace discovery_v1 {
    * @param {object=} options Options for Discovery
    */
   export class Discovery {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     apis: Resource$Apis;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.apis = new Resource$Apis(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.apis = new Resource$Apis();
     }
   }
 
@@ -436,15 +428,7 @@ export namespace discovery_v1 {
 
 
   export class Resource$Apis {
-    root: Discovery;
-    constructor(root: Discovery) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -503,7 +487,7 @@ export namespace discovery_v1 {
         params,
         requiredParams: ['api', 'version'],
         pathParams: ['api', 'version'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$RestDescription>(parameters, callback);
@@ -569,7 +553,7 @@ export namespace discovery_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$DirectoryList>(parameters, callback);

--- a/src/apis/dlp/v2.ts
+++ b/src/apis/dlp/v2.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace dlp_v2 {
   export interface Options extends GlobalOptions {
     version: 'v2';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -98,26 +100,16 @@ export namespace dlp_v2 {
    * @param {object=} options Options for Dlp
    */
   export class Dlp {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     infoTypes: Resource$Infotypes;
     organizations: Resource$Organizations;
     projects: Resource$Projects;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.infoTypes = new Resource$Infotypes(this);
-      this.organizations = new Resource$Organizations(this);
-      this.projects = new Resource$Projects(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.infoTypes = new Resource$Infotypes();
+      this.organizations = new Resource$Organizations();
+      this.projects = new Resource$Projects();
     }
   }
 
@@ -3273,15 +3265,7 @@ export namespace dlp_v2 {
 
 
   export class Resource$Infotypes {
-    root: Dlp;
-    constructor(root: Dlp) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -3346,7 +3330,7 @@ export namespace dlp_v2 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GooglePrivacyDlpV2ListInfoTypesResponse>(
@@ -3379,35 +3363,20 @@ export namespace dlp_v2 {
 
 
   export class Resource$Organizations {
-    root: Dlp;
     deidentifyTemplates: Resource$Organizations$Deidentifytemplates;
     inspectTemplates: Resource$Organizations$Inspecttemplates;
     storedInfoTypes: Resource$Organizations$Storedinfotypes;
-    constructor(root: Dlp) {
-      this.root = root;
-      this.getRoot.bind(this);
+    constructor() {
       this.deidentifyTemplates =
-          new Resource$Organizations$Deidentifytemplates(root);
-      this.inspectTemplates = new Resource$Organizations$Inspecttemplates(root);
-      this.storedInfoTypes = new Resource$Organizations$Storedinfotypes(root);
-    }
-
-    getRoot() {
-      return this.root;
+          new Resource$Organizations$Deidentifytemplates();
+      this.inspectTemplates = new Resource$Organizations$Inspecttemplates();
+      this.storedInfoTypes = new Resource$Organizations$Storedinfotypes();
     }
   }
 
 
   export class Resource$Organizations$Deidentifytemplates {
-    root: Dlp;
-    constructor(root: Dlp) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -3481,7 +3450,7 @@ export namespace dlp_v2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GooglePrivacyDlpV2DeidentifyTemplate>(
@@ -3551,7 +3520,7 @@ export namespace dlp_v2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleProtobufEmpty>(parameters, callback);
@@ -3624,7 +3593,7 @@ export namespace dlp_v2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GooglePrivacyDlpV2DeidentifyTemplate>(
@@ -3705,7 +3674,7 @@ export namespace dlp_v2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<
@@ -3788,7 +3757,7 @@ export namespace dlp_v2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GooglePrivacyDlpV2DeidentifyTemplate>(
@@ -3902,15 +3871,7 @@ export namespace dlp_v2 {
 
 
   export class Resource$Organizations$Inspecttemplates {
-    root: Dlp;
-    constructor(root: Dlp) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -3983,7 +3944,7 @@ export namespace dlp_v2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GooglePrivacyDlpV2InspectTemplate>(
@@ -4053,7 +4014,7 @@ export namespace dlp_v2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleProtobufEmpty>(parameters, callback);
@@ -4125,7 +4086,7 @@ export namespace dlp_v2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GooglePrivacyDlpV2InspectTemplate>(
@@ -4205,7 +4166,7 @@ export namespace dlp_v2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GooglePrivacyDlpV2ListInspectTemplatesResponse>(
@@ -4284,7 +4245,7 @@ export namespace dlp_v2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GooglePrivacyDlpV2InspectTemplate>(
@@ -4398,15 +4359,7 @@ export namespace dlp_v2 {
 
 
   export class Resource$Organizations$Storedinfotypes {
-    root: Dlp;
-    constructor(root: Dlp) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -4478,7 +4431,7 @@ export namespace dlp_v2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GooglePrivacyDlpV2StoredInfoType>(
@@ -4548,7 +4501,7 @@ export namespace dlp_v2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleProtobufEmpty>(parameters, callback);
@@ -4621,7 +4574,7 @@ export namespace dlp_v2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GooglePrivacyDlpV2StoredInfoType>(
@@ -4702,7 +4655,7 @@ export namespace dlp_v2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GooglePrivacyDlpV2ListStoredInfoTypesResponse>(
@@ -4783,7 +4736,7 @@ export namespace dlp_v2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GooglePrivacyDlpV2StoredInfoType>(
@@ -4898,7 +4851,6 @@ export namespace dlp_v2 {
 
 
   export class Resource$Projects {
-    root: Dlp;
     content: Resource$Projects$Content;
     deidentifyTemplates: Resource$Projects$Deidentifytemplates;
     dlpJobs: Resource$Projects$Dlpjobs;
@@ -4906,35 +4858,20 @@ export namespace dlp_v2 {
     inspectTemplates: Resource$Projects$Inspecttemplates;
     jobTriggers: Resource$Projects$Jobtriggers;
     storedInfoTypes: Resource$Projects$Storedinfotypes;
-    constructor(root: Dlp) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.content = new Resource$Projects$Content(root);
-      this.deidentifyTemplates =
-          new Resource$Projects$Deidentifytemplates(root);
-      this.dlpJobs = new Resource$Projects$Dlpjobs(root);
-      this.image = new Resource$Projects$Image(root);
-      this.inspectTemplates = new Resource$Projects$Inspecttemplates(root);
-      this.jobTriggers = new Resource$Projects$Jobtriggers(root);
-      this.storedInfoTypes = new Resource$Projects$Storedinfotypes(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.content = new Resource$Projects$Content();
+      this.deidentifyTemplates = new Resource$Projects$Deidentifytemplates();
+      this.dlpJobs = new Resource$Projects$Dlpjobs();
+      this.image = new Resource$Projects$Image();
+      this.inspectTemplates = new Resource$Projects$Inspecttemplates();
+      this.jobTriggers = new Resource$Projects$Jobtriggers();
+      this.storedInfoTypes = new Resource$Projects$Storedinfotypes();
     }
   }
 
 
   export class Resource$Projects$Content {
-    root: Dlp;
-    constructor(root: Dlp) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -5008,7 +4945,7 @@ export namespace dlp_v2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GooglePrivacyDlpV2DeidentifyContentResponse>(
@@ -5090,7 +5027,7 @@ export namespace dlp_v2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GooglePrivacyDlpV2InspectContentResponse>(
@@ -5169,7 +5106,7 @@ export namespace dlp_v2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GooglePrivacyDlpV2ReidentifyContentResponse>(
@@ -5235,15 +5172,7 @@ export namespace dlp_v2 {
 
 
   export class Resource$Projects$Deidentifytemplates {
-    root: Dlp;
-    constructor(root: Dlp) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -5316,7 +5245,7 @@ export namespace dlp_v2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GooglePrivacyDlpV2DeidentifyTemplate>(
@@ -5385,7 +5314,7 @@ export namespace dlp_v2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleProtobufEmpty>(parameters, callback);
@@ -5457,7 +5386,7 @@ export namespace dlp_v2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GooglePrivacyDlpV2DeidentifyTemplate>(
@@ -5537,7 +5466,7 @@ export namespace dlp_v2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<
@@ -5619,7 +5548,7 @@ export namespace dlp_v2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GooglePrivacyDlpV2DeidentifyTemplate>(
@@ -5733,15 +5662,7 @@ export namespace dlp_v2 {
 
 
   export class Resource$Projects$Dlpjobs {
-    root: Dlp;
-    constructor(root: Dlp) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -5805,7 +5726,7 @@ export namespace dlp_v2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleProtobufEmpty>(parameters, callback);
@@ -5880,7 +5801,7 @@ export namespace dlp_v2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GooglePrivacyDlpV2DlpJob>(parameters, callback);
@@ -5950,7 +5871,7 @@ export namespace dlp_v2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleProtobufEmpty>(parameters, callback);
@@ -6015,7 +5936,7 @@ export namespace dlp_v2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GooglePrivacyDlpV2DlpJob>(parameters, callback);
@@ -6099,7 +6020,7 @@ export namespace dlp_v2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GooglePrivacyDlpV2ListDlpJobsResponse>(
@@ -6223,15 +6144,7 @@ export namespace dlp_v2 {
 
 
   export class Resource$Projects$Image {
-    root: Dlp;
-    constructor(root: Dlp) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -6308,7 +6221,7 @@ export namespace dlp_v2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GooglePrivacyDlpV2RedactImageResponse>(
@@ -6340,15 +6253,7 @@ export namespace dlp_v2 {
 
 
   export class Resource$Projects$Inspecttemplates {
-    root: Dlp;
-    constructor(root: Dlp) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -6420,7 +6325,7 @@ export namespace dlp_v2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GooglePrivacyDlpV2InspectTemplate>(
@@ -6489,7 +6394,7 @@ export namespace dlp_v2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleProtobufEmpty>(parameters, callback);
@@ -6561,7 +6466,7 @@ export namespace dlp_v2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GooglePrivacyDlpV2InspectTemplate>(
@@ -6641,7 +6546,7 @@ export namespace dlp_v2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GooglePrivacyDlpV2ListInspectTemplatesResponse>(
@@ -6720,7 +6625,7 @@ export namespace dlp_v2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GooglePrivacyDlpV2InspectTemplate>(
@@ -6834,15 +6739,7 @@ export namespace dlp_v2 {
 
 
   export class Resource$Projects$Jobtriggers {
-    root: Dlp;
-    constructor(root: Dlp) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -6910,7 +6807,7 @@ export namespace dlp_v2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GooglePrivacyDlpV2JobTrigger>(
@@ -6979,7 +6876,7 @@ export namespace dlp_v2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleProtobufEmpty>(parameters, callback);
@@ -7047,7 +6944,7 @@ export namespace dlp_v2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GooglePrivacyDlpV2JobTrigger>(
@@ -7126,7 +7023,7 @@ export namespace dlp_v2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GooglePrivacyDlpV2ListJobTriggersResponse>(
@@ -7201,7 +7098,7 @@ export namespace dlp_v2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GooglePrivacyDlpV2JobTrigger>(
@@ -7310,15 +7207,7 @@ export namespace dlp_v2 {
 
 
   export class Resource$Projects$Storedinfotypes {
-    root: Dlp;
-    constructor(root: Dlp) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -7390,7 +7279,7 @@ export namespace dlp_v2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GooglePrivacyDlpV2StoredInfoType>(
@@ -7460,7 +7349,7 @@ export namespace dlp_v2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleProtobufEmpty>(parameters, callback);
@@ -7533,7 +7422,7 @@ export namespace dlp_v2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GooglePrivacyDlpV2StoredInfoType>(
@@ -7614,7 +7503,7 @@ export namespace dlp_v2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GooglePrivacyDlpV2ListStoredInfoTypesResponse>(
@@ -7695,7 +7584,7 @@ export namespace dlp_v2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GooglePrivacyDlpV2StoredInfoType>(

--- a/src/apis/dns/v1.ts
+++ b/src/apis/dns/v1.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace dns_v1 {
   export interface Options extends GlobalOptions {
     version: 'v1';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -79,10 +81,6 @@ export namespace dns_v1 {
    * @param {object=} options Options for Dns
    */
   export class Dns {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     changes: Resource$Changes;
     dnsKeys: Resource$Dnskeys;
     managedZoneOperations: Resource$Managedzoneoperations;
@@ -91,20 +89,14 @@ export namespace dns_v1 {
     resourceRecordSets: Resource$Resourcerecordsets;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.changes = new Resource$Changes(this);
-      this.dnsKeys = new Resource$Dnskeys(this);
-      this.managedZoneOperations = new Resource$Managedzoneoperations(this);
-      this.managedZones = new Resource$Managedzones(this);
-      this.projects = new Resource$Projects(this);
-      this.resourceRecordSets = new Resource$Resourcerecordsets(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.changes = new Resource$Changes();
+      this.dnsKeys = new Resource$Dnskeys();
+      this.managedZoneOperations = new Resource$Managedzoneoperations();
+      this.managedZones = new Resource$Managedzones();
+      this.projects = new Resource$Projects();
+      this.resourceRecordSets = new Resource$Resourcerecordsets();
     }
   }
 
@@ -632,15 +624,7 @@ export namespace dns_v1 {
 
 
   export class Resource$Changes {
-    root: Dns;
-    constructor(root: Dns) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -763,7 +747,7 @@ export namespace dns_v1 {
         params,
         requiredParams: ['project', 'managedZone'],
         pathParams: ['managedZone', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Change>(parameters, callback);
@@ -890,7 +874,7 @@ export namespace dns_v1 {
         params,
         requiredParams: ['project', 'managedZone', 'changeId'],
         pathParams: ['changeId', 'managedZone', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Change>(parameters, callback);
@@ -1032,7 +1016,7 @@ export namespace dns_v1 {
         params,
         requiredParams: ['project', 'managedZone'],
         pathParams: ['managedZone', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ChangesListResponse>(parameters, callback);
@@ -1133,15 +1117,7 @@ export namespace dns_v1 {
 
 
   export class Resource$Dnskeys {
-    root: Dns;
-    constructor(root: Dns) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -1201,7 +1177,7 @@ export namespace dns_v1 {
         params,
         requiredParams: ['project', 'managedZone', 'dnsKeyId'],
         pathParams: ['dnsKeyId', 'managedZone', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$DnsKey>(parameters, callback);
@@ -1272,7 +1248,7 @@ export namespace dns_v1 {
         params,
         requiredParams: ['project', 'managedZone'],
         pathParams: ['managedZone', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$DnsKeysListResponse>(parameters, callback);
@@ -1349,15 +1325,7 @@ export namespace dns_v1 {
 
 
   export class Resource$Managedzoneoperations {
-    root: Dns;
-    constructor(root: Dns) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -1418,7 +1386,7 @@ export namespace dns_v1 {
         params,
         requiredParams: ['project', 'managedZone', 'operation'],
         pathParams: ['managedZone', 'operation', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -1500,7 +1468,7 @@ export namespace dns_v1 {
         params,
         requiredParams: ['project', 'managedZone'],
         pathParams: ['managedZone', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ManagedZoneOperationsListResponse>(
@@ -1571,15 +1539,7 @@ export namespace dns_v1 {
 
 
   export class Resource$Managedzones {
-    root: Dns;
-    constructor(root: Dns) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -1698,7 +1658,7 @@ export namespace dns_v1 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ManagedZone>(parameters, callback);
@@ -1820,7 +1780,7 @@ export namespace dns_v1 {
         params,
         requiredParams: ['project', 'managedZone'],
         pathParams: ['managedZone', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -1942,7 +1902,7 @@ export namespace dns_v1 {
         params,
         requiredParams: ['project', 'managedZone'],
         pathParams: ['managedZone', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ManagedZone>(parameters, callback);
@@ -2079,7 +2039,7 @@ export namespace dns_v1 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ManagedZonesListResponse>(parameters, callback);
@@ -2149,7 +2109,7 @@ export namespace dns_v1 {
         params,
         requiredParams: ['project', 'managedZone'],
         pathParams: ['managedZone', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -2220,7 +2180,7 @@ export namespace dns_v1 {
         params,
         requiredParams: ['project', 'managedZone'],
         pathParams: ['managedZone', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -2383,15 +2343,7 @@ export namespace dns_v1 {
 
 
   export class Resource$Projects {
-    root: Dns;
-    constructor(root: Dns) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -2499,7 +2451,7 @@ export namespace dns_v1 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Project>(parameters, callback);
@@ -2529,15 +2481,7 @@ export namespace dns_v1 {
 
 
   export class Resource$Resourcerecordsets {
-    root: Dns;
-    constructor(root: Dns) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -2680,7 +2624,7 @@ export namespace dns_v1 {
         params,
         requiredParams: ['project', 'managedZone'],
         pathParams: ['managedZone', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ResourceRecordSetsListResponse>(

--- a/src/apis/dns/v1beta2.ts
+++ b/src/apis/dns/v1beta2.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace dns_v1beta2 {
   export interface Options extends GlobalOptions {
     version: 'v1beta2';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -79,10 +81,6 @@ export namespace dns_v1beta2 {
    * @param {object=} options Options for Dns
    */
   export class Dns {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     changes: Resource$Changes;
     dnsKeys: Resource$Dnskeys;
     managedZoneOperations: Resource$Managedzoneoperations;
@@ -92,21 +90,15 @@ export namespace dns_v1beta2 {
     resourceRecordSets: Resource$Resourcerecordsets;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.changes = new Resource$Changes(this);
-      this.dnsKeys = new Resource$Dnskeys(this);
-      this.managedZoneOperations = new Resource$Managedzoneoperations(this);
-      this.managedZones = new Resource$Managedzones(this);
-      this.policies = new Resource$Policies(this);
-      this.projects = new Resource$Projects(this);
-      this.resourceRecordSets = new Resource$Resourcerecordsets(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.changes = new Resource$Changes();
+      this.dnsKeys = new Resource$Dnskeys();
+      this.managedZoneOperations = new Resource$Managedzoneoperations();
+      this.managedZones = new Resource$Managedzones();
+      this.policies = new Resource$Policies();
+      this.projects = new Resource$Projects();
+      this.resourceRecordSets = new Resource$Resourcerecordsets();
     }
   }
 
@@ -838,15 +830,7 @@ export namespace dns_v1beta2 {
 
 
   export class Resource$Changes {
-    root: Dns;
-    constructor(root: Dns) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -908,7 +892,7 @@ export namespace dns_v1beta2 {
         params,
         requiredParams: ['project', 'managedZone'],
         pathParams: ['managedZone', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Change>(parameters, callback);
@@ -974,7 +958,7 @@ export namespace dns_v1beta2 {
         params,
         requiredParams: ['project', 'managedZone', 'changeId'],
         pathParams: ['changeId', 'managedZone', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Change>(parameters, callback);
@@ -1046,7 +1030,7 @@ export namespace dns_v1beta2 {
         params,
         requiredParams: ['project', 'managedZone'],
         pathParams: ['managedZone', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ChangesListResponse>(parameters, callback);
@@ -1147,15 +1131,7 @@ export namespace dns_v1beta2 {
 
 
   export class Resource$Dnskeys {
-    root: Dns;
-    constructor(root: Dns) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -1215,7 +1191,7 @@ export namespace dns_v1beta2 {
         params,
         requiredParams: ['project', 'managedZone', 'dnsKeyId'],
         pathParams: ['dnsKeyId', 'managedZone', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$DnsKey>(parameters, callback);
@@ -1286,7 +1262,7 @@ export namespace dns_v1beta2 {
         params,
         requiredParams: ['project', 'managedZone'],
         pathParams: ['managedZone', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$DnsKeysListResponse>(parameters, callback);
@@ -1363,15 +1339,7 @@ export namespace dns_v1beta2 {
 
 
   export class Resource$Managedzoneoperations {
-    root: Dns;
-    constructor(root: Dns) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -1432,7 +1400,7 @@ export namespace dns_v1beta2 {
         params,
         requiredParams: ['project', 'managedZone', 'operation'],
         pathParams: ['managedZone', 'operation', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -1514,7 +1482,7 @@ export namespace dns_v1beta2 {
         params,
         requiredParams: ['project', 'managedZone'],
         pathParams: ['managedZone', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ManagedZoneOperationsListResponse>(
@@ -1585,15 +1553,7 @@ export namespace dns_v1beta2 {
 
 
   export class Resource$Managedzones {
-    root: Dns;
-    constructor(root: Dns) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -1655,7 +1615,7 @@ export namespace dns_v1beta2 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ManagedZone>(parameters, callback);
@@ -1724,7 +1684,7 @@ export namespace dns_v1beta2 {
         params,
         requiredParams: ['project', 'managedZone'],
         pathParams: ['managedZone', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -1790,7 +1750,7 @@ export namespace dns_v1beta2 {
         params,
         requiredParams: ['project', 'managedZone'],
         pathParams: ['managedZone', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ManagedZone>(parameters, callback);
@@ -1860,7 +1820,7 @@ export namespace dns_v1beta2 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ManagedZonesListResponse>(parameters, callback);
@@ -1931,7 +1891,7 @@ export namespace dns_v1beta2 {
         params,
         requiredParams: ['project', 'managedZone'],
         pathParams: ['managedZone', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -2003,7 +1963,7 @@ export namespace dns_v1beta2 {
         params,
         requiredParams: ['project', 'managedZone'],
         pathParams: ['managedZone', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -2166,15 +2126,7 @@ export namespace dns_v1beta2 {
 
 
   export class Resource$Policies {
-    root: Dns;
-    constructor(root: Dns) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -2233,7 +2185,7 @@ export namespace dns_v1beta2 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -2300,7 +2252,7 @@ export namespace dns_v1beta2 {
         params,
         requiredParams: ['project', 'policy'],
         pathParams: ['policy', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -2364,7 +2316,7 @@ export namespace dns_v1beta2 {
         params,
         requiredParams: ['project', 'policy'],
         pathParams: ['policy', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -2432,7 +2384,7 @@ export namespace dns_v1beta2 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$PoliciesListResponse>(parameters, callback);
@@ -2502,7 +2454,7 @@ export namespace dns_v1beta2 {
         params,
         requiredParams: ['project', 'policy'],
         pathParams: ['policy', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$PoliciesPatchResponse>(parameters, callback);
@@ -2572,7 +2524,7 @@ export namespace dns_v1beta2 {
         params,
         requiredParams: ['project', 'policy'],
         pathParams: ['policy', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$PoliciesUpdateResponse>(parameters, callback);
@@ -2722,15 +2674,7 @@ export namespace dns_v1beta2 {
 
 
   export class Resource$Projects {
-    root: Dns;
-    constructor(root: Dns) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -2785,7 +2729,7 @@ export namespace dns_v1beta2 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Project>(parameters, callback);
@@ -2815,15 +2759,7 @@ export namespace dns_v1beta2 {
 
 
   export class Resource$Resourcerecordsets {
-    root: Dns;
-    constructor(root: Dns) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -2896,7 +2832,7 @@ export namespace dns_v1beta2 {
         params,
         requiredParams: ['project', 'managedZone'],
         pathParams: ['managedZone', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ResourceRecordSetsListResponse>(

--- a/src/apis/dns/v2beta1.ts
+++ b/src/apis/dns/v2beta1.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace dns_v2beta1 {
   export interface Options extends GlobalOptions {
     version: 'v2beta1';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -79,10 +81,6 @@ export namespace dns_v2beta1 {
    * @param {object=} options Options for Dns
    */
   export class Dns {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     changes: Resource$Changes;
     dnsKeys: Resource$Dnskeys;
     managedZoneOperations: Resource$Managedzoneoperations;
@@ -91,20 +89,14 @@ export namespace dns_v2beta1 {
     resourceRecordSets: Resource$Resourcerecordsets;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.changes = new Resource$Changes(this);
-      this.dnsKeys = new Resource$Dnskeys(this);
-      this.managedZoneOperations = new Resource$Managedzoneoperations(this);
-      this.managedZones = new Resource$Managedzones(this);
-      this.projects = new Resource$Projects(this);
-      this.resourceRecordSets = new Resource$Resourcerecordsets(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.changes = new Resource$Changes();
+      this.dnsKeys = new Resource$Dnskeys();
+      this.managedZoneOperations = new Resource$Managedzoneoperations();
+      this.managedZones = new Resource$Managedzones();
+      this.projects = new Resource$Projects();
+      this.resourceRecordSets = new Resource$Resourcerecordsets();
     }
   }
 
@@ -632,15 +624,7 @@ export namespace dns_v2beta1 {
 
 
   export class Resource$Changes {
-    root: Dns;
-    constructor(root: Dns) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -763,7 +747,7 @@ export namespace dns_v2beta1 {
         params,
         requiredParams: ['project', 'managedZone'],
         pathParams: ['managedZone', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Change>(parameters, callback);
@@ -890,7 +874,7 @@ export namespace dns_v2beta1 {
         params,
         requiredParams: ['project', 'managedZone', 'changeId'],
         pathParams: ['changeId', 'managedZone', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Change>(parameters, callback);
@@ -1032,7 +1016,7 @@ export namespace dns_v2beta1 {
         params,
         requiredParams: ['project', 'managedZone'],
         pathParams: ['managedZone', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ChangesListResponse>(parameters, callback);
@@ -1133,15 +1117,7 @@ export namespace dns_v2beta1 {
 
 
   export class Resource$Dnskeys {
-    root: Dns;
-    constructor(root: Dns) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -1261,7 +1237,7 @@ export namespace dns_v2beta1 {
         params,
         requiredParams: ['project', 'managedZone', 'dnsKeyId'],
         pathParams: ['dnsKeyId', 'managedZone', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$DnsKey>(parameters, callback);
@@ -1402,7 +1378,7 @@ export namespace dns_v2beta1 {
         params,
         requiredParams: ['project', 'managedZone'],
         pathParams: ['managedZone', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$DnsKeysListResponse>(parameters, callback);
@@ -1479,15 +1455,7 @@ export namespace dns_v2beta1 {
 
 
   export class Resource$Managedzoneoperations {
-    root: Dns;
-    constructor(root: Dns) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -1607,7 +1575,7 @@ export namespace dns_v2beta1 {
         params,
         requiredParams: ['project', 'managedZone', 'operation'],
         pathParams: ['managedZone', 'operation', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -1759,7 +1727,7 @@ export namespace dns_v2beta1 {
         params,
         requiredParams: ['project', 'managedZone'],
         pathParams: ['managedZone', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ManagedZoneOperationsListResponse>(
@@ -1830,15 +1798,7 @@ export namespace dns_v2beta1 {
 
 
   export class Resource$Managedzones {
-    root: Dns;
-    constructor(root: Dns) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -1957,7 +1917,7 @@ export namespace dns_v2beta1 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ManagedZone>(parameters, callback);
@@ -2083,7 +2043,7 @@ export namespace dns_v2beta1 {
         params,
         requiredParams: ['project', 'managedZone'],
         pathParams: ['managedZone', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -2206,7 +2166,7 @@ export namespace dns_v2beta1 {
         params,
         requiredParams: ['project', 'managedZone'],
         pathParams: ['managedZone', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ManagedZone>(parameters, callback);
@@ -2343,7 +2303,7 @@ export namespace dns_v2beta1 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ManagedZonesListResponse>(parameters, callback);
@@ -2477,7 +2437,7 @@ export namespace dns_v2beta1 {
         params,
         requiredParams: ['project', 'managedZone'],
         pathParams: ['managedZone', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -2612,7 +2572,7 @@ export namespace dns_v2beta1 {
         params,
         requiredParams: ['project', 'managedZone'],
         pathParams: ['managedZone', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -2775,15 +2735,7 @@ export namespace dns_v2beta1 {
 
 
   export class Resource$Projects {
-    root: Dns;
-    constructor(root: Dns) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -2891,7 +2843,7 @@ export namespace dns_v2beta1 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Project>(parameters, callback);
@@ -2921,15 +2873,7 @@ export namespace dns_v2beta1 {
 
 
   export class Resource$Resourcerecordsets {
-    root: Dns;
-    constructor(root: Dns) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -3072,7 +3016,7 @@ export namespace dns_v2beta1 {
         params,
         requiredParams: ['project', 'managedZone'],
         pathParams: ['managedZone', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ResourceRecordSetsListResponse>(

--- a/src/apis/doubleclickbidmanager/v1.ts
+++ b/src/apis/doubleclickbidmanager/v1.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace doubleclickbidmanager_v1 {
   export interface Options extends GlobalOptions {
     version: 'v1';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -79,28 +81,18 @@ export namespace doubleclickbidmanager_v1 {
    * @param {object=} options Options for Doubleclickbidmanager
    */
   export class Doubleclickbidmanager {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     lineitems: Resource$Lineitems;
     queries: Resource$Queries;
     reports: Resource$Reports;
     sdf: Resource$Sdf;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.lineitems = new Resource$Lineitems(this);
-      this.queries = new Resource$Queries(this);
-      this.reports = new Resource$Reports(this);
-      this.sdf = new Resource$Sdf(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.lineitems = new Resource$Lineitems();
+      this.queries = new Resource$Queries();
+      this.reports = new Resource$Reports();
+      this.sdf = new Resource$Sdf();
     }
   }
 
@@ -558,15 +550,7 @@ export namespace doubleclickbidmanager_v1 {
 
 
   export class Resource$Lineitems {
-    root: Doubleclickbidmanager;
-    constructor(root: Doubleclickbidmanager) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -631,7 +615,7 @@ export namespace doubleclickbidmanager_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$DownloadLineItemsResponse>(
@@ -703,7 +687,7 @@ export namespace doubleclickbidmanager_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$UploadLineItemsResponse>(parameters, callback);
@@ -742,15 +726,7 @@ export namespace doubleclickbidmanager_v1 {
 
 
   export class Resource$Queries {
-    root: Doubleclickbidmanager;
-    constructor(root: Doubleclickbidmanager) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -809,7 +785,7 @@ export namespace doubleclickbidmanager_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Query>(parameters, callback);
@@ -874,7 +850,7 @@ export namespace doubleclickbidmanager_v1 {
         params,
         requiredParams: ['queryId'],
         pathParams: ['queryId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -939,7 +915,7 @@ export namespace doubleclickbidmanager_v1 {
         params,
         requiredParams: ['queryId'],
         pathParams: ['queryId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Query>(parameters, callback);
@@ -1006,7 +982,7 @@ export namespace doubleclickbidmanager_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListQueriesResponse>(parameters, callback);
@@ -1071,7 +1047,7 @@ export namespace doubleclickbidmanager_v1 {
         params,
         requiredParams: ['queryId'],
         pathParams: ['queryId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -1143,15 +1119,7 @@ export namespace doubleclickbidmanager_v1 {
 
 
   export class Resource$Reports {
-    root: Doubleclickbidmanager;
-    constructor(root: Doubleclickbidmanager) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -1213,7 +1181,7 @@ export namespace doubleclickbidmanager_v1 {
         params,
         requiredParams: ['queryId'],
         pathParams: ['queryId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListReportsResponse>(parameters, callback);
@@ -1238,15 +1206,7 @@ export namespace doubleclickbidmanager_v1 {
 
 
   export class Resource$Sdf {
-    root: Doubleclickbidmanager;
-    constructor(root: Doubleclickbidmanager) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -1304,7 +1264,7 @@ export namespace doubleclickbidmanager_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$DownloadResponse>(parameters, callback);

--- a/src/apis/doubleclicksearch/v2.ts
+++ b/src/apis/doubleclicksearch/v2.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace doubleclicksearch_v2 {
   export interface Options extends GlobalOptions {
     version: 'v2';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -80,26 +82,16 @@ export namespace doubleclicksearch_v2 {
    * @param {object=} options Options for Doubleclicksearch
    */
   export class Doubleclicksearch {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     conversion: Resource$Conversion;
     reports: Resource$Reports;
     savedColumns: Resource$Savedcolumns;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.conversion = new Resource$Conversion(this);
-      this.reports = new Resource$Reports(this);
-      this.savedColumns = new Resource$Savedcolumns(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.conversion = new Resource$Conversion();
+      this.reports = new Resource$Reports();
+      this.savedColumns = new Resource$Savedcolumns();
     }
   }
 
@@ -621,15 +613,7 @@ export namespace doubleclicksearch_v2 {
 
 
   export class Resource$Conversion {
-    root: Doubleclicksearch;
-    constructor(root: Doubleclicksearch) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -700,7 +684,7 @@ export namespace doubleclicksearch_v2 {
           'startDate', 'startRow'
         ],
         pathParams: ['advertiserId', 'agencyId', 'engineAccountId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ConversionList>(parameters, callback);
@@ -766,7 +750,7 @@ export namespace doubleclicksearch_v2 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ConversionList>(parameters, callback);
@@ -842,7 +826,7 @@ export namespace doubleclicksearch_v2 {
           'startDate', 'startRow'
         ],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ConversionList>(parameters, callback);
@@ -908,7 +892,7 @@ export namespace doubleclicksearch_v2 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ConversionList>(parameters, callback);
@@ -983,7 +967,7 @@ export namespace doubleclicksearch_v2 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$UpdateAvailabilityResponse>(
@@ -1131,15 +1115,7 @@ export namespace doubleclicksearch_v2 {
 
 
   export class Resource$Reports {
-    root: Doubleclicksearch;
-    constructor(root: Doubleclicksearch) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -1197,7 +1173,7 @@ export namespace doubleclicksearch_v2 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Report>(parameters, callback);
@@ -1258,7 +1234,7 @@ export namespace doubleclicksearch_v2 {
         params,
         requiredParams: ['reportId'],
         pathParams: ['reportId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Report>(parameters, callback);
@@ -1324,7 +1300,7 @@ export namespace doubleclicksearch_v2 {
         params,
         requiredParams: ['reportId', 'reportFragment'],
         pathParams: ['reportFragment', 'reportId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -1388,7 +1364,7 @@ export namespace doubleclicksearch_v2 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Report>(parameters, callback);
@@ -1451,15 +1427,7 @@ export namespace doubleclicksearch_v2 {
 
 
   export class Resource$Savedcolumns {
-    root: Doubleclicksearch;
-    constructor(root: Doubleclicksearch) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -1521,7 +1489,7 @@ export namespace doubleclicksearch_v2 {
         params,
         requiredParams: ['agencyId', 'advertiserId'],
         pathParams: ['advertiserId', 'agencyId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$SavedColumnList>(parameters, callback);

--- a/src/apis/drive/v2.ts
+++ b/src/apis/drive/v2.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace drive_v2 {
   export interface Options extends GlobalOptions {
     version: 'v2';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -80,10 +82,6 @@ export namespace drive_v2 {
    * @param {object=} options Options for Drive
    */
   export class Drive {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     about: Resource$About;
     apps: Resource$Apps;
     changes: Resource$Changes;
@@ -100,28 +98,22 @@ export namespace drive_v2 {
     teamdrives: Resource$Teamdrives;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.about = new Resource$About(this);
-      this.apps = new Resource$Apps(this);
-      this.changes = new Resource$Changes(this);
-      this.channels = new Resource$Channels(this);
-      this.children = new Resource$Children(this);
-      this.comments = new Resource$Comments(this);
-      this.files = new Resource$Files(this);
-      this.parents = new Resource$Parents(this);
-      this.permissions = new Resource$Permissions(this);
-      this.properties = new Resource$Properties(this);
-      this.realtime = new Resource$Realtime(this);
-      this.replies = new Resource$Replies(this);
-      this.revisions = new Resource$Revisions(this);
-      this.teamdrives = new Resource$Teamdrives(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.about = new Resource$About();
+      this.apps = new Resource$Apps();
+      this.changes = new Resource$Changes();
+      this.channels = new Resource$Channels();
+      this.children = new Resource$Children();
+      this.comments = new Resource$Comments();
+      this.files = new Resource$Files();
+      this.parents = new Resource$Parents();
+      this.permissions = new Resource$Permissions();
+      this.properties = new Resource$Properties();
+      this.realtime = new Resource$Realtime();
+      this.replies = new Resource$Replies();
+      this.revisions = new Resource$Revisions();
+      this.teamdrives = new Resource$Teamdrives();
     }
   }
 
@@ -1715,15 +1707,7 @@ export namespace drive_v2 {
 
 
   export class Resource$About {
-    root: Drive;
-    constructor(root: Drive) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -1779,7 +1763,7 @@ export namespace drive_v2 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$About>(parameters, callback);
@@ -1815,15 +1799,7 @@ export namespace drive_v2 {
 
 
   export class Resource$Apps {
-    root: Drive;
-    constructor(root: Drive) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -1877,7 +1853,7 @@ export namespace drive_v2 {
         params,
         requiredParams: ['appId'],
         pathParams: ['appId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$App>(parameters, callback);
@@ -1942,7 +1918,7 @@ export namespace drive_v2 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$AppList>(parameters, callback);
@@ -1993,15 +1969,7 @@ export namespace drive_v2 {
 
 
   export class Resource$Changes {
-    root: Drive;
-    constructor(root: Drive) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -2058,7 +2026,7 @@ export namespace drive_v2 {
         params,
         requiredParams: ['changeId'],
         pathParams: ['changeId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Change>(parameters, callback);
@@ -2127,7 +2095,7 @@ export namespace drive_v2 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$StartPageToken>(parameters, callback);
@@ -2201,7 +2169,7 @@ export namespace drive_v2 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ChangeList>(parameters, callback);
@@ -2275,7 +2243,7 @@ export namespace drive_v2 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Channel>(parameters, callback);
@@ -2447,15 +2415,7 @@ export namespace drive_v2 {
 
 
   export class Resource$Channels {
-    root: Drive;
-    constructor(root: Drive) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -2511,7 +2471,7 @@ export namespace drive_v2 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -2536,15 +2496,7 @@ export namespace drive_v2 {
 
 
   export class Resource$Children {
-    root: Drive;
-    constructor(root: Drive) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -2601,7 +2553,7 @@ export namespace drive_v2 {
         params,
         requiredParams: ['folderId', 'childId'],
         pathParams: ['childId', 'folderId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -2664,7 +2616,7 @@ export namespace drive_v2 {
         params,
         requiredParams: ['folderId', 'childId'],
         pathParams: ['childId', 'folderId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ChildReference>(parameters, callback);
@@ -2731,7 +2683,7 @@ export namespace drive_v2 {
         params,
         requiredParams: ['folderId'],
         pathParams: ['folderId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ChildReference>(parameters, callback);
@@ -2800,7 +2752,7 @@ export namespace drive_v2 {
         params,
         requiredParams: ['folderId'],
         pathParams: ['folderId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ChildList>(parameters, callback);
@@ -2896,15 +2848,7 @@ export namespace drive_v2 {
 
 
   export class Resource$Comments {
-    root: Drive;
-    constructor(root: Drive) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -2961,7 +2905,7 @@ export namespace drive_v2 {
         params,
         requiredParams: ['fileId', 'commentId'],
         pathParams: ['commentId', 'fileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -3024,7 +2968,7 @@ export namespace drive_v2 {
         params,
         requiredParams: ['fileId', 'commentId'],
         pathParams: ['commentId', 'fileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Comment>(parameters, callback);
@@ -3089,7 +3033,7 @@ export namespace drive_v2 {
         params,
         requiredParams: ['fileId'],
         pathParams: ['fileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Comment>(parameters, callback);
@@ -3158,7 +3102,7 @@ export namespace drive_v2 {
         params,
         requiredParams: ['fileId'],
         pathParams: ['fileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$CommentList>(parameters, callback);
@@ -3224,7 +3168,7 @@ export namespace drive_v2 {
         params,
         requiredParams: ['fileId', 'commentId'],
         pathParams: ['commentId', 'fileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Comment>(parameters, callback);
@@ -3290,7 +3234,7 @@ export namespace drive_v2 {
         params,
         requiredParams: ['fileId', 'commentId'],
         pathParams: ['commentId', 'fileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Comment>(parameters, callback);
@@ -3426,15 +3370,7 @@ export namespace drive_v2 {
 
 
   export class Resource$Files {
-    root: Drive;
-    constructor(root: Drive) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -3500,7 +3436,7 @@ export namespace drive_v2 {
         params,
         requiredParams: ['fileId'],
         pathParams: ['fileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$File>(parameters, callback);
@@ -3566,7 +3502,7 @@ export namespace drive_v2 {
         params,
         requiredParams: ['fileId'],
         pathParams: ['fileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -3629,7 +3565,7 @@ export namespace drive_v2 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -3695,7 +3631,7 @@ export namespace drive_v2 {
         params,
         requiredParams: ['fileId', 'mimeType'],
         pathParams: ['fileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -3764,7 +3700,7 @@ export namespace drive_v2 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GeneratedIds>(parameters, callback);
@@ -3830,7 +3766,7 @@ export namespace drive_v2 {
         params,
         requiredParams: ['fileId'],
         pathParams: ['fileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$File>(parameters, callback);
@@ -3907,7 +3843,7 @@ export namespace drive_v2 {
             (rootUrl + '/upload/drive/v2/files').replace(/([^:]\/)\/+/g, '$1'),
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$File>(parameters, callback);
@@ -3980,7 +3916,7 @@ export namespace drive_v2 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$FileList>(parameters, callback);
@@ -4060,7 +3996,7 @@ export namespace drive_v2 {
         params,
         requiredParams: ['fileId'],
         pathParams: ['fileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$File>(parameters, callback);
@@ -4125,7 +4061,7 @@ export namespace drive_v2 {
         params,
         requiredParams: ['fileId'],
         pathParams: ['fileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$File>(parameters, callback);
@@ -4192,7 +4128,7 @@ export namespace drive_v2 {
         params,
         requiredParams: ['fileId'],
         pathParams: ['fileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$File>(parameters, callback);
@@ -4257,7 +4193,7 @@ export namespace drive_v2 {
         params,
         requiredParams: ['fileId'],
         pathParams: ['fileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$File>(parameters, callback);
@@ -4341,7 +4277,7 @@ export namespace drive_v2 {
                       .replace(/([^:]\/)\/+/g, '$1'),
         requiredParams: ['fileId'],
         pathParams: ['fileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$File>(parameters, callback);
@@ -4411,7 +4347,7 @@ export namespace drive_v2 {
         params,
         requiredParams: ['fileId'],
         pathParams: ['fileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Channel>(parameters, callback);
@@ -4963,15 +4899,7 @@ export namespace drive_v2 {
 
 
   export class Resource$Parents {
-    root: Drive;
-    constructor(root: Drive) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -5028,7 +4956,7 @@ export namespace drive_v2 {
         params,
         requiredParams: ['fileId', 'parentId'],
         pathParams: ['fileId', 'parentId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -5091,7 +5019,7 @@ export namespace drive_v2 {
         params,
         requiredParams: ['fileId', 'parentId'],
         pathParams: ['fileId', 'parentId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ParentReference>(parameters, callback);
@@ -5158,7 +5086,7 @@ export namespace drive_v2 {
         params,
         requiredParams: ['fileId'],
         pathParams: ['fileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ParentReference>(parameters, callback);
@@ -5223,7 +5151,7 @@ export namespace drive_v2 {
         params,
         requiredParams: ['fileId'],
         pathParams: ['fileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ParentList>(parameters, callback);
@@ -5297,15 +5225,7 @@ export namespace drive_v2 {
 
 
   export class Resource$Permissions {
-    root: Drive;
-    constructor(root: Drive) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -5367,7 +5287,7 @@ export namespace drive_v2 {
         params,
         requiredParams: ['fileId', 'permissionId'],
         pathParams: ['fileId', 'permissionId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -5433,7 +5353,7 @@ export namespace drive_v2 {
         params,
         requiredParams: ['fileId', 'permissionId'],
         pathParams: ['fileId', 'permissionId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Permission>(parameters, callback);
@@ -5500,7 +5420,7 @@ export namespace drive_v2 {
         params,
         requiredParams: ['email'],
         pathParams: ['email'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$PermissionId>(parameters, callback);
@@ -5572,7 +5492,7 @@ export namespace drive_v2 {
         params,
         requiredParams: ['fileId'],
         pathParams: ['fileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Permission>(parameters, callback);
@@ -5641,7 +5561,7 @@ export namespace drive_v2 {
         params,
         requiredParams: ['fileId'],
         pathParams: ['fileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$PermissionList>(parameters, callback);
@@ -5714,7 +5634,7 @@ export namespace drive_v2 {
         params,
         requiredParams: ['fileId', 'permissionId'],
         pathParams: ['fileId', 'permissionId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Permission>(parameters, callback);
@@ -5788,7 +5708,7 @@ export namespace drive_v2 {
         params,
         requiredParams: ['fileId', 'permissionId'],
         pathParams: ['fileId', 'permissionId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Permission>(parameters, callback);
@@ -6012,15 +5932,7 @@ export namespace drive_v2 {
 
 
   export class Resource$Properties {
-    root: Drive;
-    constructor(root: Drive) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -6080,7 +5992,7 @@ export namespace drive_v2 {
         params,
         requiredParams: ['fileId', 'propertyKey'],
         pathParams: ['fileId', 'propertyKey'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -6144,7 +6056,7 @@ export namespace drive_v2 {
         params,
         requiredParams: ['fileId', 'propertyKey'],
         pathParams: ['fileId', 'propertyKey'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Property>(parameters, callback);
@@ -6210,7 +6122,7 @@ export namespace drive_v2 {
         params,
         requiredParams: ['fileId'],
         pathParams: ['fileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Property>(parameters, callback);
@@ -6275,7 +6187,7 @@ export namespace drive_v2 {
         params,
         requiredParams: ['fileId'],
         pathParams: ['fileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$PropertyList>(parameters, callback);
@@ -6343,7 +6255,7 @@ export namespace drive_v2 {
         params,
         requiredParams: ['fileId', 'propertyKey'],
         pathParams: ['fileId', 'propertyKey'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Property>(parameters, callback);
@@ -6412,7 +6324,7 @@ export namespace drive_v2 {
         params,
         requiredParams: ['fileId', 'propertyKey'],
         pathParams: ['fileId', 'propertyKey'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Property>(parameters, callback);
@@ -6543,15 +6455,7 @@ export namespace drive_v2 {
 
 
   export class Resource$Realtime {
-    root: Drive;
-    constructor(root: Drive) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -6606,7 +6510,7 @@ export namespace drive_v2 {
         params,
         requiredParams: ['fileId'],
         pathParams: ['fileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -6676,7 +6580,7 @@ export namespace drive_v2 {
                       .replace(/([^:]\/)\/+/g, '$1'),
         requiredParams: ['fileId'],
         pathParams: ['fileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -6741,15 +6645,7 @@ export namespace drive_v2 {
 
 
   export class Resource$Replies {
-    root: Drive;
-    constructor(root: Drive) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -6809,7 +6705,7 @@ export namespace drive_v2 {
         params,
         requiredParams: ['fileId', 'commentId', 'replyId'],
         pathParams: ['commentId', 'fileId', 'replyId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -6876,7 +6772,7 @@ export namespace drive_v2 {
         params,
         requiredParams: ['fileId', 'commentId', 'replyId'],
         pathParams: ['commentId', 'fileId', 'replyId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$CommentReply>(parameters, callback);
@@ -6944,7 +6840,7 @@ export namespace drive_v2 {
         params,
         requiredParams: ['fileId', 'commentId'],
         pathParams: ['commentId', 'fileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$CommentReply>(parameters, callback);
@@ -7014,7 +6910,7 @@ export namespace drive_v2 {
         params,
         requiredParams: ['fileId', 'commentId'],
         pathParams: ['commentId', 'fileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$CommentReplyList>(parameters, callback);
@@ -7084,7 +6980,7 @@ export namespace drive_v2 {
         params,
         requiredParams: ['fileId', 'commentId', 'replyId'],
         pathParams: ['commentId', 'fileId', 'replyId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$CommentReply>(parameters, callback);
@@ -7154,7 +7050,7 @@ export namespace drive_v2 {
         params,
         requiredParams: ['fileId', 'commentId', 'replyId'],
         pathParams: ['commentId', 'fileId', 'replyId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$CommentReply>(parameters, callback);
@@ -7308,15 +7204,7 @@ export namespace drive_v2 {
 
 
   export class Resource$Revisions {
-    root: Drive;
-    constructor(root: Drive) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -7373,7 +7261,7 @@ export namespace drive_v2 {
         params,
         requiredParams: ['fileId', 'revisionId'],
         pathParams: ['fileId', 'revisionId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -7435,7 +7323,7 @@ export namespace drive_v2 {
         params,
         requiredParams: ['fileId', 'revisionId'],
         pathParams: ['fileId', 'revisionId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Revision>(parameters, callback);
@@ -7502,7 +7390,7 @@ export namespace drive_v2 {
         params,
         requiredParams: ['fileId'],
         pathParams: ['fileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$RevisionList>(parameters, callback);
@@ -7568,7 +7456,7 @@ export namespace drive_v2 {
         params,
         requiredParams: ['fileId', 'revisionId'],
         pathParams: ['fileId', 'revisionId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Revision>(parameters, callback);
@@ -7634,7 +7522,7 @@ export namespace drive_v2 {
         params,
         requiredParams: ['fileId', 'revisionId'],
         pathParams: ['fileId', 'revisionId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Revision>(parameters, callback);
@@ -7737,15 +7625,7 @@ export namespace drive_v2 {
 
 
   export class Resource$Teamdrives {
-    root: Drive;
-    constructor(root: Drive) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -7803,7 +7683,7 @@ export namespace drive_v2 {
         params,
         requiredParams: ['teamDriveId'],
         pathParams: ['teamDriveId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -7866,7 +7746,7 @@ export namespace drive_v2 {
         params,
         requiredParams: ['teamDriveId'],
         pathParams: ['teamDriveId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TeamDrive>(parameters, callback);
@@ -7933,7 +7813,7 @@ export namespace drive_v2 {
         params,
         requiredParams: ['requestId'],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TeamDrive>(parameters, callback);
@@ -8001,7 +7881,7 @@ export namespace drive_v2 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TeamDriveList>(parameters, callback);
@@ -8069,7 +7949,7 @@ export namespace drive_v2 {
         params,
         requiredParams: ['teamDriveId'],
         pathParams: ['teamDriveId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TeamDrive>(parameters, callback);

--- a/src/apis/drive/v3.ts
+++ b/src/apis/drive/v3.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace drive_v3 {
   export interface Options extends GlobalOptions {
     version: 'v3';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -80,10 +82,6 @@ export namespace drive_v3 {
    * @param {object=} options Options for Drive
    */
   export class Drive {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     about: Resource$About;
     changes: Resource$Changes;
     channels: Resource$Channels;
@@ -95,23 +93,17 @@ export namespace drive_v3 {
     teamdrives: Resource$Teamdrives;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.about = new Resource$About(this);
-      this.changes = new Resource$Changes(this);
-      this.channels = new Resource$Channels(this);
-      this.comments = new Resource$Comments(this);
-      this.files = new Resource$Files(this);
-      this.permissions = new Resource$Permissions(this);
-      this.replies = new Resource$Replies(this);
-      this.revisions = new Resource$Revisions(this);
-      this.teamdrives = new Resource$Teamdrives(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.about = new Resource$About();
+      this.changes = new Resource$Changes();
+      this.channels = new Resource$Channels();
+      this.comments = new Resource$Comments();
+      this.files = new Resource$Files();
+      this.permissions = new Resource$Permissions();
+      this.replies = new Resource$Replies();
+      this.revisions = new Resource$Revisions();
+      this.teamdrives = new Resource$Teamdrives();
     }
   }
 
@@ -1146,15 +1138,7 @@ export namespace drive_v3 {
 
 
   export class Resource$About {
-    root: Drive;
-    constructor(root: Drive) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -1207,7 +1191,7 @@ export namespace drive_v3 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$About>(parameters, callback);
@@ -1226,15 +1210,7 @@ export namespace drive_v3 {
 
 
   export class Resource$Changes {
-    root: Drive;
-    constructor(root: Drive) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -1296,7 +1272,7 @@ export namespace drive_v3 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$StartPageToken>(parameters, callback);
@@ -1369,7 +1345,7 @@ export namespace drive_v3 {
         params,
         requiredParams: ['pageToken'],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ChangeList>(parameters, callback);
@@ -1442,7 +1418,7 @@ export namespace drive_v3 {
         params,
         requiredParams: ['pageToken'],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Channel>(parameters, callback);
@@ -1585,15 +1561,7 @@ export namespace drive_v3 {
 
 
   export class Resource$Channels {
-    root: Drive;
-    constructor(root: Drive) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -1649,7 +1617,7 @@ export namespace drive_v3 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -1674,15 +1642,7 @@ export namespace drive_v3 {
 
 
   export class Resource$Comments {
-    root: Drive;
-    constructor(root: Drive) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -1740,7 +1700,7 @@ export namespace drive_v3 {
         params,
         requiredParams: ['fileId'],
         pathParams: ['fileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Comment>(parameters, callback);
@@ -1804,7 +1764,7 @@ export namespace drive_v3 {
         params,
         requiredParams: ['fileId', 'commentId'],
         pathParams: ['commentId', 'fileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -1867,7 +1827,7 @@ export namespace drive_v3 {
         params,
         requiredParams: ['fileId', 'commentId'],
         pathParams: ['commentId', 'fileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Comment>(parameters, callback);
@@ -1936,7 +1896,7 @@ export namespace drive_v3 {
         params,
         requiredParams: ['fileId'],
         pathParams: ['fileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$CommentList>(parameters, callback);
@@ -2002,7 +1962,7 @@ export namespace drive_v3 {
         params,
         requiredParams: ['fileId', 'commentId'],
         pathParams: ['commentId', 'fileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Comment>(parameters, callback);
@@ -2116,15 +2076,7 @@ export namespace drive_v3 {
 
 
   export class Resource$Files {
-    root: Drive;
-    constructor(root: Drive) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -2187,7 +2139,7 @@ export namespace drive_v3 {
         params,
         requiredParams: ['fileId'],
         pathParams: ['fileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$File>(parameters, callback);
@@ -2260,7 +2212,7 @@ export namespace drive_v3 {
             (rootUrl + '/upload/drive/v3/files').replace(/([^:]\/)\/+/g, '$1'),
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$File>(parameters, callback);
@@ -2327,7 +2279,7 @@ export namespace drive_v3 {
         params,
         requiredParams: ['fileId'],
         pathParams: ['fileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -2390,7 +2342,7 @@ export namespace drive_v3 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -2456,7 +2408,7 @@ export namespace drive_v3 {
         params,
         requiredParams: ['fileId', 'mimeType'],
         pathParams: ['fileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -2525,7 +2477,7 @@ export namespace drive_v3 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GeneratedIds>(parameters, callback);
@@ -2588,7 +2540,7 @@ export namespace drive_v3 {
         params,
         requiredParams: ['fileId'],
         pathParams: ['fileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$File>(parameters, callback);
@@ -2660,7 +2612,7 @@ export namespace drive_v3 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$FileList>(parameters, callback);
@@ -2736,7 +2688,7 @@ export namespace drive_v3 {
                       .replace(/([^:]\/)\/+/g, '$1'),
         requiredParams: ['fileId'],
         pathParams: ['fileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$File>(parameters, callback);
@@ -2803,7 +2755,7 @@ export namespace drive_v3 {
         params,
         requiredParams: ['fileId'],
         pathParams: ['fileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Channel>(parameters, callback);
@@ -3120,15 +3072,7 @@ export namespace drive_v3 {
 
 
   export class Resource$Permissions {
-    root: Drive;
-    constructor(root: Drive) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -3194,7 +3138,7 @@ export namespace drive_v3 {
         params,
         requiredParams: ['fileId'],
         pathParams: ['fileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Permission>(parameters, callback);
@@ -3263,7 +3207,7 @@ export namespace drive_v3 {
         params,
         requiredParams: ['fileId', 'permissionId'],
         pathParams: ['fileId', 'permissionId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -3329,7 +3273,7 @@ export namespace drive_v3 {
         params,
         requiredParams: ['fileId', 'permissionId'],
         pathParams: ['fileId', 'permissionId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Permission>(parameters, callback);
@@ -3398,7 +3342,7 @@ export namespace drive_v3 {
         params,
         requiredParams: ['fileId'],
         pathParams: ['fileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$PermissionList>(parameters, callback);
@@ -3472,7 +3416,7 @@ export namespace drive_v3 {
         params,
         requiredParams: ['fileId', 'permissionId'],
         pathParams: ['fileId', 'permissionId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Permission>(parameters, callback);
@@ -3652,15 +3596,7 @@ export namespace drive_v3 {
 
 
   export class Resource$Replies {
-    root: Drive;
-    constructor(root: Drive) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -3720,7 +3656,7 @@ export namespace drive_v3 {
         params,
         requiredParams: ['fileId', 'commentId'],
         pathParams: ['commentId', 'fileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Reply>(parameters, callback);
@@ -3787,7 +3723,7 @@ export namespace drive_v3 {
         params,
         requiredParams: ['fileId', 'commentId', 'replyId'],
         pathParams: ['commentId', 'fileId', 'replyId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -3853,7 +3789,7 @@ export namespace drive_v3 {
         params,
         requiredParams: ['fileId', 'commentId', 'replyId'],
         pathParams: ['commentId', 'fileId', 'replyId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Reply>(parameters, callback);
@@ -3923,7 +3859,7 @@ export namespace drive_v3 {
         params,
         requiredParams: ['fileId', 'commentId'],
         pathParams: ['commentId', 'fileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ReplyList>(parameters, callback);
@@ -3992,7 +3928,7 @@ export namespace drive_v3 {
         params,
         requiredParams: ['fileId', 'commentId', 'replyId'],
         pathParams: ['commentId', 'fileId', 'replyId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Reply>(parameters, callback);
@@ -4121,15 +4057,7 @@ export namespace drive_v3 {
 
 
   export class Resource$Revisions {
-    root: Drive;
-    constructor(root: Drive) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -4187,7 +4115,7 @@ export namespace drive_v3 {
         params,
         requiredParams: ['fileId', 'revisionId'],
         pathParams: ['fileId', 'revisionId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -4250,7 +4178,7 @@ export namespace drive_v3 {
         params,
         requiredParams: ['fileId', 'revisionId'],
         pathParams: ['fileId', 'revisionId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Revision>(parameters, callback);
@@ -4317,7 +4245,7 @@ export namespace drive_v3 {
         params,
         requiredParams: ['fileId'],
         pathParams: ['fileId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$RevisionList>(parameters, callback);
@@ -4383,7 +4311,7 @@ export namespace drive_v3 {
         params,
         requiredParams: ['fileId', 'revisionId'],
         pathParams: ['fileId', 'revisionId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Revision>(parameters, callback);
@@ -4471,15 +4399,7 @@ export namespace drive_v3 {
 
 
   export class Resource$Teamdrives {
-    root: Drive;
-    constructor(root: Drive) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -4539,7 +4459,7 @@ export namespace drive_v3 {
         params,
         requiredParams: ['requestId'],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TeamDrive>(parameters, callback);
@@ -4604,7 +4524,7 @@ export namespace drive_v3 {
         params,
         requiredParams: ['teamDriveId'],
         pathParams: ['teamDriveId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -4667,7 +4587,7 @@ export namespace drive_v3 {
         params,
         requiredParams: ['teamDriveId'],
         pathParams: ['teamDriveId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TeamDrive>(parameters, callback);
@@ -4735,7 +4655,7 @@ export namespace drive_v3 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TeamDriveList>(parameters, callback);
@@ -4803,7 +4723,7 @@ export namespace drive_v3 {
         params,
         requiredParams: ['teamDriveId'],
         pathParams: ['teamDriveId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TeamDrive>(parameters, callback);

--- a/src/apis/driveactivity/v2.ts
+++ b/src/apis/driveactivity/v2.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace driveactivity_v2 {
   export interface Options extends GlobalOptions {
     version: 'v2';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -96,22 +98,12 @@ export namespace driveactivity_v2 {
    * @param {object=} options Options for Driveactivity
    */
   export class Driveactivity {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     activity: Resource$Activity;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.activity = new Resource$Activity(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.activity = new Resource$Activity();
     }
   }
 
@@ -848,15 +840,7 @@ export namespace driveactivity_v2 {
 
 
   export class Resource$Activity {
-    root: Driveactivity;
-    constructor(root: Driveactivity) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -919,7 +903,7 @@ export namespace driveactivity_v2 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$QueryDriveActivityResponse>(

--- a/src/apis/file/v1beta1.ts
+++ b/src/apis/file/v1beta1.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace file_v1beta1 {
   export interface Options extends GlobalOptions {
     version: 'v1beta1';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -97,22 +99,12 @@ export namespace file_v1beta1 {
    * @param {object=} options Options for File
    */
   export class File {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     projects: Resource$Projects;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.projects = new Resource$Projects(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.projects = new Resource$Projects();
     }
   }
 
@@ -433,33 +425,19 @@ export namespace file_v1beta1 {
 
 
   export class Resource$Projects {
-    root: File;
     locations: Resource$Projects$Locations;
-    constructor(root: File) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.locations = new Resource$Projects$Locations(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.locations = new Resource$Projects$Locations();
     }
   }
 
 
   export class Resource$Projects$Locations {
-    root: File;
     instances: Resource$Projects$Locations$Instances;
     operations: Resource$Projects$Locations$Operations;
-    constructor(root: File) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.instances = new Resource$Projects$Locations$Instances(root);
-      this.operations = new Resource$Projects$Locations$Operations(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.instances = new Resource$Projects$Locations$Instances();
+      this.operations = new Resource$Projects$Locations$Operations();
     }
 
 
@@ -514,7 +492,7 @@ export namespace file_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Location>(parameters, callback);
@@ -585,7 +563,7 @@ export namespace file_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListLocationsResponse>(parameters, callback);
@@ -633,15 +611,7 @@ export namespace file_v1beta1 {
   }
 
   export class Resource$Projects$Locations$Instances {
-    root: File;
-    constructor(root: File) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -703,7 +673,7 @@ export namespace file_v1beta1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -769,7 +739,7 @@ export namespace file_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -830,7 +800,7 @@ export namespace file_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Instance>(parameters, callback);
@@ -903,7 +873,7 @@ export namespace file_v1beta1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListInstancesResponse>(parameters, callback);
@@ -971,7 +941,7 @@ export namespace file_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -1091,15 +1061,7 @@ export namespace file_v1beta1 {
 
 
   export class Resource$Projects$Locations$Operations {
-    root: File;
-    constructor(root: File) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -1167,7 +1129,7 @@ export namespace file_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -1235,7 +1197,7 @@ export namespace file_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -1299,7 +1261,7 @@ export namespace file_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -1378,7 +1340,7 @@ export namespace file_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListOperationsResponse>(parameters, callback);

--- a/src/apis/firebasedynamiclinks/v1.ts
+++ b/src/apis/firebasedynamiclinks/v1.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace firebasedynamiclinks_v1 {
   export interface Options extends GlobalOptions {
     version: 'v1';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -96,26 +98,16 @@ export namespace firebasedynamiclinks_v1 {
    * @param {object=} options Options for Firebasedynamiclinks
    */
   export class Firebasedynamiclinks {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     managedShortLinks: Resource$Managedshortlinks;
     shortLinks: Resource$Shortlinks;
     v1: Resource$V1;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.managedShortLinks = new Resource$Managedshortlinks(this);
-      this.shortLinks = new Resource$Shortlinks(this);
-      this.v1 = new Resource$V1(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.managedShortLinks = new Resource$Managedshortlinks();
+      this.shortLinks = new Resource$Shortlinks();
+      this.v1 = new Resource$V1();
     }
   }
 
@@ -743,15 +735,7 @@ export namespace firebasedynamiclinks_v1 {
 
 
   export class Resource$Managedshortlinks {
-    root: Firebasedynamiclinks;
-    constructor(root: Firebasedynamiclinks) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -826,7 +810,7 @@ export namespace firebasedynamiclinks_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$CreateManagedShortLinkResponse>(
@@ -854,15 +838,7 @@ export namespace firebasedynamiclinks_v1 {
 
 
   export class Resource$Shortlinks {
-    root: Firebasedynamiclinks;
-    constructor(root: Firebasedynamiclinks) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -931,7 +907,7 @@ export namespace firebasedynamiclinks_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$CreateShortDynamicLinkResponse>(
@@ -959,15 +935,7 @@ export namespace firebasedynamiclinks_v1 {
 
 
   export class Resource$V1 {
-    root: Firebasedynamiclinks;
-    constructor(root: Firebasedynamiclinks) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -1031,7 +999,7 @@ export namespace firebasedynamiclinks_v1 {
         params,
         requiredParams: ['dynamicLink'],
         pathParams: ['dynamicLink'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$DynamicLinkStats>(parameters, callback);
@@ -1109,7 +1077,7 @@ export namespace firebasedynamiclinks_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GetIosPostInstallAttributionResponse>(
@@ -1185,7 +1153,7 @@ export namespace firebasedynamiclinks_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GetIosReopenAttributionResponse>(

--- a/src/apis/firebasehosting/v1beta1.ts
+++ b/src/apis/firebasehosting/v1beta1.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace firebasehosting_v1beta1 {
   export interface Options extends GlobalOptions {
     version: 'v1beta1';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -97,22 +99,12 @@ export namespace firebasehosting_v1beta1 {
    * @param {object=} options Options for Firebasehosting
    */
   export class Firebasehosting {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     sites: Resource$Sites;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.sites = new Resource$Sites(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.sites = new Resource$Sites();
     }
   }
 
@@ -554,20 +546,13 @@ export namespace firebasehosting_v1beta1 {
 
 
   export class Resource$Sites {
-    root: Firebasehosting;
     domains: Resource$Sites$Domains;
     releases: Resource$Sites$Releases;
     versions: Resource$Sites$Versions;
-    constructor(root: Firebasehosting) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.domains = new Resource$Sites$Domains(root);
-      this.releases = new Resource$Sites$Releases(root);
-      this.versions = new Resource$Sites$Versions(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.domains = new Resource$Sites$Domains();
+      this.releases = new Resource$Sites$Releases();
+      this.versions = new Resource$Sites$Versions();
     }
 
 
@@ -627,7 +612,7 @@ export namespace firebasehosting_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$SiteConfig>(parameters, callback);
@@ -696,7 +681,7 @@ export namespace firebasehosting_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$SiteConfig>(parameters, callback);
@@ -745,15 +730,7 @@ export namespace firebasehosting_v1beta1 {
   }
 
   export class Resource$Sites$Domains {
-    root: Firebasehosting;
-    constructor(root: Firebasehosting) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -814,7 +791,7 @@ export namespace firebasehosting_v1beta1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Domain>(parameters, callback);
@@ -880,7 +857,7 @@ export namespace firebasehosting_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -942,7 +919,7 @@ export namespace firebasehosting_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Domain>(parameters, callback);
@@ -1011,7 +988,7 @@ export namespace firebasehosting_v1beta1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListDomainsResponse>(parameters, callback);
@@ -1079,7 +1056,7 @@ export namespace firebasehosting_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Domain>(parameters, callback);
@@ -1173,15 +1150,7 @@ export namespace firebasehosting_v1beta1 {
 
 
   export class Resource$Sites$Releases {
-    root: Firebasehosting;
-    constructor(root: Firebasehosting) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -1244,7 +1213,7 @@ export namespace firebasehosting_v1beta1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Release>(parameters, callback);
@@ -1314,7 +1283,7 @@ export namespace firebasehosting_v1beta1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListReleasesResponse>(parameters, callback);
@@ -1375,16 +1344,9 @@ export namespace firebasehosting_v1beta1 {
 
 
   export class Resource$Sites$Versions {
-    root: Firebasehosting;
     files: Resource$Sites$Versions$Files;
-    constructor(root: Firebasehosting) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.files = new Resource$Sites$Versions$Files(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.files = new Resource$Sites$Versions$Files();
     }
 
 
@@ -1448,7 +1410,7 @@ export namespace firebasehosting_v1beta1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Version>(parameters, callback);
@@ -1514,7 +1476,7 @@ export namespace firebasehosting_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -1587,7 +1549,7 @@ export namespace firebasehosting_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Version>(parameters, callback);
@@ -1662,7 +1624,7 @@ export namespace firebasehosting_v1beta1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$PopulateVersionFilesResponse>(
@@ -1762,15 +1724,7 @@ export namespace firebasehosting_v1beta1 {
   }
 
   export class Resource$Sites$Versions$Files {
-    root: Firebasehosting;
-    constructor(root: Firebasehosting) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -1835,7 +1789,7 @@ export namespace firebasehosting_v1beta1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListVersionFilesResponse>(parameters, callback);

--- a/src/apis/firebaserules/v1.ts
+++ b/src/apis/firebaserules/v1.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace firebaserules_v1 {
   export interface Options extends GlobalOptions {
     version: 'v1';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -97,22 +99,12 @@ export namespace firebaserules_v1 {
    * @param {object=} options Options for Firebaserules
    */
   export class Firebaserules {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     projects: Resource$Projects;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.projects = new Resource$Projects(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.projects = new Resource$Projects();
     }
   }
 
@@ -517,18 +509,11 @@ export namespace firebaserules_v1 {
 
 
   export class Resource$Projects {
-    root: Firebaserules;
     releases: Resource$Projects$Releases;
     rulesets: Resource$Projects$Rulesets;
-    constructor(root: Firebaserules) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.releases = new Resource$Projects$Releases(root);
-      this.rulesets = new Resource$Projects$Rulesets(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.releases = new Resource$Projects$Releases();
+      this.rulesets = new Resource$Projects$Rulesets();
     }
 
 
@@ -600,7 +585,7 @@ export namespace firebaserules_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TestRulesetResponse>(parameters, callback);
@@ -632,15 +617,7 @@ export namespace firebaserules_v1 {
   }
 
   export class Resource$Projects$Releases {
-    root: Firebaserules;
-    constructor(root: Firebaserules) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -715,7 +692,7 @@ export namespace firebaserules_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Release>(parameters, callback);
@@ -781,7 +758,7 @@ export namespace firebaserules_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -843,7 +820,7 @@ export namespace firebaserules_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Release>(parameters, callback);
@@ -918,7 +895,7 @@ export namespace firebaserules_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GetReleaseExecutableResponse>(
@@ -994,7 +971,7 @@ export namespace firebaserules_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListReleasesResponse>(parameters, callback);
@@ -1063,7 +1040,7 @@ export namespace firebaserules_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Release>(parameters, callback);
@@ -1201,15 +1178,7 @@ export namespace firebaserules_v1 {
 
 
   export class Resource$Projects$Rulesets {
-    root: Firebaserules;
-    constructor(root: Firebaserules) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -1274,7 +1243,7 @@ export namespace firebaserules_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Ruleset>(parameters, callback);
@@ -1341,7 +1310,7 @@ export namespace firebaserules_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -1403,7 +1372,7 @@ export namespace firebaserules_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Ruleset>(parameters, callback);
@@ -1477,7 +1446,7 @@ export namespace firebaserules_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListRulesetsResponse>(parameters, callback);

--- a/src/apis/firestore/v1.ts
+++ b/src/apis/firestore/v1.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace firestore_v1 {
   export interface Options extends GlobalOptions {
     version: 'v1';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -97,22 +99,12 @@ export namespace firestore_v1 {
    * @param {object=} options Options for Firestore
    */
   export class Firestore {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     projects: Resource$Projects;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.projects = new Resource$Projects(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.projects = new Resource$Projects();
     }
   }
 
@@ -647,36 +639,22 @@ export namespace firestore_v1 {
 
 
   export class Resource$Projects {
-    root: Firestore;
     databases: Resource$Projects$Databases;
     locations: Resource$Projects$Locations;
-    constructor(root: Firestore) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.databases = new Resource$Projects$Databases(root);
-      this.locations = new Resource$Projects$Locations(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.databases = new Resource$Projects$Databases();
+      this.locations = new Resource$Projects$Locations();
     }
   }
 
 
   export class Resource$Projects$Databases {
-    root: Firestore;
     collectionGroups: Resource$Projects$Databases$Collectiongroups;
     operations: Resource$Projects$Databases$Operations;
-    constructor(root: Firestore) {
-      this.root = root;
-      this.getRoot.bind(this);
+    constructor() {
       this.collectionGroups =
-          new Resource$Projects$Databases$Collectiongroups(root);
-      this.operations = new Resource$Projects$Databases$Operations(root);
-    }
-
-    getRoot() {
-      return this.root;
+          new Resource$Projects$Databases$Collectiongroups();
+      this.operations = new Resource$Projects$Databases$Operations();
     }
 
 
@@ -751,7 +729,7 @@ export namespace firestore_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleLongrunningOperation>(
@@ -831,7 +809,7 @@ export namespace firestore_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleLongrunningOperation>(
@@ -880,34 +858,17 @@ export namespace firestore_v1 {
   }
 
   export class Resource$Projects$Databases$Collectiongroups {
-    root: Firestore;
     fields: Resource$Projects$Databases$Collectiongroups$Fields;
     indexes: Resource$Projects$Databases$Collectiongroups$Indexes;
-    constructor(root: Firestore) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.fields =
-          new Resource$Projects$Databases$Collectiongroups$Fields(root);
-      this.indexes =
-          new Resource$Projects$Databases$Collectiongroups$Indexes(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.fields = new Resource$Projects$Databases$Collectiongroups$Fields();
+      this.indexes = new Resource$Projects$Databases$Collectiongroups$Indexes();
     }
   }
 
 
   export class Resource$Projects$Databases$Collectiongroups$Fields {
-    root: Firestore;
-    constructor(root: Firestore) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -969,7 +930,7 @@ export namespace firestore_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleFirestoreAdminV1Field>(
@@ -1053,7 +1014,7 @@ export namespace firestore_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleFirestoreAdminV1ListFieldsResponse>(
@@ -1142,7 +1103,7 @@ export namespace firestore_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleLongrunningOperation>(
@@ -1238,15 +1199,7 @@ export namespace firestore_v1 {
 
 
   export class Resource$Projects$Databases$Collectiongroups$Indexes {
-    root: Firestore;
-    constructor(root: Firestore) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -1320,7 +1273,7 @@ export namespace firestore_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleLongrunningOperation>(
@@ -1391,7 +1344,7 @@ export namespace firestore_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -1461,7 +1414,7 @@ export namespace firestore_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleFirestoreAdminV1Index>(
@@ -1543,7 +1496,7 @@ export namespace firestore_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleFirestoreAdminV1ListIndexesResponse>(
@@ -1630,15 +1583,7 @@ export namespace firestore_v1 {
 
 
   export class Resource$Projects$Databases$Operations {
-    root: Firestore;
-    constructor(root: Firestore) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -1706,7 +1651,7 @@ export namespace firestore_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -1774,7 +1719,7 @@ export namespace firestore_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -1843,7 +1788,7 @@ export namespace firestore_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleLongrunningOperation>(
@@ -1928,7 +1873,7 @@ export namespace firestore_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleLongrunningListOperationsResponse>(
@@ -2009,15 +1954,7 @@ export namespace firestore_v1 {
 
 
   export class Resource$Projects$Locations {
-    root: Firestore;
-    constructor(root: Firestore) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -2071,7 +2008,7 @@ export namespace firestore_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Location>(parameters, callback);
@@ -2142,7 +2079,7 @@ export namespace firestore_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListLocationsResponse>(parameters, callback);

--- a/src/apis/firestore/v1beta1.ts
+++ b/src/apis/firestore/v1beta1.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace firestore_v1beta1 {
   export interface Options extends GlobalOptions {
     version: 'v1beta1';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -97,22 +99,12 @@ export namespace firestore_v1beta1 {
    * @param {object=} options Options for Firestore
    */
   export class Firestore {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     projects: Resource$Projects;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.projects = new Resource$Projects(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.projects = new Resource$Projects();
     }
   }
 
@@ -1393,33 +1385,19 @@ export namespace firestore_v1beta1 {
 
 
   export class Resource$Projects {
-    root: Firestore;
     databases: Resource$Projects$Databases;
-    constructor(root: Firestore) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.databases = new Resource$Projects$Databases(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.databases = new Resource$Projects$Databases();
     }
   }
 
 
   export class Resource$Projects$Databases {
-    root: Firestore;
     documents: Resource$Projects$Databases$Documents;
     indexes: Resource$Projects$Databases$Indexes;
-    constructor(root: Firestore) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.documents = new Resource$Projects$Databases$Documents(root);
-      this.indexes = new Resource$Projects$Databases$Indexes(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.documents = new Resource$Projects$Databases$Documents();
+      this.indexes = new Resource$Projects$Databases$Indexes();
     }
 
 
@@ -1494,7 +1472,7 @@ export namespace firestore_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleLongrunningOperation>(
@@ -1574,7 +1552,7 @@ export namespace firestore_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleLongrunningOperation>(
@@ -1623,15 +1601,7 @@ export namespace firestore_v1beta1 {
   }
 
   export class Resource$Projects$Databases$Documents {
-    root: Firestore;
-    constructor(root: Firestore) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -1697,7 +1667,7 @@ export namespace firestore_v1beta1 {
         params,
         requiredParams: ['database'],
         pathParams: ['database'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$BatchGetDocumentsResponse>(
@@ -1770,7 +1740,7 @@ export namespace firestore_v1beta1 {
         params,
         requiredParams: ['database'],
         pathParams: ['database'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$BeginTransactionResponse>(parameters, callback);
@@ -1838,7 +1808,7 @@ export namespace firestore_v1beta1 {
         params,
         requiredParams: ['database'],
         pathParams: ['database'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$CommitResponse>(parameters, callback);
@@ -1910,7 +1880,7 @@ export namespace firestore_v1beta1 {
         params,
         requiredParams: ['parent', 'collectionId'],
         pathParams: ['collectionId', 'parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Document>(parameters, callback);
@@ -1977,7 +1947,7 @@ export namespace firestore_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -2041,7 +2011,7 @@ export namespace firestore_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Document>(parameters, callback);
@@ -2117,7 +2087,7 @@ export namespace firestore_v1beta1 {
         params,
         requiredParams: ['parent', 'collectionId'],
         pathParams: ['collectionId', 'parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListDocumentsResponse>(parameters, callback);
@@ -2190,7 +2160,7 @@ export namespace firestore_v1beta1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListCollectionIdsResponse>(
@@ -2259,7 +2229,7 @@ export namespace firestore_v1beta1 {
         params,
         requiredParams: ['database'],
         pathParams: ['database'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListenResponse>(parameters, callback);
@@ -2329,7 +2299,7 @@ export namespace firestore_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Document>(parameters, callback);
@@ -2397,7 +2367,7 @@ export namespace firestore_v1beta1 {
         params,
         requiredParams: ['database'],
         pathParams: ['database'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -2466,7 +2436,7 @@ export namespace firestore_v1beta1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$RunQueryResponse>(parameters, callback);
@@ -2534,7 +2504,7 @@ export namespace firestore_v1beta1 {
         params,
         requiredParams: ['database'],
         pathParams: ['database'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$WriteResponse>(parameters, callback);
@@ -2875,15 +2845,7 @@ export namespace firestore_v1beta1 {
 
 
   export class Resource$Projects$Databases$Indexes {
-    root: Firestore;
-    constructor(root: Firestore) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -2957,7 +2919,7 @@ export namespace firestore_v1beta1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleLongrunningOperation>(
@@ -3023,7 +2985,7 @@ export namespace firestore_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -3094,7 +3056,7 @@ export namespace firestore_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleFirestoreAdminV1beta1Index>(
@@ -3173,7 +3135,7 @@ export namespace firestore_v1beta1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleFirestoreAdminV1beta1ListIndexesResponse>(

--- a/src/apis/firestore/v1beta2.ts
+++ b/src/apis/firestore/v1beta2.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace firestore_v1beta2 {
   export interface Options extends GlobalOptions {
     version: 'v1beta2';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -97,22 +99,12 @@ export namespace firestore_v1beta2 {
    * @param {object=} options Options for Firestore
    */
   export class Firestore {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     projects: Resource$Projects;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.projects = new Resource$Projects(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.projects = new Resource$Projects();
     }
   }
 
@@ -584,32 +576,18 @@ export namespace firestore_v1beta2 {
 
 
   export class Resource$Projects {
-    root: Firestore;
     databases: Resource$Projects$Databases;
-    constructor(root: Firestore) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.databases = new Resource$Projects$Databases(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.databases = new Resource$Projects$Databases();
     }
   }
 
 
   export class Resource$Projects$Databases {
-    root: Firestore;
     collectionGroups: Resource$Projects$Databases$Collectiongroups;
-    constructor(root: Firestore) {
-      this.root = root;
-      this.getRoot.bind(this);
+    constructor() {
       this.collectionGroups =
-          new Resource$Projects$Databases$Collectiongroups(root);
-    }
-
-    getRoot() {
-      return this.root;
+          new Resource$Projects$Databases$Collectiongroups();
     }
 
 
@@ -684,7 +662,7 @@ export namespace firestore_v1beta2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleLongrunningOperation>(
@@ -764,7 +742,7 @@ export namespace firestore_v1beta2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleLongrunningOperation>(
@@ -813,34 +791,17 @@ export namespace firestore_v1beta2 {
   }
 
   export class Resource$Projects$Databases$Collectiongroups {
-    root: Firestore;
     fields: Resource$Projects$Databases$Collectiongroups$Fields;
     indexes: Resource$Projects$Databases$Collectiongroups$Indexes;
-    constructor(root: Firestore) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.fields =
-          new Resource$Projects$Databases$Collectiongroups$Fields(root);
-      this.indexes =
-          new Resource$Projects$Databases$Collectiongroups$Indexes(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.fields = new Resource$Projects$Databases$Collectiongroups$Fields();
+      this.indexes = new Resource$Projects$Databases$Collectiongroups$Indexes();
     }
   }
 
 
   export class Resource$Projects$Databases$Collectiongroups$Fields {
-    root: Firestore;
-    constructor(root: Firestore) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -906,7 +867,7 @@ export namespace firestore_v1beta2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleFirestoreAdminV1beta2Field>(
@@ -992,7 +953,7 @@ export namespace firestore_v1beta2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleFirestoreAdminV1beta2ListFieldsResponse>(
@@ -1081,7 +1042,7 @@ export namespace firestore_v1beta2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleLongrunningOperation>(
@@ -1177,15 +1138,7 @@ export namespace firestore_v1beta2 {
 
 
   export class Resource$Projects$Databases$Collectiongroups$Indexes {
-    root: Firestore;
-    constructor(root: Firestore) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -1259,7 +1212,7 @@ export namespace firestore_v1beta2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleLongrunningOperation>(
@@ -1330,7 +1283,7 @@ export namespace firestore_v1beta2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -1404,7 +1357,7 @@ export namespace firestore_v1beta2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleFirestoreAdminV1beta2Index>(
@@ -1488,7 +1441,7 @@ export namespace firestore_v1beta2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleFirestoreAdminV1beta2ListIndexesResponse>(

--- a/src/apis/fitness/v1.ts
+++ b/src/apis/fitness/v1.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace fitness_v1 {
   export interface Options extends GlobalOptions {
     version: 'v1';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -80,22 +82,12 @@ export namespace fitness_v1 {
    * @param {object=} options Options for Fitness
    */
   export class Fitness {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     users: Resource$Users;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.users = new Resource$Users(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.users = new Resource$Users();
     }
   }
 
@@ -647,34 +639,19 @@ export namespace fitness_v1 {
 
 
   export class Resource$Users {
-    root: Fitness;
     dataset: Resource$Users$Dataset;
     dataSources: Resource$Users$Datasources;
     sessions: Resource$Users$Sessions;
-    constructor(root: Fitness) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.dataset = new Resource$Users$Dataset(root);
-      this.dataSources = new Resource$Users$Datasources(root);
-      this.sessions = new Resource$Users$Sessions(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.dataset = new Resource$Users$Dataset();
+      this.dataSources = new Resource$Users$Datasources();
+      this.sessions = new Resource$Users$Sessions();
     }
   }
 
 
   export class Resource$Users$Dataset {
-    root: Fitness;
-    constructor(root: Fitness) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -738,7 +715,7 @@ export namespace fitness_v1 {
         params,
         requiredParams: ['userId'],
         pathParams: ['userId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$AggregateResponse>(parameters, callback);
@@ -769,19 +746,11 @@ export namespace fitness_v1 {
 
 
   export class Resource$Users$Datasources {
-    root: Fitness;
     dataPointChanges: Resource$Users$Datasources$Datapointchanges;
     datasets: Resource$Users$Datasources$Datasets;
-    constructor(root: Fitness) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.dataPointChanges =
-          new Resource$Users$Datasources$Datapointchanges(root);
-      this.datasets = new Resource$Users$Datasources$Datasets(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.dataPointChanges = new Resource$Users$Datasources$Datapointchanges();
+      this.datasets = new Resource$Users$Datasources$Datasets();
     }
 
 
@@ -850,7 +819,7 @@ export namespace fitness_v1 {
         params,
         requiredParams: ['userId'],
         pathParams: ['userId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$DataSource>(parameters, callback);
@@ -920,7 +889,7 @@ export namespace fitness_v1 {
         params,
         requiredParams: ['userId', 'dataSourceId'],
         pathParams: ['dataSourceId', 'userId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$DataSource>(parameters, callback);
@@ -985,7 +954,7 @@ export namespace fitness_v1 {
         params,
         requiredParams: ['userId', 'dataSourceId'],
         pathParams: ['dataSourceId', 'userId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$DataSource>(parameters, callback);
@@ -1057,7 +1026,7 @@ export namespace fitness_v1 {
         params,
         requiredParams: ['userId'],
         pathParams: ['userId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListDataSourcesResponse>(parameters, callback);
@@ -1130,7 +1099,7 @@ export namespace fitness_v1 {
         params,
         requiredParams: ['userId', 'dataSourceId'],
         pathParams: ['dataSourceId', 'userId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$DataSource>(parameters, callback);
@@ -1203,7 +1172,7 @@ export namespace fitness_v1 {
         params,
         requiredParams: ['userId', 'dataSourceId'],
         pathParams: ['dataSourceId', 'userId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$DataSource>(parameters, callback);
@@ -1329,15 +1298,7 @@ export namespace fitness_v1 {
   }
 
   export class Resource$Users$Datasources$Datapointchanges {
-    root: Fitness;
-    constructor(root: Fitness) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -1408,7 +1369,7 @@ export namespace fitness_v1 {
         params,
         requiredParams: ['userId', 'dataSourceId'],
         pathParams: ['dataSourceId', 'userId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListDataPointChangesResponse>(
@@ -1451,15 +1412,7 @@ export namespace fitness_v1 {
 
 
   export class Resource$Users$Datasources$Datasets {
-    root: Fitness;
-    constructor(root: Fitness) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -1529,7 +1482,7 @@ export namespace fitness_v1 {
         params,
         requiredParams: ['userId', 'dataSourceId', 'datasetId'],
         pathParams: ['datasetId', 'dataSourceId', 'userId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -1601,7 +1554,7 @@ export namespace fitness_v1 {
         params,
         requiredParams: ['userId', 'dataSourceId', 'datasetId'],
         pathParams: ['datasetId', 'dataSourceId', 'userId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Dataset>(parameters, callback);
@@ -1676,7 +1629,7 @@ export namespace fitness_v1 {
         params,
         requiredParams: ['userId', 'dataSourceId', 'datasetId'],
         pathParams: ['datasetId', 'dataSourceId', 'userId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Dataset>(parameters, callback);
@@ -1795,15 +1748,7 @@ export namespace fitness_v1 {
 
 
   export class Resource$Users$Sessions {
-    root: Fitness;
-    constructor(root: Fitness) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -1863,7 +1808,7 @@ export namespace fitness_v1 {
         params,
         requiredParams: ['userId', 'sessionId'],
         pathParams: ['sessionId', 'userId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -1934,7 +1879,7 @@ export namespace fitness_v1 {
         params,
         requiredParams: ['userId'],
         pathParams: ['userId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListSessionsResponse>(parameters, callback);
@@ -2003,7 +1948,7 @@ export namespace fitness_v1 {
         params,
         requiredParams: ['userId', 'sessionId'],
         pathParams: ['sessionId', 'userId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Session>(parameters, callback);

--- a/src/apis/fusiontables/v1.ts
+++ b/src/apis/fusiontables/v1.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace fusiontables_v1 {
   export interface Options extends GlobalOptions {
     version: 'v1';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -79,10 +81,6 @@ export namespace fusiontables_v1 {
    * @param {object=} options Options for Fusiontables
    */
   export class Fusiontables {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     column: Resource$Column;
     query: Resource$Query;
     style: Resource$Style;
@@ -91,20 +89,14 @@ export namespace fusiontables_v1 {
     template: Resource$Template;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.column = new Resource$Column(this);
-      this.query = new Resource$Query(this);
-      this.style = new Resource$Style(this);
-      this.table = new Resource$Table(this);
-      this.task = new Resource$Task(this);
-      this.template = new Resource$Template(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.column = new Resource$Column();
+      this.query = new Resource$Query();
+      this.style = new Resource$Style();
+      this.table = new Resource$Table();
+      this.task = new Resource$Task();
+      this.template = new Resource$Template();
     }
   }
 
@@ -634,15 +626,7 @@ export namespace fusiontables_v1 {
 
 
   export class Resource$Column {
-    root: Fusiontables;
-    constructor(root: Fusiontables) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -700,7 +684,7 @@ export namespace fusiontables_v1 {
         params,
         requiredParams: ['tableId', 'columnId'],
         pathParams: ['columnId', 'tableId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -763,7 +747,7 @@ export namespace fusiontables_v1 {
         params,
         requiredParams: ['tableId', 'columnId'],
         pathParams: ['columnId', 'tableId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Column>(parameters, callback);
@@ -828,7 +812,7 @@ export namespace fusiontables_v1 {
         params,
         requiredParams: ['tableId'],
         pathParams: ['tableId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Column>(parameters, callback);
@@ -895,7 +879,7 @@ export namespace fusiontables_v1 {
         params,
         requiredParams: ['tableId'],
         pathParams: ['tableId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ColumnList>(parameters, callback);
@@ -963,7 +947,7 @@ export namespace fusiontables_v1 {
         params,
         requiredParams: ['tableId', 'columnId'],
         pathParams: ['columnId', 'tableId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Column>(parameters, callback);
@@ -1030,7 +1014,7 @@ export namespace fusiontables_v1 {
         params,
         requiredParams: ['tableId', 'columnId'],
         pathParams: ['columnId', 'tableId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Column>(parameters, callback);
@@ -1148,15 +1132,7 @@ export namespace fusiontables_v1 {
 
 
   export class Resource$Query {
-    root: Fusiontables;
-    constructor(root: Fusiontables) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -1214,7 +1190,7 @@ export namespace fusiontables_v1 {
         params,
         requiredParams: ['sql'],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Sqlresponse>(parameters, callback);
@@ -1281,7 +1257,7 @@ export namespace fusiontables_v1 {
         params,
         requiredParams: ['sql'],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Sqlresponse>(parameters, callback);
@@ -1334,15 +1310,7 @@ export namespace fusiontables_v1 {
 
 
   export class Resource$Style {
-    root: Fusiontables;
-    constructor(root: Fusiontables) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -1400,7 +1368,7 @@ export namespace fusiontables_v1 {
         params,
         requiredParams: ['tableId', 'styleId'],
         pathParams: ['styleId', 'tableId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -1464,7 +1432,7 @@ export namespace fusiontables_v1 {
         params,
         requiredParams: ['tableId', 'styleId'],
         pathParams: ['styleId', 'tableId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$StyleSetting>(parameters, callback);
@@ -1530,7 +1498,7 @@ export namespace fusiontables_v1 {
         params,
         requiredParams: ['tableId'],
         pathParams: ['tableId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$StyleSetting>(parameters, callback);
@@ -1597,7 +1565,7 @@ export namespace fusiontables_v1 {
         params,
         requiredParams: ['tableId'],
         pathParams: ['tableId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$StyleSettingList>(parameters, callback);
@@ -1665,7 +1633,7 @@ export namespace fusiontables_v1 {
         params,
         requiredParams: ['tableId', 'styleId'],
         pathParams: ['styleId', 'tableId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$StyleSetting>(parameters, callback);
@@ -1733,7 +1701,7 @@ export namespace fusiontables_v1 {
         params,
         requiredParams: ['tableId', 'styleId'],
         pathParams: ['styleId', 'tableId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$StyleSetting>(parameters, callback);
@@ -1851,15 +1819,7 @@ export namespace fusiontables_v1 {
 
 
   export class Resource$Table {
-    root: Fusiontables;
-    constructor(root: Fusiontables) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -1917,7 +1877,7 @@ export namespace fusiontables_v1 {
         params,
         requiredParams: ['tableId'],
         pathParams: ['tableId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Table>(parameters, callback);
@@ -1980,7 +1940,7 @@ export namespace fusiontables_v1 {
         params,
         requiredParams: ['tableId'],
         pathParams: ['tableId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -2041,7 +2001,7 @@ export namespace fusiontables_v1 {
         params,
         requiredParams: ['tableId'],
         pathParams: ['tableId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Table>(parameters, callback);
@@ -2116,7 +2076,7 @@ export namespace fusiontables_v1 {
                       .replace(/([^:]\/)\/+/g, '$1'),
         requiredParams: ['tableId'],
         pathParams: ['tableId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Import>(parameters, callback);
@@ -2189,7 +2149,7 @@ export namespace fusiontables_v1 {
                       .replace(/([^:]\/)\/+/g, '$1'),
         requiredParams: ['name'],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Table>(parameters, callback);
@@ -2253,7 +2213,7 @@ export namespace fusiontables_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Table>(parameters, callback);
@@ -2319,7 +2279,7 @@ export namespace fusiontables_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TableList>(parameters, callback);
@@ -2387,7 +2347,7 @@ export namespace fusiontables_v1 {
         params,
         requiredParams: ['tableId'],
         pathParams: ['tableId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Table>(parameters, callback);
@@ -2454,7 +2414,7 @@ export namespace fusiontables_v1 {
         params,
         requiredParams: ['tableId'],
         pathParams: ['tableId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Table>(parameters, callback);
@@ -2672,15 +2632,7 @@ export namespace fusiontables_v1 {
 
 
   export class Resource$Task {
-    root: Fusiontables;
-    constructor(root: Fusiontables) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -2738,7 +2690,7 @@ export namespace fusiontables_v1 {
         params,
         requiredParams: ['tableId', 'taskId'],
         pathParams: ['tableId', 'taskId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -2801,7 +2753,7 @@ export namespace fusiontables_v1 {
         params,
         requiredParams: ['tableId', 'taskId'],
         pathParams: ['tableId', 'taskId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Task>(parameters, callback);
@@ -2868,7 +2820,7 @@ export namespace fusiontables_v1 {
         params,
         requiredParams: ['tableId'],
         pathParams: ['tableId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TaskList>(parameters, callback);
@@ -2934,15 +2886,7 @@ export namespace fusiontables_v1 {
 
 
   export class Resource$Template {
-    root: Fusiontables;
-    constructor(root: Fusiontables) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -3000,7 +2944,7 @@ export namespace fusiontables_v1 {
         params,
         requiredParams: ['tableId', 'templateId'],
         pathParams: ['tableId', 'templateId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -3063,7 +3007,7 @@ export namespace fusiontables_v1 {
         params,
         requiredParams: ['tableId', 'templateId'],
         pathParams: ['tableId', 'templateId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Template>(parameters, callback);
@@ -3128,7 +3072,7 @@ export namespace fusiontables_v1 {
         params,
         requiredParams: ['tableId'],
         pathParams: ['tableId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Template>(parameters, callback);
@@ -3195,7 +3139,7 @@ export namespace fusiontables_v1 {
         params,
         requiredParams: ['tableId'],
         pathParams: ['tableId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TemplateList>(parameters, callback);
@@ -3262,7 +3206,7 @@ export namespace fusiontables_v1 {
         params,
         requiredParams: ['tableId', 'templateId'],
         pathParams: ['tableId', 'templateId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Template>(parameters, callback);
@@ -3329,7 +3273,7 @@ export namespace fusiontables_v1 {
         params,
         requiredParams: ['tableId', 'templateId'],
         pathParams: ['tableId', 'templateId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Template>(parameters, callback);

--- a/src/apis/fusiontables/v2.ts
+++ b/src/apis/fusiontables/v2.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace fusiontables_v2 {
   export interface Options extends GlobalOptions {
     version: 'v2';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -79,10 +81,6 @@ export namespace fusiontables_v2 {
    * @param {object=} options Options for Fusiontables
    */
   export class Fusiontables {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     column: Resource$Column;
     query: Resource$Query;
     style: Resource$Style;
@@ -91,20 +89,14 @@ export namespace fusiontables_v2 {
     template: Resource$Template;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.column = new Resource$Column(this);
-      this.query = new Resource$Query(this);
-      this.style = new Resource$Style(this);
-      this.table = new Resource$Table(this);
-      this.task = new Resource$Task(this);
-      this.template = new Resource$Template(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.column = new Resource$Column();
+      this.query = new Resource$Query();
+      this.style = new Resource$Style();
+      this.table = new Resource$Table();
+      this.task = new Resource$Task();
+      this.template = new Resource$Template();
     }
   }
 
@@ -692,15 +684,7 @@ export namespace fusiontables_v2 {
 
 
   export class Resource$Column {
-    root: Fusiontables;
-    constructor(root: Fusiontables) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -758,7 +742,7 @@ export namespace fusiontables_v2 {
         params,
         requiredParams: ['tableId', 'columnId'],
         pathParams: ['columnId', 'tableId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -821,7 +805,7 @@ export namespace fusiontables_v2 {
         params,
         requiredParams: ['tableId', 'columnId'],
         pathParams: ['columnId', 'tableId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Column>(parameters, callback);
@@ -886,7 +870,7 @@ export namespace fusiontables_v2 {
         params,
         requiredParams: ['tableId'],
         pathParams: ['tableId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Column>(parameters, callback);
@@ -953,7 +937,7 @@ export namespace fusiontables_v2 {
         params,
         requiredParams: ['tableId'],
         pathParams: ['tableId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ColumnList>(parameters, callback);
@@ -1021,7 +1005,7 @@ export namespace fusiontables_v2 {
         params,
         requiredParams: ['tableId', 'columnId'],
         pathParams: ['columnId', 'tableId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Column>(parameters, callback);
@@ -1088,7 +1072,7 @@ export namespace fusiontables_v2 {
         params,
         requiredParams: ['tableId', 'columnId'],
         pathParams: ['columnId', 'tableId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Column>(parameters, callback);
@@ -1206,15 +1190,7 @@ export namespace fusiontables_v2 {
 
 
   export class Resource$Query {
-    root: Fusiontables;
-    constructor(root: Fusiontables) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -1272,7 +1248,7 @@ export namespace fusiontables_v2 {
         params,
         requiredParams: ['sql'],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Sqlresponse>(parameters, callback);
@@ -1340,7 +1316,7 @@ export namespace fusiontables_v2 {
         params,
         requiredParams: ['sql'],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Sqlresponse>(parameters, callback);
@@ -1394,15 +1370,7 @@ export namespace fusiontables_v2 {
 
 
   export class Resource$Style {
-    root: Fusiontables;
-    constructor(root: Fusiontables) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -1460,7 +1428,7 @@ export namespace fusiontables_v2 {
         params,
         requiredParams: ['tableId', 'styleId'],
         pathParams: ['styleId', 'tableId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -1524,7 +1492,7 @@ export namespace fusiontables_v2 {
         params,
         requiredParams: ['tableId', 'styleId'],
         pathParams: ['styleId', 'tableId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$StyleSetting>(parameters, callback);
@@ -1590,7 +1558,7 @@ export namespace fusiontables_v2 {
         params,
         requiredParams: ['tableId'],
         pathParams: ['tableId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$StyleSetting>(parameters, callback);
@@ -1657,7 +1625,7 @@ export namespace fusiontables_v2 {
         params,
         requiredParams: ['tableId'],
         pathParams: ['tableId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$StyleSettingList>(parameters, callback);
@@ -1725,7 +1693,7 @@ export namespace fusiontables_v2 {
         params,
         requiredParams: ['tableId', 'styleId'],
         pathParams: ['styleId', 'tableId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$StyleSetting>(parameters, callback);
@@ -1793,7 +1761,7 @@ export namespace fusiontables_v2 {
         params,
         requiredParams: ['tableId', 'styleId'],
         pathParams: ['styleId', 'tableId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$StyleSetting>(parameters, callback);
@@ -1911,15 +1879,7 @@ export namespace fusiontables_v2 {
 
 
   export class Resource$Table {
-    root: Fusiontables;
-    constructor(root: Fusiontables) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -1977,7 +1937,7 @@ export namespace fusiontables_v2 {
         params,
         requiredParams: ['tableId'],
         pathParams: ['tableId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Table>(parameters, callback);
@@ -2040,7 +2000,7 @@ export namespace fusiontables_v2 {
         params,
         requiredParams: ['tableId'],
         pathParams: ['tableId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -2101,7 +2061,7 @@ export namespace fusiontables_v2 {
         params,
         requiredParams: ['tableId'],
         pathParams: ['tableId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Table>(parameters, callback);
@@ -2176,7 +2136,7 @@ export namespace fusiontables_v2 {
                       .replace(/([^:]\/)\/+/g, '$1'),
         requiredParams: ['tableId'],
         pathParams: ['tableId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Import>(parameters, callback);
@@ -2249,7 +2209,7 @@ export namespace fusiontables_v2 {
                       .replace(/([^:]\/)\/+/g, '$1'),
         requiredParams: ['name'],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Table>(parameters, callback);
@@ -2313,7 +2273,7 @@ export namespace fusiontables_v2 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Table>(parameters, callback);
@@ -2379,7 +2339,7 @@ export namespace fusiontables_v2 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TableList>(parameters, callback);
@@ -2447,7 +2407,7 @@ export namespace fusiontables_v2 {
         params,
         requiredParams: ['tableId'],
         pathParams: ['tableId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Table>(parameters, callback);
@@ -2515,7 +2475,7 @@ export namespace fusiontables_v2 {
         params,
         requiredParams: ['tableId'],
         pathParams: ['tableId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Task>(parameters, callback);
@@ -2592,7 +2552,7 @@ export namespace fusiontables_v2 {
                       .replace(/([^:]\/)\/+/g, '$1'),
         requiredParams: ['tableId'],
         pathParams: ['tableId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Task>(parameters, callback);
@@ -2659,7 +2619,7 @@ export namespace fusiontables_v2 {
         params,
         requiredParams: ['tableId'],
         pathParams: ['tableId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Table>(parameters, callback);
@@ -2942,15 +2902,7 @@ export namespace fusiontables_v2 {
 
 
   export class Resource$Task {
-    root: Fusiontables;
-    constructor(root: Fusiontables) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -3009,7 +2961,7 @@ export namespace fusiontables_v2 {
         params,
         requiredParams: ['tableId', 'taskId'],
         pathParams: ['tableId', 'taskId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -3072,7 +3024,7 @@ export namespace fusiontables_v2 {
         params,
         requiredParams: ['tableId', 'taskId'],
         pathParams: ['tableId', 'taskId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Task>(parameters, callback);
@@ -3139,7 +3091,7 @@ export namespace fusiontables_v2 {
         params,
         requiredParams: ['tableId'],
         pathParams: ['tableId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TaskList>(parameters, callback);
@@ -3205,15 +3157,7 @@ export namespace fusiontables_v2 {
 
 
   export class Resource$Template {
-    root: Fusiontables;
-    constructor(root: Fusiontables) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -3271,7 +3215,7 @@ export namespace fusiontables_v2 {
         params,
         requiredParams: ['tableId', 'templateId'],
         pathParams: ['tableId', 'templateId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -3334,7 +3278,7 @@ export namespace fusiontables_v2 {
         params,
         requiredParams: ['tableId', 'templateId'],
         pathParams: ['tableId', 'templateId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Template>(parameters, callback);
@@ -3399,7 +3343,7 @@ export namespace fusiontables_v2 {
         params,
         requiredParams: ['tableId'],
         pathParams: ['tableId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Template>(parameters, callback);
@@ -3466,7 +3410,7 @@ export namespace fusiontables_v2 {
         params,
         requiredParams: ['tableId'],
         pathParams: ['tableId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TemplateList>(parameters, callback);
@@ -3533,7 +3477,7 @@ export namespace fusiontables_v2 {
         params,
         requiredParams: ['tableId', 'templateId'],
         pathParams: ['tableId', 'templateId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Template>(parameters, callback);
@@ -3600,7 +3544,7 @@ export namespace fusiontables_v2 {
         params,
         requiredParams: ['tableId', 'templateId'],
         pathParams: ['tableId', 'templateId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Template>(parameters, callback);

--- a/src/apis/games/v1.ts
+++ b/src/apis/games/v1.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace games_v1 {
   export interface Options extends GlobalOptions {
     version: 'v1';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -79,10 +81,6 @@ export namespace games_v1 {
    * @param {object=} options Options for Games
    */
   export class Games {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     achievementDefinitions: Resource$Achievementdefinitions;
     achievements: Resource$Achievements;
     applications: Resource$Applications;
@@ -100,29 +98,23 @@ export namespace games_v1 {
     turnBasedMatches: Resource$Turnbasedmatches;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.achievementDefinitions = new Resource$Achievementdefinitions(this);
-      this.achievements = new Resource$Achievements(this);
-      this.applications = new Resource$Applications(this);
-      this.events = new Resource$Events(this);
-      this.leaderboards = new Resource$Leaderboards(this);
-      this.metagame = new Resource$Metagame(this);
-      this.players = new Resource$Players(this);
-      this.pushtokens = new Resource$Pushtokens(this);
-      this.questMilestones = new Resource$Questmilestones(this);
-      this.quests = new Resource$Quests(this);
-      this.revisions = new Resource$Revisions(this);
-      this.rooms = new Resource$Rooms(this);
-      this.scores = new Resource$Scores(this);
-      this.snapshots = new Resource$Snapshots(this);
-      this.turnBasedMatches = new Resource$Turnbasedmatches(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.achievementDefinitions = new Resource$Achievementdefinitions();
+      this.achievements = new Resource$Achievements();
+      this.applications = new Resource$Applications();
+      this.events = new Resource$Events();
+      this.leaderboards = new Resource$Leaderboards();
+      this.metagame = new Resource$Metagame();
+      this.players = new Resource$Players();
+      this.pushtokens = new Resource$Pushtokens();
+      this.questMilestones = new Resource$Questmilestones();
+      this.quests = new Resource$Quests();
+      this.revisions = new Resource$Revisions();
+      this.rooms = new Resource$Rooms();
+      this.scores = new Resource$Scores();
+      this.snapshots = new Resource$Snapshots();
+      this.turnBasedMatches = new Resource$Turnbasedmatches();
     }
   }
 
@@ -2953,15 +2945,7 @@ export namespace games_v1 {
 
 
   export class Resource$Achievementdefinitions {
-    root: Games;
-    constructor(root: Games) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -3032,7 +3016,7 @@ export namespace games_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$AchievementDefinitionsListResponse>(
@@ -3069,15 +3053,7 @@ export namespace games_v1 {
 
 
   export class Resource$Achievements {
-    root: Games;
-    constructor(root: Games) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -3147,7 +3123,7 @@ export namespace games_v1 {
         params,
         requiredParams: ['achievementId', 'stepsToIncrement'],
         pathParams: ['achievementId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$AchievementIncrementResponse>(
@@ -3224,7 +3200,7 @@ export namespace games_v1 {
         params,
         requiredParams: ['playerId'],
         pathParams: ['playerId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$PlayerAchievementListResponse>(
@@ -3296,7 +3272,7 @@ export namespace games_v1 {
         params,
         requiredParams: ['achievementId'],
         pathParams: ['achievementId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$AchievementRevealResponse>(
@@ -3379,7 +3355,7 @@ export namespace games_v1 {
         params,
         requiredParams: ['achievementId', 'steps'],
         pathParams: ['achievementId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$AchievementSetStepsAtLeastResponse>(
@@ -3451,7 +3427,7 @@ export namespace games_v1 {
         params,
         requiredParams: ['achievementId'],
         pathParams: ['achievementId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$AchievementUnlockResponse>(
@@ -3531,7 +3507,7 @@ export namespace games_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$AchievementUpdateMultipleResponse>(
@@ -3661,15 +3637,7 @@ export namespace games_v1 {
 
 
   export class Resource$Applications {
-    root: Games;
-    constructor(root: Games) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -3728,7 +3696,7 @@ export namespace games_v1 {
         params,
         requiredParams: ['applicationId'],
         pathParams: ['applicationId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Application>(parameters, callback);
@@ -3794,7 +3762,7 @@ export namespace games_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -3865,7 +3833,7 @@ export namespace games_v1 {
         params,
         requiredParams: ['applicationId'],
         pathParams: ['applicationId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ApplicationVerifyResponse>(
@@ -3922,15 +3890,7 @@ export namespace games_v1 {
 
 
   export class Resource$Events {
-    root: Games;
-    constructor(root: Games) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -3994,7 +3954,7 @@ export namespace games_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$PlayerEventListResponse>(parameters, callback);
@@ -4069,7 +4029,7 @@ export namespace games_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$EventDefinitionListResponse>(
@@ -4136,7 +4096,7 @@ export namespace games_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$EventUpdateResponse>(parameters, callback);
@@ -4209,15 +4169,7 @@ export namespace games_v1 {
 
 
   export class Resource$Leaderboards {
-    root: Games;
-    constructor(root: Games) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -4273,7 +4225,7 @@ export namespace games_v1 {
         params,
         requiredParams: ['leaderboardId'],
         pathParams: ['leaderboardId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Leaderboard>(parameters, callback);
@@ -4342,7 +4294,7 @@ export namespace games_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$LeaderboardListResponse>(parameters, callback);
@@ -4392,15 +4344,7 @@ export namespace games_v1 {
 
 
   export class Resource$Metagame {
-    root: Games;
-    constructor(root: Games) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -4460,7 +4404,7 @@ export namespace games_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$MetagameConfig>(parameters, callback);
@@ -4535,7 +4479,7 @@ export namespace games_v1 {
         params,
         requiredParams: ['playerId', 'collection'],
         pathParams: ['collection', 'playerId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$CategoryListResponse>(parameters, callback);
@@ -4586,15 +4530,7 @@ export namespace games_v1 {
 
 
   export class Resource$Players {
-    root: Games;
-    constructor(root: Games) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -4650,7 +4586,7 @@ export namespace games_v1 {
         params,
         requiredParams: ['playerId'],
         pathParams: ['playerId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Player>(parameters, callback);
@@ -4718,7 +4654,7 @@ export namespace games_v1 {
         params,
         requiredParams: ['collection'],
         pathParams: ['collection'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$PlayerListResponse>(parameters, callback);
@@ -4772,15 +4708,7 @@ export namespace games_v1 {
 
 
   export class Resource$Pushtokens {
-    root: Games;
-    constructor(root: Games) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -4838,7 +4766,7 @@ export namespace games_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -4902,7 +4830,7 @@ export namespace games_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -4941,15 +4869,7 @@ export namespace games_v1 {
 
 
   export class Resource$Questmilestones {
-    root: Games;
-    constructor(root: Games) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -5012,7 +4932,7 @@ export namespace games_v1 {
         params,
         requiredParams: ['questId', 'milestoneId', 'requestId'],
         pathParams: ['milestoneId', 'questId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -5046,15 +4966,7 @@ export namespace games_v1 {
 
 
   export class Resource$Quests {
-    root: Games;
-    constructor(root: Games) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -5113,7 +5025,7 @@ export namespace games_v1 {
         params,
         requiredParams: ['questId'],
         pathParams: ['questId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Quest>(parameters, callback);
@@ -5182,7 +5094,7 @@ export namespace games_v1 {
         params,
         requiredParams: ['playerId'],
         pathParams: ['playerId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$QuestListResponse>(parameters, callback);
@@ -5237,15 +5149,7 @@ export namespace games_v1 {
 
 
   export class Resource$Revisions {
-    root: Games;
-    constructor(root: Games) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -5304,7 +5208,7 @@ export namespace games_v1 {
         params,
         requiredParams: ['clientRevision'],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$RevisionCheckResponse>(parameters, callback);
@@ -5331,15 +5235,7 @@ export namespace games_v1 {
 
 
   export class Resource$Rooms {
-    root: Games;
-    constructor(root: Games) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -5398,7 +5294,7 @@ export namespace games_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Room>(parameters, callback);
@@ -5464,7 +5360,7 @@ export namespace games_v1 {
         params,
         requiredParams: ['roomId'],
         pathParams: ['roomId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Room>(parameters, callback);
@@ -5528,7 +5424,7 @@ export namespace games_v1 {
         params,
         requiredParams: ['roomId'],
         pathParams: ['roomId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -5590,7 +5486,7 @@ export namespace games_v1 {
         params,
         requiredParams: ['roomId'],
         pathParams: ['roomId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Room>(parameters, callback);
@@ -5657,7 +5553,7 @@ export namespace games_v1 {
         params,
         requiredParams: ['roomId'],
         pathParams: ['roomId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Room>(parameters, callback);
@@ -5724,7 +5620,7 @@ export namespace games_v1 {
         params,
         requiredParams: ['roomId'],
         pathParams: ['roomId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Room>(parameters, callback);
@@ -5789,7 +5685,7 @@ export namespace games_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$RoomList>(parameters, callback);
@@ -5860,7 +5756,7 @@ export namespace games_v1 {
         params,
         requiredParams: ['roomId'],
         pathParams: ['roomId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$RoomStatus>(parameters, callback);
@@ -6012,15 +5908,7 @@ export namespace games_v1 {
 
 
   export class Resource$Scores {
-    root: Games;
-    constructor(root: Games) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -6095,7 +5983,7 @@ export namespace games_v1 {
         params,
         requiredParams: ['playerId', 'leaderboardId', 'timeSpan'],
         pathParams: ['leaderboardId', 'playerId', 'timeSpan'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$PlayerLeaderboardScoreListResponse>(
@@ -6169,7 +6057,7 @@ export namespace games_v1 {
         params,
         requiredParams: ['leaderboardId', 'collection', 'timeSpan'],
         pathParams: ['collection', 'leaderboardId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$LeaderboardScores>(parameters, callback);
@@ -6246,7 +6134,7 @@ export namespace games_v1 {
         params,
         requiredParams: ['leaderboardId', 'collection', 'timeSpan'],
         pathParams: ['collection', 'leaderboardId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$LeaderboardScores>(parameters, callback);
@@ -6314,7 +6202,7 @@ export namespace games_v1 {
         params,
         requiredParams: ['leaderboardId', 'score'],
         pathParams: ['leaderboardId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$PlayerScoreResponse>(parameters, callback);
@@ -6384,7 +6272,7 @@ export namespace games_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$PlayerScoreListResponse>(parameters, callback);
@@ -6563,15 +6451,7 @@ export namespace games_v1 {
 
 
   export class Resource$Snapshots {
-    root: Games;
-    constructor(root: Games) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -6626,7 +6506,7 @@ export namespace games_v1 {
         params,
         requiredParams: ['snapshotId'],
         pathParams: ['snapshotId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Snapshot>(parameters, callback);
@@ -6696,7 +6576,7 @@ export namespace games_v1 {
         params,
         requiredParams: ['playerId'],
         pathParams: ['playerId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$SnapshotListResponse>(parameters, callback);
@@ -6750,15 +6630,7 @@ export namespace games_v1 {
 
 
   export class Resource$Turnbasedmatches {
-    root: Games;
-    constructor(root: Games) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -6816,7 +6688,7 @@ export namespace games_v1 {
         params,
         requiredParams: ['matchId'],
         pathParams: ['matchId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -6884,7 +6756,7 @@ export namespace games_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TurnBasedMatch>(parameters, callback);
@@ -6952,7 +6824,7 @@ export namespace games_v1 {
         params,
         requiredParams: ['matchId'],
         pathParams: ['matchId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TurnBasedMatch>(parameters, callback);
@@ -7018,7 +6890,7 @@ export namespace games_v1 {
         params,
         requiredParams: ['matchId'],
         pathParams: ['matchId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -7089,7 +6961,7 @@ export namespace games_v1 {
         params,
         requiredParams: ['matchId'],
         pathParams: ['matchId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TurnBasedMatch>(parameters, callback);
@@ -7154,7 +7026,7 @@ export namespace games_v1 {
         params,
         requiredParams: ['matchId'],
         pathParams: ['matchId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TurnBasedMatch>(parameters, callback);
@@ -7222,7 +7094,7 @@ export namespace games_v1 {
         params,
         requiredParams: ['matchId'],
         pathParams: ['matchId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TurnBasedMatch>(parameters, callback);
@@ -7291,7 +7163,7 @@ export namespace games_v1 {
         params,
         requiredParams: ['matchId'],
         pathParams: ['matchId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TurnBasedMatch>(parameters, callback);
@@ -7362,7 +7234,7 @@ export namespace games_v1 {
         params,
         requiredParams: ['matchId', 'matchVersion'],
         pathParams: ['matchId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TurnBasedMatch>(parameters, callback);
@@ -7433,7 +7305,7 @@ export namespace games_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TurnBasedMatchList>(parameters, callback);
@@ -7506,7 +7378,7 @@ export namespace games_v1 {
         params,
         requiredParams: ['matchId'],
         pathParams: ['matchId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TurnBasedMatchRematch>(parameters, callback);
@@ -7580,7 +7452,7 @@ export namespace games_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TurnBasedMatchSync>(parameters, callback);
@@ -7649,7 +7521,7 @@ export namespace games_v1 {
         params,
         requiredParams: ['matchId'],
         pathParams: ['matchId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TurnBasedMatch>(parameters, callback);

--- a/src/apis/gamesConfiguration/v1configuration.ts
+++ b/src/apis/gamesConfiguration/v1configuration.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace gamesConfiguration_v1configuration {
   export interface Options extends GlobalOptions {
     version: 'v1configuration';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -79,28 +81,16 @@ export namespace gamesConfiguration_v1configuration {
    * @param {object=} options Options for Gamesconfiguration
    */
   export class Gamesconfiguration {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     achievementConfigurations: Resource$Achievementconfigurations;
     imageConfigurations: Resource$Imageconfigurations;
     leaderboardConfigurations: Resource$Leaderboardconfigurations;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.achievementConfigurations =
-          new Resource$Achievementconfigurations(this);
-      this.imageConfigurations = new Resource$Imageconfigurations(this);
-      this.leaderboardConfigurations =
-          new Resource$Leaderboardconfigurations(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.achievementConfigurations = new Resource$Achievementconfigurations();
+      this.imageConfigurations = new Resource$Imageconfigurations();
+      this.leaderboardConfigurations = new Resource$Leaderboardconfigurations();
     }
   }
 
@@ -401,15 +391,7 @@ export namespace gamesConfiguration_v1configuration {
 
 
   export class Resource$Achievementconfigurations {
-    root: Gamesconfiguration;
-    constructor(root: Gamesconfiguration) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -468,7 +450,7 @@ export namespace gamesConfiguration_v1configuration {
         params,
         requiredParams: ['achievementId'],
         pathParams: ['achievementId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -534,7 +516,7 @@ export namespace gamesConfiguration_v1configuration {
         params,
         requiredParams: ['achievementId'],
         pathParams: ['achievementId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$AchievementConfiguration>(parameters, callback);
@@ -606,7 +588,7 @@ export namespace gamesConfiguration_v1configuration {
         params,
         requiredParams: ['applicationId'],
         pathParams: ['applicationId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$AchievementConfiguration>(parameters, callback);
@@ -687,7 +669,7 @@ export namespace gamesConfiguration_v1configuration {
         params,
         requiredParams: ['applicationId'],
         pathParams: ['applicationId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$AchievementConfigurationListResponse>(
@@ -761,7 +743,7 @@ export namespace gamesConfiguration_v1configuration {
         params,
         requiredParams: ['achievementId'],
         pathParams: ['achievementId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$AchievementConfiguration>(parameters, callback);
@@ -833,7 +815,7 @@ export namespace gamesConfiguration_v1configuration {
         params,
         requiredParams: ['achievementId'],
         pathParams: ['achievementId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$AchievementConfiguration>(parameters, callback);
@@ -943,15 +925,7 @@ export namespace gamesConfiguration_v1configuration {
 
 
   export class Resource$Imageconfigurations {
-    root: Gamesconfiguration;
-    constructor(root: Gamesconfiguration) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -1021,7 +995,7 @@ export namespace gamesConfiguration_v1configuration {
                 .replace(/([^:]\/)\/+/g, '$1'),
         requiredParams: ['resourceId', 'imageType'],
         pathParams: ['imageType', 'resourceId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ImageConfiguration>(parameters, callback);
@@ -1066,15 +1040,7 @@ export namespace gamesConfiguration_v1configuration {
 
 
   export class Resource$Leaderboardconfigurations {
-    root: Gamesconfiguration;
-    constructor(root: Gamesconfiguration) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -1133,7 +1099,7 @@ export namespace gamesConfiguration_v1configuration {
         params,
         requiredParams: ['leaderboardId'],
         pathParams: ['leaderboardId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -1199,7 +1165,7 @@ export namespace gamesConfiguration_v1configuration {
         params,
         requiredParams: ['leaderboardId'],
         pathParams: ['leaderboardId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$LeaderboardConfiguration>(parameters, callback);
@@ -1271,7 +1237,7 @@ export namespace gamesConfiguration_v1configuration {
         params,
         requiredParams: ['applicationId'],
         pathParams: ['applicationId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$LeaderboardConfiguration>(parameters, callback);
@@ -1352,7 +1318,7 @@ export namespace gamesConfiguration_v1configuration {
         params,
         requiredParams: ['applicationId'],
         pathParams: ['applicationId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$LeaderboardConfigurationListResponse>(
@@ -1426,7 +1392,7 @@ export namespace gamesConfiguration_v1configuration {
         params,
         requiredParams: ['leaderboardId'],
         pathParams: ['leaderboardId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$LeaderboardConfiguration>(parameters, callback);
@@ -1498,7 +1464,7 @@ export namespace gamesConfiguration_v1configuration {
         params,
         requiredParams: ['leaderboardId'],
         pathParams: ['leaderboardId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$LeaderboardConfiguration>(parameters, callback);

--- a/src/apis/gamesManagement/v1management.ts
+++ b/src/apis/gamesManagement/v1management.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace gamesManagement_v1management {
   export interface Options extends GlobalOptions {
     version: 'v1management';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -79,10 +81,6 @@ export namespace gamesManagement_v1management {
    * @param {object=} options Options for Gamesmanagement
    */
   export class Gamesmanagement {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     achievements: Resource$Achievements;
     applications: Resource$Applications;
     events: Resource$Events;
@@ -93,22 +91,16 @@ export namespace gamesManagement_v1management {
     turnBasedMatches: Resource$Turnbasedmatches;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.achievements = new Resource$Achievements(this);
-      this.applications = new Resource$Applications(this);
-      this.events = new Resource$Events(this);
-      this.players = new Resource$Players(this);
-      this.quests = new Resource$Quests(this);
-      this.rooms = new Resource$Rooms(this);
-      this.scores = new Resource$Scores(this);
-      this.turnBasedMatches = new Resource$Turnbasedmatches(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.achievements = new Resource$Achievements();
+      this.applications = new Resource$Applications();
+      this.events = new Resource$Events();
+      this.players = new Resource$Players();
+      this.quests = new Resource$Quests();
+      this.rooms = new Resource$Rooms();
+      this.scores = new Resource$Scores();
+      this.turnBasedMatches = new Resource$Turnbasedmatches();
     }
   }
 
@@ -414,15 +406,7 @@ export namespace gamesManagement_v1management {
 
 
   export class Resource$Achievements {
-    root: Gamesmanagement;
-    constructor(root: Gamesmanagement) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -486,7 +470,7 @@ export namespace gamesManagement_v1management {
         params,
         requiredParams: ['achievementId'],
         pathParams: ['achievementId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$AchievementResetResponse>(parameters, callback);
@@ -560,7 +544,7 @@ export namespace gamesManagement_v1management {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$AchievementResetAllResponse>(
@@ -627,7 +611,7 @@ export namespace gamesManagement_v1management {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -696,7 +680,7 @@ export namespace gamesManagement_v1management {
         params,
         requiredParams: ['achievementId'],
         pathParams: ['achievementId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -766,7 +750,7 @@ export namespace gamesManagement_v1management {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -830,15 +814,7 @@ export namespace gamesManagement_v1management {
 
 
   export class Resource$Applications {
-    root: Gamesmanagement;
-    constructor(root: Gamesmanagement) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -903,7 +879,7 @@ export namespace gamesManagement_v1management {
         params,
         requiredParams: ['applicationId'],
         pathParams: ['applicationId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$HiddenPlayerList>(parameters, callback);
@@ -938,15 +914,7 @@ export namespace gamesManagement_v1management {
 
 
   export class Resource$Events {
-    root: Gamesmanagement;
-    constructor(root: Gamesmanagement) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -1005,7 +973,7 @@ export namespace gamesManagement_v1management {
         params,
         requiredParams: ['eventId'],
         pathParams: ['eventId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -1070,7 +1038,7 @@ export namespace gamesManagement_v1management {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -1137,7 +1105,7 @@ export namespace gamesManagement_v1management {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -1205,7 +1173,7 @@ export namespace gamesManagement_v1management {
         params,
         requiredParams: ['eventId'],
         pathParams: ['eventId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -1274,7 +1242,7 @@ export namespace gamesManagement_v1management {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -1336,15 +1304,7 @@ export namespace gamesManagement_v1management {
 
 
   export class Resource$Players {
-    root: Gamesmanagement;
-    constructor(root: Gamesmanagement) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -1405,7 +1365,7 @@ export namespace gamesManagement_v1management {
         params,
         requiredParams: ['applicationId', 'playerId'],
         pathParams: ['applicationId', 'playerId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -1473,7 +1433,7 @@ export namespace gamesManagement_v1management {
         params,
         requiredParams: ['applicationId', 'playerId'],
         pathParams: ['applicationId', 'playerId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -1518,15 +1478,7 @@ export namespace gamesManagement_v1management {
 
 
   export class Resource$Quests {
-    root: Gamesmanagement;
-    constructor(root: Gamesmanagement) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -1584,7 +1536,7 @@ export namespace gamesManagement_v1management {
         params,
         requiredParams: ['questId'],
         pathParams: ['questId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -1648,7 +1600,7 @@ export namespace gamesManagement_v1management {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -1714,7 +1666,7 @@ export namespace gamesManagement_v1management {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -1782,7 +1734,7 @@ export namespace gamesManagement_v1management {
         params,
         requiredParams: ['questId'],
         pathParams: ['questId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -1850,7 +1802,7 @@ export namespace gamesManagement_v1management {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -1912,15 +1864,7 @@ export namespace gamesManagement_v1management {
 
 
   export class Resource$Rooms {
-    root: Gamesmanagement;
-    constructor(root: Gamesmanagement) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -1977,7 +1921,7 @@ export namespace gamesManagement_v1management {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -2043,7 +1987,7 @@ export namespace gamesManagement_v1management {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -2069,15 +2013,7 @@ export namespace gamesManagement_v1management {
 
 
   export class Resource$Scores {
-    root: Gamesmanagement;
-    constructor(root: Gamesmanagement) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -2141,7 +2077,7 @@ export namespace gamesManagement_v1management {
         params,
         requiredParams: ['leaderboardId'],
         pathParams: ['leaderboardId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$PlayerScoreResetResponse>(parameters, callback);
@@ -2212,7 +2148,7 @@ export namespace gamesManagement_v1management {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$PlayerScoreResetAllResponse>(
@@ -2279,7 +2215,7 @@ export namespace gamesManagement_v1management {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -2348,7 +2284,7 @@ export namespace gamesManagement_v1management {
         params,
         requiredParams: ['leaderboardId'],
         pathParams: ['leaderboardId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -2416,7 +2352,7 @@ export namespace gamesManagement_v1management {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -2478,15 +2414,7 @@ export namespace gamesManagement_v1management {
 
 
   export class Resource$Turnbasedmatches {
-    root: Gamesmanagement;
-    constructor(root: Gamesmanagement) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -2544,7 +2472,7 @@ export namespace gamesManagement_v1management {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -2611,7 +2539,7 @@ export namespace gamesManagement_v1management {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);

--- a/src/apis/genomics/v1.ts
+++ b/src/apis/genomics/v1.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace genomics_v1 {
   export interface Options extends GlobalOptions {
     version: 'v1';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -96,10 +98,6 @@ export namespace genomics_v1 {
    * @param {object=} options Options for Genomics
    */
   export class Genomics {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     annotations: Resource$Annotations;
     annotationsets: Resource$Annotationsets;
     callsets: Resource$Callsets;
@@ -113,25 +111,19 @@ export namespace genomics_v1 {
     variantsets: Resource$Variantsets;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.annotations = new Resource$Annotations(this);
-      this.annotationsets = new Resource$Annotationsets(this);
-      this.callsets = new Resource$Callsets(this);
-      this.datasets = new Resource$Datasets(this);
-      this.operations = new Resource$Operations(this);
-      this.readgroupsets = new Resource$Readgroupsets(this);
-      this.reads = new Resource$Reads(this);
-      this.references = new Resource$References(this);
-      this.referencesets = new Resource$Referencesets(this);
-      this.variants = new Resource$Variants(this);
-      this.variantsets = new Resource$Variantsets(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.annotations = new Resource$Annotations();
+      this.annotationsets = new Resource$Annotationsets();
+      this.callsets = new Resource$Callsets();
+      this.datasets = new Resource$Datasets();
+      this.operations = new Resource$Operations();
+      this.readgroupsets = new Resource$Readgroupsets();
+      this.reads = new Resource$Reads();
+      this.references = new Resource$References();
+      this.referencesets = new Resource$Referencesets();
+      this.variants = new Resource$Variants();
+      this.variantsets = new Resource$Variantsets();
     }
   }
 
@@ -2367,15 +2359,7 @@ export namespace genomics_v1 {
 
 
   export class Resource$Annotations {
-    root: Genomics;
-    constructor(root: Genomics) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -2504,7 +2488,7 @@ export namespace genomics_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$BatchCreateAnnotationsResponse>(
@@ -2634,7 +2618,7 @@ export namespace genomics_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Annotation>(parameters, callback);
@@ -2751,7 +2735,7 @@ export namespace genomics_v1 {
         params,
         requiredParams: ['annotationId'],
         pathParams: ['annotationId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -2867,7 +2851,7 @@ export namespace genomics_v1 {
         params,
         requiredParams: ['annotationId'],
         pathParams: ['annotationId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Annotation>(parameters, callback);
@@ -3010,7 +2994,7 @@ export namespace genomics_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$SearchAnnotationsResponse>(
@@ -3140,7 +3124,7 @@ export namespace genomics_v1 {
         params,
         requiredParams: ['annotationId'],
         pathParams: ['annotationId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Annotation>(parameters, callback);
@@ -3238,15 +3222,7 @@ export namespace genomics_v1 {
 
 
   export class Resource$Annotationsets {
-    root: Genomics;
-    constructor(root: Genomics) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -3364,7 +3340,7 @@ export namespace genomics_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$AnnotationSet>(parameters, callback);
@@ -3482,7 +3458,7 @@ export namespace genomics_v1 {
         params,
         requiredParams: ['annotationSetId'],
         pathParams: ['annotationSetId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -3600,7 +3576,7 @@ export namespace genomics_v1 {
         params,
         requiredParams: ['annotationSetId'],
         pathParams: ['annotationSetId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$AnnotationSet>(parameters, callback);
@@ -3745,7 +3721,7 @@ export namespace genomics_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$SearchAnnotationSetsResponse>(
@@ -3878,7 +3854,7 @@ export namespace genomics_v1 {
         params,
         requiredParams: ['annotationSetId'],
         pathParams: ['annotationSetId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$AnnotationSet>(parameters, callback);
@@ -3964,15 +3940,7 @@ export namespace genomics_v1 {
 
 
   export class Resource$Callsets {
-    root: Genomics;
-    constructor(root: Genomics) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -4082,7 +4050,7 @@ export namespace genomics_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$CallSet>(parameters, callback);
@@ -4196,7 +4164,7 @@ export namespace genomics_v1 {
         params,
         requiredParams: ['callSetId'],
         pathParams: ['callSetId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -4310,7 +4278,7 @@ export namespace genomics_v1 {
         params,
         requiredParams: ['callSetId'],
         pathParams: ['callSetId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$CallSet>(parameters, callback);
@@ -4435,7 +4403,7 @@ export namespace genomics_v1 {
         params,
         requiredParams: ['callSetId'],
         pathParams: ['callSetId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$CallSet>(parameters, callback);
@@ -4569,7 +4537,7 @@ export namespace genomics_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$SearchCallSetsResponse>(parameters, callback);
@@ -4650,15 +4618,7 @@ export namespace genomics_v1 {
 
 
   export class Resource$Datasets {
-    root: Genomics;
-    constructor(root: Genomics) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -4768,7 +4728,7 @@ export namespace genomics_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Dataset>(parameters, callback);
@@ -4885,7 +4845,7 @@ export namespace genomics_v1 {
         params,
         requiredParams: ['datasetId'],
         pathParams: ['datasetId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -4999,7 +4959,7 @@ export namespace genomics_v1 {
         params,
         requiredParams: ['datasetId'],
         pathParams: ['datasetId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Dataset>(parameters, callback);
@@ -5128,7 +5088,7 @@ export namespace genomics_v1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -5258,7 +5218,7 @@ export namespace genomics_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListDatasetsResponse>(parameters, callback);
@@ -5383,7 +5343,7 @@ export namespace genomics_v1 {
         params,
         requiredParams: ['datasetId'],
         pathParams: ['datasetId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Dataset>(parameters, callback);
@@ -5512,7 +5472,7 @@ export namespace genomics_v1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -5647,7 +5607,7 @@ export namespace genomics_v1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TestIamPermissionsResponse>(
@@ -5774,7 +5734,7 @@ export namespace genomics_v1 {
         params,
         requiredParams: ['datasetId'],
         pathParams: ['datasetId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Dataset>(parameters, callback);
@@ -5936,15 +5896,7 @@ export namespace genomics_v1 {
 
 
   export class Resource$Operations {
-    root: Genomics;
-    constructor(root: Genomics) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -6063,7 +6015,7 @@ export namespace genomics_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -6181,7 +6133,7 @@ export namespace genomics_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -6319,7 +6271,7 @@ export namespace genomics_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListOperationsResponse>(parameters, callback);
@@ -6402,16 +6354,9 @@ export namespace genomics_v1 {
 
 
   export class Resource$Readgroupsets {
-    root: Genomics;
     coveragebuckets: Resource$Readgroupsets$Coveragebuckets;
-    constructor(root: Genomics) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.coveragebuckets = new Resource$Readgroupsets$Coveragebuckets(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.coveragebuckets = new Resource$Readgroupsets$Coveragebuckets();
     }
 
 
@@ -6524,7 +6469,7 @@ export namespace genomics_v1 {
         params,
         requiredParams: ['readGroupSetId'],
         pathParams: ['readGroupSetId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -6655,7 +6600,7 @@ export namespace genomics_v1 {
         params,
         requiredParams: ['readGroupSetId'],
         pathParams: ['readGroupSetId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -6772,7 +6717,7 @@ export namespace genomics_v1 {
         params,
         requiredParams: ['readGroupSetId'],
         pathParams: ['readGroupSetId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ReadGroupSet>(parameters, callback);
@@ -6871,7 +6816,7 @@ import(paramsOrCallback?: Params$Resource$Readgroupsets$Import|BodyResponseCallb
     options = {};
                                                                                                                                                                                                                                                                               }
 
-                                                                                                                                                                                                                                                                              const rootUrl = options.rootUrl || 'https://genomics.googleapis.com/'; const parameters = {options: Object.assign({url: (rootUrl + '/v1/readgroupsets:import').replace(/([^:]\/)\/+/g, '$1'), method: 'POST'}, options), params, requiredParams: [], pathParams: [], context: this.getRoot()}; if(callback) {
+                                                                                                                                                                                                                                                                              const rootUrl = options.rootUrl || 'https://genomics.googleapis.com/'; const parameters = {options: Object.assign({url: (rootUrl + '/v1/readgroupsets:import').replace(/([^:]\/)\/+/g, '$1'), method: 'POST'}, options), params, requiredParams: [], pathParams: [], context}; if(callback) {
     createAPIRequest<Schema$Operation>(parameters, callback);
                                                                                                                                                                                                                                                                               } else {
     return createAPIRequest<Schema$Operation>(parameters);
@@ -6991,7 +6936,7 @@ import(paramsOrCallback?: Params$Resource$Readgroupsets$Import|BodyResponseCallb
         params,
         requiredParams: ['readGroupSetId'],
         pathParams: ['readGroupSetId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ReadGroupSet>(parameters, callback);
@@ -7131,7 +7076,7 @@ import(paramsOrCallback?: Params$Resource$Readgroupsets$Import|BodyResponseCallb
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$SearchReadGroupSetsResponse>(
@@ -7237,15 +7182,7 @@ import(paramsOrCallback?: Params$Resource$Readgroupsets$Import|BodyResponseCallb
   }
 
   export class Resource$Readgroupsets$Coveragebuckets {
-    root: Genomics;
-    constructor(root: Genomics) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -7392,7 +7329,7 @@ import(paramsOrCallback?: Params$Resource$Readgroupsets$Import|BodyResponseCallb
         params,
         requiredParams: ['readGroupSetId'],
         pathParams: ['readGroupSetId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListCoverageBucketsResponse>(
@@ -7455,15 +7392,7 @@ import(paramsOrCallback?: Params$Resource$Readgroupsets$Import|BodyResponseCallb
 
 
   export class Resource$Reads {
-    root: Genomics;
-    constructor(root: Genomics) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -7601,7 +7530,7 @@ import(paramsOrCallback?: Params$Resource$Readgroupsets$Import|BodyResponseCallb
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$SearchReadsResponse>(parameters, callback);
@@ -7626,16 +7555,9 @@ import(paramsOrCallback?: Params$Resource$Readgroupsets$Import|BodyResponseCallb
 
 
   export class Resource$References {
-    root: Genomics;
     bases: Resource$References$Bases;
-    constructor(root: Genomics) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.bases = new Resource$References$Bases(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.bases = new Resource$References$Bases();
     }
 
 
@@ -7745,7 +7667,7 @@ import(paramsOrCallback?: Params$Resource$Readgroupsets$Import|BodyResponseCallb
         params,
         requiredParams: ['referenceId'],
         pathParams: ['referenceId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Reference>(parameters, callback);
@@ -7882,7 +7804,7 @@ import(paramsOrCallback?: Params$Resource$Readgroupsets$Import|BodyResponseCallb
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$SearchReferencesResponse>(parameters, callback);
@@ -7918,15 +7840,7 @@ import(paramsOrCallback?: Params$Resource$Readgroupsets$Import|BodyResponseCallb
   }
 
   export class Resource$References$Bases {
-    root: Genomics;
-    constructor(root: Genomics) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -8056,7 +7970,7 @@ import(paramsOrCallback?: Params$Resource$Readgroupsets$Import|BodyResponseCallb
         params,
         requiredParams: ['referenceId'],
         pathParams: ['referenceId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListBasesResponse>(parameters, callback);
@@ -8103,15 +8017,7 @@ import(paramsOrCallback?: Params$Resource$Readgroupsets$Import|BodyResponseCallb
 
 
   export class Resource$Referencesets {
-    root: Genomics;
-    constructor(root: Genomics) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -8222,7 +8128,7 @@ import(paramsOrCallback?: Params$Resource$Readgroupsets$Import|BodyResponseCallb
         params,
         requiredParams: ['referenceSetId'],
         pathParams: ['referenceSetId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ReferenceSet>(parameters, callback);
@@ -8363,7 +8269,7 @@ import(paramsOrCallback?: Params$Resource$Readgroupsets$Import|BodyResponseCallb
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$SearchReferenceSetsResponse>(
@@ -8402,15 +8308,7 @@ import(paramsOrCallback?: Params$Resource$Readgroupsets$Import|BodyResponseCallb
 
 
   export class Resource$Variants {
-    root: Genomics;
-    constructor(root: Genomics) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -8520,7 +8418,7 @@ import(paramsOrCallback?: Params$Resource$Readgroupsets$Import|BodyResponseCallb
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Variant>(parameters, callback);
@@ -8634,7 +8532,7 @@ import(paramsOrCallback?: Params$Resource$Readgroupsets$Import|BodyResponseCallb
         params,
         requiredParams: ['variantId'],
         pathParams: ['variantId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -8748,7 +8646,7 @@ import(paramsOrCallback?: Params$Resource$Readgroupsets$Import|BodyResponseCallb
         params,
         requiredParams: ['variantId'],
         pathParams: ['variantId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Variant>(parameters, callback);
@@ -8848,7 +8746,7 @@ import(paramsOrCallback?: Params$Resource$Variants$Import|BodyResponseCallback<S
     options = {};
                                                                                                                                                                                                                                                                          }
 
-                                                                                                                                                                                                                                                                         const rootUrl = options.rootUrl || 'https://genomics.googleapis.com/'; const parameters = {options: Object.assign({url: (rootUrl + '/v1/variants:import').replace(/([^:]\/)\/+/g, '$1'), method: 'POST'}, options), params, requiredParams: [], pathParams: [], context: this.getRoot()}; if(callback) {
+                                                                                                                                                                                                                                                                         const rootUrl = options.rootUrl || 'https://genomics.googleapis.com/'; const parameters = {options: Object.assign({url: (rootUrl + '/v1/variants:import').replace(/([^:]\/)\/+/g, '$1'), method: 'POST'}, options), params, requiredParams: [], pathParams: [], context}; if(callback) {
     createAPIRequest<Schema$Operation>(parameters, callback);
                                                                                                                                                                                                                                                                          } else {
     return createAPIRequest<Schema$Operation>(parameters);
@@ -8956,7 +8854,7 @@ import(paramsOrCallback?: Params$Resource$Variants$Import|BodyResponseCallback<S
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -9082,7 +8980,7 @@ import(paramsOrCallback?: Params$Resource$Variants$Import|BodyResponseCallback<S
         params,
         requiredParams: ['variantId'],
         pathParams: ['variantId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Variant>(parameters, callback);
@@ -9216,7 +9114,7 @@ import(paramsOrCallback?: Params$Resource$Variants$Import|BodyResponseCallback<S
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$SearchVariantsResponse>(parameters, callback);
@@ -9321,15 +9219,7 @@ import(paramsOrCallback?: Params$Resource$Variants$Import|BodyResponseCallback<S
 
 
   export class Resource$Variantsets {
-    root: Genomics;
-    constructor(root: Genomics) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -9444,7 +9334,7 @@ import(paramsOrCallback?: Params$Resource$Variants$Import|BodyResponseCallback<S
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$VariantSet>(parameters, callback);
@@ -9562,7 +9452,7 @@ import(paramsOrCallback?: Params$Resource$Variants$Import|BodyResponseCallback<S
         params,
         requiredParams: ['variantSetId'],
         pathParams: ['variantSetId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -9690,7 +9580,7 @@ import(paramsOrCallback?: Params$Resource$Variants$Import|BodyResponseCallback<S
         params,
         requiredParams: ['variantSetId'],
         pathParams: ['variantSetId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -9806,7 +9696,7 @@ import(paramsOrCallback?: Params$Resource$Variants$Import|BodyResponseCallback<S
         params,
         requiredParams: ['variantSetId'],
         pathParams: ['variantSetId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$VariantSet>(parameters, callback);
@@ -9934,7 +9824,7 @@ import(paramsOrCallback?: Params$Resource$Variants$Import|BodyResponseCallback<S
         params,
         requiredParams: ['variantSetId'],
         pathParams: ['variantSetId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$VariantSet>(parameters, callback);
@@ -10073,7 +9963,7 @@ import(paramsOrCallback?: Params$Resource$Variants$Import|BodyResponseCallback<S
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$SearchVariantSetsResponse>(

--- a/src/apis/genomics/v1alpha2.ts
+++ b/src/apis/genomics/v1alpha2.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace genomics_v1alpha2 {
   export interface Options extends GlobalOptions {
     version: 'v1alpha2';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -96,24 +98,14 @@ export namespace genomics_v1alpha2 {
    * @param {object=} options Options for Genomics
    */
   export class Genomics {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     operations: Resource$Operations;
     pipelines: Resource$Pipelines;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.operations = new Resource$Operations(this);
-      this.pipelines = new Resource$Pipelines(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.operations = new Resource$Operations();
+      this.pipelines = new Resource$Pipelines();
     }
   }
 
@@ -970,15 +962,7 @@ export namespace genomics_v1alpha2 {
 
 
   export class Resource$Operations {
-    root: Genomics;
-    constructor(root: Genomics) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -1097,7 +1081,7 @@ export namespace genomics_v1alpha2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -1216,7 +1200,7 @@ export namespace genomics_v1alpha2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -1355,7 +1339,7 @@ export namespace genomics_v1alpha2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListOperationsResponse>(parameters, callback);
@@ -1438,15 +1422,7 @@ export namespace genomics_v1alpha2 {
 
 
   export class Resource$Pipelines {
-    root: Genomics;
-    constructor(root: Genomics) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -1560,7 +1536,7 @@ export namespace genomics_v1alpha2 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Pipeline>(parameters, callback);
@@ -1677,7 +1653,7 @@ export namespace genomics_v1alpha2 {
         params,
         requiredParams: ['pipelineId'],
         pathParams: ['pipelineId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -1793,7 +1769,7 @@ export namespace genomics_v1alpha2 {
         params,
         requiredParams: ['pipelineId'],
         pathParams: ['pipelineId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Pipeline>(parameters, callback);
@@ -1911,7 +1887,7 @@ export namespace genomics_v1alpha2 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ControllerConfig>(parameters, callback);
@@ -2043,7 +2019,7 @@ export namespace genomics_v1alpha2 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListPipelinesResponse>(parameters, callback);
@@ -2165,7 +2141,7 @@ export namespace genomics_v1alpha2 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -2286,7 +2262,7 @@ export namespace genomics_v1alpha2 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);

--- a/src/apis/genomics/v2alpha1.ts
+++ b/src/apis/genomics/v2alpha1.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace genomics_v2alpha1 {
   export interface Options extends GlobalOptions {
     version: 'v2alpha1';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -96,26 +98,16 @@ export namespace genomics_v2alpha1 {
    * @param {object=} options Options for Genomics
    */
   export class Genomics {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     pipelines: Resource$Pipelines;
     projects: Resource$Projects;
     workers: Resource$Workers;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.pipelines = new Resource$Pipelines(this);
-      this.projects = new Resource$Projects(this);
-      this.workers = new Resource$Workers(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.pipelines = new Resource$Pipelines();
+      this.projects = new Resource$Projects();
+      this.workers = new Resource$Workers();
     }
   }
 
@@ -1013,15 +1005,7 @@ export namespace genomics_v2alpha1 {
 
 
   export class Resource$Pipelines {
-    root: Genomics;
-    constructor(root: Genomics) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -1083,7 +1067,7 @@ export namespace genomics_v2alpha1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -1108,30 +1092,15 @@ export namespace genomics_v2alpha1 {
 
 
   export class Resource$Projects {
-    root: Genomics;
     operations: Resource$Projects$Operations;
-    constructor(root: Genomics) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.operations = new Resource$Projects$Operations(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.operations = new Resource$Projects$Operations();
     }
   }
 
 
   export class Resource$Projects$Operations {
-    root: Genomics;
-    constructor(root: Genomics) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -1197,7 +1166,7 @@ export namespace genomics_v2alpha1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -1264,7 +1233,7 @@ export namespace genomics_v2alpha1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -1338,7 +1307,7 @@ export namespace genomics_v2alpha1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListOperationsResponse>(parameters, callback);
@@ -1424,15 +1393,7 @@ export namespace genomics_v2alpha1 {
 
 
   export class Resource$Workers {
-    root: Genomics;
-    constructor(root: Genomics) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -1492,7 +1453,7 @@ export namespace genomics_v2alpha1 {
         params,
         requiredParams: ['id'],
         pathParams: ['id'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$CheckInResponse>(parameters, callback);

--- a/src/apis/gmail/v1.ts
+++ b/src/apis/gmail/v1.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace gmail_v1 {
   export interface Options extends GlobalOptions {
     version: 'v1';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -79,22 +81,12 @@ export namespace gmail_v1 {
    * @param {object=} options Options for Gmail
    */
   export class Gmail {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     users: Resource$Users;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.users = new Resource$Users(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.users = new Resource$Users();
     }
   }
 
@@ -962,26 +954,19 @@ export namespace gmail_v1 {
 
 
   export class Resource$Users {
-    root: Gmail;
     drafts: Resource$Users$Drafts;
     history: Resource$Users$History;
     labels: Resource$Users$Labels;
     messages: Resource$Users$Messages;
     settings: Resource$Users$Settings;
     threads: Resource$Users$Threads;
-    constructor(root: Gmail) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.drafts = new Resource$Users$Drafts(root);
-      this.history = new Resource$Users$History(root);
-      this.labels = new Resource$Users$Labels(root);
-      this.messages = new Resource$Users$Messages(root);
-      this.settings = new Resource$Users$Settings(root);
-      this.threads = new Resource$Users$Threads(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.drafts = new Resource$Users$Drafts();
+      this.history = new Resource$Users$History();
+      this.labels = new Resource$Users$Labels();
+      this.messages = new Resource$Users$Messages();
+      this.settings = new Resource$Users$Settings();
+      this.threads = new Resource$Users$Threads();
     }
 
 
@@ -1040,7 +1025,7 @@ export namespace gmail_v1 {
         params,
         requiredParams: ['userId'],
         pathParams: ['userId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Profile>(parameters, callback);
@@ -1103,7 +1088,7 @@ export namespace gmail_v1 {
         params,
         requiredParams: ['userId'],
         pathParams: ['userId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -1170,7 +1155,7 @@ export namespace gmail_v1 {
         params,
         requiredParams: ['userId'],
         pathParams: ['userId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$WatchResponse>(parameters, callback);
@@ -1223,15 +1208,7 @@ export namespace gmail_v1 {
   }
 
   export class Resource$Users$Drafts {
-    root: Gmail;
-    constructor(root: Gmail) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -1296,7 +1273,7 @@ export namespace gmail_v1 {
                       .replace(/([^:]\/)\/+/g, '$1'),
         requiredParams: ['userId'],
         pathParams: ['userId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Draft>(parameters, callback);
@@ -1363,7 +1340,7 @@ export namespace gmail_v1 {
         params,
         requiredParams: ['userId', 'id'],
         pathParams: ['id', 'userId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -1426,7 +1403,7 @@ export namespace gmail_v1 {
         params,
         requiredParams: ['userId', 'id'],
         pathParams: ['id', 'userId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Draft>(parameters, callback);
@@ -1496,7 +1473,7 @@ export namespace gmail_v1 {
         params,
         requiredParams: ['userId'],
         pathParams: ['userId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListDraftsResponse>(parameters, callback);
@@ -1568,7 +1545,7 @@ export namespace gmail_v1 {
                       .replace(/([^:]\/)\/+/g, '$1'),
         requiredParams: ['userId'],
         pathParams: ['userId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Message>(parameters, callback);
@@ -1641,7 +1618,7 @@ export namespace gmail_v1 {
                       .replace(/([^:]\/)\/+/g, '$1'),
         requiredParams: ['userId', 'id'],
         pathParams: ['id', 'userId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Draft>(parameters, callback);
@@ -1825,15 +1802,7 @@ export namespace gmail_v1 {
 
 
   export class Resource$Users$History {
-    root: Gmail;
-    constructor(root: Gmail) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -1898,7 +1867,7 @@ export namespace gmail_v1 {
         params,
         requiredParams: ['userId'],
         pathParams: ['userId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListHistoryResponse>(parameters, callback);
@@ -1954,15 +1923,7 @@ export namespace gmail_v1 {
 
 
   export class Resource$Users$Labels {
-    root: Gmail;
-    constructor(root: Gmail) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -2022,7 +1983,7 @@ export namespace gmail_v1 {
         params,
         requiredParams: ['userId'],
         pathParams: ['userId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Label>(parameters, callback);
@@ -2089,7 +2050,7 @@ export namespace gmail_v1 {
         params,
         requiredParams: ['userId', 'id'],
         pathParams: ['id', 'userId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -2151,7 +2112,7 @@ export namespace gmail_v1 {
         params,
         requiredParams: ['userId', 'id'],
         pathParams: ['id', 'userId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Label>(parameters, callback);
@@ -2217,7 +2178,7 @@ export namespace gmail_v1 {
         params,
         requiredParams: ['userId'],
         pathParams: ['userId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListLabelsResponse>(parameters, callback);
@@ -2284,7 +2245,7 @@ export namespace gmail_v1 {
         params,
         requiredParams: ['userId', 'id'],
         pathParams: ['id', 'userId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Label>(parameters, callback);
@@ -2352,7 +2313,7 @@ export namespace gmail_v1 {
         params,
         requiredParams: ['userId', 'id'],
         pathParams: ['id', 'userId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Label>(parameters, callback);
@@ -2473,16 +2434,9 @@ export namespace gmail_v1 {
 
 
   export class Resource$Users$Messages {
-    root: Gmail;
     attachments: Resource$Users$Messages$Attachments;
-    constructor(root: Gmail) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.attachments = new Resource$Users$Messages$Attachments(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.attachments = new Resource$Users$Messages$Attachments();
     }
 
 
@@ -2543,7 +2497,7 @@ export namespace gmail_v1 {
         params,
         requiredParams: ['userId'],
         pathParams: ['userId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -2609,7 +2563,7 @@ export namespace gmail_v1 {
         params,
         requiredParams: ['userId'],
         pathParams: ['userId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -2676,7 +2630,7 @@ export namespace gmail_v1 {
         params,
         requiredParams: ['userId', 'id'],
         pathParams: ['id', 'userId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -2741,7 +2695,7 @@ export namespace gmail_v1 {
         params,
         requiredParams: ['userId', 'id'],
         pathParams: ['id', 'userId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Message>(parameters, callback);
@@ -2790,7 +2744,7 @@ import(paramsOrCallback?: Params$Resource$Users$Messages$Import|BodyResponseCall
     options = {};
                                                                                                                                                                                                                                                                        }
 
-                                                                                                                                                                                                                                                                       const rootUrl = options.rootUrl || 'https://www.googleapis.com/'; const parameters = {options: Object.assign({url: (rootUrl + '/gmail/v1/users/{userId}/messages/import').replace(/([^:]\/)\/+/g, '$1'), method: 'POST'}, options), params, mediaUrl: (rootUrl + '/upload/gmail/v1/users/{userId}/messages/import').replace(/([^:]\/)\/+/g, '$1'), requiredParams: ['userId'], pathParams: ['userId'], context: this.getRoot()}; if(callback) {
+                                                                                                                                                                                                                                                                       const rootUrl = options.rootUrl || 'https://www.googleapis.com/'; const parameters = {options: Object.assign({url: (rootUrl + '/gmail/v1/users/{userId}/messages/import').replace(/([^:]\/)\/+/g, '$1'), method: 'POST'}, options), params, mediaUrl: (rootUrl + '/upload/gmail/v1/users/{userId}/messages/import').replace(/([^:]\/)\/+/g, '$1'), requiredParams: ['userId'], pathParams: ['userId'], context}; if(callback) {
     createAPIRequest<Schema$Message>(parameters, callback);
                                                                                                                                                                                                                                                                        } else {
     return createAPIRequest<Schema$Message>(parameters);
@@ -2859,7 +2813,7 @@ import(paramsOrCallback?: Params$Resource$Users$Messages$Import|BodyResponseCall
                       .replace(/([^:]\/)\/+/g, '$1'),
         requiredParams: ['userId'],
         pathParams: ['userId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Message>(parameters, callback);
@@ -2931,7 +2885,7 @@ import(paramsOrCallback?: Params$Resource$Users$Messages$Import|BodyResponseCall
         params,
         requiredParams: ['userId'],
         pathParams: ['userId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListMessagesResponse>(parameters, callback);
@@ -2999,7 +2953,7 @@ import(paramsOrCallback?: Params$Resource$Users$Messages$Import|BodyResponseCall
         params,
         requiredParams: ['userId', 'id'],
         pathParams: ['id', 'userId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Message>(parameters, callback);
@@ -3071,7 +3025,7 @@ import(paramsOrCallback?: Params$Resource$Users$Messages$Import|BodyResponseCall
                       .replace(/([^:]\/)\/+/g, '$1'),
         requiredParams: ['userId'],
         pathParams: ['userId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Message>(parameters, callback);
@@ -3138,7 +3092,7 @@ import(paramsOrCallback?: Params$Resource$Users$Messages$Import|BodyResponseCall
         params,
         requiredParams: ['userId', 'id'],
         pathParams: ['id', 'userId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Message>(parameters, callback);
@@ -3205,7 +3159,7 @@ import(paramsOrCallback?: Params$Resource$Users$Messages$Import|BodyResponseCall
         params,
         requiredParams: ['userId', 'id'],
         pathParams: ['id', 'userId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Message>(parameters, callback);
@@ -3516,15 +3470,7 @@ import(paramsOrCallback?: Params$Resource$Users$Messages$Import|BodyResponseCall
   }
 
   export class Resource$Users$Messages$Attachments {
-    root: Gmail;
-    constructor(root: Gmail) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -3584,7 +3530,7 @@ import(paramsOrCallback?: Params$Resource$Users$Messages$Import|BodyResponseCall
         params,
         requiredParams: ['userId', 'messageId', 'id'],
         pathParams: ['id', 'messageId', 'userId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$MessagePartBody>(parameters, callback);
@@ -3619,23 +3565,16 @@ import(paramsOrCallback?: Params$Resource$Users$Messages$Import|BodyResponseCall
 
 
   export class Resource$Users$Settings {
-    root: Gmail;
     delegates: Resource$Users$Settings$Delegates;
     filters: Resource$Users$Settings$Filters;
     forwardingAddresses: Resource$Users$Settings$Forwardingaddresses;
     sendAs: Resource$Users$Settings$Sendas;
-    constructor(root: Gmail) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.delegates = new Resource$Users$Settings$Delegates(root);
-      this.filters = new Resource$Users$Settings$Filters(root);
+    constructor() {
+      this.delegates = new Resource$Users$Settings$Delegates();
+      this.filters = new Resource$Users$Settings$Filters();
       this.forwardingAddresses =
-          new Resource$Users$Settings$Forwardingaddresses(root);
-      this.sendAs = new Resource$Users$Settings$Sendas(root);
-    }
-
-    getRoot() {
-      return this.root;
+          new Resource$Users$Settings$Forwardingaddresses();
+      this.sendAs = new Resource$Users$Settings$Sendas();
     }
 
 
@@ -3698,7 +3637,7 @@ import(paramsOrCallback?: Params$Resource$Users$Messages$Import|BodyResponseCall
         params,
         requiredParams: ['userId'],
         pathParams: ['userId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$AutoForwarding>(parameters, callback);
@@ -3765,7 +3704,7 @@ import(paramsOrCallback?: Params$Resource$Users$Messages$Import|BodyResponseCall
         params,
         requiredParams: ['userId'],
         pathParams: ['userId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ImapSettings>(parameters, callback);
@@ -3832,7 +3771,7 @@ import(paramsOrCallback?: Params$Resource$Users$Messages$Import|BodyResponseCall
         params,
         requiredParams: ['userId'],
         pathParams: ['userId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$PopSettings>(parameters, callback);
@@ -3899,7 +3838,7 @@ import(paramsOrCallback?: Params$Resource$Users$Messages$Import|BodyResponseCall
         params,
         requiredParams: ['userId'],
         pathParams: ['userId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$VacationSettings>(parameters, callback);
@@ -3972,7 +3911,7 @@ import(paramsOrCallback?: Params$Resource$Users$Messages$Import|BodyResponseCall
         params,
         requiredParams: ['userId'],
         pathParams: ['userId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$AutoForwarding>(parameters, callback);
@@ -4040,7 +3979,7 @@ import(paramsOrCallback?: Params$Resource$Users$Messages$Import|BodyResponseCall
         params,
         requiredParams: ['userId'],
         pathParams: ['userId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ImapSettings>(parameters, callback);
@@ -4108,7 +4047,7 @@ import(paramsOrCallback?: Params$Resource$Users$Messages$Import|BodyResponseCall
         params,
         requiredParams: ['userId'],
         pathParams: ['userId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$PopSettings>(parameters, callback);
@@ -4177,7 +4116,7 @@ import(paramsOrCallback?: Params$Resource$Users$Messages$Import|BodyResponseCall
         params,
         requiredParams: ['userId'],
         pathParams: ['userId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$VacationSettings>(parameters, callback);
@@ -4313,15 +4252,7 @@ import(paramsOrCallback?: Params$Resource$Users$Messages$Import|BodyResponseCall
   }
 
   export class Resource$Users$Settings$Delegates {
-    root: Gmail;
-    constructor(root: Gmail) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -4391,7 +4322,7 @@ import(paramsOrCallback?: Params$Resource$Users$Messages$Import|BodyResponseCall
         params,
         requiredParams: ['userId'],
         pathParams: ['userId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Delegate>(parameters, callback);
@@ -4463,7 +4394,7 @@ import(paramsOrCallback?: Params$Resource$Users$Messages$Import|BodyResponseCall
         params,
         requiredParams: ['userId', 'delegateEmail'],
         pathParams: ['delegateEmail', 'userId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -4531,7 +4462,7 @@ import(paramsOrCallback?: Params$Resource$Users$Messages$Import|BodyResponseCall
         params,
         requiredParams: ['userId', 'delegateEmail'],
         pathParams: ['delegateEmail', 'userId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Delegate>(parameters, callback);
@@ -4601,7 +4532,7 @@ import(paramsOrCallback?: Params$Resource$Users$Messages$Import|BodyResponseCall
         params,
         requiredParams: ['userId'],
         pathParams: ['userId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListDelegatesResponse>(parameters, callback);
@@ -4680,15 +4611,7 @@ import(paramsOrCallback?: Params$Resource$Users$Messages$Import|BodyResponseCall
 
 
   export class Resource$Users$Settings$Filters {
-    root: Gmail;
-    constructor(root: Gmail) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -4748,7 +4671,7 @@ import(paramsOrCallback?: Params$Resource$Users$Messages$Import|BodyResponseCall
         params,
         requiredParams: ['userId'],
         pathParams: ['userId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Filter>(parameters, callback);
@@ -4814,7 +4737,7 @@ import(paramsOrCallback?: Params$Resource$Users$Messages$Import|BodyResponseCall
         params,
         requiredParams: ['userId', 'id'],
         pathParams: ['id', 'userId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -4877,7 +4800,7 @@ import(paramsOrCallback?: Params$Resource$Users$Messages$Import|BodyResponseCall
         params,
         requiredParams: ['userId', 'id'],
         pathParams: ['id', 'userId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Filter>(parameters, callback);
@@ -4944,7 +4867,7 @@ import(paramsOrCallback?: Params$Resource$Users$Messages$Import|BodyResponseCall
         params,
         requiredParams: ['userId'],
         pathParams: ['userId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListFiltersResponse>(parameters, callback);
@@ -5022,15 +4945,7 @@ import(paramsOrCallback?: Params$Resource$Users$Messages$Import|BodyResponseCall
 
 
   export class Resource$Users$Settings$Forwardingaddresses {
-    root: Gmail;
-    constructor(root: Gmail) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -5099,7 +5014,7 @@ import(paramsOrCallback?: Params$Resource$Users$Messages$Import|BodyResponseCall
         params,
         requiredParams: ['userId'],
         pathParams: ['userId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ForwardingAddress>(parameters, callback);
@@ -5172,7 +5087,7 @@ import(paramsOrCallback?: Params$Resource$Users$Messages$Import|BodyResponseCall
         params,
         requiredParams: ['userId', 'forwardingEmail'],
         pathParams: ['forwardingEmail', 'userId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -5239,7 +5154,7 @@ import(paramsOrCallback?: Params$Resource$Users$Messages$Import|BodyResponseCall
         params,
         requiredParams: ['userId', 'forwardingEmail'],
         pathParams: ['forwardingEmail', 'userId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ForwardingAddress>(parameters, callback);
@@ -5315,7 +5230,7 @@ import(paramsOrCallback?: Params$Resource$Users$Messages$Import|BodyResponseCall
         params,
         requiredParams: ['userId'],
         pathParams: ['userId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListForwardingAddressesResponse>(
@@ -5395,16 +5310,9 @@ import(paramsOrCallback?: Params$Resource$Users$Messages$Import|BodyResponseCall
 
 
   export class Resource$Users$Settings$Sendas {
-    root: Gmail;
     smimeInfo: Resource$Users$Settings$Sendas$Smimeinfo;
-    constructor(root: Gmail) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.smimeInfo = new Resource$Users$Settings$Sendas$Smimeinfo(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.smimeInfo = new Resource$Users$Settings$Sendas$Smimeinfo();
     }
 
 
@@ -5473,7 +5381,7 @@ import(paramsOrCallback?: Params$Resource$Users$Messages$Import|BodyResponseCall
         params,
         requiredParams: ['userId'],
         pathParams: ['userId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$SendAs>(parameters, callback);
@@ -5542,7 +5450,7 @@ import(paramsOrCallback?: Params$Resource$Users$Messages$Import|BodyResponseCall
         params,
         requiredParams: ['userId', 'sendAsEmail'],
         pathParams: ['sendAsEmail', 'userId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -5607,7 +5515,7 @@ import(paramsOrCallback?: Params$Resource$Users$Messages$Import|BodyResponseCall
         params,
         requiredParams: ['userId', 'sendAsEmail'],
         pathParams: ['sendAsEmail', 'userId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$SendAs>(parameters, callback);
@@ -5676,7 +5584,7 @@ import(paramsOrCallback?: Params$Resource$Users$Messages$Import|BodyResponseCall
         params,
         requiredParams: ['userId'],
         pathParams: ['userId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListSendAsResponse>(parameters, callback);
@@ -5749,7 +5657,7 @@ import(paramsOrCallback?: Params$Resource$Users$Messages$Import|BodyResponseCall
         params,
         requiredParams: ['userId', 'sendAsEmail'],
         pathParams: ['sendAsEmail', 'userId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$SendAs>(parameters, callback);
@@ -5821,7 +5729,7 @@ import(paramsOrCallback?: Params$Resource$Users$Messages$Import|BodyResponseCall
         params,
         requiredParams: ['userId', 'sendAsEmail'],
         pathParams: ['sendAsEmail', 'userId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$SendAs>(parameters, callback);
@@ -5892,7 +5800,7 @@ import(paramsOrCallback?: Params$Resource$Users$Messages$Import|BodyResponseCall
         params,
         requiredParams: ['userId', 'sendAsEmail'],
         pathParams: ['sendAsEmail', 'userId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -6030,15 +5938,7 @@ import(paramsOrCallback?: Params$Resource$Users$Messages$Import|BodyResponseCall
   }
 
   export class Resource$Users$Settings$Sendas$Smimeinfo {
-    root: Gmail;
-    constructor(root: Gmail) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -6102,7 +6002,7 @@ import(paramsOrCallback?: Params$Resource$Users$Messages$Import|BodyResponseCall
         params,
         requiredParams: ['userId', 'sendAsEmail', 'id'],
         pathParams: ['id', 'sendAsEmail', 'userId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -6169,7 +6069,7 @@ import(paramsOrCallback?: Params$Resource$Users$Messages$Import|BodyResponseCall
         params,
         requiredParams: ['userId', 'sendAsEmail', 'id'],
         pathParams: ['id', 'sendAsEmail', 'userId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$SmimeInfo>(parameters, callback);
@@ -6242,7 +6142,7 @@ import(paramsOrCallback?: Params$Resource$Users$Messages$Import|BodyResponseCall
         params,
         requiredParams: ['userId', 'sendAsEmail'],
         pathParams: ['sendAsEmail', 'userId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$SmimeInfo>(parameters, callback);
@@ -6313,7 +6213,7 @@ import(paramsOrCallback?: Params$Resource$Users$Messages$Import|BodyResponseCall
         params,
         requiredParams: ['userId', 'sendAsEmail'],
         pathParams: ['sendAsEmail', 'userId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListSmimeInfoResponse>(parameters, callback);
@@ -6384,7 +6284,7 @@ import(paramsOrCallback?: Params$Resource$Users$Messages$Import|BodyResponseCall
         params,
         requiredParams: ['userId', 'sendAsEmail', 'id'],
         pathParams: ['id', 'sendAsEmail', 'userId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -6505,15 +6405,7 @@ import(paramsOrCallback?: Params$Resource$Users$Messages$Import|BodyResponseCall
 
 
   export class Resource$Users$Threads {
-    root: Gmail;
-    constructor(root: Gmail) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -6573,7 +6465,7 @@ import(paramsOrCallback?: Params$Resource$Users$Messages$Import|BodyResponseCall
         params,
         requiredParams: ['userId', 'id'],
         pathParams: ['id', 'userId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -6638,7 +6530,7 @@ import(paramsOrCallback?: Params$Resource$Users$Messages$Import|BodyResponseCall
         params,
         requiredParams: ['userId', 'id'],
         pathParams: ['id', 'userId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Thread>(parameters, callback);
@@ -6709,7 +6601,7 @@ import(paramsOrCallback?: Params$Resource$Users$Messages$Import|BodyResponseCall
         params,
         requiredParams: ['userId'],
         pathParams: ['userId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListThreadsResponse>(parameters, callback);
@@ -6778,7 +6670,7 @@ import(paramsOrCallback?: Params$Resource$Users$Messages$Import|BodyResponseCall
         params,
         requiredParams: ['userId', 'id'],
         pathParams: ['id', 'userId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Thread>(parameters, callback);
@@ -6845,7 +6737,7 @@ import(paramsOrCallback?: Params$Resource$Users$Messages$Import|BodyResponseCall
         params,
         requiredParams: ['userId', 'id'],
         pathParams: ['id', 'userId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Thread>(parameters, callback);
@@ -6912,7 +6804,7 @@ import(paramsOrCallback?: Params$Resource$Users$Messages$Import|BodyResponseCall
         params,
         requiredParams: ['userId', 'id'],
         pathParams: ['id', 'userId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Thread>(parameters, callback);

--- a/src/apis/groupsmigration/v1.ts
+++ b/src/apis/groupsmigration/v1.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace groupsmigration_v1 {
   export interface Options extends GlobalOptions {
     version: 'v1';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -79,22 +81,12 @@ export namespace groupsmigration_v1 {
    * @param {object=} options Options for Groupsmigration
    */
   export class Groupsmigration {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     archive: Resource$Archive;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.archive = new Resource$Archive(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.archive = new Resource$Archive();
     }
   }
 
@@ -114,15 +106,7 @@ export namespace groupsmigration_v1 {
 
 
   export class Resource$Archive {
-    root: Groupsmigration;
-    constructor(root: Groupsmigration) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -184,7 +168,7 @@ export namespace groupsmigration_v1 {
                       .replace(/([^:]\/)\/+/g, '$1'),
         requiredParams: ['groupId'],
         pathParams: ['groupId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Groups>(parameters, callback);

--- a/src/apis/groupssettings/v1.ts
+++ b/src/apis/groupssettings/v1.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace groupssettings_v1 {
   export interface Options extends GlobalOptions {
     version: 'v1';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -79,22 +81,12 @@ export namespace groupssettings_v1 {
    * @param {object=} options Options for Groupssettings
    */
   export class Groupssettings {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     groups: Resource$Groups;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.groups = new Resource$Groups(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.groups = new Resource$Groups();
     }
   }
 
@@ -310,15 +302,7 @@ export namespace groupssettings_v1 {
 
 
   export class Resource$Groups {
-    root: Groupssettings;
-    constructor(root: Groupssettings) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -372,7 +356,7 @@ export namespace groupssettings_v1 {
         params,
         requiredParams: ['groupUniqueId'],
         pathParams: ['groupUniqueId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Groups>(parameters, callback);
@@ -437,7 +421,7 @@ export namespace groupssettings_v1 {
         params,
         requiredParams: ['groupUniqueId'],
         pathParams: ['groupUniqueId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Groups>(parameters, callback);
@@ -502,7 +486,7 @@ export namespace groupssettings_v1 {
         params,
         requiredParams: ['groupUniqueId'],
         pathParams: ['groupUniqueId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Groups>(parameters, callback);

--- a/src/apis/iam/v1.ts
+++ b/src/apis/iam/v1.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace iam_v1 {
   export interface Options extends GlobalOptions {
     version: 'v1';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -98,10 +100,6 @@ export namespace iam_v1 {
    * @param {object=} options Options for Iam
    */
   export class Iam {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     iamPolicies: Resource$Iampolicies;
     organizations: Resource$Organizations;
     permissions: Resource$Permissions;
@@ -109,19 +107,13 @@ export namespace iam_v1 {
     roles: Resource$Roles;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.iamPolicies = new Resource$Iampolicies(this);
-      this.organizations = new Resource$Organizations(this);
-      this.permissions = new Resource$Permissions(this);
-      this.projects = new Resource$Projects(this);
-      this.roles = new Resource$Roles(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.iamPolicies = new Resource$Iampolicies();
+      this.organizations = new Resource$Organizations();
+      this.permissions = new Resource$Permissions();
+      this.projects = new Resource$Projects();
+      this.roles = new Resource$Roles();
     }
   }
 
@@ -907,15 +899,7 @@ export namespace iam_v1 {
 
 
   export class Resource$Iampolicies {
-    root: Iam;
-    constructor(root: Iam) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -991,7 +975,7 @@ export namespace iam_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$LintPolicyResponse>(parameters, callback);
@@ -1065,7 +1049,7 @@ export namespace iam_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$QueryAuditableServicesResponse>(
@@ -1106,30 +1090,15 @@ export namespace iam_v1 {
 
 
   export class Resource$Organizations {
-    root: Iam;
     roles: Resource$Organizations$Roles;
-    constructor(root: Iam) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.roles = new Resource$Organizations$Roles(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.roles = new Resource$Organizations$Roles();
     }
   }
 
 
   export class Resource$Organizations$Roles {
-    root: Iam;
-    constructor(root: Iam) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -1189,7 +1158,7 @@ export namespace iam_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Role>(parameters, callback);
@@ -1260,7 +1229,7 @@ export namespace iam_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Role>(parameters, callback);
@@ -1321,7 +1290,7 @@ export namespace iam_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Role>(parameters, callback);
@@ -1392,7 +1361,7 @@ export namespace iam_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListRolesResponse>(parameters, callback);
@@ -1459,7 +1428,7 @@ export namespace iam_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Role>(parameters, callback);
@@ -1526,7 +1495,7 @@ export namespace iam_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Role>(parameters, callback);
@@ -1662,15 +1631,7 @@ export namespace iam_v1 {
 
 
   export class Resource$Permissions {
-    root: Iam;
-    constructor(root: Iam) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -1741,7 +1702,7 @@ export namespace iam_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$QueryTestablePermissionsResponse>(
@@ -1769,32 +1730,17 @@ export namespace iam_v1 {
 
 
   export class Resource$Projects {
-    root: Iam;
     roles: Resource$Projects$Roles;
     serviceAccounts: Resource$Projects$Serviceaccounts;
-    constructor(root: Iam) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.roles = new Resource$Projects$Roles(root);
-      this.serviceAccounts = new Resource$Projects$Serviceaccounts(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.roles = new Resource$Projects$Roles();
+      this.serviceAccounts = new Resource$Projects$Serviceaccounts();
     }
   }
 
 
   export class Resource$Projects$Roles {
-    root: Iam;
-    constructor(root: Iam) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -1854,7 +1800,7 @@ export namespace iam_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Role>(parameters, callback);
@@ -1925,7 +1871,7 @@ export namespace iam_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Role>(parameters, callback);
@@ -1986,7 +1932,7 @@ export namespace iam_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Role>(parameters, callback);
@@ -2056,7 +2002,7 @@ export namespace iam_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListRolesResponse>(parameters, callback);
@@ -2123,7 +2069,7 @@ export namespace iam_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Role>(parameters, callback);
@@ -2190,7 +2136,7 @@ export namespace iam_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Role>(parameters, callback);
@@ -2325,16 +2271,9 @@ export namespace iam_v1 {
 
 
   export class Resource$Projects$Serviceaccounts {
-    root: Iam;
     keys: Resource$Projects$Serviceaccounts$Keys;
-    constructor(root: Iam) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.keys = new Resource$Projects$Serviceaccounts$Keys(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.keys = new Resource$Projects$Serviceaccounts$Keys();
     }
 
 
@@ -2396,7 +2335,7 @@ export namespace iam_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ServiceAccount>(parameters, callback);
@@ -2461,7 +2400,7 @@ export namespace iam_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -2523,7 +2462,7 @@ export namespace iam_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ServiceAccount>(parameters, callback);
@@ -2590,7 +2529,7 @@ export namespace iam_v1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -2664,7 +2603,7 @@ export namespace iam_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListServiceAccountsResponse>(
@@ -2733,7 +2672,7 @@ export namespace iam_v1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -2801,7 +2740,7 @@ export namespace iam_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$SignBlobResponse>(parameters, callback);
@@ -2872,7 +2811,7 @@ export namespace iam_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$SignJwtResponse>(parameters, callback);
@@ -2949,7 +2888,7 @@ export namespace iam_v1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TestIamPermissionsResponse>(
@@ -3018,7 +2957,7 @@ export namespace iam_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ServiceAccount>(parameters, callback);
@@ -3217,15 +3156,7 @@ export namespace iam_v1 {
   }
 
   export class Resource$Projects$Serviceaccounts$Keys {
-    root: Iam;
-    constructor(root: Iam) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -3285,7 +3216,7 @@ export namespace iam_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ServiceAccountKey>(parameters, callback);
@@ -3350,7 +3281,7 @@ export namespace iam_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -3413,7 +3344,7 @@ export namespace iam_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ServiceAccountKey>(parameters, callback);
@@ -3485,7 +3416,7 @@ export namespace iam_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListServiceAccountKeysResponse>(
@@ -3581,15 +3512,7 @@ export namespace iam_v1 {
 
 
   export class Resource$Roles {
-    root: Iam;
-    constructor(root: Iam) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -3642,7 +3565,7 @@ export namespace iam_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Role>(parameters, callback);
@@ -3710,7 +3633,7 @@ export namespace iam_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListRolesResponse>(parameters, callback);
@@ -3785,7 +3708,7 @@ export namespace iam_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$QueryGrantableRolesResponse>(

--- a/src/apis/iamcredentials/v1.ts
+++ b/src/apis/iamcredentials/v1.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace iamcredentials_v1 {
   export interface Options extends GlobalOptions {
     version: 'v1';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -97,22 +99,12 @@ export namespace iamcredentials_v1 {
    * @param {object=} options Options for Iamcredentials
    */
   export class Iamcredentials {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     projects: Resource$Projects;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.projects = new Resource$Projects(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.projects = new Resource$Projects();
     }
   }
 
@@ -286,30 +278,15 @@ export namespace iamcredentials_v1 {
 
 
   export class Resource$Projects {
-    root: Iamcredentials;
     serviceAccounts: Resource$Projects$Serviceaccounts;
-    constructor(root: Iamcredentials) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.serviceAccounts = new Resource$Projects$Serviceaccounts(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.serviceAccounts = new Resource$Projects$Serviceaccounts();
     }
   }
 
 
   export class Resource$Projects$Serviceaccounts {
-    root: Iamcredentials;
-    constructor(root: Iamcredentials) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -379,7 +356,7 @@ export namespace iamcredentials_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GenerateAccessTokenResponse>(
@@ -461,7 +438,7 @@ export namespace iamcredentials_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GenerateIdentityBindingAccessTokenResponse>(
@@ -535,7 +512,7 @@ export namespace iamcredentials_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GenerateIdTokenResponse>(parameters, callback);
@@ -604,7 +581,7 @@ export namespace iamcredentials_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$SignBlobResponse>(parameters, callback);
@@ -673,7 +650,7 @@ export namespace iamcredentials_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$SignJwtResponse>(parameters, callback);

--- a/src/apis/iap/v1beta1.ts
+++ b/src/apis/iap/v1beta1.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace iap_v1beta1 {
   export interface Options extends GlobalOptions {
     version: 'v1beta1';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -96,22 +98,12 @@ export namespace iap_v1beta1 {
    * @param {object=} options Options for Iap
    */
   export class Iap {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     projects: Resource$Projects;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.projects = new Resource$Projects(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.projects = new Resource$Projects();
     }
   }
 
@@ -327,33 +319,19 @@ export namespace iap_v1beta1 {
 
 
   export class Resource$Projects {
-    root: Iap;
     iap_tunnel: Resource$Projects$Iap_tunnel;
     iap_web: Resource$Projects$Iap_web;
-    constructor(root: Iap) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.iap_tunnel = new Resource$Projects$Iap_tunnel(root);
-      this.iap_web = new Resource$Projects$Iap_web(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.iap_tunnel = new Resource$Projects$Iap_tunnel();
+      this.iap_web = new Resource$Projects$Iap_web();
     }
   }
 
 
   export class Resource$Projects$Iap_tunnel {
-    root: Iap;
     zones: Resource$Projects$Iap_tunnel$Zones;
-    constructor(root: Iap) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.zones = new Resource$Projects$Iap_tunnel$Zones(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.zones = new Resource$Projects$Iap_tunnel$Zones();
     }
 
 
@@ -417,7 +395,7 @@ export namespace iap_v1beta1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -487,7 +465,7 @@ export namespace iap_v1beta1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -567,7 +545,7 @@ export namespace iap_v1beta1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TestIamPermissionsResponse>(
@@ -634,16 +612,9 @@ export namespace iap_v1beta1 {
   }
 
   export class Resource$Projects$Iap_tunnel$Zones {
-    root: Iap;
     instances: Resource$Projects$Iap_tunnel$Zones$Instances;
-    constructor(root: Iap) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.instances = new Resource$Projects$Iap_tunnel$Zones$Instances(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.instances = new Resource$Projects$Iap_tunnel$Zones$Instances();
     }
 
 
@@ -708,7 +679,7 @@ export namespace iap_v1beta1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -779,7 +750,7 @@ export namespace iap_v1beta1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -860,7 +831,7 @@ export namespace iap_v1beta1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TestIamPermissionsResponse>(
@@ -927,15 +898,7 @@ export namespace iap_v1beta1 {
   }
 
   export class Resource$Projects$Iap_tunnel$Zones$Instances {
-    root: Iap;
-    constructor(root: Iap) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -1003,7 +966,7 @@ export namespace iap_v1beta1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -1078,7 +1041,7 @@ export namespace iap_v1beta1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -1162,7 +1125,7 @@ export namespace iap_v1beta1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TestIamPermissionsResponse>(
@@ -1231,16 +1194,9 @@ export namespace iap_v1beta1 {
 
 
   export class Resource$Projects$Iap_web {
-    root: Iap;
     services: Resource$Projects$Iap_web$Services;
-    constructor(root: Iap) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.services = new Resource$Projects$Iap_web$Services(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.services = new Resource$Projects$Iap_web$Services();
     }
 
 
@@ -1304,7 +1260,7 @@ export namespace iap_v1beta1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -1374,7 +1330,7 @@ export namespace iap_v1beta1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -1453,7 +1409,7 @@ export namespace iap_v1beta1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TestIamPermissionsResponse>(
@@ -1520,16 +1476,9 @@ export namespace iap_v1beta1 {
   }
 
   export class Resource$Projects$Iap_web$Services {
-    root: Iap;
     versions: Resource$Projects$Iap_web$Services$Versions;
-    constructor(root: Iap) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.versions = new Resource$Projects$Iap_web$Services$Versions(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.versions = new Resource$Projects$Iap_web$Services$Versions();
     }
 
 
@@ -1594,7 +1543,7 @@ export namespace iap_v1beta1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -1665,7 +1614,7 @@ export namespace iap_v1beta1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -1746,7 +1695,7 @@ export namespace iap_v1beta1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TestIamPermissionsResponse>(
@@ -1813,15 +1762,7 @@ export namespace iap_v1beta1 {
   }
 
   export class Resource$Projects$Iap_web$Services$Versions {
-    root: Iap;
-    constructor(root: Iap) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -1887,7 +1828,7 @@ export namespace iap_v1beta1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -1960,7 +1901,7 @@ export namespace iap_v1beta1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -2044,7 +1985,7 @@ export namespace iap_v1beta1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TestIamPermissionsResponse>(

--- a/src/apis/identitytoolkit/v3.ts
+++ b/src/apis/identitytoolkit/v3.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace identitytoolkit_v3 {
   export interface Options extends GlobalOptions {
     version: 'v3';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -79,22 +81,12 @@ export namespace identitytoolkit_v3 {
    * @param {object=} options Options for Identitytoolkit
    */
   export class Identitytoolkit {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     relyingparty: Resource$Relyingparty;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.relyingparty = new Resource$Relyingparty(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.relyingparty = new Resource$Relyingparty();
     }
   }
 
@@ -1599,15 +1591,7 @@ export namespace identitytoolkit_v3 {
 
 
   export class Resource$Relyingparty {
-    root: Identitytoolkit;
-    constructor(root: Identitytoolkit) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -1669,7 +1653,7 @@ export namespace identitytoolkit_v3 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$CreateAuthUriResponse>(parameters, callback);
@@ -1738,7 +1722,7 @@ export namespace identitytoolkit_v3 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$DeleteAccountResponse>(parameters, callback);
@@ -1808,7 +1792,7 @@ export namespace identitytoolkit_v3 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$DownloadAccountResponse>(parameters, callback);
@@ -1878,7 +1862,7 @@ export namespace identitytoolkit_v3 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$EmailLinkSigninResponse>(parameters, callback);
@@ -1947,7 +1931,7 @@ export namespace identitytoolkit_v3 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GetAccountInfoResponse>(parameters, callback);
@@ -2021,7 +2005,7 @@ export namespace identitytoolkit_v3 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GetOobConfirmationCodeResponse>(
@@ -2102,7 +2086,7 @@ export namespace identitytoolkit_v3 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<
@@ -2180,7 +2164,7 @@ export namespace identitytoolkit_v3 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<
@@ -2254,7 +2238,7 @@ export namespace identitytoolkit_v3 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GetRecaptchaParamResponse>(
@@ -2324,7 +2308,7 @@ export namespace identitytoolkit_v3 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ResetPasswordResponse>(parameters, callback);
@@ -2405,7 +2389,7 @@ export namespace identitytoolkit_v3 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<
@@ -2478,7 +2462,7 @@ export namespace identitytoolkit_v3 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$SetAccountInfoResponse>(parameters, callback);
@@ -2556,7 +2540,7 @@ export namespace identitytoolkit_v3 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<
@@ -2634,7 +2618,7 @@ export namespace identitytoolkit_v3 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$IdentitytoolkitRelyingpartySignOutUserResponse>(
@@ -2705,7 +2689,7 @@ export namespace identitytoolkit_v3 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$SignupNewUserResponse>(parameters, callback);
@@ -2774,7 +2758,7 @@ export namespace identitytoolkit_v3 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$UploadAccountResponse>(parameters, callback);
@@ -2844,7 +2828,7 @@ export namespace identitytoolkit_v3 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$VerifyAssertionResponse>(parameters, callback);
@@ -2915,7 +2899,7 @@ export namespace identitytoolkit_v3 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$VerifyCustomTokenResponse>(
@@ -2985,7 +2969,7 @@ export namespace identitytoolkit_v3 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$VerifyPasswordResponse>(parameters, callback);
@@ -3064,7 +3048,7 @@ export namespace identitytoolkit_v3 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<

--- a/src/apis/indexing/v3.ts
+++ b/src/apis/indexing/v3.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace indexing_v3 {
   export interface Options extends GlobalOptions {
     version: 'v3';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -96,22 +98,12 @@ export namespace indexing_v3 {
    * @param {object=} options Options for Indexing
    */
   export class Indexing {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     urlNotifications: Resource$Urlnotifications;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.urlNotifications = new Resource$Urlnotifications(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.urlNotifications = new Resource$Urlnotifications();
     }
   }
 
@@ -166,15 +158,7 @@ export namespace indexing_v3 {
 
 
   export class Resource$Urlnotifications {
-    root: Indexing;
-    constructor(root: Indexing) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -239,7 +223,7 @@ export namespace indexing_v3 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$UrlNotificationMetadata>(parameters, callback);
@@ -312,7 +296,7 @@ export namespace indexing_v3 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$PublishUrlNotificationResponse>(

--- a/src/apis/jobs/v2.ts
+++ b/src/apis/jobs/v2.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace jobs_v2 {
   export interface Options extends GlobalOptions {
     version: 'v2';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -97,26 +99,16 @@ export namespace jobs_v2 {
    * @param {object=} options Options for Jobs
    */
   export class Jobs {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     companies: Resource$Companies;
     jobs: Resource$Jobs;
     v2: Resource$V2;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.companies = new Resource$Companies(this);
-      this.jobs = new Resource$Jobs(this);
-      this.v2 = new Resource$V2(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.companies = new Resource$Companies();
+      this.jobs = new Resource$Jobs();
+      this.v2 = new Resource$V2();
     }
   }
 
@@ -2218,16 +2210,9 @@ export namespace jobs_v2 {
 
 
   export class Resource$Companies {
-    root: Jobs;
     jobs: Resource$Companies$Jobs;
-    constructor(root: Jobs) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.jobs = new Resource$Companies$Jobs(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.jobs = new Resource$Companies$Jobs();
     }
 
 
@@ -2284,7 +2269,7 @@ export namespace jobs_v2 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Company>(parameters, callback);
@@ -2347,7 +2332,7 @@ export namespace jobs_v2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -2407,7 +2392,7 @@ export namespace jobs_v2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Company>(parameters, callback);
@@ -2475,7 +2460,7 @@ export namespace jobs_v2 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListCompaniesResponse>(parameters, callback);
@@ -2542,7 +2527,7 @@ export namespace jobs_v2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Company>(parameters, callback);
@@ -2641,15 +2626,7 @@ export namespace jobs_v2 {
   }
 
   export class Resource$Companies$Jobs {
-    root: Jobs;
-    constructor(root: Jobs) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -2715,7 +2692,7 @@ export namespace jobs_v2 {
         params,
         requiredParams: ['companyName'],
         pathParams: ['companyName'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListCompanyJobsResponse>(parameters, callback);
@@ -2770,15 +2747,7 @@ export namespace jobs_v2 {
 
 
   export class Resource$Jobs {
-    root: Jobs;
-    constructor(root: Jobs) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -2836,7 +2805,7 @@ export namespace jobs_v2 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -2900,7 +2869,7 @@ export namespace jobs_v2 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Job>(parameters, callback);
@@ -2965,7 +2934,7 @@ export namespace jobs_v2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -3034,7 +3003,7 @@ export namespace jobs_v2 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -3095,7 +3064,7 @@ export namespace jobs_v2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Job>(parameters, callback);
@@ -3169,7 +3138,7 @@ export namespace jobs_v2 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GetHistogramResponse>(parameters, callback);
@@ -3236,7 +3205,7 @@ export namespace jobs_v2 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListJobsResponse>(parameters, callback);
@@ -3301,7 +3270,7 @@ export namespace jobs_v2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Job>(parameters, callback);
@@ -3367,7 +3336,7 @@ export namespace jobs_v2 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$SearchJobsResponse>(parameters, callback);
@@ -3441,7 +3410,7 @@ export namespace jobs_v2 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$SearchJobsResponse>(parameters, callback);
@@ -3609,15 +3578,7 @@ export namespace jobs_v2 {
 
 
   export class Resource$V2 {
-    root: Jobs;
-    constructor(root: Jobs) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -3682,7 +3643,7 @@ export namespace jobs_v2 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$CompleteQueryResponse>(parameters, callback);

--- a/src/apis/jobs/v3.ts
+++ b/src/apis/jobs/v3.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace jobs_v3 {
   export interface Options extends GlobalOptions {
     version: 'v3';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -97,22 +99,12 @@ export namespace jobs_v3 {
    * @param {object=} options Options for Jobs
    */
   export class Jobs {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     projects: Resource$Projects;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.projects = new Resource$Projects(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.projects = new Resource$Projects();
     }
   }
 
@@ -1685,18 +1677,11 @@ export namespace jobs_v3 {
 
 
   export class Resource$Projects {
-    root: Jobs;
     companies: Resource$Projects$Companies;
     jobs: Resource$Projects$Jobs;
-    constructor(root: Jobs) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.companies = new Resource$Projects$Companies(root);
-      this.jobs = new Resource$Projects$Jobs(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.companies = new Resource$Projects$Companies();
+      this.jobs = new Resource$Projects$Jobs();
     }
 
 
@@ -1767,7 +1752,7 @@ export namespace jobs_v3 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$CompleteQueryResponse>(parameters, callback);
@@ -1842,15 +1827,7 @@ export namespace jobs_v3 {
   }
 
   export class Resource$Projects$Companies {
-    root: Jobs;
-    constructor(root: Jobs) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -1910,7 +1887,7 @@ export namespace jobs_v3 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Company>(parameters, callback);
@@ -1976,7 +1953,7 @@ export namespace jobs_v3 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -2037,7 +2014,7 @@ export namespace jobs_v3 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Company>(parameters, callback);
@@ -2108,7 +2085,7 @@ export namespace jobs_v3 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListCompaniesResponse>(parameters, callback);
@@ -2176,7 +2153,7 @@ export namespace jobs_v3 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Company>(parameters, callback);
@@ -2285,15 +2262,7 @@ export namespace jobs_v3 {
 
 
   export class Resource$Projects$Jobs {
-    root: Jobs;
-    constructor(root: Jobs) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -2353,7 +2322,7 @@ export namespace jobs_v3 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -2421,7 +2390,7 @@ export namespace jobs_v3 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Job>(parameters, callback);
@@ -2487,7 +2456,7 @@ export namespace jobs_v3 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -2549,7 +2518,7 @@ export namespace jobs_v3 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Job>(parameters, callback);
@@ -2619,7 +2588,7 @@ export namespace jobs_v3 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListJobsResponse>(parameters, callback);
@@ -2686,7 +2655,7 @@ export namespace jobs_v3 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Job>(parameters, callback);
@@ -2756,7 +2725,7 @@ export namespace jobs_v3 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$SearchJobsResponse>(parameters, callback);
@@ -2831,7 +2800,7 @@ export namespace jobs_v3 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$SearchJobsResponse>(parameters, callback);

--- a/src/apis/jobs/v3p1beta1.ts
+++ b/src/apis/jobs/v3p1beta1.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace jobs_v3p1beta1 {
   export interface Options extends GlobalOptions {
     version: 'v3p1beta1';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -97,22 +99,12 @@ export namespace jobs_v3p1beta1 {
    * @param {object=} options Options for Jobs
    */
   export class Jobs {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     projects: Resource$Projects;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.projects = new Resource$Projects(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.projects = new Resource$Projects();
     }
   }
 
@@ -1911,20 +1903,13 @@ export namespace jobs_v3p1beta1 {
 
 
   export class Resource$Projects {
-    root: Jobs;
     clientEvents: Resource$Projects$Clientevents;
     companies: Resource$Projects$Companies;
     jobs: Resource$Projects$Jobs;
-    constructor(root: Jobs) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.clientEvents = new Resource$Projects$Clientevents(root);
-      this.companies = new Resource$Projects$Companies(root);
-      this.jobs = new Resource$Projects$Jobs(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.clientEvents = new Resource$Projects$Clientevents();
+      this.companies = new Resource$Projects$Companies();
+      this.jobs = new Resource$Projects$Jobs();
     }
 
 
@@ -1995,7 +1980,7 @@ export namespace jobs_v3p1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$CompleteQueryResponse>(parameters, callback);
@@ -2070,15 +2055,7 @@ export namespace jobs_v3p1beta1 {
   }
 
   export class Resource$Projects$Clientevents {
-    root: Jobs;
-    constructor(root: Jobs) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -2144,7 +2121,7 @@ export namespace jobs_v3p1beta1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ClientEvent>(parameters, callback);
@@ -2174,15 +2151,7 @@ export namespace jobs_v3p1beta1 {
 
 
   export class Resource$Projects$Companies {
-    root: Jobs;
-    constructor(root: Jobs) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -2242,7 +2211,7 @@ export namespace jobs_v3p1beta1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Company>(parameters, callback);
@@ -2309,7 +2278,7 @@ export namespace jobs_v3p1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -2371,7 +2340,7 @@ export namespace jobs_v3p1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Company>(parameters, callback);
@@ -2442,7 +2411,7 @@ export namespace jobs_v3p1beta1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListCompaniesResponse>(parameters, callback);
@@ -2511,7 +2480,7 @@ export namespace jobs_v3p1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Company>(parameters, callback);
@@ -2620,15 +2589,7 @@ export namespace jobs_v3p1beta1 {
 
 
   export class Resource$Projects$Jobs {
-    root: Jobs;
-    constructor(root: Jobs) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -2688,7 +2649,7 @@ export namespace jobs_v3p1beta1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -2756,7 +2717,7 @@ export namespace jobs_v3p1beta1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Job>(parameters, callback);
@@ -2823,7 +2784,7 @@ export namespace jobs_v3p1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -2886,7 +2847,7 @@ export namespace jobs_v3p1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Job>(parameters, callback);
@@ -2956,7 +2917,7 @@ export namespace jobs_v3p1beta1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListJobsResponse>(parameters, callback);
@@ -3024,7 +2985,7 @@ export namespace jobs_v3p1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Job>(parameters, callback);
@@ -3094,7 +3055,7 @@ export namespace jobs_v3p1beta1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$SearchJobsResponse>(parameters, callback);
@@ -3169,7 +3130,7 @@ export namespace jobs_v3p1beta1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$SearchJobsResponse>(parameters, callback);

--- a/src/apis/kgsearch/v1.ts
+++ b/src/apis/kgsearch/v1.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace kgsearch_v1 {
   export interface Options extends GlobalOptions {
     version: 'v1';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -96,22 +98,12 @@ export namespace kgsearch_v1 {
    * @param {object=} options Options for Kgsearch
    */
   export class Kgsearch {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     entities: Resource$Entities;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.entities = new Resource$Entities(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.entities = new Resource$Entities();
     }
   }
 
@@ -137,15 +129,7 @@ export namespace kgsearch_v1 {
 
 
   export class Resource$Entities {
-    root: Kgsearch;
-    constructor(root: Kgsearch) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -211,7 +195,7 @@ export namespace kgsearch_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$SearchResponse>(parameters, callback);

--- a/src/apis/language/v1.ts
+++ b/src/apis/language/v1.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace language_v1 {
   export interface Options extends GlobalOptions {
     version: 'v1';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -98,22 +100,12 @@ export namespace language_v1 {
    * @param {object=} options Options for Language
    */
   export class Language {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     documents: Resource$Documents;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.documents = new Resource$Documents(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.documents = new Resource$Documents();
     }
   }
 
@@ -642,15 +634,7 @@ export namespace language_v1 {
 
 
   export class Resource$Documents {
-    root: Language;
-    constructor(root: Language) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -714,7 +698,7 @@ export namespace language_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$AnalyzeEntitiesResponse>(parameters, callback);
@@ -788,7 +772,7 @@ export namespace language_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$AnalyzeEntitySentimentResponse>(
@@ -859,7 +843,7 @@ export namespace language_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$AnalyzeSentimentResponse>(parameters, callback);
@@ -930,7 +914,7 @@ export namespace language_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$AnalyzeSyntaxResponse>(parameters, callback);
@@ -1000,7 +984,7 @@ export namespace language_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$AnnotateTextResponse>(parameters, callback);
@@ -1069,7 +1053,7 @@ export namespace language_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ClassifyTextResponse>(parameters, callback);

--- a/src/apis/language/v1beta1.ts
+++ b/src/apis/language/v1beta1.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace language_v1beta1 {
   export interface Options extends GlobalOptions {
     version: 'v1beta1';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -98,22 +100,12 @@ export namespace language_v1beta1 {
    * @param {object=} options Options for Language
    */
   export class Language {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     documents: Resource$Documents;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.documents = new Resource$Documents(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.documents = new Resource$Documents();
     }
   }
 
@@ -559,15 +551,7 @@ export namespace language_v1beta1 {
 
 
   export class Resource$Documents {
-    root: Language;
-    constructor(root: Language) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -631,7 +615,7 @@ export namespace language_v1beta1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$AnalyzeEntitiesResponse>(parameters, callback);
@@ -700,7 +684,7 @@ export namespace language_v1beta1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$AnalyzeSentimentResponse>(parameters, callback);
@@ -771,7 +755,7 @@ export namespace language_v1beta1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$AnalyzeSyntaxResponse>(parameters, callback);
@@ -841,7 +825,7 @@ export namespace language_v1beta1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$AnnotateTextResponse>(parameters, callback);

--- a/src/apis/language/v1beta2.ts
+++ b/src/apis/language/v1beta2.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace language_v1beta2 {
   export interface Options extends GlobalOptions {
     version: 'v1beta2';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -98,22 +100,12 @@ export namespace language_v1beta2 {
    * @param {object=} options Options for Language
    */
   export class Language {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     documents: Resource$Documents;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.documents = new Resource$Documents(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.documents = new Resource$Documents();
     }
   }
 
@@ -643,15 +635,7 @@ export namespace language_v1beta2 {
 
 
   export class Resource$Documents {
-    root: Language;
-    constructor(root: Language) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -715,7 +699,7 @@ export namespace language_v1beta2 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$AnalyzeEntitiesResponse>(parameters, callback);
@@ -789,7 +773,7 @@ export namespace language_v1beta2 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$AnalyzeEntitySentimentResponse>(
@@ -860,7 +844,7 @@ export namespace language_v1beta2 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$AnalyzeSentimentResponse>(parameters, callback);
@@ -931,7 +915,7 @@ export namespace language_v1beta2 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$AnalyzeSyntaxResponse>(parameters, callback);
@@ -1001,7 +985,7 @@ export namespace language_v1beta2 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$AnnotateTextResponse>(parameters, callback);
@@ -1070,7 +1054,7 @@ export namespace language_v1beta2 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ClassifyTextResponse>(parameters, callback);

--- a/src/apis/licensing/v1.ts
+++ b/src/apis/licensing/v1.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace licensing_v1 {
   export interface Options extends GlobalOptions {
     version: 'v1';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -79,22 +81,12 @@ export namespace licensing_v1 {
    * @param {object=} options Options for Licensing
    */
   export class Licensing {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     licenseAssignments: Resource$Licenseassignments;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.licenseAssignments = new Resource$Licenseassignments(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.licenseAssignments = new Resource$Licenseassignments();
     }
   }
 
@@ -169,15 +161,7 @@ export namespace licensing_v1 {
 
 
   export class Resource$Licenseassignments {
-    root: Licensing;
-    constructor(root: Licensing) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -239,7 +223,7 @@ export namespace licensing_v1 {
         params,
         requiredParams: ['productId', 'skuId', 'userId'],
         pathParams: ['productId', 'skuId', 'userId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -306,7 +290,7 @@ export namespace licensing_v1 {
         params,
         requiredParams: ['productId', 'skuId', 'userId'],
         pathParams: ['productId', 'skuId', 'userId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$LicenseAssignment>(parameters, callback);
@@ -376,7 +360,7 @@ export namespace licensing_v1 {
         params,
         requiredParams: ['productId', 'skuId'],
         pathParams: ['productId', 'skuId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$LicenseAssignment>(parameters, callback);
@@ -448,7 +432,7 @@ export namespace licensing_v1 {
         params,
         requiredParams: ['productId', 'customerId'],
         pathParams: ['productId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$LicenseAssignmentList>(parameters, callback);
@@ -523,7 +507,7 @@ export namespace licensing_v1 {
         params,
         requiredParams: ['productId', 'skuId', 'customerId'],
         pathParams: ['productId', 'skuId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$LicenseAssignmentList>(parameters, callback);
@@ -595,7 +579,7 @@ export namespace licensing_v1 {
         params,
         requiredParams: ['productId', 'skuId', 'userId'],
         pathParams: ['productId', 'skuId', 'userId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$LicenseAssignment>(parameters, callback);
@@ -667,7 +651,7 @@ export namespace licensing_v1 {
         params,
         requiredParams: ['productId', 'skuId', 'userId'],
         pathParams: ['productId', 'skuId', 'userId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$LicenseAssignment>(parameters, callback);

--- a/src/apis/logging/v2.ts
+++ b/src/apis/logging/v2.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace logging_v2 {
   export interface Options extends GlobalOptions {
     version: 'v2';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -96,10 +98,6 @@ export namespace logging_v2 {
    * @param {object=} options Options for Logging
    */
   export class Logging {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     billingAccounts: Resource$Billingaccounts;
     entries: Resource$Entries;
     exclusions: Resource$Exclusions;
@@ -111,24 +109,18 @@ export namespace logging_v2 {
     sinks: Resource$Sinks;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.billingAccounts = new Resource$Billingaccounts(this);
-      this.entries = new Resource$Entries(this);
-      this.exclusions = new Resource$Exclusions(this);
-      this.folders = new Resource$Folders(this);
-      this.logs = new Resource$Logs(this);
+      this.billingAccounts = new Resource$Billingaccounts();
+      this.entries = new Resource$Entries();
+      this.exclusions = new Resource$Exclusions();
+      this.folders = new Resource$Folders();
+      this.logs = new Resource$Logs();
       this.monitoredResourceDescriptors =
-          new Resource$Monitoredresourcedescriptors(this);
-      this.organizations = new Resource$Organizations(this);
-      this.projects = new Resource$Projects(this);
-      this.sinks = new Resource$Sinks(this);
-    }
-
-    getRoot() {
-      return this.root;
+          new Resource$Monitoredresourcedescriptors();
+      this.organizations = new Resource$Organizations();
+      this.projects = new Resource$Projects();
+      this.sinks = new Resource$Sinks();
     }
   }
 
@@ -1350,34 +1342,19 @@ export namespace logging_v2 {
 
 
   export class Resource$Billingaccounts {
-    root: Logging;
     exclusions: Resource$Billingaccounts$Exclusions;
     logs: Resource$Billingaccounts$Logs;
     sinks: Resource$Billingaccounts$Sinks;
-    constructor(root: Logging) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.exclusions = new Resource$Billingaccounts$Exclusions(root);
-      this.logs = new Resource$Billingaccounts$Logs(root);
-      this.sinks = new Resource$Billingaccounts$Sinks(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.exclusions = new Resource$Billingaccounts$Exclusions();
+      this.logs = new Resource$Billingaccounts$Logs();
+      this.sinks = new Resource$Billingaccounts$Sinks();
     }
   }
 
 
   export class Resource$Billingaccounts$Exclusions {
-    root: Logging;
-    constructor(root: Logging) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -1440,7 +1417,7 @@ export namespace logging_v2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$LogExclusion>(parameters, callback);
@@ -1505,7 +1482,7 @@ export namespace logging_v2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -1567,7 +1544,7 @@ export namespace logging_v2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$LogExclusion>(parameters, callback);
@@ -1637,7 +1614,7 @@ export namespace logging_v2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListExclusionsResponse>(parameters, callback);
@@ -1705,7 +1682,7 @@ export namespace logging_v2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$LogExclusion>(parameters, callback);
@@ -1830,15 +1807,7 @@ export namespace logging_v2 {
 
 
   export class Resource$Billingaccounts$Logs {
-    root: Logging;
-    constructor(root: Logging) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -1898,7 +1867,7 @@ export namespace logging_v2 {
         params,
         requiredParams: ['logName'],
         pathParams: ['logName'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -1968,7 +1937,7 @@ export namespace logging_v2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListLogsResponse>(parameters, callback);
@@ -2027,15 +1996,7 @@ export namespace logging_v2 {
 
 
   export class Resource$Billingaccounts$Sinks {
-    root: Logging;
-    constructor(root: Logging) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -2099,7 +2060,7 @@ export namespace logging_v2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$LogSink>(parameters, callback);
@@ -2165,7 +2126,7 @@ export namespace logging_v2 {
         params,
         requiredParams: ['sinkName'],
         pathParams: ['sinkName'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -2226,7 +2187,7 @@ export namespace logging_v2 {
         params,
         requiredParams: ['sinkName'],
         pathParams: ['sinkName'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$LogSink>(parameters, callback);
@@ -2295,7 +2256,7 @@ export namespace logging_v2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListSinksResponse>(parameters, callback);
@@ -2366,7 +2327,7 @@ export namespace logging_v2 {
         params,
         requiredParams: ['sinkName'],
         pathParams: ['sinkName'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$LogSink>(parameters, callback);
@@ -2437,7 +2398,7 @@ export namespace logging_v2 {
         params,
         requiredParams: ['sinkName'],
         pathParams: ['sinkName'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$LogSink>(parameters, callback);
@@ -2640,15 +2601,7 @@ export namespace logging_v2 {
 
 
   export class Resource$Entries {
-    root: Logging;
-    constructor(root: Logging) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -2707,7 +2660,7 @@ export namespace logging_v2 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListLogEntriesResponse>(parameters, callback);
@@ -2778,7 +2731,7 @@ export namespace logging_v2 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$WriteLogEntriesResponse>(parameters, callback);
@@ -2815,15 +2768,7 @@ export namespace logging_v2 {
 
 
   export class Resource$Exclusions {
-    root: Logging;
-    constructor(root: Logging) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -2885,7 +2830,7 @@ export namespace logging_v2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$LogExclusion>(parameters, callback);
@@ -2949,7 +2894,7 @@ export namespace logging_v2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -3010,7 +2955,7 @@ export namespace logging_v2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$LogExclusion>(parameters, callback);
@@ -3078,7 +3023,7 @@ export namespace logging_v2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListExclusionsResponse>(parameters, callback);
@@ -3144,7 +3089,7 @@ export namespace logging_v2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$LogExclusion>(parameters, callback);
@@ -3266,34 +3211,19 @@ export namespace logging_v2 {
 
 
   export class Resource$Folders {
-    root: Logging;
     exclusions: Resource$Folders$Exclusions;
     logs: Resource$Folders$Logs;
     sinks: Resource$Folders$Sinks;
-    constructor(root: Logging) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.exclusions = new Resource$Folders$Exclusions(root);
-      this.logs = new Resource$Folders$Logs(root);
-      this.sinks = new Resource$Folders$Sinks(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.exclusions = new Resource$Folders$Exclusions();
+      this.logs = new Resource$Folders$Logs();
+      this.sinks = new Resource$Folders$Sinks();
     }
   }
 
 
   export class Resource$Folders$Exclusions {
-    root: Logging;
-    constructor(root: Logging) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -3356,7 +3286,7 @@ export namespace logging_v2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$LogExclusion>(parameters, callback);
@@ -3421,7 +3351,7 @@ export namespace logging_v2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -3483,7 +3413,7 @@ export namespace logging_v2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$LogExclusion>(parameters, callback);
@@ -3553,7 +3483,7 @@ export namespace logging_v2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListExclusionsResponse>(parameters, callback);
@@ -3621,7 +3551,7 @@ export namespace logging_v2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$LogExclusion>(parameters, callback);
@@ -3746,15 +3676,7 @@ export namespace logging_v2 {
 
 
   export class Resource$Folders$Logs {
-    root: Logging;
-    constructor(root: Logging) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -3814,7 +3736,7 @@ export namespace logging_v2 {
         params,
         requiredParams: ['logName'],
         pathParams: ['logName'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -3883,7 +3805,7 @@ export namespace logging_v2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListLogsResponse>(parameters, callback);
@@ -3942,15 +3864,7 @@ export namespace logging_v2 {
 
 
   export class Resource$Folders$Sinks {
-    root: Logging;
-    constructor(root: Logging) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -4014,7 +3928,7 @@ export namespace logging_v2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$LogSink>(parameters, callback);
@@ -4080,7 +3994,7 @@ export namespace logging_v2 {
         params,
         requiredParams: ['sinkName'],
         pathParams: ['sinkName'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -4141,7 +4055,7 @@ export namespace logging_v2 {
         params,
         requiredParams: ['sinkName'],
         pathParams: ['sinkName'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$LogSink>(parameters, callback);
@@ -4209,7 +4123,7 @@ export namespace logging_v2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListSinksResponse>(parameters, callback);
@@ -4280,7 +4194,7 @@ export namespace logging_v2 {
         params,
         requiredParams: ['sinkName'],
         pathParams: ['sinkName'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$LogSink>(parameters, callback);
@@ -4351,7 +4265,7 @@ export namespace logging_v2 {
         params,
         requiredParams: ['sinkName'],
         pathParams: ['sinkName'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$LogSink>(parameters, callback);
@@ -4554,15 +4468,7 @@ export namespace logging_v2 {
 
 
   export class Resource$Logs {
-    root: Logging;
-    constructor(root: Logging) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -4620,7 +4526,7 @@ export namespace logging_v2 {
         params,
         requiredParams: ['logName'],
         pathParams: ['logName'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -4688,7 +4594,7 @@ export namespace logging_v2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListLogsResponse>(parameters, callback);
@@ -4745,15 +4651,7 @@ export namespace logging_v2 {
 
 
   export class Resource$Monitoredresourcedescriptors {
-    root: Logging;
-    constructor(root: Logging) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -4820,7 +4718,7 @@ export namespace logging_v2 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListMonitoredResourceDescriptorsResponse>(
@@ -4856,34 +4754,19 @@ export namespace logging_v2 {
 
 
   export class Resource$Organizations {
-    root: Logging;
     exclusions: Resource$Organizations$Exclusions;
     logs: Resource$Organizations$Logs;
     sinks: Resource$Organizations$Sinks;
-    constructor(root: Logging) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.exclusions = new Resource$Organizations$Exclusions(root);
-      this.logs = new Resource$Organizations$Logs(root);
-      this.sinks = new Resource$Organizations$Sinks(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.exclusions = new Resource$Organizations$Exclusions();
+      this.logs = new Resource$Organizations$Logs();
+      this.sinks = new Resource$Organizations$Sinks();
     }
   }
 
 
   export class Resource$Organizations$Exclusions {
-    root: Logging;
-    constructor(root: Logging) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -4946,7 +4829,7 @@ export namespace logging_v2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$LogExclusion>(parameters, callback);
@@ -5011,7 +4894,7 @@ export namespace logging_v2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -5073,7 +4956,7 @@ export namespace logging_v2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$LogExclusion>(parameters, callback);
@@ -5143,7 +5026,7 @@ export namespace logging_v2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListExclusionsResponse>(parameters, callback);
@@ -5211,7 +5094,7 @@ export namespace logging_v2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$LogExclusion>(parameters, callback);
@@ -5336,15 +5219,7 @@ export namespace logging_v2 {
 
 
   export class Resource$Organizations$Logs {
-    root: Logging;
-    constructor(root: Logging) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -5404,7 +5279,7 @@ export namespace logging_v2 {
         params,
         requiredParams: ['logName'],
         pathParams: ['logName'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -5474,7 +5349,7 @@ export namespace logging_v2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListLogsResponse>(parameters, callback);
@@ -5533,15 +5408,7 @@ export namespace logging_v2 {
 
 
   export class Resource$Organizations$Sinks {
-    root: Logging;
-    constructor(root: Logging) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -5605,7 +5472,7 @@ export namespace logging_v2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$LogSink>(parameters, callback);
@@ -5671,7 +5538,7 @@ export namespace logging_v2 {
         params,
         requiredParams: ['sinkName'],
         pathParams: ['sinkName'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -5732,7 +5599,7 @@ export namespace logging_v2 {
         params,
         requiredParams: ['sinkName'],
         pathParams: ['sinkName'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$LogSink>(parameters, callback);
@@ -5801,7 +5668,7 @@ export namespace logging_v2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListSinksResponse>(parameters, callback);
@@ -5872,7 +5739,7 @@ export namespace logging_v2 {
         params,
         requiredParams: ['sinkName'],
         pathParams: ['sinkName'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$LogSink>(parameters, callback);
@@ -5943,7 +5810,7 @@ export namespace logging_v2 {
         params,
         requiredParams: ['sinkName'],
         pathParams: ['sinkName'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$LogSink>(parameters, callback);
@@ -6146,36 +6013,21 @@ export namespace logging_v2 {
 
 
   export class Resource$Projects {
-    root: Logging;
     exclusions: Resource$Projects$Exclusions;
     logs: Resource$Projects$Logs;
     metrics: Resource$Projects$Metrics;
     sinks: Resource$Projects$Sinks;
-    constructor(root: Logging) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.exclusions = new Resource$Projects$Exclusions(root);
-      this.logs = new Resource$Projects$Logs(root);
-      this.metrics = new Resource$Projects$Metrics(root);
-      this.sinks = new Resource$Projects$Sinks(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.exclusions = new Resource$Projects$Exclusions();
+      this.logs = new Resource$Projects$Logs();
+      this.metrics = new Resource$Projects$Metrics();
+      this.sinks = new Resource$Projects$Sinks();
     }
   }
 
 
   export class Resource$Projects$Exclusions {
-    root: Logging;
-    constructor(root: Logging) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -6238,7 +6090,7 @@ export namespace logging_v2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$LogExclusion>(parameters, callback);
@@ -6303,7 +6155,7 @@ export namespace logging_v2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -6365,7 +6217,7 @@ export namespace logging_v2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$LogExclusion>(parameters, callback);
@@ -6435,7 +6287,7 @@ export namespace logging_v2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListExclusionsResponse>(parameters, callback);
@@ -6503,7 +6355,7 @@ export namespace logging_v2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$LogExclusion>(parameters, callback);
@@ -6628,15 +6480,7 @@ export namespace logging_v2 {
 
 
   export class Resource$Projects$Logs {
-    root: Logging;
-    constructor(root: Logging) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -6696,7 +6540,7 @@ export namespace logging_v2 {
         params,
         requiredParams: ['logName'],
         pathParams: ['logName'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -6765,7 +6609,7 @@ export namespace logging_v2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListLogsResponse>(parameters, callback);
@@ -6824,15 +6668,7 @@ export namespace logging_v2 {
 
 
   export class Resource$Projects$Metrics {
-    root: Logging;
-    constructor(root: Logging) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -6893,7 +6729,7 @@ export namespace logging_v2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$LogMetric>(parameters, callback);
@@ -6959,7 +6795,7 @@ export namespace logging_v2 {
         params,
         requiredParams: ['metricName'],
         pathParams: ['metricName'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -7022,7 +6858,7 @@ export namespace logging_v2 {
         params,
         requiredParams: ['metricName'],
         pathParams: ['metricName'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$LogMetric>(parameters, callback);
@@ -7092,7 +6928,7 @@ export namespace logging_v2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListLogMetricsResponse>(parameters, callback);
@@ -7160,7 +6996,7 @@ export namespace logging_v2 {
         params,
         requiredParams: ['metricName'],
         pathParams: ['metricName'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$LogMetric>(parameters, callback);
@@ -7264,15 +7100,7 @@ export namespace logging_v2 {
 
 
   export class Resource$Projects$Sinks {
-    root: Logging;
-    constructor(root: Logging) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -7336,7 +7164,7 @@ export namespace logging_v2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$LogSink>(parameters, callback);
@@ -7402,7 +7230,7 @@ export namespace logging_v2 {
         params,
         requiredParams: ['sinkName'],
         pathParams: ['sinkName'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -7463,7 +7291,7 @@ export namespace logging_v2 {
         params,
         requiredParams: ['sinkName'],
         pathParams: ['sinkName'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$LogSink>(parameters, callback);
@@ -7531,7 +7359,7 @@ export namespace logging_v2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListSinksResponse>(parameters, callback);
@@ -7602,7 +7430,7 @@ export namespace logging_v2 {
         params,
         requiredParams: ['sinkName'],
         pathParams: ['sinkName'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$LogSink>(parameters, callback);
@@ -7673,7 +7501,7 @@ export namespace logging_v2 {
         params,
         requiredParams: ['sinkName'],
         pathParams: ['sinkName'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$LogSink>(parameters, callback);
@@ -7876,15 +7704,7 @@ export namespace logging_v2 {
 
 
   export class Resource$Sinks {
-    root: Logging;
-    constructor(root: Logging) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -7946,7 +7766,7 @@ export namespace logging_v2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$LogSink>(parameters, callback);
@@ -8010,7 +7830,7 @@ export namespace logging_v2 {
         params,
         requiredParams: ['sinkName'],
         pathParams: ['sinkName'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -8070,7 +7890,7 @@ export namespace logging_v2 {
         params,
         requiredParams: ['sinkName'],
         pathParams: ['sinkName'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$LogSink>(parameters, callback);
@@ -8137,7 +7957,7 @@ export namespace logging_v2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListSinksResponse>(parameters, callback);
@@ -8206,7 +8026,7 @@ export namespace logging_v2 {
         params,
         requiredParams: ['sinkName'],
         pathParams: ['sinkName'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$LogSink>(parameters, callback);

--- a/src/apis/logging/v2beta1.ts
+++ b/src/apis/logging/v2beta1.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace logging_v2beta1 {
   export interface Options extends GlobalOptions {
     version: 'v2beta1';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -96,27 +98,17 @@ export namespace logging_v2beta1 {
    * @param {object=} options Options for Logging
    */
   export class Logging {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     entries: Resource$Entries;
     monitoredResourceDescriptors: Resource$Monitoredresourcedescriptors;
     projects: Resource$Projects;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.entries = new Resource$Entries(this);
+      this.entries = new Resource$Entries();
       this.monitoredResourceDescriptors =
-          new Resource$Monitoredresourcedescriptors(this);
-      this.projects = new Resource$Projects(this);
-    }
-
-    getRoot() {
-      return this.root;
+          new Resource$Monitoredresourcedescriptors();
+      this.projects = new Resource$Projects();
     }
   }
 
@@ -1271,15 +1263,7 @@ export namespace logging_v2beta1 {
 
 
   export class Resource$Entries {
-    root: Logging;
-    constructor(root: Logging) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -1406,7 +1390,7 @@ export namespace logging_v2beta1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListLogEntriesResponse>(parameters, callback);
@@ -1531,7 +1515,7 @@ export namespace logging_v2beta1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$WriteLogEntriesResponse>(parameters, callback);
@@ -1568,15 +1552,7 @@ export namespace logging_v2beta1 {
 
 
   export class Resource$Monitoredresourcedescriptors {
-    root: Logging;
-    constructor(root: Logging) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -1707,7 +1683,7 @@ export namespace logging_v2beta1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListMonitoredResourceDescriptorsResponse>(
@@ -1743,32 +1719,17 @@ export namespace logging_v2beta1 {
 
 
   export class Resource$Projects {
-    root: Logging;
     metrics: Resource$Projects$Metrics;
     sinks: Resource$Projects$Sinks;
-    constructor(root: Logging) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.metrics = new Resource$Projects$Metrics(root);
-      this.sinks = new Resource$Projects$Sinks(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.metrics = new Resource$Projects$Metrics();
+      this.sinks = new Resource$Projects$Sinks();
     }
   }
 
 
   export class Resource$Projects$Metrics {
-    root: Logging;
-    constructor(root: Logging) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -1888,7 +1849,7 @@ export namespace logging_v2beta1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$LogMetric>(parameters, callback);
@@ -2006,7 +1967,7 @@ export namespace logging_v2beta1 {
         params,
         requiredParams: ['metricName'],
         pathParams: ['metricName'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -2124,7 +2085,7 @@ export namespace logging_v2beta1 {
         params,
         requiredParams: ['metricName'],
         pathParams: ['metricName'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$LogMetric>(parameters, callback);
@@ -2261,7 +2222,7 @@ export namespace logging_v2beta1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListLogMetricsResponse>(parameters, callback);
@@ -2394,7 +2355,7 @@ export namespace logging_v2beta1 {
         params,
         requiredParams: ['metricName'],
         pathParams: ['metricName'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$LogMetric>(parameters, callback);
@@ -2498,15 +2459,7 @@ export namespace logging_v2beta1 {
 
 
   export class Resource$Projects$Sinks {
-    root: Logging;
-    constructor(root: Logging) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -2633,7 +2586,7 @@ export namespace logging_v2beta1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$LogSink>(parameters, callback);
@@ -2758,7 +2711,7 @@ export namespace logging_v2beta1 {
         params,
         requiredParams: ['sinkName'],
         pathParams: ['sinkName'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -2879,7 +2832,7 @@ export namespace logging_v2beta1 {
         params,
         requiredParams: ['sinkName'],
         pathParams: ['sinkName'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$LogSink>(parameters, callback);
@@ -3017,7 +2970,7 @@ export namespace logging_v2beta1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListSinksResponse>(parameters, callback);
@@ -3156,7 +3109,7 @@ export namespace logging_v2beta1 {
         params,
         requiredParams: ['sinkName'],
         pathParams: ['sinkName'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$LogSink>(parameters, callback);

--- a/src/apis/manufacturers/v1.ts
+++ b/src/apis/manufacturers/v1.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace manufacturers_v1 {
   export interface Options extends GlobalOptions {
     version: 'v1';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -96,22 +98,12 @@ export namespace manufacturers_v1 {
    * @param {object=} options Options for Manufacturers
    */
   export class Manufacturers {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     accounts: Resource$Accounts;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.accounts = new Resource$Accounts(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.accounts = new Resource$Accounts();
     }
   }
 
@@ -513,30 +505,15 @@ export namespace manufacturers_v1 {
 
 
   export class Resource$Accounts {
-    root: Manufacturers;
     products: Resource$Accounts$Products;
-    constructor(root: Manufacturers) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.products = new Resource$Accounts$Products(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.products = new Resource$Accounts$Products();
     }
   }
 
 
   export class Resource$Accounts$Products {
-    root: Manufacturers;
-    constructor(root: Manufacturers) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -597,7 +574,7 @@ export namespace manufacturers_v1 {
         params,
         requiredParams: ['parent', 'name'],
         pathParams: ['name', 'parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -666,7 +643,7 @@ export namespace manufacturers_v1 {
         params,
         requiredParams: ['parent', 'name'],
         pathParams: ['name', 'parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Product>(parameters, callback);
@@ -738,7 +715,7 @@ export namespace manufacturers_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListProductsResponse>(parameters, callback);
@@ -818,7 +795,7 @@ export namespace manufacturers_v1 {
         params,
         requiredParams: ['parent', 'name'],
         pathParams: ['name', 'parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);

--- a/src/apis/mirror/v1.ts
+++ b/src/apis/mirror/v1.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace mirror_v1 {
   export interface Options extends GlobalOptions {
     version: 'v1';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -79,10 +81,6 @@ export namespace mirror_v1 {
    * @param {object=} options Options for Mirror
    */
   export class Mirror {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     accounts: Resource$Accounts;
     contacts: Resource$Contacts;
     locations: Resource$Locations;
@@ -91,20 +89,14 @@ export namespace mirror_v1 {
     timeline: Resource$Timeline;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.accounts = new Resource$Accounts(this);
-      this.contacts = new Resource$Contacts(this);
-      this.locations = new Resource$Locations(this);
-      this.settings = new Resource$Settings(this);
-      this.subscriptions = new Resource$Subscriptions(this);
-      this.timeline = new Resource$Timeline(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.accounts = new Resource$Accounts();
+      this.contacts = new Resource$Contacts();
+      this.locations = new Resource$Locations();
+      this.settings = new Resource$Settings();
+      this.subscriptions = new Resource$Subscriptions();
+      this.timeline = new Resource$Timeline();
     }
   }
 
@@ -752,15 +744,7 @@ export namespace mirror_v1 {
 
 
   export class Resource$Accounts {
-    root: Mirror;
-    constructor(root: Mirror) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -822,7 +806,7 @@ export namespace mirror_v1 {
         params,
         requiredParams: ['userToken', 'accountType', 'accountName'],
         pathParams: ['accountName', 'accountType', 'userToken'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Account>(parameters, callback);
@@ -859,15 +843,7 @@ export namespace mirror_v1 {
 
 
   export class Resource$Contacts {
-    root: Mirror;
-    constructor(root: Mirror) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -923,7 +899,7 @@ export namespace mirror_v1 {
         params,
         requiredParams: ['id'],
         pathParams: ['id'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -984,7 +960,7 @@ export namespace mirror_v1 {
         params,
         requiredParams: ['id'],
         pathParams: ['id'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Contact>(parameters, callback);
@@ -1048,7 +1024,7 @@ export namespace mirror_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Contact>(parameters, callback);
@@ -1113,7 +1089,7 @@ export namespace mirror_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ContactsListResponse>(parameters, callback);
@@ -1178,7 +1154,7 @@ export namespace mirror_v1 {
         params,
         requiredParams: ['id'],
         pathParams: ['id'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Contact>(parameters, callback);
@@ -1243,7 +1219,7 @@ export namespace mirror_v1 {
         params,
         requiredParams: ['id'],
         pathParams: ['id'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Contact>(parameters, callback);
@@ -1328,15 +1304,7 @@ export namespace mirror_v1 {
 
 
   export class Resource$Locations {
-    root: Mirror;
-    constructor(root: Mirror) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -1390,7 +1358,7 @@ export namespace mirror_v1 {
         params,
         requiredParams: ['id'],
         pathParams: ['id'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Location>(parameters, callback);
@@ -1455,7 +1423,7 @@ export namespace mirror_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$LocationsListResponse>(parameters, callback);
@@ -1485,15 +1453,7 @@ export namespace mirror_v1 {
 
 
   export class Resource$Settings {
-    root: Mirror;
-    constructor(root: Mirror) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -1547,7 +1507,7 @@ export namespace mirror_v1 {
         params,
         requiredParams: ['id'],
         pathParams: ['id'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Setting>(parameters, callback);
@@ -1575,15 +1535,7 @@ export namespace mirror_v1 {
 
 
   export class Resource$Subscriptions {
-    root: Mirror;
-    constructor(root: Mirror) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -1641,7 +1593,7 @@ export namespace mirror_v1 {
         params,
         requiredParams: ['id'],
         pathParams: ['id'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -1708,7 +1660,7 @@ export namespace mirror_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Subscription>(parameters, callback);
@@ -1776,7 +1728,7 @@ export namespace mirror_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$SubscriptionsListResponse>(
@@ -1845,7 +1797,7 @@ export namespace mirror_v1 {
         params,
         requiredParams: ['id'],
         pathParams: ['id'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Subscription>(parameters, callback);
@@ -1907,16 +1859,9 @@ export namespace mirror_v1 {
 
 
   export class Resource$Timeline {
-    root: Mirror;
     attachments: Resource$Timeline$Attachments;
-    constructor(root: Mirror) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.attachments = new Resource$Timeline$Attachments(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.attachments = new Resource$Timeline$Attachments();
     }
 
 
@@ -1973,7 +1918,7 @@ export namespace mirror_v1 {
         params,
         requiredParams: ['id'],
         pathParams: ['id'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -2035,7 +1980,7 @@ export namespace mirror_v1 {
         params,
         requiredParams: ['id'],
         pathParams: ['id'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TimelineItem>(parameters, callback);
@@ -2105,7 +2050,7 @@ export namespace mirror_v1 {
                       .replace(/([^:]\/)\/+/g, '$1'),
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TimelineItem>(parameters, callback);
@@ -2177,7 +2122,7 @@ export namespace mirror_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TimelineListResponse>(parameters, callback);
@@ -2244,7 +2189,7 @@ export namespace mirror_v1 {
         params,
         requiredParams: ['id'],
         pathParams: ['id'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TimelineItem>(parameters, callback);
@@ -2315,7 +2260,7 @@ export namespace mirror_v1 {
                       .replace(/([^:]\/)\/+/g, '$1'),
         requiredParams: ['id'],
         pathParams: ['id'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TimelineItem>(parameters, callback);
@@ -2458,15 +2403,7 @@ export namespace mirror_v1 {
   }
 
   export class Resource$Timeline$Attachments {
-    root: Mirror;
-    constructor(root: Mirror) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -2526,7 +2463,7 @@ export namespace mirror_v1 {
         params,
         requiredParams: ['itemId', 'attachmentId'],
         pathParams: ['attachmentId', 'itemId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -2592,7 +2529,7 @@ export namespace mirror_v1 {
         params,
         requiredParams: ['itemId', 'attachmentId'],
         pathParams: ['attachmentId', 'itemId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Attachment>(parameters, callback);
@@ -2664,7 +2601,7 @@ export namespace mirror_v1 {
                       .replace(/([^:]\/)\/+/g, '$1'),
         requiredParams: ['itemId'],
         pathParams: ['itemId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Attachment>(parameters, callback);
@@ -2732,7 +2669,7 @@ export namespace mirror_v1 {
         params,
         requiredParams: ['itemId'],
         pathParams: ['itemId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$AttachmentsListResponse>(parameters, callback);

--- a/src/apis/ml/v1.ts
+++ b/src/apis/ml/v1.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace ml_v1 {
   export interface Options extends GlobalOptions {
     version: 'v1';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -96,22 +98,12 @@ export namespace ml_v1 {
    * @param {object=} options Options for Ml
    */
   export class Ml {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     projects: Resource$Projects;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.projects = new Resource$Projects(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.projects = new Resource$Projects();
     }
   }
 
@@ -1326,22 +1318,15 @@ export namespace ml_v1 {
 
 
   export class Resource$Projects {
-    root: Ml;
     jobs: Resource$Projects$Jobs;
     locations: Resource$Projects$Locations;
     models: Resource$Projects$Models;
     operations: Resource$Projects$Operations;
-    constructor(root: Ml) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.jobs = new Resource$Projects$Jobs(root);
-      this.locations = new Resource$Projects$Locations(root);
-      this.models = new Resource$Projects$Models(root);
-      this.operations = new Resource$Projects$Operations(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.jobs = new Resource$Projects$Jobs();
+      this.locations = new Resource$Projects$Locations();
+      this.models = new Resource$Projects$Models();
+      this.operations = new Resource$Projects$Operations();
     }
 
 
@@ -1415,7 +1400,7 @@ export namespace ml_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleCloudMlV1__GetConfigResponse>(
@@ -1486,7 +1471,7 @@ export namespace ml_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleApi__HttpBody>(parameters, callback);
@@ -1527,15 +1512,7 @@ export namespace ml_v1 {
   }
 
   export class Resource$Projects$Jobs {
-    root: Ml;
-    constructor(root: Ml) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -1597,7 +1574,7 @@ export namespace ml_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleProtobuf__Empty>(parameters, callback);
@@ -1666,7 +1643,7 @@ export namespace ml_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleCloudMlV1__Job>(parameters, callback);
@@ -1729,7 +1706,7 @@ export namespace ml_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleCloudMlV1__Job>(parameters, callback);
@@ -1798,7 +1775,7 @@ export namespace ml_v1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleIamV1__Policy>(parameters, callback);
@@ -1876,7 +1853,7 @@ export namespace ml_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleCloudMlV1__ListJobsResponse>(
@@ -1948,7 +1925,7 @@ export namespace ml_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleCloudMlV1__Job>(parameters, callback);
@@ -2018,7 +1995,7 @@ export namespace ml_v1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleIamV1__Policy>(parameters, callback);
@@ -2096,7 +2073,7 @@ export namespace ml_v1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleIamV1__TestIamPermissionsResponse>(
@@ -2273,15 +2250,7 @@ export namespace ml_v1 {
 
 
   export class Resource$Projects$Locations {
-    root: Ml;
-    constructor(root: Ml) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -2339,7 +2308,7 @@ export namespace ml_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleCloudMlV1__Location>(
@@ -2416,7 +2385,7 @@ export namespace ml_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleCloudMlV1__ListLocationsResponse>(
@@ -2469,16 +2438,9 @@ export namespace ml_v1 {
 
 
   export class Resource$Projects$Models {
-    root: Ml;
     versions: Resource$Projects$Models$Versions;
-    constructor(root: Ml) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.versions = new Resource$Projects$Models$Versions(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.versions = new Resource$Projects$Models$Versions();
     }
 
 
@@ -2544,7 +2506,7 @@ export namespace ml_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleCloudMlV1__Model>(parameters, callback);
@@ -2617,7 +2579,7 @@ export namespace ml_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleLongrunning__Operation>(
@@ -2684,7 +2646,7 @@ export namespace ml_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleCloudMlV1__Model>(parameters, callback);
@@ -2753,7 +2715,7 @@ export namespace ml_v1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleIamV1__Policy>(parameters, callback);
@@ -2834,7 +2796,7 @@ export namespace ml_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleCloudMlV1__ListModelsResponse>(
@@ -2910,7 +2872,7 @@ export namespace ml_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleLongrunning__Operation>(
@@ -2982,7 +2944,7 @@ export namespace ml_v1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleIamV1__Policy>(parameters, callback);
@@ -3060,7 +3022,7 @@ export namespace ml_v1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleIamV1__TestIamPermissionsResponse>(
@@ -3221,15 +3183,7 @@ export namespace ml_v1 {
   }
 
   export class Resource$Projects$Models$Versions {
-    root: Ml;
-    constructor(root: Ml) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -3301,7 +3255,7 @@ export namespace ml_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleLongrunning__Operation>(
@@ -3377,7 +3331,7 @@ export namespace ml_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleLongrunning__Operation>(
@@ -3446,7 +3400,7 @@ export namespace ml_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleCloudMlV1__Version>(parameters, callback);
@@ -3531,7 +3485,7 @@ export namespace ml_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleCloudMlV1__ListVersionsResponse>(
@@ -3607,7 +3561,7 @@ export namespace ml_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleLongrunning__Operation>(
@@ -3683,7 +3637,7 @@ export namespace ml_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleCloudMlV1__Version>(parameters, callback);
@@ -3815,15 +3769,7 @@ export namespace ml_v1 {
 
 
   export class Resource$Projects$Operations {
-    root: Ml;
-    constructor(root: Ml) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -3892,7 +3838,7 @@ export namespace ml_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleProtobuf__Empty>(parameters, callback);
@@ -3962,7 +3908,7 @@ export namespace ml_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleProtobuf__Empty>(parameters, callback);
@@ -4031,7 +3977,7 @@ export namespace ml_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleLongrunning__Operation>(
@@ -4117,7 +4063,7 @@ export namespace ml_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleLongrunning__ListOperationsResponse>(

--- a/src/apis/monitoring/v3.ts
+++ b/src/apis/monitoring/v3.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace monitoring_v3 {
   export interface Options extends GlobalOptions {
     version: 'v3';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -98,24 +100,14 @@ export namespace monitoring_v3 {
    * @param {object=} options Options for Monitoring
    */
   export class Monitoring {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     projects: Resource$Projects;
     uptimeCheckIps: Resource$Uptimecheckips;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.projects = new Resource$Projects(this);
-      this.uptimeCheckIps = new Resource$Uptimecheckips(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.projects = new Resource$Projects();
+      this.uptimeCheckIps = new Resource$Uptimecheckips();
     }
   }
 
@@ -1995,7 +1987,6 @@ export namespace monitoring_v3 {
 
 
   export class Resource$Projects {
-    root: Monitoring;
     alertPolicies: Resource$Projects$Alertpolicies;
     collectdTimeSeries: Resource$Projects$Collectdtimeseries;
     groups: Resource$Projects$Groups;
@@ -2007,39 +1998,24 @@ export namespace monitoring_v3 {
     notificationChannels: Resource$Projects$Notificationchannels;
     timeSeries: Resource$Projects$Timeseries;
     uptimeCheckConfigs: Resource$Projects$Uptimecheckconfigs;
-    constructor(root: Monitoring) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.alertPolicies = new Resource$Projects$Alertpolicies(root);
-      this.collectdTimeSeries = new Resource$Projects$Collectdtimeseries(root);
-      this.groups = new Resource$Projects$Groups(root);
-      this.metricDescriptors = new Resource$Projects$Metricdescriptors(root);
+    constructor() {
+      this.alertPolicies = new Resource$Projects$Alertpolicies();
+      this.collectdTimeSeries = new Resource$Projects$Collectdtimeseries();
+      this.groups = new Resource$Projects$Groups();
+      this.metricDescriptors = new Resource$Projects$Metricdescriptors();
       this.monitoredResourceDescriptors =
-          new Resource$Projects$Monitoredresourcedescriptors(root);
+          new Resource$Projects$Monitoredresourcedescriptors();
       this.notificationChannelDescriptors =
-          new Resource$Projects$Notificationchanneldescriptors(root);
-      this.notificationChannels =
-          new Resource$Projects$Notificationchannels(root);
-      this.timeSeries = new Resource$Projects$Timeseries(root);
-      this.uptimeCheckConfigs = new Resource$Projects$Uptimecheckconfigs(root);
-    }
-
-    getRoot() {
-      return this.root;
+          new Resource$Projects$Notificationchanneldescriptors();
+      this.notificationChannels = new Resource$Projects$Notificationchannels();
+      this.timeSeries = new Resource$Projects$Timeseries();
+      this.uptimeCheckConfigs = new Resource$Projects$Uptimecheckconfigs();
     }
   }
 
 
   export class Resource$Projects$Alertpolicies {
-    root: Monitoring;
-    constructor(root: Monitoring) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -2100,7 +2076,7 @@ export namespace monitoring_v3 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$AlertPolicy>(parameters, callback);
@@ -2165,7 +2141,7 @@ export namespace monitoring_v3 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -2227,7 +2203,7 @@ export namespace monitoring_v3 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$AlertPolicy>(parameters, callback);
@@ -2301,7 +2277,7 @@ export namespace monitoring_v3 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListAlertPoliciesResponse>(
@@ -2373,7 +2349,7 @@ export namespace monitoring_v3 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$AlertPolicy>(parameters, callback);
@@ -2515,15 +2491,7 @@ export namespace monitoring_v3 {
 
 
   export class Resource$Projects$Collectdtimeseries {
-    root: Monitoring;
-    constructor(root: Monitoring) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -2639,7 +2607,7 @@ export namespace monitoring_v3 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$CreateCollectdTimeSeriesResponse>(
@@ -2672,16 +2640,9 @@ export namespace monitoring_v3 {
 
 
   export class Resource$Projects$Groups {
-    root: Monitoring;
     members: Resource$Projects$Groups$Members;
-    constructor(root: Monitoring) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.members = new Resource$Projects$Groups$Members(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.members = new Resource$Projects$Groups$Members();
     }
 
 
@@ -2790,7 +2751,7 @@ export namespace monitoring_v3 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Group>(parameters, callback);
@@ -2902,7 +2863,7 @@ export namespace monitoring_v3 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -3010,7 +2971,7 @@ export namespace monitoring_v3 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Group>(parameters, callback);
@@ -3135,7 +3096,7 @@ export namespace monitoring_v3 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListGroupsResponse>(parameters, callback);
@@ -3256,7 +3217,7 @@ export namespace monitoring_v3 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Group>(parameters, callback);
@@ -3385,15 +3346,7 @@ export namespace monitoring_v3 {
   }
 
   export class Resource$Projects$Groups$Members {
-    root: Monitoring;
-    constructor(root: Monitoring) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -3513,7 +3466,7 @@ export namespace monitoring_v3 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListGroupMembersResponse>(parameters, callback);
@@ -3568,15 +3521,7 @@ export namespace monitoring_v3 {
 
 
   export class Resource$Projects$Metricdescriptors {
-    root: Monitoring;
-    constructor(root: Monitoring) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -3682,7 +3627,7 @@ export namespace monitoring_v3 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$MetricDescriptor>(parameters, callback);
@@ -3795,7 +3740,7 @@ export namespace monitoring_v3 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -3905,7 +3850,7 @@ export namespace monitoring_v3 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$MetricDescriptor>(parameters, callback);
@@ -4034,7 +3979,7 @@ export namespace monitoring_v3 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListMetricDescriptorsResponse>(
@@ -4126,15 +4071,7 @@ export namespace monitoring_v3 {
 
 
   export class Resource$Projects$Monitoredresourcedescriptors {
-    root: Monitoring;
-    constructor(root: Monitoring) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -4246,7 +4183,7 @@ export namespace monitoring_v3 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$MonitoredResourceDescriptor>(
@@ -4380,7 +4317,7 @@ export namespace monitoring_v3 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListMonitoredResourceDescriptorsResponse>(
@@ -4439,15 +4376,7 @@ export namespace monitoring_v3 {
 
 
   export class Resource$Projects$Notificationchanneldescriptors {
-    root: Monitoring;
-    constructor(root: Monitoring) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -4511,7 +4440,7 @@ export namespace monitoring_v3 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$NotificationChannelDescriptor>(
@@ -4592,7 +4521,7 @@ export namespace monitoring_v3 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListNotificationChannelDescriptorsResponse>(
@@ -4647,15 +4576,7 @@ export namespace monitoring_v3 {
 
 
   export class Resource$Projects$Notificationchannels {
-    root: Monitoring;
-    constructor(root: Monitoring) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -4718,7 +4639,7 @@ export namespace monitoring_v3 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$NotificationChannel>(parameters, callback);
@@ -4784,7 +4705,7 @@ export namespace monitoring_v3 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -4850,7 +4771,7 @@ export namespace monitoring_v3 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$NotificationChannel>(parameters, callback);
@@ -4950,7 +4871,7 @@ export namespace monitoring_v3 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GetNotificationChannelVerificationCodeResponse>(
@@ -5033,7 +4954,7 @@ export namespace monitoring_v3 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListNotificationChannelsResponse>(
@@ -5104,7 +5025,7 @@ export namespace monitoring_v3 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$NotificationChannel>(parameters, callback);
@@ -5177,7 +5098,7 @@ export namespace monitoring_v3 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -5247,7 +5168,7 @@ export namespace monitoring_v3 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$NotificationChannel>(parameters, callback);
@@ -5431,15 +5352,7 @@ export namespace monitoring_v3 {
 
 
   export class Resource$Projects$Timeseries {
-    root: Monitoring;
-    constructor(root: Monitoring) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -5549,7 +5462,7 @@ export namespace monitoring_v3 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -5682,7 +5595,7 @@ export namespace monitoring_v3 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListTimeSeriesResponse>(parameters, callback);
@@ -5814,15 +5727,7 @@ export namespace monitoring_v3 {
 
 
   export class Resource$Projects$Uptimecheckconfigs {
-    root: Monitoring;
-    constructor(root: Monitoring) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -5883,7 +5788,7 @@ export namespace monitoring_v3 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$UptimeCheckConfig>(parameters, callback);
@@ -5951,7 +5856,7 @@ export namespace monitoring_v3 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -6013,7 +5918,7 @@ export namespace monitoring_v3 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$UptimeCheckConfig>(parameters, callback);
@@ -6088,7 +5993,7 @@ export namespace monitoring_v3 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListUptimeCheckConfigsResponse>(
@@ -6161,7 +6066,7 @@ export namespace monitoring_v3 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$UptimeCheckConfig>(parameters, callback);
@@ -6273,15 +6178,7 @@ export namespace monitoring_v3 {
 
 
   export class Resource$Uptimecheckips {
-    root: Monitoring;
-    constructor(root: Monitoring) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -6345,7 +6242,7 @@ export namespace monitoring_v3 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListUptimeCheckIpsResponse>(

--- a/src/apis/oauth2/v1.ts
+++ b/src/apis/oauth2/v1.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace oauth2_v1 {
   export interface Options extends GlobalOptions {
     version: 'v1';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -79,22 +81,12 @@ export namespace oauth2_v1 {
    * @param {object=} options Options for Oauth2
    */
   export class Oauth2 {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     userinfo: Resource$Userinfo;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.userinfo = new Resource$Userinfo(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.userinfo = new Resource$Userinfo();
     }
 
 
@@ -150,7 +142,7 @@ export namespace oauth2_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$X509>(parameters, callback);
@@ -215,7 +207,7 @@ export namespace oauth2_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Raw>(parameters, callback);
@@ -277,7 +269,7 @@ export namespace oauth2_v1 {
         params,
         requiredParams: ['robotEmail'],
         pathParams: ['robotEmail'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Jwk>(parameters, callback);
@@ -341,7 +333,7 @@ export namespace oauth2_v1 {
         params,
         requiredParams: ['robotEmail'],
         pathParams: ['robotEmail'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Raw>(parameters, callback);
@@ -405,7 +397,7 @@ export namespace oauth2_v1 {
         params,
         requiredParams: ['robotEmail'],
         pathParams: ['robotEmail'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$X509>(parameters, callback);
@@ -471,7 +463,7 @@ export namespace oauth2_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Tokeninfo>(parameters, callback);
@@ -665,16 +657,9 @@ export namespace oauth2_v1 {
   }
 
   export class Resource$Userinfo {
-    root: Oauth2;
     v2: Resource$Userinfo$V2;
-    constructor(root: Oauth2) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.v2 = new Resource$Userinfo$V2(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.v2 = new Resource$Userinfo$V2();
     }
 
 
@@ -729,7 +714,7 @@ export namespace oauth2_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Userinfoplus>(parameters, callback);
@@ -747,30 +732,15 @@ export namespace oauth2_v1 {
   }
 
   export class Resource$Userinfo$V2 {
-    root: Oauth2;
     me: Resource$Userinfo$V2$Me;
-    constructor(root: Oauth2) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.me = new Resource$Userinfo$V2$Me(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.me = new Resource$Userinfo$V2$Me();
     }
   }
 
 
   export class Resource$Userinfo$V2$Me {
-    root: Oauth2;
-    constructor(root: Oauth2) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -824,7 +794,7 @@ export namespace oauth2_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Userinfoplus>(parameters, callback);

--- a/src/apis/oauth2/v2.ts
+++ b/src/apis/oauth2/v2.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace oauth2_v2 {
   export interface Options extends GlobalOptions {
     version: 'v2';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -79,22 +81,12 @@ export namespace oauth2_v2 {
    * @param {object=} options Options for Oauth2
    */
   export class Oauth2 {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     userinfo: Resource$Userinfo;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.userinfo = new Resource$Userinfo(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.userinfo = new Resource$Userinfo();
     }
 
 
@@ -150,7 +142,7 @@ export namespace oauth2_v2 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Jwk>(parameters, callback);
@@ -216,7 +208,7 @@ export namespace oauth2_v2 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Tokeninfo>(parameters, callback);
@@ -352,16 +344,9 @@ export namespace oauth2_v2 {
   }
 
   export class Resource$Userinfo {
-    root: Oauth2;
     v2: Resource$Userinfo$V2;
-    constructor(root: Oauth2) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.v2 = new Resource$Userinfo$V2(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.v2 = new Resource$Userinfo$V2();
     }
 
 
@@ -415,7 +400,7 @@ export namespace oauth2_v2 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Userinfoplus>(parameters, callback);
@@ -433,30 +418,15 @@ export namespace oauth2_v2 {
   }
 
   export class Resource$Userinfo$V2 {
-    root: Oauth2;
     me: Resource$Userinfo$V2$Me;
-    constructor(root: Oauth2) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.me = new Resource$Userinfo$V2$Me(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.me = new Resource$Userinfo$V2$Me();
     }
   }
 
 
   export class Resource$Userinfo$V2$Me {
-    root: Oauth2;
-    constructor(root: Oauth2) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -509,7 +479,7 @@ export namespace oauth2_v2 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Userinfoplus>(parameters, callback);

--- a/src/apis/oslogin/v1.ts
+++ b/src/apis/oslogin/v1.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace oslogin_v1 {
   export interface Options extends GlobalOptions {
     version: 'v1';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -96,22 +98,12 @@ export namespace oslogin_v1 {
    * @param {object=} options Options for Oslogin
    */
   export class Oslogin {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     users: Resource$Users;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.users = new Resource$Users(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.users = new Resource$Users();
     }
   }
 
@@ -218,18 +210,11 @@ export namespace oslogin_v1 {
 
 
   export class Resource$Users {
-    root: Oslogin;
     projects: Resource$Users$Projects;
     sshPublicKeys: Resource$Users$Sshpublickeys;
-    constructor(root: Oslogin) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.projects = new Resource$Users$Projects(root);
-      this.sshPublicKeys = new Resource$Users$Sshpublickeys(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.projects = new Resource$Users$Projects();
+      this.sshPublicKeys = new Resource$Users$Sshpublickeys();
     }
 
 
@@ -293,7 +278,7 @@ export namespace oslogin_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$LoginProfile>(parameters, callback);
@@ -370,7 +355,7 @@ export namespace oslogin_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ImportSshPublicKeyResponse>(
@@ -424,15 +409,7 @@ export namespace oslogin_v1 {
   }
 
   export class Resource$Users$Projects {
-    root: Oslogin;
-    constructor(root: Oslogin) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -490,7 +467,7 @@ export namespace oslogin_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -517,15 +494,7 @@ export namespace oslogin_v1 {
 
 
   export class Resource$Users$Sshpublickeys {
-    root: Oslogin;
-    constructor(root: Oslogin) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -583,7 +552,7 @@ export namespace oslogin_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -645,7 +614,7 @@ export namespace oslogin_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$SshPublicKey>(parameters, callback);
@@ -714,7 +683,7 @@ export namespace oslogin_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$SshPublicKey>(parameters, callback);

--- a/src/apis/oslogin/v1alpha.ts
+++ b/src/apis/oslogin/v1alpha.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace oslogin_v1alpha {
   export interface Options extends GlobalOptions {
     version: 'v1alpha';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -96,22 +98,12 @@ export namespace oslogin_v1alpha {
    * @param {object=} options Options for Oslogin
    */
   export class Oslogin {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     users: Resource$Users;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.users = new Resource$Users(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.users = new Resource$Users();
     }
   }
 
@@ -218,18 +210,11 @@ export namespace oslogin_v1alpha {
 
 
   export class Resource$Users {
-    root: Oslogin;
     projects: Resource$Users$Projects;
     sshPublicKeys: Resource$Users$Sshpublickeys;
-    constructor(root: Oslogin) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.projects = new Resource$Users$Projects(root);
-      this.sshPublicKeys = new Resource$Users$Sshpublickeys(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.projects = new Resource$Users$Projects();
+      this.sshPublicKeys = new Resource$Users$Sshpublickeys();
     }
 
 
@@ -294,7 +279,7 @@ export namespace oslogin_v1alpha {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$LoginProfile>(parameters, callback);
@@ -371,7 +356,7 @@ export namespace oslogin_v1alpha {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ImportSshPublicKeyResponse>(
@@ -429,15 +414,7 @@ export namespace oslogin_v1alpha {
   }
 
   export class Resource$Users$Projects {
-    root: Oslogin;
-    constructor(root: Oslogin) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -496,7 +473,7 @@ export namespace oslogin_v1alpha {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -527,15 +504,7 @@ export namespace oslogin_v1alpha {
 
 
   export class Resource$Users$Sshpublickeys {
-    root: Oslogin;
-    constructor(root: Oslogin) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -593,7 +562,7 @@ export namespace oslogin_v1alpha {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -655,7 +624,7 @@ export namespace oslogin_v1alpha {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$SshPublicKey>(parameters, callback);
@@ -724,7 +693,7 @@ export namespace oslogin_v1alpha {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$SshPublicKey>(parameters, callback);

--- a/src/apis/oslogin/v1beta.ts
+++ b/src/apis/oslogin/v1beta.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace oslogin_v1beta {
   export interface Options extends GlobalOptions {
     version: 'v1beta';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -96,22 +98,12 @@ export namespace oslogin_v1beta {
    * @param {object=} options Options for Oslogin
    */
   export class Oslogin {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     users: Resource$Users;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.users = new Resource$Users(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.users = new Resource$Users();
     }
   }
 
@@ -218,18 +210,11 @@ export namespace oslogin_v1beta {
 
 
   export class Resource$Users {
-    root: Oslogin;
     projects: Resource$Users$Projects;
     sshPublicKeys: Resource$Users$Sshpublickeys;
-    constructor(root: Oslogin) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.projects = new Resource$Users$Projects(root);
-      this.sshPublicKeys = new Resource$Users$Sshpublickeys(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.projects = new Resource$Users$Projects();
+      this.sshPublicKeys = new Resource$Users$Sshpublickeys();
     }
 
 
@@ -293,7 +278,7 @@ export namespace oslogin_v1beta {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$LoginProfile>(parameters, callback);
@@ -370,7 +355,7 @@ export namespace oslogin_v1beta {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ImportSshPublicKeyResponse>(
@@ -424,15 +409,7 @@ export namespace oslogin_v1beta {
   }
 
   export class Resource$Users$Projects {
-    root: Oslogin;
-    constructor(root: Oslogin) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -490,7 +467,7 @@ export namespace oslogin_v1beta {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -517,15 +494,7 @@ export namespace oslogin_v1beta {
 
 
   export class Resource$Users$Sshpublickeys {
-    root: Oslogin;
-    constructor(root: Oslogin) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -583,7 +552,7 @@ export namespace oslogin_v1beta {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -645,7 +614,7 @@ export namespace oslogin_v1beta {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$SshPublicKey>(parameters, callback);
@@ -714,7 +683,7 @@ export namespace oslogin_v1beta {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$SshPublicKey>(parameters, callback);

--- a/src/apis/pagespeedonline/v1.ts
+++ b/src/apis/pagespeedonline/v1.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace pagespeedonline_v1 {
   export interface Options extends GlobalOptions {
     version: 'v1';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -80,22 +82,12 @@ export namespace pagespeedonline_v1 {
    * @param {object=} options Options for Pagespeedonline
    */
   export class Pagespeedonline {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     pagespeedapi: Resource$Pagespeedapi;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.pagespeedapi = new Resource$Pagespeedapi(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.pagespeedapi = new Resource$Pagespeedapi();
     }
   }
 
@@ -194,15 +186,7 @@ export namespace pagespeedonline_v1 {
 
 
   export class Resource$Pagespeedapi {
-    root: Pagespeedonline;
-    constructor(root: Pagespeedonline) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -268,7 +252,7 @@ export namespace pagespeedonline_v1 {
         params,
         requiredParams: ['url'],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Result>(parameters, callback);

--- a/src/apis/pagespeedonline/v2.ts
+++ b/src/apis/pagespeedonline/v2.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace pagespeedonline_v2 {
   export interface Options extends GlobalOptions {
     version: 'v2';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -80,22 +82,12 @@ export namespace pagespeedonline_v2 {
    * @param {object=} options Options for Pagespeedonline
    */
   export class Pagespeedonline {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     pagespeedapi: Resource$Pagespeedapi;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.pagespeedapi = new Resource$Pagespeedapi(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.pagespeedapi = new Resource$Pagespeedapi();
     }
   }
 
@@ -232,15 +224,7 @@ export namespace pagespeedonline_v2 {
 
 
   export class Resource$Pagespeedapi {
-    root: Pagespeedonline;
-    constructor(root: Pagespeedonline) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -306,7 +290,7 @@ export namespace pagespeedonline_v2 {
         params,
         requiredParams: ['url'],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Result>(parameters, callback);

--- a/src/apis/pagespeedonline/v4.ts
+++ b/src/apis/pagespeedonline/v4.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace pagespeedonline_v4 {
   export interface Options extends GlobalOptions {
     version: 'v4';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -80,22 +82,12 @@ export namespace pagespeedonline_v4 {
    * @param {object=} options Options for Pagespeedonline
    */
   export class Pagespeedonline {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     pagespeedapi: Resource$Pagespeedapi;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.pagespeedapi = new Resource$Pagespeedapi(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.pagespeedapi = new Resource$Pagespeedapi();
     }
   }
 
@@ -258,15 +250,7 @@ export namespace pagespeedonline_v4 {
 
 
   export class Resource$Pagespeedapi {
-    root: Pagespeedonline;
-    constructor(root: Pagespeedonline) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -343,7 +327,7 @@ export namespace pagespeedonline_v4 {
         params,
         requiredParams: ['url'],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$PagespeedApiPagespeedResponseV4>(

--- a/src/apis/pagespeedonline/v5.ts
+++ b/src/apis/pagespeedonline/v5.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace pagespeedonline_v5 {
   export interface Options extends GlobalOptions {
     version: 'v5';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -80,22 +82,12 @@ export namespace pagespeedonline_v5 {
    * @param {object=} options Options for Pagespeedonline
    */
   export class Pagespeedonline {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     pagespeedapi: Resource$Pagespeedapi;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.pagespeedapi = new Resource$Pagespeedapi(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.pagespeedapi = new Resource$Pagespeedapi();
     }
   }
 
@@ -296,15 +288,7 @@ export namespace pagespeedonline_v5 {
 
 
   export class Resource$Pagespeedapi {
-    root: Pagespeedonline;
-    constructor(root: Pagespeedonline) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -378,7 +362,7 @@ export namespace pagespeedonline_v5 {
         params,
         requiredParams: ['url'],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$PagespeedApiPagespeedResponseV5>(

--- a/src/apis/people/v1.ts
+++ b/src/apis/people/v1.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace people_v1 {
   export interface Options extends GlobalOptions {
     version: 'v1';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -96,24 +98,14 @@ export namespace people_v1 {
    * @param {object=} options Options for People
    */
   export class People {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     contactGroups: Resource$Contactgroups;
     people: Resource$People;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.contactGroups = new Resource$Contactgroups(this);
-      this.people = new Resource$People(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.contactGroups = new Resource$Contactgroups();
+      this.people = new Resource$People();
     }
   }
 
@@ -1355,16 +1347,9 @@ export namespace people_v1 {
 
 
   export class Resource$Contactgroups {
-    root: People;
     members: Resource$Contactgroups$Members;
-    constructor(root: People) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.members = new Resource$Contactgroups$Members(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.members = new Resource$Contactgroups$Members();
     }
 
 
@@ -1433,7 +1418,7 @@ export namespace people_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$BatchGetContactGroupsResponse>(
@@ -1502,7 +1487,7 @@ export namespace people_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ContactGroup>(parameters, callback);
@@ -1570,7 +1555,7 @@ export namespace people_v1 {
         params,
         requiredParams: ['resourceName'],
         pathParams: ['resourceName'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -1635,7 +1620,7 @@ export namespace people_v1 {
         params,
         requiredParams: ['resourceName'],
         pathParams: ['resourceName'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ContactGroup>(parameters, callback);
@@ -1706,7 +1691,7 @@ export namespace people_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListContactGroupsResponse>(
@@ -1776,7 +1761,7 @@ export namespace people_v1 {
         params,
         requiredParams: ['resourceName'],
         pathParams: ['resourceName'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ContactGroup>(parameters, callback);
@@ -1890,15 +1875,7 @@ export namespace people_v1 {
   }
 
   export class Resource$Contactgroups$Members {
-    root: People;
-    constructor(root: People) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -1969,7 +1946,7 @@ export namespace people_v1 {
         params,
         requiredParams: ['resourceName'],
         pathParams: ['resourceName'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ModifyContactGroupMembersResponse>(
@@ -2002,16 +1979,9 @@ export namespace people_v1 {
 
 
   export class Resource$People {
-    root: People;
     connections: Resource$People$Connections;
-    constructor(root: People) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.connections = new Resource$People$Connections(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.connections = new Resource$People$Connections();
     }
 
 
@@ -2073,7 +2043,7 @@ export namespace people_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Person>(parameters, callback);
@@ -2139,7 +2109,7 @@ export namespace people_v1 {
         params,
         requiredParams: ['resourceName'],
         pathParams: ['resourceName'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -2204,7 +2174,7 @@ export namespace people_v1 {
         params,
         requiredParams: ['resourceName'],
         pathParams: ['resourceName'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Person>(parameters, callback);
@@ -2276,7 +2246,7 @@ export namespace people_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GetPeopleResponse>(parameters, callback);
@@ -2352,7 +2322,7 @@ export namespace people_v1 {
         params,
         requiredParams: ['resourceName'],
         pathParams: ['resourceName'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Person>(parameters, callback);
@@ -2489,15 +2459,7 @@ export namespace people_v1 {
   }
 
   export class Resource$People$Connections {
-    root: People;
-    constructor(root: People) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -2567,7 +2529,7 @@ export namespace people_v1 {
         params,
         requiredParams: ['resourceName'],
         pathParams: ['resourceName'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListConnectionsResponse>(parameters, callback);

--- a/src/apis/playcustomapp/v1.ts
+++ b/src/apis/playcustomapp/v1.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace playcustomapp_v1 {
   export interface Options extends GlobalOptions {
     version: 'v1';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -79,22 +81,12 @@ export namespace playcustomapp_v1 {
    * @param {object=} options Options for Playcustomapp
    */
   export class Playcustomapp {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     accounts: Resource$Accounts;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.accounts = new Resource$Accounts(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.accounts = new Resource$Accounts();
     }
   }
 
@@ -114,30 +106,15 @@ export namespace playcustomapp_v1 {
 
 
   export class Resource$Accounts {
-    root: Playcustomapp;
     customApps: Resource$Accounts$Customapps;
-    constructor(root: Playcustomapp) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.customApps = new Resource$Accounts$Customapps(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.customApps = new Resource$Accounts$Customapps();
     }
   }
 
 
   export class Resource$Accounts$Customapps {
-    root: Playcustomapp;
-    constructor(root: Playcustomapp) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -204,7 +181,7 @@ export namespace playcustomapp_v1 {
                 .replace(/([^:]\/)\/+/g, '$1'),
         requiredParams: ['account'],
         pathParams: ['account'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$CustomApp>(parameters, callback);

--- a/src/apis/plus/v1.ts
+++ b/src/apis/plus/v1.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace plus_v1 {
   export interface Options extends GlobalOptions {
     version: 'v1';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -79,26 +81,16 @@ export namespace plus_v1 {
    * @param {object=} options Options for Plus
    */
   export class Plus {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     activities: Resource$Activities;
     comments: Resource$Comments;
     people: Resource$People;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.activities = new Resource$Activities(this);
-      this.comments = new Resource$Comments(this);
-      this.people = new Resource$People(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.activities = new Resource$Activities();
+      this.comments = new Resource$Comments();
+      this.people = new Resource$People();
     }
   }
 
@@ -639,15 +631,7 @@ export namespace plus_v1 {
 
 
   export class Resource$Activities {
-    root: Plus;
-    constructor(root: Plus) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -701,7 +685,7 @@ export namespace plus_v1 {
         params,
         requiredParams: ['activityId'],
         pathParams: ['activityId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Activity>(parameters, callback);
@@ -771,7 +755,7 @@ export namespace plus_v1 {
         params,
         requiredParams: ['userId', 'collection'],
         pathParams: ['collection', 'userId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ActivityFeed>(parameters, callback);
@@ -841,7 +825,7 @@ export namespace plus_v1 {
         params,
         requiredParams: ['query'],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ActivityFeed>(parameters, callback);
@@ -927,15 +911,7 @@ export namespace plus_v1 {
 
 
   export class Resource$Comments {
-    root: Plus;
-    constructor(root: Plus) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -989,7 +965,7 @@ export namespace plus_v1 {
         params,
         requiredParams: ['commentId'],
         pathParams: ['commentId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Comment>(parameters, callback);
@@ -1057,7 +1033,7 @@ export namespace plus_v1 {
         params,
         requiredParams: ['activityId'],
         pathParams: ['activityId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$CommentFeed>(parameters, callback);
@@ -1108,15 +1084,7 @@ export namespace plus_v1 {
 
 
   export class Resource$People {
-    root: Plus;
-    constructor(root: Plus) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -1172,7 +1140,7 @@ export namespace plus_v1 {
         params,
         requiredParams: ['userId'],
         pathParams: ['userId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Person>(parameters, callback);
@@ -1241,7 +1209,7 @@ export namespace plus_v1 {
         params,
         requiredParams: ['userId', 'collection'],
         pathParams: ['collection', 'userId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$PeopleFeed>(parameters, callback);
@@ -1313,7 +1281,7 @@ export namespace plus_v1 {
         params,
         requiredParams: ['activityId', 'collection'],
         pathParams: ['activityId', 'collection'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$PeopleFeed>(parameters, callback);
@@ -1380,7 +1348,7 @@ export namespace plus_v1 {
         params,
         requiredParams: ['query'],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$PeopleFeed>(parameters, callback);

--- a/src/apis/plusDomains/v1.ts
+++ b/src/apis/plusDomains/v1.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace plusDomains_v1 {
   export interface Options extends GlobalOptions {
     version: 'v1';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -79,10 +81,6 @@ export namespace plusDomains_v1 {
    * @param {object=} options Options for Plusdomains
    */
   export class Plusdomains {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     activities: Resource$Activities;
     audiences: Resource$Audiences;
     circles: Resource$Circles;
@@ -91,20 +89,14 @@ export namespace plusDomains_v1 {
     people: Resource$People;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.activities = new Resource$Activities(this);
-      this.audiences = new Resource$Audiences(this);
-      this.circles = new Resource$Circles(this);
-      this.comments = new Resource$Comments(this);
-      this.media = new Resource$Media(this);
-      this.people = new Resource$People(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.activities = new Resource$Activities();
+      this.audiences = new Resource$Audiences();
+      this.circles = new Resource$Circles();
+      this.comments = new Resource$Comments();
+      this.media = new Resource$Media();
+      this.people = new Resource$People();
     }
   }
 
@@ -876,15 +868,7 @@ export namespace plusDomains_v1 {
 
 
   export class Resource$Activities {
-    root: Plusdomains;
-    constructor(root: Plusdomains) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -938,7 +922,7 @@ export namespace plusDomains_v1 {
         params,
         requiredParams: ['activityId'],
         pathParams: ['activityId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Activity>(parameters, callback);
@@ -1005,7 +989,7 @@ export namespace plusDomains_v1 {
         params,
         requiredParams: ['userId'],
         pathParams: ['userId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Activity>(parameters, callback);
@@ -1075,7 +1059,7 @@ export namespace plusDomains_v1 {
         params,
         requiredParams: ['userId', 'collection'],
         pathParams: ['collection', 'userId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ActivityFeed>(parameters, callback);
@@ -1151,15 +1135,7 @@ export namespace plusDomains_v1 {
 
 
   export class Resource$Audiences {
-    root: Plusdomains;
-    constructor(root: Plusdomains) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -1219,7 +1195,7 @@ export namespace plusDomains_v1 {
         params,
         requiredParams: ['userId'],
         pathParams: ['userId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$AudiencesFeed>(parameters, callback);
@@ -1256,15 +1232,7 @@ export namespace plusDomains_v1 {
 
 
   export class Resource$Circles {
-    root: Plusdomains;
-    constructor(root: Plusdomains) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -1326,7 +1294,7 @@ export namespace plusDomains_v1 {
         params,
         requiredParams: ['circleId'],
         pathParams: ['circleId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Circle>(parameters, callback);
@@ -1387,7 +1355,7 @@ export namespace plusDomains_v1 {
         params,
         requiredParams: ['circleId'],
         pathParams: ['circleId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Circle>(parameters, callback);
@@ -1452,7 +1420,7 @@ export namespace plusDomains_v1 {
         params,
         requiredParams: ['userId'],
         pathParams: ['userId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Circle>(parameters, callback);
@@ -1519,7 +1487,7 @@ export namespace plusDomains_v1 {
         params,
         requiredParams: ['userId'],
         pathParams: ['userId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$CircleFeed>(parameters, callback);
@@ -1585,7 +1553,7 @@ export namespace plusDomains_v1 {
         params,
         requiredParams: ['circleId'],
         pathParams: ['circleId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Circle>(parameters, callback);
@@ -1648,7 +1616,7 @@ export namespace plusDomains_v1 {
         params,
         requiredParams: ['circleId'],
         pathParams: ['circleId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -1715,7 +1683,7 @@ export namespace plusDomains_v1 {
         params,
         requiredParams: ['circleId'],
         pathParams: ['circleId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -1780,7 +1748,7 @@ export namespace plusDomains_v1 {
         params,
         requiredParams: ['circleId'],
         pathParams: ['circleId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Circle>(parameters, callback);
@@ -1928,15 +1896,7 @@ export namespace plusDomains_v1 {
 
 
   export class Resource$Comments {
-    root: Plusdomains;
-    constructor(root: Plusdomains) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -1990,7 +1950,7 @@ export namespace plusDomains_v1 {
         params,
         requiredParams: ['commentId'],
         pathParams: ['commentId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Comment>(parameters, callback);
@@ -2056,7 +2016,7 @@ export namespace plusDomains_v1 {
         params,
         requiredParams: ['activityId'],
         pathParams: ['activityId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Comment>(parameters, callback);
@@ -2125,7 +2085,7 @@ export namespace plusDomains_v1 {
         params,
         requiredParams: ['activityId'],
         pathParams: ['activityId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$CommentFeed>(parameters, callback);
@@ -2192,15 +2152,7 @@ export namespace plusDomains_v1 {
 
 
   export class Resource$Media {
-    root: Plusdomains;
-    constructor(root: Plusdomains) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -2269,7 +2221,7 @@ export namespace plusDomains_v1 {
                       .replace(/([^:]\/)\/+/g, '$1'),
         requiredParams: ['userId', 'collection'],
         pathParams: ['collection', 'userId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Media>(parameters, callback);
@@ -2317,15 +2269,7 @@ export namespace plusDomains_v1 {
 
 
   export class Resource$People {
-    root: Plusdomains;
-    constructor(root: Plusdomains) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -2379,7 +2323,7 @@ export namespace plusDomains_v1 {
         params,
         requiredParams: ['userId'],
         pathParams: ['userId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Person>(parameters, callback);
@@ -2449,7 +2393,7 @@ export namespace plusDomains_v1 {
         params,
         requiredParams: ['userId', 'collection'],
         pathParams: ['collection', 'userId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$PeopleFeed>(parameters, callback);
@@ -2522,7 +2466,7 @@ export namespace plusDomains_v1 {
         params,
         requiredParams: ['activityId', 'collection'],
         pathParams: ['activityId', 'collection'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$PeopleFeed>(parameters, callback);
@@ -2591,7 +2535,7 @@ export namespace plusDomains_v1 {
         params,
         requiredParams: ['circleId'],
         pathParams: ['circleId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$PeopleFeed>(parameters, callback);

--- a/src/apis/poly/v1.ts
+++ b/src/apis/poly/v1.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace poly_v1 {
   export interface Options extends GlobalOptions {
     version: 'v1';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -100,24 +102,14 @@ export namespace poly_v1 {
    * @param {object=} options Options for Poly
    */
   export class Poly {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     assets: Resource$Assets;
     users: Resource$Users;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.assets = new Resource$Assets(this);
-      this.users = new Resource$Users(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.assets = new Resource$Assets();
+      this.users = new Resource$Users();
     }
   }
 
@@ -494,15 +486,7 @@ export namespace poly_v1 {
 
 
   export class Resource$Assets {
-    root: Poly;
-    constructor(root: Poly) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -557,7 +541,7 @@ export namespace poly_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Asset>(parameters, callback);
@@ -629,7 +613,7 @@ export namespace poly_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListAssetsResponse>(parameters, callback);
@@ -704,32 +688,17 @@ export namespace poly_v1 {
 
 
   export class Resource$Users {
-    root: Poly;
     assets: Resource$Users$Assets;
     likedassets: Resource$Users$Likedassets;
-    constructor(root: Poly) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.assets = new Resource$Users$Assets(root);
-      this.likedassets = new Resource$Users$Likedassets(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.assets = new Resource$Users$Assets();
+      this.likedassets = new Resource$Users$Likedassets();
     }
   }
 
 
   export class Resource$Users$Assets {
-    root: Poly;
-    constructor(root: Poly) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -797,7 +766,7 @@ export namespace poly_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListUserAssetsResponse>(parameters, callback);
@@ -851,15 +820,7 @@ export namespace poly_v1 {
 
 
   export class Resource$Users$Likedassets {
-    root: Poly;
-    constructor(root: Poly) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -926,7 +887,7 @@ export namespace poly_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListLikedAssetsResponse>(parameters, callback);

--- a/src/apis/proximitybeacon/v1beta1.ts
+++ b/src/apis/proximitybeacon/v1beta1.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace proximitybeacon_v1beta1 {
   export interface Options extends GlobalOptions {
     version: 'v1beta1';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -96,28 +98,18 @@ export namespace proximitybeacon_v1beta1 {
    * @param {object=} options Options for Proximitybeacon
    */
   export class Proximitybeacon {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     beaconinfo: Resource$Beaconinfo;
     beacons: Resource$Beacons;
     namespaces: Resource$Namespaces;
     v1beta1: Resource$V1beta1;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.beaconinfo = new Resource$Beaconinfo(this);
-      this.beacons = new Resource$Beacons(this);
-      this.namespaces = new Resource$Namespaces(this);
-      this.v1beta1 = new Resource$V1beta1(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.beaconinfo = new Resource$Beaconinfo();
+      this.beacons = new Resource$Beacons();
+      this.namespaces = new Resource$Namespaces();
+      this.v1beta1 = new Resource$V1beta1();
     }
   }
 
@@ -621,15 +613,7 @@ export namespace proximitybeacon_v1beta1 {
 
 
   export class Resource$Beaconinfo {
-    root: Proximitybeacon;
-    constructor(root: Proximitybeacon) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -704,7 +688,7 @@ export namespace proximitybeacon_v1beta1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GetInfoForObservedBeaconsResponse>(
@@ -732,18 +716,11 @@ export namespace proximitybeacon_v1beta1 {
 
 
   export class Resource$Beacons {
-    root: Proximitybeacon;
     attachments: Resource$Beacons$Attachments;
     diagnostics: Resource$Beacons$Diagnostics;
-    constructor(root: Proximitybeacon) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.attachments = new Resource$Beacons$Attachments(root);
-      this.diagnostics = new Resource$Beacons$Diagnostics(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.attachments = new Resource$Beacons$Attachments();
+      this.diagnostics = new Resource$Beacons$Diagnostics();
     }
 
 
@@ -810,7 +787,7 @@ export namespace proximitybeacon_v1beta1 {
         params,
         requiredParams: ['beaconName'],
         pathParams: ['beaconName'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -885,7 +862,7 @@ export namespace proximitybeacon_v1beta1 {
         params,
         requiredParams: ['beaconName'],
         pathParams: ['beaconName'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -959,7 +936,7 @@ export namespace proximitybeacon_v1beta1 {
         params,
         requiredParams: ['beaconName'],
         pathParams: ['beaconName'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -1031,7 +1008,7 @@ export namespace proximitybeacon_v1beta1 {
         params,
         requiredParams: ['beaconName'],
         pathParams: ['beaconName'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -1103,7 +1080,7 @@ export namespace proximitybeacon_v1beta1 {
         params,
         requiredParams: ['beaconName'],
         pathParams: ['beaconName'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Beacon>(parameters, callback);
@@ -1176,7 +1153,7 @@ export namespace proximitybeacon_v1beta1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListBeaconsResponse>(parameters, callback);
@@ -1248,7 +1225,7 @@ export namespace proximitybeacon_v1beta1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Beacon>(parameters, callback);
@@ -1324,7 +1301,7 @@ export namespace proximitybeacon_v1beta1 {
         params,
         requiredParams: ['beaconName'],
         pathParams: ['beaconName'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Beacon>(parameters, callback);
@@ -1566,15 +1543,7 @@ export namespace proximitybeacon_v1beta1 {
   }
 
   export class Resource$Beacons$Attachments {
-    root: Proximitybeacon;
-    constructor(root: Proximitybeacon) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -1648,7 +1617,7 @@ export namespace proximitybeacon_v1beta1 {
         params,
         requiredParams: ['beaconName'],
         pathParams: ['beaconName'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$DeleteAttachmentsResponse>(
@@ -1729,7 +1698,7 @@ export namespace proximitybeacon_v1beta1 {
         params,
         requiredParams: ['beaconName'],
         pathParams: ['beaconName'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$BeaconAttachment>(parameters, callback);
@@ -1804,7 +1773,7 @@ export namespace proximitybeacon_v1beta1 {
         params,
         requiredParams: ['attachmentName'],
         pathParams: ['attachmentName'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -1887,7 +1856,7 @@ export namespace proximitybeacon_v1beta1 {
         params,
         requiredParams: ['beaconName'],
         pathParams: ['beaconName'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListBeaconAttachmentsResponse>(
@@ -2013,15 +1982,7 @@ export namespace proximitybeacon_v1beta1 {
 
 
   export class Resource$Beacons$Diagnostics {
-    root: Proximitybeacon;
-    constructor(root: Proximitybeacon) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -2093,7 +2054,7 @@ export namespace proximitybeacon_v1beta1 {
         params,
         requiredParams: ['beaconName'],
         pathParams: ['beaconName'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListDiagnosticsResponse>(parameters, callback);
@@ -2140,15 +2101,7 @@ export namespace proximitybeacon_v1beta1 {
 
 
   export class Resource$Namespaces {
-    root: Proximitybeacon;
-    constructor(root: Proximitybeacon) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -2214,7 +2167,7 @@ export namespace proximitybeacon_v1beta1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListNamespacesResponse>(parameters, callback);
@@ -2284,7 +2237,7 @@ export namespace proximitybeacon_v1beta1 {
         params,
         requiredParams: ['namespaceName'],
         pathParams: ['namespaceName'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Namespace>(parameters, callback);
@@ -2332,15 +2285,7 @@ export namespace proximitybeacon_v1beta1 {
 
 
   export class Resource$V1beta1 {
-    root: Proximitybeacon;
-    constructor(root: Proximitybeacon) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -2411,7 +2356,7 @@ export namespace proximitybeacon_v1beta1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$EphemeralIdRegistrationParams>(

--- a/src/apis/pubsub/v1.ts
+++ b/src/apis/pubsub/v1.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace pubsub_v1 {
   export interface Options extends GlobalOptions {
     version: 'v1';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -97,22 +99,12 @@ export namespace pubsub_v1 {
    * @param {object=} options Options for Pubsub
    */
   export class Pubsub {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     projects: Resource$Projects;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.projects = new Resource$Projects(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.projects = new Resource$Projects();
     }
   }
 
@@ -777,34 +769,19 @@ export namespace pubsub_v1 {
 
 
   export class Resource$Projects {
-    root: Pubsub;
     snapshots: Resource$Projects$Snapshots;
     subscriptions: Resource$Projects$Subscriptions;
     topics: Resource$Projects$Topics;
-    constructor(root: Pubsub) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.snapshots = new Resource$Projects$Snapshots(root);
-      this.subscriptions = new Resource$Projects$Subscriptions(root);
-      this.topics = new Resource$Projects$Topics(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.snapshots = new Resource$Projects$Snapshots();
+      this.subscriptions = new Resource$Projects$Subscriptions();
+      this.topics = new Resource$Projects$Topics();
     }
   }
 
 
   export class Resource$Projects$Snapshots {
-    root: Pubsub;
-    constructor(root: Pubsub) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -881,7 +858,7 @@ export namespace pubsub_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Snapshot>(parameters, callback);
@@ -957,7 +934,7 @@ export namespace pubsub_v1 {
         params,
         requiredParams: ['snapshot'],
         pathParams: ['snapshot'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -1025,7 +1002,7 @@ export namespace pubsub_v1 {
         params,
         requiredParams: ['snapshot'],
         pathParams: ['snapshot'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Snapshot>(parameters, callback);
@@ -1145,7 +1122,7 @@ export namespace pubsub_v1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -1222,7 +1199,7 @@ export namespace pubsub_v1 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListSnapshotsResponse>(parameters, callback);
@@ -1296,7 +1273,7 @@ export namespace pubsub_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Snapshot>(parameters, callback);
@@ -1421,7 +1398,7 @@ export namespace pubsub_v1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -1558,7 +1535,7 @@ export namespace pubsub_v1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TestIamPermissionsResponse>(
@@ -1709,15 +1686,7 @@ export namespace pubsub_v1 {
 
 
   export class Resource$Projects$Subscriptions {
-    root: Pubsub;
-    constructor(root: Pubsub) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -1837,7 +1806,7 @@ export namespace pubsub_v1 {
         params,
         requiredParams: ['subscription'],
         pathParams: ['subscription'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -1982,7 +1951,7 @@ export namespace pubsub_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Subscription>(parameters, callback);
@@ -2104,7 +2073,7 @@ export namespace pubsub_v1 {
         params,
         requiredParams: ['subscription'],
         pathParams: ['subscription'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -2222,7 +2191,7 @@ export namespace pubsub_v1 {
         params,
         requiredParams: ['subscription'],
         pathParams: ['subscription'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Subscription>(parameters, callback);
@@ -2342,7 +2311,7 @@ export namespace pubsub_v1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -2482,7 +2451,7 @@ export namespace pubsub_v1 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListSubscriptionsResponse>(
@@ -2609,7 +2578,7 @@ export namespace pubsub_v1 {
         params,
         requiredParams: ['subscription'],
         pathParams: ['subscription'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -2737,7 +2706,7 @@ export namespace pubsub_v1 {
         params,
         requiredParams: ['subscription'],
         pathParams: ['subscription'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -2805,7 +2774,7 @@ export namespace pubsub_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Subscription>(parameters, callback);
@@ -2934,7 +2903,7 @@ export namespace pubsub_v1 {
         params,
         requiredParams: ['subscription'],
         pathParams: ['subscription'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$PullResponse>(parameters, callback);
@@ -3011,7 +2980,7 @@ export namespace pubsub_v1 {
         params,
         requiredParams: ['subscription'],
         pathParams: ['subscription'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$SeekResponse>(parameters, callback);
@@ -3136,7 +3105,7 @@ export namespace pubsub_v1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -3274,7 +3243,7 @@ export namespace pubsub_v1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TestIamPermissionsResponse>(
@@ -3519,18 +3488,11 @@ export namespace pubsub_v1 {
 
 
   export class Resource$Projects$Topics {
-    root: Pubsub;
     snapshots: Resource$Projects$Topics$Snapshots;
     subscriptions: Resource$Projects$Topics$Subscriptions;
-    constructor(root: Pubsub) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.snapshots = new Resource$Projects$Topics$Snapshots(root);
-      this.subscriptions = new Resource$Projects$Topics$Subscriptions(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.snapshots = new Resource$Projects$Topics$Snapshots();
+      this.subscriptions = new Resource$Projects$Topics$Subscriptions();
     }
 
 
@@ -3661,7 +3623,7 @@ export namespace pubsub_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Topic>(parameters, callback);
@@ -3783,7 +3745,7 @@ export namespace pubsub_v1 {
         params,
         requiredParams: ['topic'],
         pathParams: ['topic'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -3899,7 +3861,7 @@ export namespace pubsub_v1 {
         params,
         requiredParams: ['topic'],
         pathParams: ['topic'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Topic>(parameters, callback);
@@ -4021,7 +3983,7 @@ export namespace pubsub_v1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -4157,7 +4119,7 @@ export namespace pubsub_v1 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListTopicsResponse>(parameters, callback);
@@ -4224,7 +4186,7 @@ export namespace pubsub_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Topic>(parameters, callback);
@@ -4352,7 +4314,7 @@ export namespace pubsub_v1 {
         params,
         requiredParams: ['topic'],
         pathParams: ['topic'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$PublishResponse>(parameters, callback);
@@ -4479,7 +4441,7 @@ export namespace pubsub_v1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -4615,7 +4577,7 @@ export namespace pubsub_v1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TestIamPermissionsResponse>(
@@ -4788,15 +4750,7 @@ export namespace pubsub_v1 {
   }
 
   export class Resource$Projects$Topics$Snapshots {
-    root: Pubsub;
-    constructor(root: Pubsub) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -4871,7 +4825,7 @@ export namespace pubsub_v1 {
         params,
         requiredParams: ['topic'],
         pathParams: ['topic'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListTopicSnapshotsResponse>(
@@ -4908,15 +4862,7 @@ export namespace pubsub_v1 {
 
 
   export class Resource$Projects$Topics$Subscriptions {
-    root: Pubsub;
-    constructor(root: Pubsub) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -5052,7 +4998,7 @@ export namespace pubsub_v1 {
         params,
         requiredParams: ['topic'],
         pathParams: ['topic'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListTopicSubscriptionsResponse>(

--- a/src/apis/pubsub/v1beta1a.ts
+++ b/src/apis/pubsub/v1beta1a.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace pubsub_v1beta1a {
   export interface Options extends GlobalOptions {
     version: 'v1beta1a';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -97,24 +99,14 @@ export namespace pubsub_v1beta1a {
    * @param {object=} options Options for Pubsub
    */
   export class Pubsub {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     subscriptions: Resource$Subscriptions;
     topics: Resource$Topics;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.subscriptions = new Resource$Subscriptions(this);
-      this.topics = new Resource$Topics(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.subscriptions = new Resource$Subscriptions();
+      this.topics = new Resource$Topics();
     }
   }
 
@@ -454,15 +446,7 @@ export namespace pubsub_v1beta1a {
 
 
   export class Resource$Subscriptions {
-    root: Pubsub;
-    constructor(root: Pubsub) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -525,7 +509,7 @@ export namespace pubsub_v1beta1a {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -596,7 +580,7 @@ export namespace pubsub_v1beta1a {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Subscription>(parameters, callback);
@@ -664,7 +648,7 @@ export namespace pubsub_v1beta1a {
         params,
         requiredParams: ['subscription'],
         pathParams: ['subscription'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -727,7 +711,7 @@ export namespace pubsub_v1beta1a {
         params,
         requiredParams: ['subscription'],
         pathParams: ['subscription'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Subscription>(parameters, callback);
@@ -797,7 +781,7 @@ export namespace pubsub_v1beta1a {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListSubscriptionsResponse>(
@@ -865,7 +849,7 @@ export namespace pubsub_v1beta1a {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -935,7 +919,7 @@ export namespace pubsub_v1beta1a {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -1005,7 +989,7 @@ export namespace pubsub_v1beta1a {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$PullResponse>(parameters, callback);
@@ -1075,7 +1059,7 @@ export namespace pubsub_v1beta1a {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$PullBatchResponse>(parameters, callback);
@@ -1211,15 +1195,7 @@ export namespace pubsub_v1beta1a {
 
 
   export class Resource$Topics {
-    root: Pubsub;
-    constructor(root: Pubsub) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -1275,7 +1251,7 @@ export namespace pubsub_v1beta1a {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Topic>(parameters, callback);
@@ -1341,7 +1317,7 @@ export namespace pubsub_v1beta1a {
         params,
         requiredParams: ['topic'],
         pathParams: ['topic'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -1405,7 +1381,7 @@ export namespace pubsub_v1beta1a {
         params,
         requiredParams: ['topic'],
         pathParams: ['topic'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Topic>(parameters, callback);
@@ -1471,7 +1447,7 @@ export namespace pubsub_v1beta1a {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListTopicsResponse>(parameters, callback);
@@ -1536,7 +1512,7 @@ export namespace pubsub_v1beta1a {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -1606,7 +1582,7 @@ export namespace pubsub_v1beta1a {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$PublishBatchResponse>(parameters, callback);

--- a/src/apis/pubsub/v1beta2.ts
+++ b/src/apis/pubsub/v1beta2.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace pubsub_v1beta2 {
   export interface Options extends GlobalOptions {
     version: 'v1beta2';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -97,22 +99,12 @@ export namespace pubsub_v1beta2 {
    * @param {object=} options Options for Pubsub
    */
   export class Pubsub {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     projects: Resource$Projects;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.projects = new Resource$Projects(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.projects = new Resource$Projects();
     }
   }
 
@@ -531,32 +523,17 @@ export namespace pubsub_v1beta2 {
 
 
   export class Resource$Projects {
-    root: Pubsub;
     subscriptions: Resource$Projects$Subscriptions;
     topics: Resource$Projects$Topics;
-    constructor(root: Pubsub) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.subscriptions = new Resource$Projects$Subscriptions(root);
-      this.topics = new Resource$Projects$Topics(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.subscriptions = new Resource$Projects$Subscriptions();
+      this.topics = new Resource$Projects$Topics();
     }
   }
 
 
   export class Resource$Projects$Subscriptions {
-    root: Pubsub;
-    constructor(root: Pubsub) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -620,7 +597,7 @@ export namespace pubsub_v1beta2 {
         params,
         requiredParams: ['subscription'],
         pathParams: ['subscription'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -692,7 +669,7 @@ export namespace pubsub_v1beta2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Subscription>(parameters, callback);
@@ -762,7 +739,7 @@ export namespace pubsub_v1beta2 {
         params,
         requiredParams: ['subscription'],
         pathParams: ['subscription'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -825,7 +802,7 @@ export namespace pubsub_v1beta2 {
         params,
         requiredParams: ['subscription'],
         pathParams: ['subscription'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Subscription>(parameters, callback);
@@ -892,7 +869,7 @@ export namespace pubsub_v1beta2 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -964,7 +941,7 @@ export namespace pubsub_v1beta2 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListSubscriptionsResponse>(
@@ -1037,7 +1014,7 @@ export namespace pubsub_v1beta2 {
         params,
         requiredParams: ['subscription'],
         pathParams: ['subscription'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -1109,7 +1086,7 @@ export namespace pubsub_v1beta2 {
         params,
         requiredParams: ['subscription'],
         pathParams: ['subscription'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -1180,7 +1157,7 @@ export namespace pubsub_v1beta2 {
         params,
         requiredParams: ['subscription'],
         pathParams: ['subscription'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$PullResponse>(parameters, callback);
@@ -1248,7 +1225,7 @@ export namespace pubsub_v1beta2 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -1328,7 +1305,7 @@ export namespace pubsub_v1beta2 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TestIamPermissionsResponse>(
@@ -1527,16 +1504,9 @@ export namespace pubsub_v1beta2 {
 
 
   export class Resource$Projects$Topics {
-    root: Pubsub;
     subscriptions: Resource$Projects$Topics$Subscriptions;
-    constructor(root: Pubsub) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.subscriptions = new Resource$Projects$Topics$Subscriptions(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.subscriptions = new Resource$Projects$Topics$Subscriptions();
     }
 
 
@@ -1596,7 +1566,7 @@ export namespace pubsub_v1beta2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Topic>(parameters, callback);
@@ -1667,7 +1637,7 @@ export namespace pubsub_v1beta2 {
         params,
         requiredParams: ['topic'],
         pathParams: ['topic'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -1729,7 +1699,7 @@ export namespace pubsub_v1beta2 {
         params,
         requiredParams: ['topic'],
         pathParams: ['topic'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Topic>(parameters, callback);
@@ -1796,7 +1766,7 @@ export namespace pubsub_v1beta2 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -1865,7 +1835,7 @@ export namespace pubsub_v1beta2 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListTopicsResponse>(parameters, callback);
@@ -1935,7 +1905,7 @@ export namespace pubsub_v1beta2 {
         params,
         requiredParams: ['topic'],
         pathParams: ['topic'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$PublishResponse>(parameters, callback);
@@ -2003,7 +1973,7 @@ export namespace pubsub_v1beta2 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -2081,7 +2051,7 @@ export namespace pubsub_v1beta2 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TestIamPermissionsResponse>(
@@ -2228,15 +2198,7 @@ export namespace pubsub_v1beta2 {
   }
 
   export class Resource$Projects$Topics$Subscriptions {
-    root: Pubsub;
-    constructor(root: Pubsub) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -2303,7 +2265,7 @@ export namespace pubsub_v1beta2 {
         params,
         requiredParams: ['topic'],
         pathParams: ['topic'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListTopicSubscriptionsResponse>(

--- a/src/apis/redis/v1.ts
+++ b/src/apis/redis/v1.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace redis_v1 {
   export interface Options extends GlobalOptions {
     version: 'v1';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -97,22 +99,12 @@ export namespace redis_v1 {
    * @param {object=} options Options for Redis
    */
   export class Redis {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     projects: Resource$Projects;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.projects = new Resource$Projects(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.projects = new Resource$Projects();
     }
   }
 
@@ -463,33 +455,19 @@ export namespace redis_v1 {
 
 
   export class Resource$Projects {
-    root: Redis;
     locations: Resource$Projects$Locations;
-    constructor(root: Redis) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.locations = new Resource$Projects$Locations(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.locations = new Resource$Projects$Locations();
     }
   }
 
 
   export class Resource$Projects$Locations {
-    root: Redis;
     instances: Resource$Projects$Locations$Instances;
     operations: Resource$Projects$Locations$Operations;
-    constructor(root: Redis) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.instances = new Resource$Projects$Locations$Instances(root);
-      this.operations = new Resource$Projects$Locations$Operations(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.instances = new Resource$Projects$Locations$Instances();
+      this.operations = new Resource$Projects$Locations$Operations();
     }
 
 
@@ -544,7 +522,7 @@ export namespace redis_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Location>(parameters, callback);
@@ -615,7 +593,7 @@ export namespace redis_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListLocationsResponse>(parameters, callback);
@@ -663,15 +641,7 @@ export namespace redis_v1 {
   }
 
   export class Resource$Projects$Locations$Instances {
-    root: Redis;
-    constructor(root: Redis) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -741,7 +711,7 @@ export namespace redis_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -808,7 +778,7 @@ export namespace redis_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -869,7 +839,7 @@ export namespace redis_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Instance>(parameters, callback);
@@ -943,7 +913,7 @@ export namespace redis_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListInstancesResponse>(parameters, callback);
@@ -1014,7 +984,7 @@ export namespace redis_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -1139,15 +1109,7 @@ export namespace redis_v1 {
 
 
   export class Resource$Projects$Locations$Operations {
-    root: Redis;
-    constructor(root: Redis) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -1214,7 +1176,7 @@ export namespace redis_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -1282,7 +1244,7 @@ export namespace redis_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -1346,7 +1308,7 @@ export namespace redis_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -1425,7 +1387,7 @@ export namespace redis_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListOperationsResponse>(parameters, callback);

--- a/src/apis/redis/v1beta1.ts
+++ b/src/apis/redis/v1beta1.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace redis_v1beta1 {
   export interface Options extends GlobalOptions {
     version: 'v1beta1';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -97,22 +99,12 @@ export namespace redis_v1beta1 {
    * @param {object=} options Options for Redis
    */
   export class Redis {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     projects: Resource$Projects;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.projects = new Resource$Projects(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.projects = new Resource$Projects();
     }
   }
 
@@ -476,33 +468,19 @@ export namespace redis_v1beta1 {
 
 
   export class Resource$Projects {
-    root: Redis;
     locations: Resource$Projects$Locations;
-    constructor(root: Redis) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.locations = new Resource$Projects$Locations(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.locations = new Resource$Projects$Locations();
     }
   }
 
 
   export class Resource$Projects$Locations {
-    root: Redis;
     instances: Resource$Projects$Locations$Instances;
     operations: Resource$Projects$Locations$Operations;
-    constructor(root: Redis) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.instances = new Resource$Projects$Locations$Instances(root);
-      this.operations = new Resource$Projects$Locations$Operations(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.instances = new Resource$Projects$Locations$Instances();
+      this.operations = new Resource$Projects$Locations$Operations();
     }
 
 
@@ -557,7 +535,7 @@ export namespace redis_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Location>(parameters, callback);
@@ -628,7 +606,7 @@ export namespace redis_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListLocationsResponse>(parameters, callback);
@@ -676,15 +654,7 @@ export namespace redis_v1beta1 {
   }
 
   export class Resource$Projects$Locations$Instances {
-    root: Redis;
-    constructor(root: Redis) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -754,7 +724,7 @@ export namespace redis_v1beta1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -821,7 +791,7 @@ export namespace redis_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -882,7 +852,7 @@ export namespace redis_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Instance>(parameters, callback);
@@ -956,7 +926,7 @@ export namespace redis_v1beta1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListInstancesResponse>(parameters, callback);
@@ -1027,7 +997,7 @@ export namespace redis_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -1152,15 +1122,7 @@ export namespace redis_v1beta1 {
 
 
   export class Resource$Projects$Locations$Operations {
-    root: Redis;
-    constructor(root: Redis) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -1227,7 +1189,7 @@ export namespace redis_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -1295,7 +1257,7 @@ export namespace redis_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -1359,7 +1321,7 @@ export namespace redis_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -1438,7 +1400,7 @@ export namespace redis_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListOperationsResponse>(parameters, callback);

--- a/src/apis/replicapool/v1beta1.ts
+++ b/src/apis/replicapool/v1beta1.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace replicapool_v1beta1 {
   export interface Options extends GlobalOptions {
     version: 'v1beta1';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -80,24 +82,14 @@ export namespace replicapool_v1beta1 {
    * @param {object=} options Options for Replicapool
    */
   export class Replicapool {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     pools: Resource$Pools;
     replicas: Resource$Replicas;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.pools = new Resource$Pools(this);
-      this.replicas = new Resource$Replicas(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.pools = new Resource$Pools();
+      this.replicas = new Resource$Replicas();
     }
   }
 
@@ -613,15 +605,7 @@ export namespace replicapool_v1beta1 {
 
 
   export class Resource$Pools {
-    root: Replicapool;
-    constructor(root: Replicapool) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -682,7 +666,7 @@ export namespace replicapool_v1beta1 {
         params,
         requiredParams: ['projectName', 'zone', 'poolName'],
         pathParams: ['poolName', 'projectName', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -747,7 +731,7 @@ export namespace replicapool_v1beta1 {
         params,
         requiredParams: ['projectName', 'zone', 'poolName'],
         pathParams: ['poolName', 'projectName', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Pool>(parameters, callback);
@@ -815,7 +799,7 @@ export namespace replicapool_v1beta1 {
         params,
         requiredParams: ['projectName', 'zone'],
         pathParams: ['projectName', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Pool>(parameters, callback);
@@ -885,7 +869,7 @@ export namespace replicapool_v1beta1 {
         params,
         requiredParams: ['projectName', 'zone'],
         pathParams: ['projectName', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$PoolsListResponse>(parameters, callback);
@@ -956,7 +940,7 @@ export namespace replicapool_v1beta1 {
         params,
         requiredParams: ['projectName', 'zone', 'poolName'],
         pathParams: ['poolName', 'projectName', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Pool>(parameters, callback);
@@ -1026,7 +1010,7 @@ export namespace replicapool_v1beta1 {
         params,
         requiredParams: ['projectName', 'zone', 'poolName'],
         pathParams: ['poolName', 'projectName', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -1177,15 +1161,7 @@ export namespace replicapool_v1beta1 {
 
 
   export class Resource$Replicas {
-    root: Replicapool;
-    constructor(root: Replicapool) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -1248,7 +1224,7 @@ export namespace replicapool_v1beta1 {
         params,
         requiredParams: ['projectName', 'zone', 'poolName', 'replicaName'],
         pathParams: ['poolName', 'projectName', 'replicaName', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Replica>(parameters, callback);
@@ -1314,7 +1290,7 @@ export namespace replicapool_v1beta1 {
         params,
         requiredParams: ['projectName', 'zone', 'poolName', 'replicaName'],
         pathParams: ['poolName', 'projectName', 'replicaName', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Replica>(parameters, callback);
@@ -1386,7 +1362,7 @@ export namespace replicapool_v1beta1 {
         params,
         requiredParams: ['projectName', 'zone', 'poolName'],
         pathParams: ['poolName', 'projectName', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ReplicasListResponse>(parameters, callback);
@@ -1455,7 +1431,7 @@ export namespace replicapool_v1beta1 {
         params,
         requiredParams: ['projectName', 'zone', 'poolName', 'replicaName'],
         pathParams: ['poolName', 'projectName', 'replicaName', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Replica>(parameters, callback);

--- a/src/apis/replicapoolupdater/v1beta1.ts
+++ b/src/apis/replicapoolupdater/v1beta1.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace replicapoolupdater_v1beta1 {
   export interface Options extends GlobalOptions {
     version: 'v1beta1';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -81,24 +83,14 @@ export namespace replicapoolupdater_v1beta1 {
    * @param {object=} options Options for Replicapoolupdater
    */
   export class Replicapoolupdater {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     rollingUpdates: Resource$Rollingupdates;
     zoneOperations: Resource$Zoneoperations;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.rollingUpdates = new Resource$Rollingupdates(this);
-      this.zoneOperations = new Resource$Zoneoperations(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.rollingUpdates = new Resource$Rollingupdates();
+      this.zoneOperations = new Resource$Zoneoperations();
     }
   }
 
@@ -384,15 +376,7 @@ export namespace replicapoolupdater_v1beta1 {
 
 
   export class Resource$Rollingupdates {
-    root: Replicapoolupdater;
-    constructor(root: Replicapoolupdater) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -457,7 +441,7 @@ export namespace replicapoolupdater_v1beta1 {
         params,
         requiredParams: ['project', 'zone', 'rollingUpdate'],
         pathParams: ['project', 'rollingUpdate', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -524,7 +508,7 @@ export namespace replicapoolupdater_v1beta1 {
         params,
         requiredParams: ['project', 'zone', 'rollingUpdate'],
         pathParams: ['project', 'rollingUpdate', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$RollingUpdate>(parameters, callback);
@@ -595,7 +579,7 @@ export namespace replicapoolupdater_v1beta1 {
         params,
         requiredParams: ['project', 'zone'],
         pathParams: ['project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -668,7 +652,7 @@ export namespace replicapoolupdater_v1beta1 {
         params,
         requiredParams: ['project', 'zone'],
         pathParams: ['project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$RollingUpdateList>(parameters, callback);
@@ -743,7 +727,7 @@ export namespace replicapoolupdater_v1beta1 {
         params,
         requiredParams: ['project', 'zone', 'rollingUpdate'],
         pathParams: ['project', 'rollingUpdate', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$InstanceUpdateList>(parameters, callback);
@@ -815,7 +799,7 @@ export namespace replicapoolupdater_v1beta1 {
         params,
         requiredParams: ['project', 'zone', 'rollingUpdate'],
         pathParams: ['project', 'rollingUpdate', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -887,7 +871,7 @@ export namespace replicapoolupdater_v1beta1 {
         params,
         requiredParams: ['project', 'zone', 'rollingUpdate'],
         pathParams: ['project', 'rollingUpdate', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -959,7 +943,7 @@ export namespace replicapoolupdater_v1beta1 {
         params,
         requiredParams: ['project', 'zone', 'rollingUpdate'],
         pathParams: ['project', 'rollingUpdate', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -1157,15 +1141,7 @@ export namespace replicapoolupdater_v1beta1 {
 
 
   export class Resource$Zoneoperations {
-    root: Replicapoolupdater;
-    constructor(root: Replicapoolupdater) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -1225,7 +1201,7 @@ export namespace replicapoolupdater_v1beta1 {
         params,
         requiredParams: ['project', 'zone', 'operation'],
         pathParams: ['operation', 'project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -1298,7 +1274,7 @@ export namespace replicapoolupdater_v1beta1 {
         params,
         requiredParams: ['project', 'zone'],
         pathParams: ['project', 'zone'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$OperationList>(parameters, callback);

--- a/src/apis/reseller/v1.ts
+++ b/src/apis/reseller/v1.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace reseller_v1 {
   export interface Options extends GlobalOptions {
     version: 'v1';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -79,26 +81,16 @@ export namespace reseller_v1 {
    * @param {object=} options Options for Reseller
    */
   export class Reseller {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     customers: Resource$Customers;
     resellernotify: Resource$Resellernotify;
     subscriptions: Resource$Subscriptions;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.customers = new Resource$Customers(this);
-      this.resellernotify = new Resource$Resellernotify(this);
-      this.subscriptions = new Resource$Subscriptions(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.customers = new Resource$Customers();
+      this.resellernotify = new Resource$Resellernotify();
+      this.subscriptions = new Resource$Subscriptions();
     }
   }
 
@@ -481,15 +473,7 @@ export namespace reseller_v1 {
 
 
   export class Resource$Customers {
-    root: Reseller;
-    constructor(root: Reseller) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -543,7 +527,7 @@ export namespace reseller_v1 {
         params,
         requiredParams: ['customerId'],
         pathParams: ['customerId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Customer>(parameters, callback);
@@ -608,7 +592,7 @@ export namespace reseller_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Customer>(parameters, callback);
@@ -674,7 +658,7 @@ export namespace reseller_v1 {
         params,
         requiredParams: ['customerId'],
         pathParams: ['customerId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Customer>(parameters, callback);
@@ -739,7 +723,7 @@ export namespace reseller_v1 {
         params,
         requiredParams: ['customerId'],
         pathParams: ['customerId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Customer>(parameters, callback);
@@ -825,15 +809,7 @@ export namespace reseller_v1 {
 
 
   export class Resource$Resellernotify {
-    root: Reseller;
-    constructor(root: Reseller) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -903,7 +879,7 @@ export namespace reseller_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ResellernotifyGetwatchdetailsResponse>(
@@ -974,7 +950,7 @@ export namespace reseller_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ResellernotifyResource>(parameters, callback);
@@ -1043,7 +1019,7 @@ export namespace reseller_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ResellernotifyResource>(parameters, callback);
@@ -1087,15 +1063,7 @@ export namespace reseller_v1 {
 
 
   export class Resource$Subscriptions {
-    root: Reseller;
-    constructor(root: Reseller) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -1158,7 +1126,7 @@ export namespace reseller_v1 {
         params,
         requiredParams: ['customerId', 'subscriptionId'],
         pathParams: ['customerId', 'subscriptionId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Subscription>(parameters, callback);
@@ -1231,7 +1199,7 @@ export namespace reseller_v1 {
         params,
         requiredParams: ['customerId', 'subscriptionId'],
         pathParams: ['customerId', 'subscriptionId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Subscription>(parameters, callback);
@@ -1304,7 +1272,7 @@ export namespace reseller_v1 {
         params,
         requiredParams: ['customerId', 'subscriptionId'],
         pathParams: ['customerId', 'subscriptionId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Subscription>(parameters, callback);
@@ -1375,7 +1343,7 @@ export namespace reseller_v1 {
         params,
         requiredParams: ['customerId', 'subscriptionId'],
         pathParams: ['customerId', 'subscriptionId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Subscription>(parameters, callback);
@@ -1444,7 +1412,7 @@ export namespace reseller_v1 {
         params,
         requiredParams: ['customerId', 'subscriptionId', 'deletionType'],
         pathParams: ['customerId', 'subscriptionId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -1510,7 +1478,7 @@ export namespace reseller_v1 {
         params,
         requiredParams: ['customerId', 'subscriptionId'],
         pathParams: ['customerId', 'subscriptionId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Subscription>(parameters, callback);
@@ -1580,7 +1548,7 @@ export namespace reseller_v1 {
         params,
         requiredParams: ['customerId'],
         pathParams: ['customerId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Subscription>(parameters, callback);
@@ -1652,7 +1620,7 @@ export namespace reseller_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Subscriptions>(parameters, callback);
@@ -1723,7 +1691,7 @@ export namespace reseller_v1 {
         params,
         requiredParams: ['customerId', 'subscriptionId'],
         pathParams: ['customerId', 'subscriptionId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Subscription>(parameters, callback);
@@ -1793,7 +1761,7 @@ export namespace reseller_v1 {
         params,
         requiredParams: ['customerId', 'subscriptionId'],
         pathParams: ['customerId', 'subscriptionId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Subscription>(parameters, callback);

--- a/src/apis/runtimeconfig/v1.ts
+++ b/src/apis/runtimeconfig/v1.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace runtimeconfig_v1 {
   export interface Options extends GlobalOptions {
     version: 'v1';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -99,22 +101,12 @@ export namespace runtimeconfig_v1 {
    * @param {object=} options Options for Runtimeconfig
    */
   export class Runtimeconfig {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     operations: Resource$Operations;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.operations = new Resource$Operations(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.operations = new Resource$Operations();
     }
   }
 
@@ -238,15 +230,7 @@ export namespace runtimeconfig_v1 {
 
 
   export class Resource$Operations {
-    root: Runtimeconfig;
-    constructor(root: Runtimeconfig) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -314,7 +298,7 @@ export namespace runtimeconfig_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -382,7 +366,7 @@ export namespace runtimeconfig_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -459,7 +443,7 @@ export namespace runtimeconfig_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListOperationsResponse>(parameters, callback);

--- a/src/apis/runtimeconfig/v1beta1.ts
+++ b/src/apis/runtimeconfig/v1beta1.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace runtimeconfig_v1beta1 {
   export interface Options extends GlobalOptions {
     version: 'v1beta1';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -99,22 +101,12 @@ export namespace runtimeconfig_v1beta1 {
    * @param {object=} options Options for Runtimeconfig
    */
   export class Runtimeconfig {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     projects: Resource$Projects;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.projects = new Resource$Projects(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.projects = new Resource$Projects();
     }
   }
 
@@ -595,35 +587,21 @@ export namespace runtimeconfig_v1beta1 {
 
 
   export class Resource$Projects {
-    root: Runtimeconfig;
     configs: Resource$Projects$Configs;
-    constructor(root: Runtimeconfig) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.configs = new Resource$Projects$Configs(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.configs = new Resource$Projects$Configs();
     }
   }
 
 
   export class Resource$Projects$Configs {
-    root: Runtimeconfig;
     operations: Resource$Projects$Configs$Operations;
     variables: Resource$Projects$Configs$Variables;
     waiters: Resource$Projects$Configs$Waiters;
-    constructor(root: Runtimeconfig) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.operations = new Resource$Projects$Configs$Operations(root);
-      this.variables = new Resource$Projects$Configs$Variables(root);
-      this.waiters = new Resource$Projects$Configs$Waiters(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.operations = new Resource$Projects$Configs$Operations();
+      this.variables = new Resource$Projects$Configs$Variables();
+      this.waiters = new Resource$Projects$Configs$Waiters();
     }
 
 
@@ -688,7 +666,7 @@ export namespace runtimeconfig_v1beta1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$RuntimeConfig>(parameters, callback);
@@ -754,7 +732,7 @@ export namespace runtimeconfig_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -817,7 +795,7 @@ export namespace runtimeconfig_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$RuntimeConfig>(parameters, callback);
@@ -885,7 +863,7 @@ export namespace runtimeconfig_v1beta1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -955,7 +933,7 @@ export namespace runtimeconfig_v1beta1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListConfigsResponse>(parameters, callback);
@@ -1024,7 +1002,7 @@ export namespace runtimeconfig_v1beta1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -1103,7 +1081,7 @@ export namespace runtimeconfig_v1beta1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TestIamPermissionsResponse>(
@@ -1173,7 +1151,7 @@ export namespace runtimeconfig_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$RuntimeConfig>(parameters, callback);
@@ -1330,15 +1308,7 @@ export namespace runtimeconfig_v1beta1 {
   }
 
   export class Resource$Projects$Configs$Operations {
-    root: Runtimeconfig;
-    constructor(root: Runtimeconfig) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -1396,7 +1366,7 @@ export namespace runtimeconfig_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -1477,7 +1447,7 @@ export namespace runtimeconfig_v1beta1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TestIamPermissionsResponse>(
@@ -1521,15 +1491,7 @@ export namespace runtimeconfig_v1beta1 {
 
 
   export class Resource$Projects$Configs$Variables {
-    root: Runtimeconfig;
-    constructor(root: Runtimeconfig) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -1596,7 +1558,7 @@ export namespace runtimeconfig_v1beta1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Variable>(parameters, callback);
@@ -1666,7 +1628,7 @@ export namespace runtimeconfig_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -1728,7 +1690,7 @@ export namespace runtimeconfig_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Variable>(parameters, callback);
@@ -1804,7 +1766,7 @@ export namespace runtimeconfig_v1beta1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListVariablesResponse>(parameters, callback);
@@ -1885,7 +1847,7 @@ export namespace runtimeconfig_v1beta1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TestIamPermissionsResponse>(
@@ -1953,7 +1915,7 @@ export namespace runtimeconfig_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Variable>(parameters, callback);
@@ -2030,7 +1992,7 @@ export namespace runtimeconfig_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Variable>(parameters, callback);
@@ -2191,15 +2153,7 @@ export namespace runtimeconfig_v1beta1 {
 
 
   export class Resource$Projects$Configs$Waiters {
-    root: Runtimeconfig;
-    constructor(root: Runtimeconfig) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -2267,7 +2221,7 @@ export namespace runtimeconfig_v1beta1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -2333,7 +2287,7 @@ export namespace runtimeconfig_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -2395,7 +2349,7 @@ export namespace runtimeconfig_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Waiter>(parameters, callback);
@@ -2465,7 +2419,7 @@ export namespace runtimeconfig_v1beta1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListWaitersResponse>(parameters, callback);
@@ -2546,7 +2500,7 @@ export namespace runtimeconfig_v1beta1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TestIamPermissionsResponse>(

--- a/src/apis/safebrowsing/v4.ts
+++ b/src/apis/safebrowsing/v4.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace safebrowsing_v4 {
   export interface Options extends GlobalOptions {
     version: 'v4';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -97,10 +99,6 @@ export namespace safebrowsing_v4 {
    * @param {object=} options Options for Safebrowsing
    */
   export class Safebrowsing {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     encodedFullHashes: Resource$Encodedfullhashes;
     encodedUpdates: Resource$Encodedupdates;
     fullHashes: Resource$Fullhashes;
@@ -110,21 +108,15 @@ export namespace safebrowsing_v4 {
     threatMatches: Resource$Threatmatches;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.encodedFullHashes = new Resource$Encodedfullhashes(this);
-      this.encodedUpdates = new Resource$Encodedupdates(this);
-      this.fullHashes = new Resource$Fullhashes(this);
-      this.threatHits = new Resource$Threathits(this);
-      this.threatLists = new Resource$Threatlists(this);
-      this.threatListUpdates = new Resource$Threatlistupdates(this);
-      this.threatMatches = new Resource$Threatmatches(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.encodedFullHashes = new Resource$Encodedfullhashes();
+      this.encodedUpdates = new Resource$Encodedupdates();
+      this.fullHashes = new Resource$Fullhashes();
+      this.threatHits = new Resource$Threathits();
+      this.threatLists = new Resource$Threatlists();
+      this.threatListUpdates = new Resource$Threatlistupdates();
+      this.threatMatches = new Resource$Threatmatches();
     }
   }
 
@@ -627,15 +619,7 @@ export namespace safebrowsing_v4 {
 
 
   export class Resource$Encodedfullhashes {
-    root: Safebrowsing;
-    constructor(root: Safebrowsing) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -693,7 +677,7 @@ export namespace safebrowsing_v4 {
         params,
         requiredParams: ['encodedRequest'],
         pathParams: ['encodedRequest'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$FindFullHashesResponse>(parameters, callback);
@@ -727,15 +711,7 @@ export namespace safebrowsing_v4 {
 
 
   export class Resource$Encodedupdates {
-    root: Safebrowsing;
-    constructor(root: Safebrowsing) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -796,7 +772,7 @@ export namespace safebrowsing_v4 {
         params,
         requiredParams: ['encodedRequest'],
         pathParams: ['encodedRequest'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$FetchThreatListUpdatesResponse>(
@@ -832,15 +808,7 @@ export namespace safebrowsing_v4 {
 
 
   export class Resource$Fullhashes {
-    root: Safebrowsing;
-    constructor(root: Safebrowsing) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -899,7 +867,7 @@ export namespace safebrowsing_v4 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$FindFullHashesResponse>(parameters, callback);
@@ -924,15 +892,7 @@ export namespace safebrowsing_v4 {
 
 
   export class Resource$Threathits {
-    root: Safebrowsing;
-    constructor(root: Safebrowsing) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -990,7 +950,7 @@ export namespace safebrowsing_v4 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -1016,15 +976,7 @@ export namespace safebrowsing_v4 {
 
 
   export class Resource$Threatlists {
-    root: Safebrowsing;
-    constructor(root: Safebrowsing) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -1081,7 +1033,7 @@ export namespace safebrowsing_v4 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListThreatListsResponse>(parameters, callback);
@@ -1100,15 +1052,7 @@ export namespace safebrowsing_v4 {
 
 
   export class Resource$Threatlistupdates {
-    root: Safebrowsing;
-    constructor(root: Safebrowsing) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -1175,7 +1119,7 @@ export namespace safebrowsing_v4 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$FetchThreatListUpdatesResponse>(
@@ -1203,15 +1147,7 @@ export namespace safebrowsing_v4 {
 
 
   export class Resource$Threatmatches {
-    root: Safebrowsing;
-    constructor(root: Safebrowsing) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -1272,7 +1208,7 @@ export namespace safebrowsing_v4 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$FindThreatMatchesResponse>(

--- a/src/apis/script/v1.ts
+++ b/src/apis/script/v1.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace script_v1 {
   export interface Options extends GlobalOptions {
     version: 'v1';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -96,26 +98,16 @@ export namespace script_v1 {
    * @param {object=} options Options for Script
    */
   export class Script {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     processes: Resource$Processes;
     projects: Resource$Projects;
     scripts: Resource$Scripts;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.processes = new Resource$Processes(this);
-      this.projects = new Resource$Projects(this);
-      this.scripts = new Resource$Scripts(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.processes = new Resource$Processes();
+      this.projects = new Resource$Projects();
+      this.scripts = new Resource$Scripts();
     }
   }
 
@@ -737,15 +729,7 @@ export namespace script_v1 {
 
 
   export class Resource$Processes {
-    root: Script;
-    constructor(root: Script) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -815,7 +799,7 @@ export namespace script_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListUserProcessesResponse>(
@@ -899,7 +883,7 @@ export namespace script_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListScriptProcessesResponse>(
@@ -1032,18 +1016,11 @@ export namespace script_v1 {
 
 
   export class Resource$Projects {
-    root: Script;
     deployments: Resource$Projects$Deployments;
     versions: Resource$Projects$Versions;
-    constructor(root: Script) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.deployments = new Resource$Projects$Deployments(root);
-      this.versions = new Resource$Projects$Versions(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.deployments = new Resource$Projects$Deployments();
+      this.versions = new Resource$Projects$Versions();
     }
 
 
@@ -1101,7 +1078,7 @@ export namespace script_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Project>(parameters, callback);
@@ -1162,7 +1139,7 @@ export namespace script_v1 {
         params,
         requiredParams: ['scriptId'],
         pathParams: ['scriptId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Project>(parameters, callback);
@@ -1230,7 +1207,7 @@ export namespace script_v1 {
         params,
         requiredParams: ['scriptId'],
         pathParams: ['scriptId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Content>(parameters, callback);
@@ -1299,7 +1276,7 @@ export namespace script_v1 {
         params,
         requiredParams: ['scriptId'],
         pathParams: ['scriptId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Metrics>(parameters, callback);
@@ -1370,7 +1347,7 @@ export namespace script_v1 {
         params,
         requiredParams: ['scriptId'],
         pathParams: ['scriptId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Content>(parameters, callback);
@@ -1459,15 +1436,7 @@ export namespace script_v1 {
   }
 
   export class Resource$Projects$Deployments {
-    root: Script;
-    constructor(root: Script) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -1528,7 +1497,7 @@ export namespace script_v1 {
         params,
         requiredParams: ['scriptId'],
         pathParams: ['scriptId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Deployment>(parameters, callback);
@@ -1596,7 +1565,7 @@ export namespace script_v1 {
         params,
         requiredParams: ['scriptId', 'deploymentId'],
         pathParams: ['deploymentId', 'scriptId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -1661,7 +1630,7 @@ export namespace script_v1 {
         params,
         requiredParams: ['scriptId', 'deploymentId'],
         pathParams: ['deploymentId', 'scriptId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Deployment>(parameters, callback);
@@ -1731,7 +1700,7 @@ export namespace script_v1 {
         params,
         requiredParams: ['scriptId'],
         pathParams: ['scriptId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListDeploymentsResponse>(parameters, callback);
@@ -1801,7 +1770,7 @@ export namespace script_v1 {
         params,
         requiredParams: ['scriptId', 'deploymentId'],
         pathParams: ['deploymentId', 'scriptId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Deployment>(parameters, callback);
@@ -1905,15 +1874,7 @@ export namespace script_v1 {
 
 
   export class Resource$Projects$Versions {
-    root: Script;
-    constructor(root: Script) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -1974,7 +1935,7 @@ export namespace script_v1 {
         params,
         requiredParams: ['scriptId'],
         pathParams: ['scriptId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Version>(parameters, callback);
@@ -2038,7 +1999,7 @@ export namespace script_v1 {
         params,
         requiredParams: ['scriptId', 'versionNumber'],
         pathParams: ['scriptId', 'versionNumber'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Version>(parameters, callback);
@@ -2108,7 +2069,7 @@ export namespace script_v1 {
         params,
         requiredParams: ['scriptId'],
         pathParams: ['scriptId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListVersionsResponse>(parameters, callback);
@@ -2176,15 +2137,7 @@ export namespace script_v1 {
 
 
   export class Resource$Scripts {
-    root: Script;
-    constructor(root: Script) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -2251,7 +2204,7 @@ export namespace script_v1 {
         params,
         requiredParams: ['scriptId'],
         pathParams: ['scriptId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);

--- a/src/apis/searchconsole/v1.ts
+++ b/src/apis/searchconsole/v1.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace searchconsole_v1 {
   export interface Options extends GlobalOptions {
     version: 'v1';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -96,22 +98,12 @@ export namespace searchconsole_v1 {
    * @param {object=} options Options for Searchconsole
    */
   export class Searchconsole {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     urlTestingTools: Resource$Urltestingtools;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.urlTestingTools = new Resource$Urltestingtools(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.urlTestingTools = new Resource$Urltestingtools();
     }
   }
 
@@ -212,31 +204,16 @@ export namespace searchconsole_v1 {
 
 
   export class Resource$Urltestingtools {
-    root: Searchconsole;
     mobileFriendlyTest: Resource$Urltestingtools$Mobilefriendlytest;
-    constructor(root: Searchconsole) {
-      this.root = root;
-      this.getRoot.bind(this);
+    constructor() {
       this.mobileFriendlyTest =
-          new Resource$Urltestingtools$Mobilefriendlytest(root);
-    }
-
-    getRoot() {
-      return this.root;
+          new Resource$Urltestingtools$Mobilefriendlytest();
     }
   }
 
 
   export class Resource$Urltestingtools$Mobilefriendlytest {
-    root: Searchconsole;
-    constructor(root: Searchconsole) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -299,7 +276,7 @@ export namespace searchconsole_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$RunMobileFriendlyTestResponse>(

--- a/src/apis/servicebroker/v1.ts
+++ b/src/apis/servicebroker/v1.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace servicebroker_v1 {
   export interface Options extends GlobalOptions {
     version: 'v1';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -98,22 +100,12 @@ export namespace servicebroker_v1 {
    * @param {object=} options Options for Servicebroker
    */
   export class Servicebroker {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     v1: Resource$V1;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.v1 = new Resource$V1(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.v1 = new Resource$V1();
     }
   }
 
@@ -259,15 +251,7 @@ export namespace servicebroker_v1 {
 
 
   export class Resource$V1 {
-    root: Servicebroker;
-    constructor(root: Servicebroker) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -329,7 +313,7 @@ export namespace servicebroker_v1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleIamV1__Policy>(parameters, callback);
@@ -399,7 +383,7 @@ export namespace servicebroker_v1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleIamV1__Policy>(parameters, callback);
@@ -478,7 +462,7 @@ export namespace servicebroker_v1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleIamV1__TestIamPermissionsResponse>(

--- a/src/apis/servicebroker/v1alpha1.ts
+++ b/src/apis/servicebroker/v1alpha1.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace servicebroker_v1alpha1 {
   export interface Options extends GlobalOptions {
     version: 'v1alpha1';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -98,24 +100,14 @@ export namespace servicebroker_v1alpha1 {
    * @param {object=} options Options for Servicebroker
    */
   export class Servicebroker {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     projects: Resource$Projects;
     v1alpha1: Resource$V1alpha1;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.projects = new Resource$Projects(this);
-      this.v1alpha1 = new Resource$V1alpha1(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.projects = new Resource$Projects();
+      this.v1alpha1 = new Resource$V1alpha1();
     }
   }
 
@@ -683,52 +675,31 @@ export namespace servicebroker_v1alpha1 {
 
 
   export class Resource$Projects {
-    root: Servicebroker;
     brokers: Resource$Projects$Brokers;
-    constructor(root: Servicebroker) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.brokers = new Resource$Projects$Brokers(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.brokers = new Resource$Projects$Brokers();
     }
   }
 
 
   export class Resource$Projects$Brokers {
-    root: Servicebroker;
     instances: Resource$Projects$Brokers$Instances;
     service_instances: Resource$Projects$Brokers$Service_instances;
     v2: Resource$Projects$Brokers$V2;
-    constructor(root: Servicebroker) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.instances = new Resource$Projects$Brokers$Instances(root);
+    constructor() {
+      this.instances = new Resource$Projects$Brokers$Instances();
       this.service_instances =
-          new Resource$Projects$Brokers$Service_instances(root);
-      this.v2 = new Resource$Projects$Brokers$V2(root);
-    }
-
-    getRoot() {
-      return this.root;
+          new Resource$Projects$Brokers$Service_instances();
+      this.v2 = new Resource$Projects$Brokers$V2();
     }
   }
 
 
   export class Resource$Projects$Brokers$Instances {
-    root: Servicebroker;
     service_bindings: Resource$Projects$Brokers$Instances$Service_bindings;
-    constructor(root: Servicebroker) {
-      this.root = root;
-      this.getRoot.bind(this);
+    constructor() {
       this.service_bindings =
-          new Resource$Projects$Brokers$Instances$Service_bindings(root);
-    }
-
-    getRoot() {
-      return this.root;
+          new Resource$Projects$Brokers$Instances$Service_bindings();
     }
 
 
@@ -795,7 +766,7 @@ export namespace servicebroker_v1alpha1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<
@@ -823,15 +794,7 @@ export namespace servicebroker_v1alpha1 {
   }
 
   export class Resource$Projects$Brokers$Instances$Service_bindings {
-    root: Servicebroker;
-    constructor(root: Servicebroker) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -910,7 +873,7 @@ export namespace servicebroker_v1alpha1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<
@@ -952,15 +915,7 @@ export namespace servicebroker_v1alpha1 {
 
 
   export class Resource$Projects$Brokers$Service_instances {
-    root: Servicebroker;
-    constructor(root: Servicebroker) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -1037,7 +992,7 @@ export namespace servicebroker_v1alpha1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<
@@ -1077,33 +1032,18 @@ export namespace servicebroker_v1alpha1 {
 
 
   export class Resource$Projects$Brokers$V2 {
-    root: Servicebroker;
     catalog: Resource$Projects$Brokers$V2$Catalog;
     service_instances: Resource$Projects$Brokers$V2$Service_instances;
-    constructor(root: Servicebroker) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.catalog = new Resource$Projects$Brokers$V2$Catalog(root);
+    constructor() {
+      this.catalog = new Resource$Projects$Brokers$V2$Catalog();
       this.service_instances =
-          new Resource$Projects$Brokers$V2$Service_instances(root);
-    }
-
-    getRoot() {
-      return this.root;
+          new Resource$Projects$Brokers$V2$Service_instances();
     }
   }
 
 
   export class Resource$Projects$Brokers$V2$Catalog {
-    root: Servicebroker;
-    constructor(root: Servicebroker) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -1179,7 +1119,7 @@ export namespace servicebroker_v1alpha1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<
@@ -1219,19 +1159,11 @@ export namespace servicebroker_v1alpha1 {
 
 
   export class Resource$Projects$Brokers$V2$Service_instances {
-    root: Servicebroker;
     service_bindings:
         Resource$Projects$Brokers$V2$Service_instances$Service_bindings;
-    constructor(root: Servicebroker) {
-      this.root = root;
-      this.getRoot.bind(this);
+    constructor() {
       this.service_bindings =
-          new Resource$Projects$Brokers$V2$Service_instances$Service_bindings(
-              root);
-    }
-
-    getRoot() {
-      return this.root;
+          new Resource$Projects$Brokers$V2$Service_instances$Service_bindings();
     }
 
 
@@ -1320,7 +1252,7 @@ export namespace servicebroker_v1alpha1 {
         params,
         requiredParams: ['parent', 'instance_id'],
         pathParams: ['instance_id', 'parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<
@@ -1413,7 +1345,7 @@ export namespace servicebroker_v1alpha1 {
         params,
         requiredParams: ['parent', 'instanceId'],
         pathParams: ['instanceId', 'parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<
@@ -1492,7 +1424,7 @@ export namespace servicebroker_v1alpha1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<
@@ -1585,7 +1517,7 @@ export namespace servicebroker_v1alpha1 {
         params,
         requiredParams: ['parent', 'instanceId'],
         pathParams: ['instanceId', 'parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleCloudServicebrokerV1alpha1__Operation>(
@@ -1674,7 +1606,7 @@ export namespace servicebroker_v1alpha1 {
         params,
         requiredParams: ['parent', 'instance_id'],
         pathParams: ['instance_id', 'parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<
@@ -1816,15 +1748,7 @@ export namespace servicebroker_v1alpha1 {
   }
 
   export class Resource$Projects$Brokers$V2$Service_instances$Service_bindings {
-    root: Servicebroker;
-    constructor(root: Servicebroker) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -1910,7 +1834,7 @@ export namespace servicebroker_v1alpha1 {
         params,
         requiredParams: ['parent', 'instanceId', 'binding_id'],
         pathParams: ['binding_id', 'instanceId', 'parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<
@@ -2009,7 +1933,7 @@ export namespace servicebroker_v1alpha1 {
         params,
         requiredParams: ['parent', 'instanceId', 'bindingId'],
         pathParams: ['bindingId', 'instanceId', 'parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<
@@ -2098,7 +2022,7 @@ export namespace servicebroker_v1alpha1 {
         params,
         requiredParams: ['parent', 'instanceId', 'bindingId'],
         pathParams: ['bindingId', 'instanceId', 'parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<
@@ -2192,7 +2116,7 @@ export namespace servicebroker_v1alpha1 {
         params,
         requiredParams: ['parent', 'instanceId', 'bindingId'],
         pathParams: ['bindingId', 'instanceId', 'parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleCloudServicebrokerV1alpha1__Operation>(
@@ -2332,15 +2256,7 @@ export namespace servicebroker_v1alpha1 {
 
 
   export class Resource$V1alpha1 {
-    root: Servicebroker;
-    constructor(root: Servicebroker) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -2403,7 +2319,7 @@ export namespace servicebroker_v1alpha1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleIamV1__Policy>(parameters, callback);
@@ -2474,7 +2390,7 @@ export namespace servicebroker_v1alpha1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleIamV1__Policy>(parameters, callback);
@@ -2553,7 +2469,7 @@ export namespace servicebroker_v1alpha1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleIamV1__TestIamPermissionsResponse>(

--- a/src/apis/servicebroker/v1beta1.ts
+++ b/src/apis/servicebroker/v1beta1.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace servicebroker_v1beta1 {
   export interface Options extends GlobalOptions {
     version: 'v1beta1';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -98,24 +100,14 @@ export namespace servicebroker_v1beta1 {
    * @param {object=} options Options for Servicebroker
    */
   export class Servicebroker {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     projects: Resource$Projects;
     v1beta1: Resource$V1beta1;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.projects = new Resource$Projects(this);
-      this.v1beta1 = new Resource$V1beta1(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.projects = new Resource$Projects();
+      this.v1beta1 = new Resource$V1beta1();
     }
   }
 
@@ -764,33 +756,19 @@ export namespace servicebroker_v1beta1 {
 
 
   export class Resource$Projects {
-    root: Servicebroker;
     brokers: Resource$Projects$Brokers;
-    constructor(root: Servicebroker) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.brokers = new Resource$Projects$Brokers(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.brokers = new Resource$Projects$Brokers();
     }
   }
 
 
   export class Resource$Projects$Brokers {
-    root: Servicebroker;
     instances: Resource$Projects$Brokers$Instances;
     v2: Resource$Projects$Brokers$V2;
-    constructor(root: Servicebroker) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.instances = new Resource$Projects$Brokers$Instances(root);
-      this.v2 = new Resource$Projects$Brokers$V2(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.instances = new Resource$Projects$Brokers$Instances();
+      this.v2 = new Resource$Projects$Brokers$V2();
     }
 
 
@@ -859,7 +837,7 @@ export namespace servicebroker_v1beta1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleCloudServicebrokerV1beta1__Broker>(
@@ -929,7 +907,7 @@ export namespace servicebroker_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleProtobuf__Empty>(parameters, callback);
@@ -1008,7 +986,7 @@ export namespace servicebroker_v1beta1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<
@@ -1076,16 +1054,9 @@ export namespace servicebroker_v1beta1 {
   }
 
   export class Resource$Projects$Brokers$Instances {
-    root: Servicebroker;
     bindings: Resource$Projects$Brokers$Instances$Bindings;
-    constructor(root: Servicebroker) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.bindings = new Resource$Projects$Brokers$Instances$Bindings(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.bindings = new Resource$Projects$Brokers$Instances$Bindings();
     }
 
 
@@ -1152,7 +1123,7 @@ export namespace servicebroker_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<
@@ -1236,7 +1207,7 @@ export namespace servicebroker_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleCloudServicebrokerV1beta1__Operation>(
@@ -1321,7 +1292,7 @@ export namespace servicebroker_v1beta1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<
@@ -1401,15 +1372,7 @@ export namespace servicebroker_v1beta1 {
   }
 
   export class Resource$Projects$Brokers$Instances$Bindings {
-    root: Servicebroker;
-    constructor(root: Servicebroker) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -1486,7 +1449,7 @@ export namespace servicebroker_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleCloudServicebrokerV1beta1__Operation>(
@@ -1570,7 +1533,7 @@ export namespace servicebroker_v1beta1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<
@@ -1639,33 +1602,18 @@ export namespace servicebroker_v1beta1 {
 
 
   export class Resource$Projects$Brokers$V2 {
-    root: Servicebroker;
     catalog: Resource$Projects$Brokers$V2$Catalog;
     service_instances: Resource$Projects$Brokers$V2$Service_instances;
-    constructor(root: Servicebroker) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.catalog = new Resource$Projects$Brokers$V2$Catalog(root);
+    constructor() {
+      this.catalog = new Resource$Projects$Brokers$V2$Catalog();
       this.service_instances =
-          new Resource$Projects$Brokers$V2$Service_instances(root);
-    }
-
-    getRoot() {
-      return this.root;
+          new Resource$Projects$Brokers$V2$Service_instances();
     }
   }
 
 
   export class Resource$Projects$Brokers$V2$Catalog {
-    root: Servicebroker;
-    constructor(root: Servicebroker) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -1739,7 +1687,7 @@ export namespace servicebroker_v1beta1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<
@@ -1779,19 +1727,11 @@ export namespace servicebroker_v1beta1 {
 
 
   export class Resource$Projects$Brokers$V2$Service_instances {
-    root: Servicebroker;
     service_bindings:
         Resource$Projects$Brokers$V2$Service_instances$Service_bindings;
-    constructor(root: Servicebroker) {
-      this.root = root;
-      this.getRoot.bind(this);
+    constructor() {
       this.service_bindings =
-          new Resource$Projects$Brokers$V2$Service_instances$Service_bindings(
-              root);
-    }
-
-    getRoot() {
-      return this.root;
+          new Resource$Projects$Brokers$V2$Service_instances$Service_bindings();
     }
 
 
@@ -1880,7 +1820,7 @@ export namespace servicebroker_v1beta1 {
         params,
         requiredParams: ['parent', 'instance_id'],
         pathParams: ['instance_id', 'parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<
@@ -1970,7 +1910,7 @@ export namespace servicebroker_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<
@@ -2049,7 +1989,7 @@ export namespace servicebroker_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<
@@ -2137,7 +2077,7 @@ export namespace servicebroker_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleCloudServicebrokerV1beta1__Operation>(
@@ -2223,7 +2163,7 @@ export namespace servicebroker_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<
@@ -2359,15 +2299,7 @@ export namespace servicebroker_v1beta1 {
   }
 
   export class Resource$Projects$Brokers$V2$Service_instances$Service_bindings {
-    root: Servicebroker;
-    constructor(root: Servicebroker) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -2451,7 +2383,7 @@ export namespace servicebroker_v1beta1 {
         params,
         requiredParams: ['parent', 'binding_id'],
         pathParams: ['binding_id', 'parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<
@@ -2545,7 +2477,7 @@ export namespace servicebroker_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<
@@ -2629,7 +2561,7 @@ export namespace servicebroker_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<
@@ -2717,7 +2649,7 @@ export namespace servicebroker_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleCloudServicebrokerV1beta1__Operation>(
@@ -2834,15 +2766,7 @@ export namespace servicebroker_v1beta1 {
 
 
   export class Resource$V1beta1 {
-    root: Servicebroker;
-    constructor(root: Servicebroker) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -2905,7 +2829,7 @@ export namespace servicebroker_v1beta1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleIamV1__Policy>(parameters, callback);
@@ -2976,7 +2900,7 @@ export namespace servicebroker_v1beta1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleIamV1__Policy>(parameters, callback);
@@ -3055,7 +2979,7 @@ export namespace servicebroker_v1beta1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleIamV1__TestIamPermissionsResponse>(

--- a/src/apis/serviceconsumermanagement/v1.ts
+++ b/src/apis/serviceconsumermanagement/v1.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace serviceconsumermanagement_v1 {
   export interface Options extends GlobalOptions {
     version: 'v1';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -96,24 +98,14 @@ export namespace serviceconsumermanagement_v1 {
    * @param {object=} options Options for Serviceconsumermanagement
    */
   export class Serviceconsumermanagement {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     operations: Resource$Operations;
     services: Resource$Services;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.operations = new Resource$Operations(this);
-      this.services = new Resource$Services(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.operations = new Resource$Operations();
+      this.services = new Resource$Services();
     }
   }
 
@@ -2256,15 +2248,7 @@ export namespace serviceconsumermanagement_v1 {
 
 
   export class Resource$Operations {
-    root: Serviceconsumermanagement;
-    constructor(root: Serviceconsumermanagement) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -2332,7 +2316,7 @@ export namespace serviceconsumermanagement_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -2400,7 +2384,7 @@ export namespace serviceconsumermanagement_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -2464,7 +2448,7 @@ export namespace serviceconsumermanagement_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -2541,7 +2525,7 @@ export namespace serviceconsumermanagement_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListOperationsResponse>(parameters, callback);
@@ -2617,16 +2601,9 @@ export namespace serviceconsumermanagement_v1 {
 
 
   export class Resource$Services {
-    root: Serviceconsumermanagement;
     tenancyUnits: Resource$Services$Tenancyunits;
-    constructor(root: Serviceconsumermanagement) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.tenancyUnits = new Resource$Services$Tenancyunits(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.tenancyUnits = new Resource$Services$Tenancyunits();
     }
 
 
@@ -2693,7 +2670,7 @@ export namespace serviceconsumermanagement_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$SearchTenancyUnitsResponse>(
@@ -2746,15 +2723,7 @@ export namespace serviceconsumermanagement_v1 {
   }
 
   export class Resource$Services$Tenancyunits {
-    root: Serviceconsumermanagement;
-    constructor(root: Serviceconsumermanagement) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -2820,7 +2789,7 @@ export namespace serviceconsumermanagement_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -2900,7 +2869,7 @@ export namespace serviceconsumermanagement_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -2977,7 +2946,7 @@ export namespace serviceconsumermanagement_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -3046,7 +3015,7 @@ export namespace serviceconsumermanagement_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TenancyUnit>(parameters, callback);
@@ -3114,7 +3083,7 @@ export namespace serviceconsumermanagement_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -3189,7 +3158,7 @@ export namespace serviceconsumermanagement_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListTenancyUnitsResponse>(parameters, callback);
@@ -3261,7 +3230,7 @@ export namespace serviceconsumermanagement_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);

--- a/src/apis/servicecontrol/v1.ts
+++ b/src/apis/servicecontrol/v1.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace servicecontrol_v1 {
   export interface Options extends GlobalOptions {
     version: 'v1';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -97,22 +99,12 @@ export namespace servicecontrol_v1 {
    * @param {object=} options Options for Servicecontrol
    */
   export class Servicecontrol {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     services: Resource$Services;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.services = new Resource$Services(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.services = new Resource$Services();
     }
   }
 
@@ -1435,15 +1427,7 @@ export namespace servicecontrol_v1 {
 
 
   export class Resource$Services {
-    root: Servicecontrol;
-    constructor(root: Servicecontrol) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -1514,7 +1498,7 @@ export namespace servicecontrol_v1 {
         params,
         requiredParams: ['serviceName'],
         pathParams: ['serviceName'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$AllocateQuotaResponse>(parameters, callback);
@@ -1591,7 +1575,7 @@ export namespace servicecontrol_v1 {
         params,
         requiredParams: ['serviceName'],
         pathParams: ['serviceName'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$CheckResponse>(parameters, callback);
@@ -1668,7 +1652,7 @@ export namespace servicecontrol_v1 {
         params,
         requiredParams: ['serviceName'],
         pathParams: ['serviceName'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ReportResponse>(parameters, callback);

--- a/src/apis/servicemanagement/v1.ts
+++ b/src/apis/servicemanagement/v1.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace servicemanagement_v1 {
   export interface Options extends GlobalOptions {
     version: 'v1';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -98,24 +100,14 @@ export namespace servicemanagement_v1 {
    * @param {object=} options Options for Servicemanagement
    */
   export class Servicemanagement {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     operations: Resource$Operations;
     services: Resource$Services;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.operations = new Resource$Operations(this);
-      this.services = new Resource$Services(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.operations = new Resource$Operations();
+      this.services = new Resource$Services();
     }
   }
 
@@ -2596,15 +2588,7 @@ export namespace servicemanagement_v1 {
 
 
   export class Resource$Operations {
-    root: Servicemanagement;
-    constructor(root: Servicemanagement) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -2661,7 +2645,7 @@ export namespace servicemanagement_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -2731,7 +2715,7 @@ export namespace servicemanagement_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListOperationsResponse>(parameters, callback);
@@ -2792,20 +2776,13 @@ export namespace servicemanagement_v1 {
 
 
   export class Resource$Services {
-    root: Servicemanagement;
     configs: Resource$Services$Configs;
     consumers: Resource$Services$Consumers;
     rollouts: Resource$Services$Rollouts;
-    constructor(root: Servicemanagement) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.configs = new Resource$Services$Configs(root);
-      this.consumers = new Resource$Services$Consumers(root);
-      this.rollouts = new Resource$Services$Rollouts(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.configs = new Resource$Services$Configs();
+      this.consumers = new Resource$Services$Consumers();
+      this.rollouts = new Resource$Services$Rollouts();
     }
 
 
@@ -2865,7 +2842,7 @@ export namespace servicemanagement_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -2935,7 +2912,7 @@ export namespace servicemanagement_v1 {
         params,
         requiredParams: ['serviceName'],
         pathParams: ['serviceName'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -3005,7 +2982,7 @@ export namespace servicemanagement_v1 {
         params,
         requiredParams: ['serviceName'],
         pathParams: ['serviceName'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -3074,7 +3051,7 @@ export namespace servicemanagement_v1 {
         params,
         requiredParams: ['serviceName'],
         pathParams: ['serviceName'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -3157,7 +3134,7 @@ export namespace servicemanagement_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GenerateConfigReportResponse>(
@@ -3223,7 +3200,7 @@ export namespace servicemanagement_v1 {
         params,
         requiredParams: ['serviceName'],
         pathParams: ['serviceName'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ManagedService>(parameters, callback);
@@ -3292,7 +3269,7 @@ export namespace servicemanagement_v1 {
         params,
         requiredParams: ['serviceName'],
         pathParams: ['serviceName'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Service>(parameters, callback);
@@ -3361,7 +3338,7 @@ export namespace servicemanagement_v1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -3435,7 +3412,7 @@ export namespace servicemanagement_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListServicesResponse>(parameters, callback);
@@ -3504,7 +3481,7 @@ export namespace servicemanagement_v1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -3583,7 +3560,7 @@ export namespace servicemanagement_v1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TestIamPermissionsResponse>(
@@ -3655,7 +3632,7 @@ export namespace servicemanagement_v1 {
         params,
         requiredParams: ['serviceName'],
         pathParams: ['serviceName'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -3868,15 +3845,7 @@ export namespace servicemanagement_v1 {
   }
 
   export class Resource$Services$Configs {
-    root: Servicemanagement;
-    constructor(root: Servicemanagement) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -3942,7 +3911,7 @@ export namespace servicemanagement_v1 {
         params,
         requiredParams: ['serviceName'],
         pathParams: ['serviceName'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Service>(parameters, callback);
@@ -4007,7 +3976,7 @@ export namespace servicemanagement_v1 {
         params,
         requiredParams: ['serviceName', 'configId'],
         pathParams: ['configId', 'serviceName'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Service>(parameters, callback);
@@ -4083,7 +4052,7 @@ export namespace servicemanagement_v1 {
         params,
         requiredParams: ['serviceName'],
         pathParams: ['serviceName'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListServiceConfigsResponse>(
@@ -4160,7 +4129,7 @@ export namespace servicemanagement_v1 {
         params,
         requiredParams: ['serviceName'],
         pathParams: ['serviceName'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -4257,15 +4226,7 @@ export namespace servicemanagement_v1 {
 
 
   export class Resource$Services$Consumers {
-    root: Servicemanagement;
-    constructor(root: Servicemanagement) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -4327,7 +4288,7 @@ export namespace servicemanagement_v1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -4396,7 +4357,7 @@ export namespace servicemanagement_v1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -4476,7 +4437,7 @@ export namespace servicemanagement_v1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TestIamPermissionsResponse>(
@@ -4544,15 +4505,7 @@ export namespace servicemanagement_v1 {
 
 
   export class Resource$Services$Rollouts {
-    root: Servicemanagement;
-    constructor(root: Servicemanagement) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -4623,7 +4576,7 @@ export namespace servicemanagement_v1 {
         params,
         requiredParams: ['serviceName'],
         pathParams: ['serviceName'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -4687,7 +4640,7 @@ export namespace servicemanagement_v1 {
         params,
         requiredParams: ['serviceName', 'rolloutId'],
         pathParams: ['rolloutId', 'serviceName'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Rollout>(parameters, callback);
@@ -4764,7 +4717,7 @@ export namespace servicemanagement_v1 {
         params,
         requiredParams: ['serviceName'],
         pathParams: ['serviceName'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListServiceRolloutsResponse>(

--- a/src/apis/servicenetworking/v1beta.ts
+++ b/src/apis/servicenetworking/v1beta.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace servicenetworking_v1beta {
   export interface Options extends GlobalOptions {
     version: 'v1beta';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -97,24 +99,14 @@ export namespace servicenetworking_v1beta {
    * @param {object=} options Options for Servicenetworking
    */
   export class Servicenetworking {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     operations: Resource$Operations;
     services: Resource$Services;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.operations = new Resource$Operations(this);
-      this.services = new Resource$Services(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.operations = new Resource$Operations();
+      this.services = new Resource$Services();
     }
   }
 
@@ -2097,15 +2089,7 @@ export namespace servicenetworking_v1beta {
 
 
   export class Resource$Operations {
-    root: Servicenetworking;
-    constructor(root: Servicenetworking) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -2162,7 +2146,7 @@ export namespace servicenetworking_v1beta {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -2186,16 +2170,9 @@ export namespace servicenetworking_v1beta {
 
 
   export class Resource$Services {
-    root: Servicenetworking;
     connections: Resource$Services$Connections;
-    constructor(root: Servicenetworking) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.connections = new Resource$Services$Connections(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.connections = new Resource$Services$Connections();
     }
 
 
@@ -2265,7 +2242,7 @@ export namespace servicenetworking_v1beta {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -2334,7 +2311,7 @@ export namespace servicenetworking_v1beta {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -2397,15 +2374,7 @@ export namespace servicenetworking_v1beta {
   }
 
   export class Resource$Services$Connections {
-    root: Servicenetworking;
-    constructor(root: Servicenetworking) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -2474,7 +2443,7 @@ export namespace servicenetworking_v1beta {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -2545,7 +2514,7 @@ export namespace servicenetworking_v1beta {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListConnectionsResponse>(parameters, callback);

--- a/src/apis/serviceusage/v1.ts
+++ b/src/apis/serviceusage/v1.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace serviceusage_v1 {
   export interface Options extends GlobalOptions {
     version: 'v1';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -98,24 +100,14 @@ export namespace serviceusage_v1 {
    * @param {object=} options Options for Serviceusage
    */
   export class Serviceusage {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     operations: Resource$Operations;
     services: Resource$Services;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.operations = new Resource$Operations(this);
-      this.services = new Resource$Services(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.operations = new Resource$Operations();
+      this.services = new Resource$Services();
     }
   }
 
@@ -2194,15 +2186,7 @@ export namespace serviceusage_v1 {
 
 
   export class Resource$Operations {
-    root: Serviceusage;
-    constructor(root: Serviceusage) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -2269,7 +2253,7 @@ export namespace serviceusage_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -2336,7 +2320,7 @@ export namespace serviceusage_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -2399,7 +2383,7 @@ export namespace serviceusage_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -2475,7 +2459,7 @@ export namespace serviceusage_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListOperationsResponse>(parameters, callback);
@@ -2551,15 +2535,7 @@ export namespace serviceusage_v1 {
 
 
   export class Resource$Services {
-    root: Serviceusage;
-    constructor(root: Serviceusage) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -2622,7 +2598,7 @@ export namespace serviceusage_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -2693,7 +2669,7 @@ export namespace serviceusage_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -2760,7 +2736,7 @@ export namespace serviceusage_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -2826,7 +2802,7 @@ export namespace serviceusage_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleApiServiceusageV1Service>(
@@ -2903,7 +2879,7 @@ export namespace serviceusage_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListServicesResponse>(parameters, callback);

--- a/src/apis/serviceusage/v1beta1.ts
+++ b/src/apis/serviceusage/v1beta1.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace serviceusage_v1beta1 {
   export interface Options extends GlobalOptions {
     version: 'v1beta1';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -98,24 +100,14 @@ export namespace serviceusage_v1beta1 {
    * @param {object=} options Options for Serviceusage
    */
   export class Serviceusage {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     operations: Resource$Operations;
     services: Resource$Services;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.operations = new Resource$Operations(this);
-      this.services = new Resource$Services(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.operations = new Resource$Operations();
+      this.services = new Resource$Services();
     }
   }
 
@@ -2247,15 +2239,7 @@ export namespace serviceusage_v1beta1 {
 
 
   export class Resource$Operations {
-    root: Serviceusage;
-    constructor(root: Serviceusage) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -2311,7 +2295,7 @@ export namespace serviceusage_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -2388,7 +2372,7 @@ export namespace serviceusage_v1beta1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListOperationsResponse>(parameters, callback);
@@ -2435,15 +2419,7 @@ export namespace serviceusage_v1beta1 {
 
 
   export class Resource$Services {
-    root: Serviceusage;
-    constructor(root: Serviceusage) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -2506,7 +2482,7 @@ export namespace serviceusage_v1beta1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -2577,7 +2553,7 @@ export namespace serviceusage_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -2644,7 +2620,7 @@ export namespace serviceusage_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -2705,7 +2681,7 @@ export namespace serviceusage_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Service>(parameters, callback);
@@ -2780,7 +2756,7 @@ export namespace serviceusage_v1beta1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListServicesResponse>(parameters, callback);

--- a/src/apis/sheets/v4.ts
+++ b/src/apis/sheets/v4.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace sheets_v4 {
   export interface Options extends GlobalOptions {
     version: 'v4';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -96,22 +98,12 @@ export namespace sheets_v4 {
    * @param {object=} options Options for Sheets
    */
   export class Sheets {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     spreadsheets: Resource$Spreadsheets;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.spreadsheets = new Resource$Spreadsheets(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.spreadsheets = new Resource$Spreadsheets();
     }
   }
 
@@ -4433,21 +4425,13 @@ export namespace sheets_v4 {
 
 
   export class Resource$Spreadsheets {
-    root: Sheets;
     developerMetadata: Resource$Spreadsheets$Developermetadata;
     sheets: Resource$Spreadsheets$Sheets;
     values: Resource$Spreadsheets$Values;
-    constructor(root: Sheets) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.developerMetadata =
-          new Resource$Spreadsheets$Developermetadata(root);
-      this.sheets = new Resource$Spreadsheets$Sheets(root);
-      this.values = new Resource$Spreadsheets$Values(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.developerMetadata = new Resource$Spreadsheets$Developermetadata();
+      this.sheets = new Resource$Spreadsheets$Sheets();
+      this.values = new Resource$Spreadsheets$Values();
     }
 
 
@@ -4586,7 +4570,7 @@ export namespace sheets_v4 {
         params,
         requiredParams: ['spreadsheetId'],
         pathParams: ['spreadsheetId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$BatchUpdateSpreadsheetResponse>(
@@ -4704,7 +4688,7 @@ export namespace sheets_v4 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Spreadsheet>(parameters, callback);
@@ -4837,7 +4821,7 @@ export namespace sheets_v4 {
         params,
         requiredParams: ['spreadsheetId'],
         pathParams: ['spreadsheetId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Spreadsheet>(parameters, callback);
@@ -4979,7 +4963,7 @@ export namespace sheets_v4 {
         params,
         requiredParams: ['spreadsheetId'],
         pathParams: ['spreadsheetId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Spreadsheet>(parameters, callback);
@@ -5058,15 +5042,7 @@ export namespace sheets_v4 {
   }
 
   export class Resource$Spreadsheets$Developermetadata {
-    root: Sheets;
-    constructor(root: Sheets) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -5178,7 +5154,7 @@ export namespace sheets_v4 {
         params,
         requiredParams: ['spreadsheetId', 'metadataId'],
         pathParams: ['metadataId', 'spreadsheetId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$DeveloperMetadata>(parameters, callback);
@@ -5311,7 +5287,7 @@ export namespace sheets_v4 {
         params,
         requiredParams: ['spreadsheetId'],
         pathParams: ['spreadsheetId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$SearchDeveloperMetadataResponse>(
@@ -5359,15 +5335,7 @@ export namespace sheets_v4 {
 
 
   export class Resource$Spreadsheets$Sheets {
-    root: Sheets;
-    constructor(root: Sheets) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -5491,7 +5459,7 @@ export namespace sheets_v4 {
         params,
         requiredParams: ['spreadsheetId', 'sheetId'],
         pathParams: ['sheetId', 'spreadsheetId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$SheetProperties>(parameters, callback);
@@ -5525,15 +5493,7 @@ export namespace sheets_v4 {
 
 
   export class Resource$Spreadsheets$Values {
-    root: Sheets;
-    constructor(root: Sheets) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -5675,7 +5635,7 @@ export namespace sheets_v4 {
         params,
         requiredParams: ['spreadsheetId', 'range'],
         pathParams: ['range', 'spreadsheetId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$AppendValuesResponse>(parameters, callback);
@@ -5804,7 +5764,7 @@ export namespace sheets_v4 {
         params,
         requiredParams: ['spreadsheetId'],
         pathParams: ['spreadsheetId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$BatchClearValuesResponse>(parameters, callback);
@@ -5945,7 +5905,7 @@ export namespace sheets_v4 {
         params,
         requiredParams: ['spreadsheetId'],
         pathParams: ['spreadsheetId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$BatchClearValuesByDataFilterResponse>(
@@ -6089,7 +6049,7 @@ export namespace sheets_v4 {
         params,
         requiredParams: ['spreadsheetId'],
         pathParams: ['spreadsheetId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$BatchGetValuesResponse>(parameters, callback);
@@ -6244,7 +6204,7 @@ export namespace sheets_v4 {
         params,
         requiredParams: ['spreadsheetId'],
         pathParams: ['spreadsheetId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$BatchGetValuesByDataFilterResponse>(
@@ -6378,7 +6338,7 @@ export namespace sheets_v4 {
         params,
         requiredParams: ['spreadsheetId'],
         pathParams: ['spreadsheetId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$BatchUpdateValuesResponse>(
@@ -6524,7 +6484,7 @@ export namespace sheets_v4 {
         params,
         requiredParams: ['spreadsheetId'],
         pathParams: ['spreadsheetId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$BatchUpdateValuesByDataFilterResponse>(
@@ -6655,7 +6615,7 @@ export namespace sheets_v4 {
         params,
         requiredParams: ['spreadsheetId', 'range'],
         pathParams: ['range', 'spreadsheetId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ClearValuesResponse>(parameters, callback);
@@ -6790,7 +6750,7 @@ export namespace sheets_v4 {
         params,
         requiredParams: ['spreadsheetId', 'range'],
         pathParams: ['range', 'spreadsheetId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ValueRange>(parameters, callback);
@@ -6927,7 +6887,7 @@ export namespace sheets_v4 {
         params,
         requiredParams: ['spreadsheetId', 'range'],
         pathParams: ['range', 'spreadsheetId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$UpdateValuesResponse>(parameters, callback);

--- a/src/apis/siteVerification/v1.ts
+++ b/src/apis/siteVerification/v1.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace siteVerification_v1 {
   export interface Options extends GlobalOptions {
     version: 'v1';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -79,22 +81,12 @@ export namespace siteVerification_v1 {
    * @param {object=} options Options for Siteverification
    */
   export class Siteverification {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     webResource: Resource$Webresource;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.webResource = new Resource$Webresource(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.webResource = new Resource$Webresource();
     }
   }
 
@@ -150,15 +142,7 @@ export namespace siteVerification_v1 {
 
 
   export class Resource$Webresource {
-    root: Siteverification;
-    constructor(root: Siteverification) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -216,7 +200,7 @@ export namespace siteVerification_v1 {
         params,
         requiredParams: ['id'],
         pathParams: ['id'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -286,7 +270,7 @@ export namespace siteVerification_v1 {
         params,
         requiredParams: ['id'],
         pathParams: ['id'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$SiteVerificationWebResourceResource>(
@@ -361,7 +345,7 @@ export namespace siteVerification_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$SiteVerificationWebResourceGettokenResponse>(
@@ -440,7 +424,7 @@ export namespace siteVerification_v1 {
         params,
         requiredParams: ['verificationMethod'],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$SiteVerificationWebResourceResource>(
@@ -511,7 +495,7 @@ export namespace siteVerification_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$SiteVerificationWebResourceListResponse>(
@@ -589,7 +573,7 @@ export namespace siteVerification_v1 {
         params,
         requiredParams: ['id'],
         pathParams: ['id'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$SiteVerificationWebResourceResource>(
@@ -668,7 +652,7 @@ export namespace siteVerification_v1 {
         params,
         requiredParams: ['id'],
         pathParams: ['id'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$SiteVerificationWebResourceResource>(

--- a/src/apis/slides/v1.ts
+++ b/src/apis/slides/v1.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace slides_v1 {
   export interface Options extends GlobalOptions {
     version: 'v1';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -96,22 +98,12 @@ export namespace slides_v1 {
    * @param {object=} options Options for Slides
    */
   export class Slides {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     presentations: Resource$Presentations;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.presentations = new Resource$Presentations(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.presentations = new Resource$Presentations();
     }
   }
 
@@ -3310,16 +3302,9 @@ export namespace slides_v1 {
 
 
   export class Resource$Presentations {
-    root: Slides;
     pages: Resource$Presentations$Pages;
-    constructor(root: Slides) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.pages = new Resource$Presentations$Pages(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.pages = new Resource$Presentations$Pages();
     }
 
 
@@ -3401,7 +3386,7 @@ export namespace slides_v1 {
         params,
         requiredParams: ['presentationId'],
         pathParams: ['presentationId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$BatchUpdatePresentationResponse>(
@@ -3474,7 +3459,7 @@ export namespace slides_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Presentation>(parameters, callback);
@@ -3537,7 +3522,7 @@ export namespace slides_v1 {
         params,
         requiredParams: ['presentationId'],
         pathParams: ['presentationId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Presentation>(parameters, callback);
@@ -3591,15 +3576,7 @@ export namespace slides_v1 {
   }
 
   export class Resource$Presentations$Pages {
-    root: Slides;
-    constructor(root: Slides) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -3656,7 +3633,7 @@ export namespace slides_v1 {
         params,
         requiredParams: ['presentationId', 'pageObjectId'],
         pathParams: ['pageObjectId', 'presentationId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Page>(parameters, callback);
@@ -3731,7 +3708,7 @@ export namespace slides_v1 {
         params,
         requiredParams: ['presentationId', 'pageObjectId'],
         pathParams: ['pageObjectId', 'presentationId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Thumbnail>(parameters, callback);

--- a/src/apis/sourcerepo/v1.ts
+++ b/src/apis/sourcerepo/v1.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace sourcerepo_v1 {
   export interface Options extends GlobalOptions {
     version: 'v1';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -96,22 +98,12 @@ export namespace sourcerepo_v1 {
    * @param {object=} options Options for Sourcerepo
    */
   export class Sourcerepo {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     projects: Resource$Projects;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.projects = new Resource$Projects(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.projects = new Resource$Projects();
     }
   }
 
@@ -473,16 +465,9 @@ export namespace sourcerepo_v1 {
 
 
   export class Resource$Projects {
-    root: Sourcerepo;
     repos: Resource$Projects$Repos;
-    constructor(root: Sourcerepo) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.repos = new Resource$Projects$Repos(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.repos = new Resource$Projects$Repos();
     }
 
 
@@ -543,7 +528,7 @@ export namespace sourcerepo_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ProjectConfig>(parameters, callback);
@@ -611,7 +596,7 @@ export namespace sourcerepo_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ProjectConfig>(parameters, callback);
@@ -654,15 +639,7 @@ export namespace sourcerepo_v1 {
   }
 
   export class Resource$Projects$Repos {
-    root: Sourcerepo;
-    constructor(root: Sourcerepo) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -723,7 +700,7 @@ export namespace sourcerepo_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Repo>(parameters, callback);
@@ -788,7 +765,7 @@ export namespace sourcerepo_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -849,7 +826,7 @@ export namespace sourcerepo_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Repo>(parameters, callback);
@@ -916,7 +893,7 @@ export namespace sourcerepo_v1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -985,7 +962,7 @@ export namespace sourcerepo_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListReposResponse>(parameters, callback);
@@ -1051,7 +1028,7 @@ export namespace sourcerepo_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Repo>(parameters, callback);
@@ -1119,7 +1096,7 @@ export namespace sourcerepo_v1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -1195,7 +1172,7 @@ export namespace sourcerepo_v1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TestIamPermissionsResponse>(

--- a/src/apis/spanner/v1.ts
+++ b/src/apis/spanner/v1.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace spanner_v1 {
   export interface Options extends GlobalOptions {
     version: 'v1';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -97,22 +99,12 @@ export namespace spanner_v1 {
    * @param {object=} options Options for Spanner
    */
   export class Spanner {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     projects: Resource$Projects;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.projects = new Resource$Projects(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.projects = new Resource$Projects();
     }
   }
 
@@ -1813,32 +1805,17 @@ export namespace spanner_v1 {
 
 
   export class Resource$Projects {
-    root: Spanner;
     instanceConfigs: Resource$Projects$Instanceconfigs;
     instances: Resource$Projects$Instances;
-    constructor(root: Spanner) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.instanceConfigs = new Resource$Projects$Instanceconfigs(root);
-      this.instances = new Resource$Projects$Instances(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.instanceConfigs = new Resource$Projects$Instanceconfigs();
+      this.instances = new Resource$Projects$Instances();
     }
   }
 
 
   export class Resource$Projects$Instanceconfigs {
-    root: Spanner;
-    constructor(root: Spanner) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -1893,7 +1870,7 @@ export namespace spanner_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$InstanceConfig>(parameters, callback);
@@ -1967,7 +1944,7 @@ export namespace spanner_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListInstanceConfigsResponse>(
@@ -2017,18 +1994,11 @@ export namespace spanner_v1 {
 
 
   export class Resource$Projects$Instances {
-    root: Spanner;
     databases: Resource$Projects$Instances$Databases;
     operations: Resource$Projects$Instances$Operations;
-    constructor(root: Spanner) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.databases = new Resource$Projects$Instances$Databases(root);
-      this.operations = new Resource$Projects$Instances$Operations(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.databases = new Resource$Projects$Instances$Databases();
+      this.operations = new Resource$Projects$Instances$Operations();
     }
 
 
@@ -2109,7 +2079,7 @@ export namespace spanner_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -2178,7 +2148,7 @@ export namespace spanner_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -2239,7 +2209,7 @@ export namespace spanner_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Instance>(parameters, callback);
@@ -2308,7 +2278,7 @@ export namespace spanner_v1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -2379,7 +2349,7 @@ export namespace spanner_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListInstancesResponse>(parameters, callback);
@@ -2468,7 +2438,7 @@ export namespace spanner_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -2537,7 +2507,7 @@ export namespace spanner_v1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -2616,7 +2586,7 @@ export namespace spanner_v1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TestIamPermissionsResponse>(
@@ -2790,19 +2760,11 @@ export namespace spanner_v1 {
   }
 
   export class Resource$Projects$Instances$Databases {
-    root: Spanner;
     operations: Resource$Projects$Instances$Databases$Operations;
     sessions: Resource$Projects$Instances$Databases$Sessions;
-    constructor(root: Spanner) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.operations =
-          new Resource$Projects$Instances$Databases$Operations(root);
-      this.sessions = new Resource$Projects$Instances$Databases$Sessions(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.operations = new Resource$Projects$Instances$Databases$Operations();
+      this.sessions = new Resource$Projects$Instances$Databases$Sessions();
     }
 
 
@@ -2869,7 +2831,7 @@ export namespace spanner_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -2936,7 +2898,7 @@ export namespace spanner_v1 {
         params,
         requiredParams: ['database'],
         pathParams: ['database'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -2997,7 +2959,7 @@ export namespace spanner_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Database>(parameters, callback);
@@ -3067,7 +3029,7 @@ export namespace spanner_v1 {
         params,
         requiredParams: ['database'],
         pathParams: ['database'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GetDatabaseDdlResponse>(parameters, callback);
@@ -3139,7 +3101,7 @@ export namespace spanner_v1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -3209,7 +3171,7 @@ export namespace spanner_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListDatabasesResponse>(parameters, callback);
@@ -3280,7 +3242,7 @@ export namespace spanner_v1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -3361,7 +3323,7 @@ export namespace spanner_v1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TestIamPermissionsResponse>(
@@ -3436,7 +3398,7 @@ export namespace spanner_v1 {
         params,
         requiredParams: ['database'],
         pathParams: ['database'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -3603,15 +3565,7 @@ export namespace spanner_v1 {
   }
 
   export class Resource$Projects$Instances$Databases$Operations {
-    root: Spanner;
-    constructor(root: Spanner) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -3680,7 +3634,7 @@ export namespace spanner_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -3750,7 +3704,7 @@ export namespace spanner_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -3816,7 +3770,7 @@ export namespace spanner_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -3896,7 +3850,7 @@ export namespace spanner_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListOperationsResponse>(parameters, callback);
@@ -3969,15 +3923,7 @@ export namespace spanner_v1 {
 
 
   export class Resource$Projects$Instances$Databases$Sessions {
-    root: Spanner;
-    constructor(root: Spanner) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -4044,7 +3990,7 @@ export namespace spanner_v1 {
         params,
         requiredParams: ['session'],
         pathParams: ['session'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Transaction>(parameters, callback);
@@ -4119,7 +4065,7 @@ export namespace spanner_v1 {
         params,
         requiredParams: ['session'],
         pathParams: ['session'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$CommitResponse>(parameters, callback);
@@ -4200,7 +4146,7 @@ export namespace spanner_v1 {
         params,
         requiredParams: ['database'],
         pathParams: ['database'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Session>(parameters, callback);
@@ -4267,7 +4213,7 @@ export namespace spanner_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -4347,7 +4293,7 @@ export namespace spanner_v1 {
         params,
         requiredParams: ['session'],
         pathParams: ['session'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ResultSet>(parameters, callback);
@@ -4424,7 +4370,7 @@ export namespace spanner_v1 {
         params,
         requiredParams: ['session'],
         pathParams: ['session'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$PartialResultSet>(parameters, callback);
@@ -4488,7 +4434,7 @@ export namespace spanner_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Session>(parameters, callback);
@@ -4561,7 +4507,7 @@ export namespace spanner_v1 {
         params,
         requiredParams: ['database'],
         pathParams: ['database'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListSessionsResponse>(parameters, callback);
@@ -4644,7 +4590,7 @@ export namespace spanner_v1 {
         params,
         requiredParams: ['session'],
         pathParams: ['session'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$PartitionResponse>(parameters, callback);
@@ -4729,7 +4675,7 @@ export namespace spanner_v1 {
         params,
         requiredParams: ['session'],
         pathParams: ['session'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$PartitionResponse>(parameters, callback);
@@ -4806,7 +4752,7 @@ export namespace spanner_v1 {
         params,
         requiredParams: ['session'],
         pathParams: ['session'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ResultSet>(parameters, callback);
@@ -4880,7 +4826,7 @@ export namespace spanner_v1 {
         params,
         requiredParams: ['session'],
         pathParams: ['session'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -4957,7 +4903,7 @@ export namespace spanner_v1 {
         params,
         requiredParams: ['session'],
         pathParams: ['session'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$PartialResultSet>(parameters, callback);
@@ -5197,15 +5143,7 @@ export namespace spanner_v1 {
 
 
   export class Resource$Projects$Instances$Operations {
-    root: Spanner;
-    constructor(root: Spanner) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -5272,7 +5210,7 @@ export namespace spanner_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -5340,7 +5278,7 @@ export namespace spanner_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -5404,7 +5342,7 @@ export namespace spanner_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -5482,7 +5420,7 @@ export namespace spanner_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListOperationsResponse>(parameters, callback);

--- a/src/apis/speech/v1.ts
+++ b/src/apis/speech/v1.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace speech_v1 {
   export interface Options extends GlobalOptions {
     version: 'v1';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -96,24 +98,14 @@ export namespace speech_v1 {
    * @param {object=} options Options for Speech
    */
   export class Speech {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     operations: Resource$Operations;
     speech: Resource$Speech;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.operations = new Resource$Operations(this);
-      this.speech = new Resource$Speech(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.operations = new Resource$Operations();
+      this.speech = new Resource$Speech();
     }
   }
 
@@ -482,15 +474,7 @@ export namespace speech_v1 {
 
 
   export class Resource$Operations {
-    root: Speech;
-    constructor(root: Speech) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -547,7 +531,7 @@ export namespace speech_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -623,7 +607,7 @@ export namespace speech_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListOperationsResponse>(parameters, callback);
@@ -670,15 +654,7 @@ export namespace speech_v1 {
 
 
   export class Resource$Speech {
-    root: Speech;
-    constructor(root: Speech) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -742,7 +718,7 @@ export namespace speech_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -809,7 +785,7 @@ export namespace speech_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$RecognizeResponse>(parameters, callback);

--- a/src/apis/speech/v1p1beta1.ts
+++ b/src/apis/speech/v1p1beta1.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace speech_v1p1beta1 {
   export interface Options extends GlobalOptions {
     version: 'v1p1beta1';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -96,26 +98,16 @@ export namespace speech_v1p1beta1 {
    * @param {object=} options Options for Speech
    */
   export class Speech {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     operations: Resource$Operations;
     projects: Resource$Projects;
     speech: Resource$Speech;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.operations = new Resource$Operations(this);
-      this.projects = new Resource$Projects(this);
-      this.speech = new Resource$Speech(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.operations = new Resource$Operations();
+      this.projects = new Resource$Projects();
+      this.speech = new Resource$Speech();
     }
   }
 
@@ -890,15 +882,7 @@ export namespace speech_v1p1beta1 {
 
 
   export class Resource$Operations {
-    root: Speech;
-    constructor(root: Speech) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -955,7 +939,7 @@ export namespace speech_v1p1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -979,50 +963,27 @@ export namespace speech_v1p1beta1 {
 
 
   export class Resource$Projects {
-    root: Speech;
     locations: Resource$Projects$Locations;
-    constructor(root: Speech) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.locations = new Resource$Projects$Locations(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.locations = new Resource$Projects$Locations();
     }
   }
 
 
   export class Resource$Projects$Locations {
-    root: Speech;
     datasets: Resource$Projects$Locations$Datasets;
     log_data_stats: Resource$Projects$Locations$Log_data_stats;
     models: Resource$Projects$Locations$Models;
-    constructor(root: Speech) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.datasets = new Resource$Projects$Locations$Datasets(root);
-      this.log_data_stats =
-          new Resource$Projects$Locations$Log_data_stats(root);
-      this.models = new Resource$Projects$Locations$Models(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.datasets = new Resource$Projects$Locations$Datasets();
+      this.log_data_stats = new Resource$Projects$Locations$Log_data_stats();
+      this.models = new Resource$Projects$Locations$Models();
     }
   }
 
 
   export class Resource$Projects$Locations$Datasets {
-    root: Speech;
-    constructor(root: Speech) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -1086,7 +1047,7 @@ export namespace speech_v1p1beta1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -1149,7 +1110,7 @@ export namespace speech_v1p1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Dataset>(parameters, callback);
@@ -1221,7 +1182,7 @@ export namespace speech_v1p1beta1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListDatasetsResponse>(parameters, callback);
@@ -1290,7 +1251,7 @@ export namespace speech_v1p1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -1387,15 +1348,7 @@ export namespace speech_v1p1beta1 {
 
 
   export class Resource$Projects$Locations$Log_data_stats {
-    root: Speech;
-    constructor(root: Speech) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -1457,7 +1410,7 @@ export namespace speech_v1p1beta1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListLogDataStatsResponse>(parameters, callback);
@@ -1483,15 +1436,7 @@ export namespace speech_v1p1beta1 {
 
 
   export class Resource$Projects$Locations$Models {
-    root: Speech;
-    constructor(root: Speech) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -1556,7 +1501,7 @@ export namespace speech_v1p1beta1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -1627,7 +1572,7 @@ export namespace speech_v1p1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -1698,7 +1643,7 @@ export namespace speech_v1p1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -1768,7 +1713,7 @@ export namespace speech_v1p1beta1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListModelsResponse>(parameters, callback);
@@ -1867,15 +1812,7 @@ export namespace speech_v1p1beta1 {
 
 
   export class Resource$Speech {
-    root: Speech;
-    constructor(root: Speech) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -1939,7 +1876,7 @@ export namespace speech_v1p1beta1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -2006,7 +1943,7 @@ export namespace speech_v1p1beta1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$RecognizeResponse>(parameters, callback);

--- a/src/apis/sqladmin/v1beta4.ts
+++ b/src/apis/sqladmin/v1beta4.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace sqladmin_v1beta4 {
   export interface Options extends GlobalOptions {
     version: 'v1beta4';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -80,10 +82,6 @@ export namespace sqladmin_v1beta4 {
    * @param {object=} options Options for Sqladmin
    */
   export class Sqladmin {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     backupRuns: Resource$Backupruns;
     databases: Resource$Databases;
     flags: Resource$Flags;
@@ -94,22 +92,16 @@ export namespace sqladmin_v1beta4 {
     users: Resource$Users;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.backupRuns = new Resource$Backupruns(this);
-      this.databases = new Resource$Databases(this);
-      this.flags = new Resource$Flags(this);
-      this.instances = new Resource$Instances(this);
-      this.operations = new Resource$Operations(this);
-      this.sslCerts = new Resource$Sslcerts(this);
-      this.tiers = new Resource$Tiers(this);
-      this.users = new Resource$Users(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.backupRuns = new Resource$Backupruns();
+      this.databases = new Resource$Databases();
+      this.flags = new Resource$Flags();
+      this.instances = new Resource$Instances();
+      this.operations = new Resource$Operations();
+      this.sslCerts = new Resource$Sslcerts();
+      this.tiers = new Resource$Tiers();
+      this.users = new Resource$Users();
     }
   }
 
@@ -1538,15 +1530,7 @@ export namespace sqladmin_v1beta4 {
 
 
   export class Resource$Backupruns {
-    root: Sqladmin;
-    constructor(root: Sqladmin) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -1609,7 +1593,7 @@ export namespace sqladmin_v1beta4 {
         params,
         requiredParams: ['project', 'instance', 'id'],
         pathParams: ['id', 'instance', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -1675,7 +1659,7 @@ export namespace sqladmin_v1beta4 {
         params,
         requiredParams: ['project', 'instance', 'id'],
         pathParams: ['id', 'instance', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$BackupRun>(parameters, callback);
@@ -1746,7 +1730,7 @@ export namespace sqladmin_v1beta4 {
         params,
         requiredParams: ['project', 'instance'],
         pathParams: ['instance', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -1819,7 +1803,7 @@ export namespace sqladmin_v1beta4 {
         params,
         requiredParams: ['project', 'instance'],
         pathParams: ['instance', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$BackupRunsListResponse>(parameters, callback);
@@ -1917,15 +1901,7 @@ export namespace sqladmin_v1beta4 {
 
 
   export class Resource$Databases {
-    root: Sqladmin;
-    constructor(root: Sqladmin) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -1987,7 +1963,7 @@ export namespace sqladmin_v1beta4 {
         params,
         requiredParams: ['project', 'instance', 'database'],
         pathParams: ['database', 'instance', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -2053,7 +2029,7 @@ export namespace sqladmin_v1beta4 {
         params,
         requiredParams: ['project', 'instance', 'database'],
         pathParams: ['database', 'instance', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Database>(parameters, callback);
@@ -2123,7 +2099,7 @@ export namespace sqladmin_v1beta4 {
         params,
         requiredParams: ['project', 'instance'],
         pathParams: ['instance', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -2192,7 +2168,7 @@ export namespace sqladmin_v1beta4 {
         params,
         requiredParams: ['project', 'instance'],
         pathParams: ['instance', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$DatabasesListResponse>(parameters, callback);
@@ -2263,7 +2239,7 @@ export namespace sqladmin_v1beta4 {
         params,
         requiredParams: ['project', 'instance', 'database'],
         pathParams: ['database', 'instance', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -2334,7 +2310,7 @@ export namespace sqladmin_v1beta4 {
         params,
         requiredParams: ['project', 'instance', 'database'],
         pathParams: ['database', 'instance', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -2468,15 +2444,7 @@ export namespace sqladmin_v1beta4 {
 
 
   export class Resource$Flags {
-    root: Sqladmin;
-    constructor(root: Sqladmin) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -2534,7 +2502,7 @@ export namespace sqladmin_v1beta4 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$FlagsListResponse>(parameters, callback);
@@ -2559,15 +2527,7 @@ export namespace sqladmin_v1beta4 {
 
 
   export class Resource$Instances {
-    root: Sqladmin;
-    constructor(root: Sqladmin) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -2634,7 +2594,7 @@ export namespace sqladmin_v1beta4 {
         params,
         requiredParams: ['project', 'instance'],
         pathParams: ['instance', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -2703,7 +2663,7 @@ export namespace sqladmin_v1beta4 {
         params,
         requiredParams: ['project', 'instance'],
         pathParams: ['instance', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -2770,7 +2730,7 @@ export namespace sqladmin_v1beta4 {
         params,
         requiredParams: ['project', 'instance'],
         pathParams: ['instance', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -2842,7 +2802,7 @@ export namespace sqladmin_v1beta4 {
         params,
         requiredParams: ['project', 'instance'],
         pathParams: ['instance', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -2912,7 +2872,7 @@ export namespace sqladmin_v1beta4 {
         params,
         requiredParams: ['project', 'instance'],
         pathParams: ['instance', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -2983,7 +2943,7 @@ export namespace sqladmin_v1beta4 {
         params,
         requiredParams: ['project', 'instance'],
         pathParams: ['instance', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -3048,7 +3008,7 @@ export namespace sqladmin_v1beta4 {
         params,
         requiredParams: ['project', 'instance'],
         pathParams: ['instance', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$DatabaseInstance>(parameters, callback);
@@ -3090,7 +3050,7 @@ import(paramsOrCallback?: Params$Resource$Instances$Import|BodyResponseCallback<
     options = {};
                                                                                                                                                                                                                                                                           }
 
-                                                                                                                                                                                                                                                                          const rootUrl = options.rootUrl || 'https://www.googleapis.com/'; const parameters = {options: Object.assign({url: (rootUrl + '/sql/v1beta4/projects/{project}/instances/{instance}/import').replace(/([^:]\/)\/+/g, '$1'), method: 'POST'}, options), params, requiredParams: ['project', 'instance'], pathParams: ['instance', 'project'], context: this.getRoot()}; if(callback) {
+                                                                                                                                                                                                                                                                          const rootUrl = options.rootUrl || 'https://www.googleapis.com/'; const parameters = {options: Object.assign({url: (rootUrl + '/sql/v1beta4/projects/{project}/instances/{instance}/import').replace(/([^:]\/)\/+/g, '$1'), method: 'POST'}, options), params, requiredParams: ['project', 'instance'], pathParams: ['instance', 'project'], context}; if(callback) {
     createAPIRequest<Schema$Operation>(parameters, callback);
                                                                                                                                                                                                                                                                           } else {
     return createAPIRequest<Schema$Operation>(parameters);
@@ -3152,7 +3112,7 @@ import(paramsOrCallback?: Params$Resource$Instances$Import|BodyResponseCallback<
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -3222,7 +3182,7 @@ import(paramsOrCallback?: Params$Resource$Instances$Import|BodyResponseCallback<
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$InstancesListResponse>(parameters, callback);
@@ -3302,7 +3262,7 @@ import(paramsOrCallback?: Params$Resource$Instances$Import|BodyResponseCallback<
         params,
         requiredParams: ['project', 'instance'],
         pathParams: ['instance', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$InstancesListServerCasResponse>(
@@ -3375,7 +3335,7 @@ import(paramsOrCallback?: Params$Resource$Instances$Import|BodyResponseCallback<
         params,
         requiredParams: ['project', 'instance'],
         pathParams: ['instance', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -3446,7 +3406,7 @@ import(paramsOrCallback?: Params$Resource$Instances$Import|BodyResponseCallback<
         params,
         requiredParams: ['project', 'instance'],
         pathParams: ['instance', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -3517,7 +3477,7 @@ import(paramsOrCallback?: Params$Resource$Instances$Import|BodyResponseCallback<
         params,
         requiredParams: ['project', 'instance'],
         pathParams: ['instance', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -3587,7 +3547,7 @@ import(paramsOrCallback?: Params$Resource$Instances$Import|BodyResponseCallback<
         params,
         requiredParams: ['project', 'instance'],
         pathParams: ['instance', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -3658,7 +3618,7 @@ import(paramsOrCallback?: Params$Resource$Instances$Import|BodyResponseCallback<
         params,
         requiredParams: ['project', 'instance'],
         pathParams: ['instance', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -3730,7 +3690,7 @@ import(paramsOrCallback?: Params$Resource$Instances$Import|BodyResponseCallback<
         params,
         requiredParams: ['project', 'instance'],
         pathParams: ['instance', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -3800,7 +3760,7 @@ import(paramsOrCallback?: Params$Resource$Instances$Import|BodyResponseCallback<
         params,
         requiredParams: ['project', 'instance'],
         pathParams: ['instance', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -3870,7 +3830,7 @@ import(paramsOrCallback?: Params$Resource$Instances$Import|BodyResponseCallback<
         params,
         requiredParams: ['project', 'instance'],
         pathParams: ['instance', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -3941,7 +3901,7 @@ import(paramsOrCallback?: Params$Resource$Instances$Import|BodyResponseCallback<
         params,
         requiredParams: ['project', 'instance'],
         pathParams: ['instance', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -4011,7 +3971,7 @@ import(paramsOrCallback?: Params$Resource$Instances$Import|BodyResponseCallback<
         params,
         requiredParams: ['project', 'instance'],
         pathParams: ['instance', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -4414,15 +4374,7 @@ import(paramsOrCallback?: Params$Resource$Instances$Import|BodyResponseCallback<
 
 
   export class Resource$Operations {
-    root: Sqladmin;
-    constructor(root: Sqladmin) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -4480,7 +4432,7 @@ import(paramsOrCallback?: Params$Resource$Instances$Import|BodyResponseCallback<
         params,
         requiredParams: ['project', 'operation'],
         pathParams: ['operation', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -4550,7 +4502,7 @@ import(paramsOrCallback?: Params$Resource$Instances$Import|BodyResponseCallback<
         params,
         requiredParams: ['project', 'instance'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$OperationsListResponse>(parameters, callback);
@@ -4602,15 +4554,7 @@ import(paramsOrCallback?: Params$Resource$Instances$Import|BodyResponseCallback<
 
 
   export class Resource$Sslcerts {
-    root: Sqladmin;
-    constructor(root: Sqladmin) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -4676,7 +4620,7 @@ import(paramsOrCallback?: Params$Resource$Instances$Import|BodyResponseCallback<
         params,
         requiredParams: ['project', 'instance'],
         pathParams: ['instance', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$SslCert>(parameters, callback);
@@ -4746,7 +4690,7 @@ import(paramsOrCallback?: Params$Resource$Instances$Import|BodyResponseCallback<
         params,
         requiredParams: ['project', 'instance', 'sha1Fingerprint'],
         pathParams: ['instance', 'project', 'sha1Fingerprint'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -4813,7 +4757,7 @@ import(paramsOrCallback?: Params$Resource$Instances$Import|BodyResponseCallback<
         params,
         requiredParams: ['project', 'instance', 'sha1Fingerprint'],
         pathParams: ['instance', 'project', 'sha1Fingerprint'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$SslCert>(parameters, callback);
@@ -4885,7 +4829,7 @@ import(paramsOrCallback?: Params$Resource$Instances$Import|BodyResponseCallback<
         params,
         requiredParams: ['project', 'instance'],
         pathParams: ['instance', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$SslCertsInsertResponse>(parameters, callback);
@@ -4954,7 +4898,7 @@ import(paramsOrCallback?: Params$Resource$Instances$Import|BodyResponseCallback<
         params,
         requiredParams: ['project', 'instance'],
         pathParams: ['instance', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$SslCertsListResponse>(parameters, callback);
@@ -5061,15 +5005,7 @@ import(paramsOrCallback?: Params$Resource$Instances$Import|BodyResponseCallback<
 
 
   export class Resource$Tiers {
-    root: Sqladmin;
-    constructor(root: Sqladmin) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -5128,7 +5064,7 @@ import(paramsOrCallback?: Params$Resource$Instances$Import|BodyResponseCallback<
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TiersListResponse>(parameters, callback);
@@ -5152,15 +5088,7 @@ import(paramsOrCallback?: Params$Resource$Instances$Import|BodyResponseCallback<
 
 
   export class Resource$Users {
-    root: Sqladmin;
-    constructor(root: Sqladmin) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -5223,7 +5151,7 @@ import(paramsOrCallback?: Params$Resource$Instances$Import|BodyResponseCallback<
         params,
         requiredParams: ['project', 'instance', 'host', 'name'],
         pathParams: ['instance', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -5292,7 +5220,7 @@ import(paramsOrCallback?: Params$Resource$Instances$Import|BodyResponseCallback<
         params,
         requiredParams: ['project', 'instance'],
         pathParams: ['instance', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -5360,7 +5288,7 @@ import(paramsOrCallback?: Params$Resource$Instances$Import|BodyResponseCallback<
         params,
         requiredParams: ['project', 'instance'],
         pathParams: ['instance', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$UsersListResponse>(parameters, callback);
@@ -5431,7 +5359,7 @@ import(paramsOrCallback?: Params$Resource$Instances$Import|BodyResponseCallback<
         params,
         requiredParams: ['project', 'instance', 'name'],
         pathParams: ['instance', 'project'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);

--- a/src/apis/storage/v1.ts
+++ b/src/apis/storage/v1.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace storage_v1 {
   export interface Options extends GlobalOptions {
     version: 'v1';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -79,10 +81,6 @@ export namespace storage_v1 {
    * @param {object=} options Options for Storage
    */
   export class Storage {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     bucketAccessControls: Resource$Bucketaccesscontrols;
     buckets: Resource$Buckets;
     channels: Resource$Channels;
@@ -93,23 +91,17 @@ export namespace storage_v1 {
     projects: Resource$Projects;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.bucketAccessControls = new Resource$Bucketaccesscontrols(this);
-      this.buckets = new Resource$Buckets(this);
-      this.channels = new Resource$Channels(this);
+      this.bucketAccessControls = new Resource$Bucketaccesscontrols();
+      this.buckets = new Resource$Buckets();
+      this.channels = new Resource$Channels();
       this.defaultObjectAccessControls =
-          new Resource$Defaultobjectaccesscontrols(this);
-      this.notifications = new Resource$Notifications(this);
-      this.objectAccessControls = new Resource$Objectaccesscontrols(this);
-      this.objects = new Resource$Objects(this);
-      this.projects = new Resource$Projects(this);
-    }
-
-    getRoot() {
-      return this.root;
+          new Resource$Defaultobjectaccesscontrols();
+      this.notifications = new Resource$Notifications();
+      this.objectAccessControls = new Resource$Objectaccesscontrols();
+      this.objects = new Resource$Objects();
+      this.projects = new Resource$Projects();
     }
   }
 
@@ -869,15 +861,7 @@ export namespace storage_v1 {
 
 
   export class Resource$Bucketaccesscontrols {
-    root: Storage;
-    constructor(root: Storage) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -993,7 +977,7 @@ export namespace storage_v1 {
         params,
         requiredParams: ['bucket', 'entity'],
         pathParams: ['bucket', 'entity'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -1117,7 +1101,7 @@ export namespace storage_v1 {
         params,
         requiredParams: ['bucket', 'entity'],
         pathParams: ['bucket', 'entity'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$BucketAccessControl>(parameters, callback);
@@ -1243,7 +1227,7 @@ export namespace storage_v1 {
         params,
         requiredParams: ['bucket'],
         pathParams: ['bucket'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$BucketAccessControl>(parameters, callback);
@@ -1365,7 +1349,7 @@ export namespace storage_v1 {
         params,
         requiredParams: ['bucket'],
         pathParams: ['bucket'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$BucketAccessControls>(parameters, callback);
@@ -1499,7 +1483,7 @@ export namespace storage_v1 {
         params,
         requiredParams: ['bucket', 'entity'],
         pathParams: ['bucket', 'entity'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$BucketAccessControl>(parameters, callback);
@@ -1633,7 +1617,7 @@ export namespace storage_v1 {
         params,
         requiredParams: ['bucket', 'entity'],
         pathParams: ['bucket', 'entity'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$BucketAccessControl>(parameters, callback);
@@ -1783,15 +1767,7 @@ export namespace storage_v1 {
 
 
   export class Resource$Buckets {
-    root: Storage;
-    constructor(root: Storage) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -1900,7 +1876,7 @@ export namespace storage_v1 {
         params,
         requiredParams: ['bucket'],
         pathParams: ['bucket'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -2018,7 +1994,7 @@ export namespace storage_v1 {
         params,
         requiredParams: ['bucket'],
         pathParams: ['bucket'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Bucket>(parameters, callback);
@@ -2138,7 +2114,7 @@ export namespace storage_v1 {
         params,
         requiredParams: ['bucket'],
         pathParams: ['bucket'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -2263,7 +2239,7 @@ export namespace storage_v1 {
         params,
         requiredParams: ['project'],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Bucket>(parameters, callback);
@@ -2397,7 +2373,7 @@ export namespace storage_v1 {
         params,
         requiredParams: ['project'],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Buckets>(parameters, callback);
@@ -2465,7 +2441,7 @@ export namespace storage_v1 {
         params,
         requiredParams: ['bucket', 'ifMetagenerationMatch'],
         pathParams: ['bucket'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Bucket>(parameters, callback);
@@ -2597,7 +2573,7 @@ export namespace storage_v1 {
         params,
         requiredParams: ['bucket'],
         pathParams: ['bucket'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Bucket>(parameters, callback);
@@ -2724,7 +2700,7 @@ export namespace storage_v1 {
         params,
         requiredParams: ['bucket'],
         pathParams: ['bucket'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -2856,7 +2832,7 @@ export namespace storage_v1 {
         params,
         requiredParams: ['bucket', 'permissions'],
         pathParams: ['bucket'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TestIamPermissionsResponse>(
@@ -2989,7 +2965,7 @@ export namespace storage_v1 {
         params,
         requiredParams: ['bucket'],
         pathParams: ['bucket'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Bucket>(parameters, callback);
@@ -3292,15 +3268,7 @@ export namespace storage_v1 {
 
 
   export class Resource$Channels {
-    root: Storage;
-    constructor(root: Storage) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -3407,7 +3375,7 @@ export namespace storage_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -3432,15 +3400,7 @@ export namespace storage_v1 {
 
 
   export class Resource$Defaultobjectaccesscontrols {
-    root: Storage;
-    constructor(root: Storage) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -3557,7 +3517,7 @@ export namespace storage_v1 {
         params,
         requiredParams: ['bucket', 'entity'],
         pathParams: ['bucket', 'entity'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -3680,7 +3640,7 @@ export namespace storage_v1 {
         params,
         requiredParams: ['bucket', 'entity'],
         pathParams: ['bucket', 'entity'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ObjectAccessControl>(parameters, callback);
@@ -3804,7 +3764,7 @@ export namespace storage_v1 {
         params,
         requiredParams: ['bucket'],
         pathParams: ['bucket'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ObjectAccessControl>(parameters, callback);
@@ -3926,7 +3886,7 @@ export namespace storage_v1 {
         params,
         requiredParams: ['bucket'],
         pathParams: ['bucket'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ObjectAccessControls>(parameters, callback);
@@ -4059,7 +4019,7 @@ export namespace storage_v1 {
         params,
         requiredParams: ['bucket', 'entity'],
         pathParams: ['bucket', 'entity'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ObjectAccessControl>(parameters, callback);
@@ -4192,7 +4152,7 @@ export namespace storage_v1 {
         params,
         requiredParams: ['bucket', 'entity'],
         pathParams: ['bucket', 'entity'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ObjectAccessControl>(parameters, callback);
@@ -4352,15 +4312,7 @@ export namespace storage_v1 {
 
 
   export class Resource$Notifications {
-    root: Storage;
-    constructor(root: Storage) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -4474,7 +4426,7 @@ export namespace storage_v1 {
         params,
         requiredParams: ['bucket', 'notification'],
         pathParams: ['bucket', 'notification'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -4596,7 +4548,7 @@ export namespace storage_v1 {
         params,
         requiredParams: ['bucket', 'notification'],
         pathParams: ['bucket', 'notification'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Notification>(parameters, callback);
@@ -4722,7 +4674,7 @@ export namespace storage_v1 {
         params,
         requiredParams: ['bucket'],
         pathParams: ['bucket'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Notification>(parameters, callback);
@@ -4842,7 +4794,7 @@ export namespace storage_v1 {
         params,
         requiredParams: ['bucket'],
         pathParams: ['bucket'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Notifications>(parameters, callback);
@@ -4936,15 +4888,7 @@ export namespace storage_v1 {
 
 
   export class Resource$Objectaccesscontrols {
-    root: Storage;
-    constructor(root: Storage) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -5067,7 +5011,7 @@ export namespace storage_v1 {
         params,
         requiredParams: ['bucket', 'object', 'entity'],
         pathParams: ['bucket', 'entity', 'object'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -5198,7 +5142,7 @@ export namespace storage_v1 {
         params,
         requiredParams: ['bucket', 'object', 'entity'],
         pathParams: ['bucket', 'entity', 'object'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ObjectAccessControl>(parameters, callback);
@@ -5331,7 +5275,7 @@ export namespace storage_v1 {
         params,
         requiredParams: ['bucket', 'object'],
         pathParams: ['bucket', 'object'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ObjectAccessControl>(parameters, callback);
@@ -5460,7 +5404,7 @@ export namespace storage_v1 {
         params,
         requiredParams: ['bucket', 'object'],
         pathParams: ['bucket', 'object'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ObjectAccessControls>(parameters, callback);
@@ -5601,7 +5545,7 @@ export namespace storage_v1 {
         params,
         requiredParams: ['bucket', 'object', 'entity'],
         pathParams: ['bucket', 'entity', 'object'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ObjectAccessControl>(parameters, callback);
@@ -5742,7 +5686,7 @@ export namespace storage_v1 {
         params,
         requiredParams: ['bucket', 'object', 'entity'],
         pathParams: ['bucket', 'entity', 'object'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ObjectAccessControl>(parameters, callback);
@@ -5952,15 +5896,7 @@ export namespace storage_v1 {
 
 
   export class Resource$Objects {
-    root: Storage;
-    constructor(root: Storage) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -6091,7 +6027,7 @@ export namespace storage_v1 {
         params,
         requiredParams: ['destinationBucket', 'destinationObject'],
         pathParams: ['destinationBucket', 'destinationObject'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Object>(parameters, callback);
@@ -6256,7 +6192,7 @@ export namespace storage_v1 {
           'destinationBucket', 'destinationObject', 'sourceBucket',
           'sourceObject'
         ],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Object>(parameters, callback);
@@ -6383,7 +6319,7 @@ export namespace storage_v1 {
         params,
         requiredParams: ['bucket', 'object'],
         pathParams: ['bucket', 'object'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -6514,7 +6450,7 @@ export namespace storage_v1 {
         params,
         requiredParams: ['bucket', 'object'],
         pathParams: ['bucket', 'object'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Object>(parameters, callback);
@@ -6641,7 +6577,7 @@ export namespace storage_v1 {
         params,
         requiredParams: ['bucket', 'object'],
         pathParams: ['bucket', 'object'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -6787,7 +6723,7 @@ export namespace storage_v1 {
                       .replace(/([^:]\/)\/+/g, '$1'),
         requiredParams: ['bucket'],
         pathParams: ['bucket'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Object>(parameters, callback);
@@ -6925,7 +6861,7 @@ export namespace storage_v1 {
         params,
         requiredParams: ['bucket'],
         pathParams: ['bucket'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Objects>(parameters, callback);
@@ -7063,7 +6999,7 @@ export namespace storage_v1 {
         params,
         requiredParams: ['bucket', 'object'],
         pathParams: ['bucket', 'object'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Object>(parameters, callback);
@@ -7232,7 +7168,7 @@ export namespace storage_v1 {
           'destinationBucket', 'destinationObject', 'sourceBucket',
           'sourceObject'
         ],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$RewriteResponse>(parameters, callback);
@@ -7366,7 +7302,7 @@ export namespace storage_v1 {
         params,
         requiredParams: ['bucket', 'object'],
         pathParams: ['bucket', 'object'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -7506,7 +7442,7 @@ export namespace storage_v1 {
         params,
         requiredParams: ['bucket', 'object', 'permissions'],
         pathParams: ['bucket', 'object'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TestIamPermissionsResponse>(
@@ -7645,7 +7581,7 @@ export namespace storage_v1 {
         params,
         requiredParams: ['bucket', 'object'],
         pathParams: ['bucket', 'object'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Object>(parameters, callback);
@@ -7776,7 +7712,7 @@ export namespace storage_v1 {
         params,
         requiredParams: ['bucket'],
         pathParams: ['bucket'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Channel>(parameters, callback);
@@ -8571,30 +8507,15 @@ export namespace storage_v1 {
 
 
   export class Resource$Projects {
-    root: Storage;
     serviceAccount: Resource$Projects$Serviceaccount;
-    constructor(root: Storage) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.serviceAccount = new Resource$Projects$Serviceaccount(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.serviceAccount = new Resource$Projects$Serviceaccount();
     }
   }
 
 
   export class Resource$Projects$Serviceaccount {
-    root: Storage;
-    constructor(root: Storage) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -8705,7 +8626,7 @@ export namespace storage_v1 {
         params,
         requiredParams: ['projectId'],
         pathParams: ['projectId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ServiceAccount>(parameters, callback);

--- a/src/apis/storage/v1beta1.ts
+++ b/src/apis/storage/v1beta1.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace storage_v1beta1 {
   export interface Options extends GlobalOptions {
     version: 'v1beta1';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -79,28 +81,18 @@ export namespace storage_v1beta1 {
    * @param {object=} options Options for Storage
    */
   export class Storage {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     bucketAccessControls: Resource$Bucketaccesscontrols;
     buckets: Resource$Buckets;
     objectAccessControls: Resource$Objectaccesscontrols;
     objects: Resource$Objects;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.bucketAccessControls = new Resource$Bucketaccesscontrols(this);
-      this.buckets = new Resource$Buckets(this);
-      this.objectAccessControls = new Resource$Objectaccesscontrols(this);
-      this.objects = new Resource$Objects(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.bucketAccessControls = new Resource$Bucketaccesscontrols();
+      this.buckets = new Resource$Buckets();
+      this.objectAccessControls = new Resource$Objectaccesscontrols();
+      this.objects = new Resource$Objects();
     }
   }
 
@@ -391,15 +383,7 @@ export namespace storage_v1beta1 {
 
 
   export class Resource$Bucketaccesscontrols {
-    root: Storage;
-    constructor(root: Storage) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -459,7 +443,7 @@ export namespace storage_v1beta1 {
         params,
         requiredParams: ['bucket', 'entity'],
         pathParams: ['bucket', 'entity'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -524,7 +508,7 @@ export namespace storage_v1beta1 {
         params,
         requiredParams: ['bucket', 'entity'],
         pathParams: ['bucket', 'entity'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$BucketAccessControl>(parameters, callback);
@@ -592,7 +576,7 @@ export namespace storage_v1beta1 {
         params,
         requiredParams: ['bucket'],
         pathParams: ['bucket'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$BucketAccessControl>(parameters, callback);
@@ -660,7 +644,7 @@ export namespace storage_v1beta1 {
         params,
         requiredParams: ['bucket'],
         pathParams: ['bucket'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$BucketAccessControls>(parameters, callback);
@@ -730,7 +714,7 @@ export namespace storage_v1beta1 {
         params,
         requiredParams: ['bucket', 'entity'],
         pathParams: ['bucket', 'entity'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$BucketAccessControl>(parameters, callback);
@@ -799,7 +783,7 @@ export namespace storage_v1beta1 {
         params,
         requiredParams: ['bucket', 'entity'],
         pathParams: ['bucket', 'entity'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$BucketAccessControl>(parameters, callback);
@@ -919,15 +903,7 @@ export namespace storage_v1beta1 {
 
 
   export class Resource$Buckets {
-    root: Storage;
-    constructor(root: Storage) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -983,7 +959,7 @@ export namespace storage_v1beta1 {
         params,
         requiredParams: ['bucket'],
         pathParams: ['bucket'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -1045,7 +1021,7 @@ export namespace storage_v1beta1 {
         params,
         requiredParams: ['bucket'],
         pathParams: ['bucket'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Bucket>(parameters, callback);
@@ -1110,7 +1086,7 @@ export namespace storage_v1beta1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Bucket>(parameters, callback);
@@ -1177,7 +1153,7 @@ export namespace storage_v1beta1 {
         params,
         requiredParams: ['projectId'],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Buckets>(parameters, callback);
@@ -1243,7 +1219,7 @@ export namespace storage_v1beta1 {
         params,
         requiredParams: ['bucket'],
         pathParams: ['bucket'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Bucket>(parameters, callback);
@@ -1309,7 +1285,7 @@ export namespace storage_v1beta1 {
         params,
         requiredParams: ['bucket'],
         pathParams: ['bucket'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Bucket>(parameters, callback);
@@ -1430,15 +1406,7 @@ export namespace storage_v1beta1 {
 
 
   export class Resource$Objectaccesscontrols {
-    root: Storage;
-    constructor(root: Storage) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -1500,7 +1468,7 @@ export namespace storage_v1beta1 {
         params,
         requiredParams: ['bucket', 'object', 'entity'],
         pathParams: ['bucket', 'entity', 'object'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -1567,7 +1535,7 @@ export namespace storage_v1beta1 {
         params,
         requiredParams: ['bucket', 'object', 'entity'],
         pathParams: ['bucket', 'entity', 'object'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ObjectAccessControl>(parameters, callback);
@@ -1636,7 +1604,7 @@ export namespace storage_v1beta1 {
         params,
         requiredParams: ['bucket', 'object'],
         pathParams: ['bucket', 'object'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ObjectAccessControl>(parameters, callback);
@@ -1705,7 +1673,7 @@ export namespace storage_v1beta1 {
         params,
         requiredParams: ['bucket', 'object'],
         pathParams: ['bucket', 'object'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ObjectAccessControls>(parameters, callback);
@@ -1777,7 +1745,7 @@ export namespace storage_v1beta1 {
         params,
         requiredParams: ['bucket', 'object', 'entity'],
         pathParams: ['bucket', 'entity', 'object'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ObjectAccessControl>(parameters, callback);
@@ -1848,7 +1816,7 @@ export namespace storage_v1beta1 {
         params,
         requiredParams: ['bucket', 'object', 'entity'],
         pathParams: ['bucket', 'entity', 'object'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ObjectAccessControl>(parameters, callback);
@@ -1992,15 +1960,7 @@ export namespace storage_v1beta1 {
 
 
   export class Resource$Objects {
-    root: Storage;
-    constructor(root: Storage) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -2057,7 +2017,7 @@ export namespace storage_v1beta1 {
         params,
         requiredParams: ['bucket', 'object'],
         pathParams: ['bucket', 'object'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -2120,7 +2080,7 @@ export namespace storage_v1beta1 {
         params,
         requiredParams: ['bucket', 'object'],
         pathParams: ['bucket', 'object'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Object>(parameters, callback);
@@ -2192,7 +2152,7 @@ export namespace storage_v1beta1 {
                       .replace(/([^:]\/)\/+/g, '$1'),
         requiredParams: ['bucket'],
         pathParams: ['bucket'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Object>(parameters, callback);
@@ -2261,7 +2221,7 @@ export namespace storage_v1beta1 {
         params,
         requiredParams: ['bucket'],
         pathParams: ['bucket'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Objects>(parameters, callback);
@@ -2329,7 +2289,7 @@ export namespace storage_v1beta1 {
         params,
         requiredParams: ['bucket', 'object'],
         pathParams: ['bucket', 'object'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Object>(parameters, callback);
@@ -2396,7 +2356,7 @@ export namespace storage_v1beta1 {
         params,
         requiredParams: ['bucket', 'object'],
         pathParams: ['bucket', 'object'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Object>(parameters, callback);

--- a/src/apis/storage/v1beta2.ts
+++ b/src/apis/storage/v1beta2.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace storage_v1beta2 {
   export interface Options extends GlobalOptions {
     version: 'v1beta2';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -79,10 +81,6 @@ export namespace storage_v1beta2 {
    * @param {object=} options Options for Storage
    */
   export class Storage {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     bucketAccessControls: Resource$Bucketaccesscontrols;
     buckets: Resource$Buckets;
     channels: Resource$Channels;
@@ -91,21 +89,15 @@ export namespace storage_v1beta2 {
     objects: Resource$Objects;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.bucketAccessControls = new Resource$Bucketaccesscontrols(this);
-      this.buckets = new Resource$Buckets(this);
-      this.channels = new Resource$Channels(this);
+      this.bucketAccessControls = new Resource$Bucketaccesscontrols();
+      this.buckets = new Resource$Buckets();
+      this.channels = new Resource$Channels();
       this.defaultObjectAccessControls =
-          new Resource$Defaultobjectaccesscontrols(this);
-      this.objectAccessControls = new Resource$Objectaccesscontrols(this);
-      this.objects = new Resource$Objects(this);
-    }
-
-    getRoot() {
-      return this.root;
+          new Resource$Defaultobjectaccesscontrols();
+      this.objectAccessControls = new Resource$Objectaccesscontrols();
+      this.objects = new Resource$Objects();
     }
   }
 
@@ -568,15 +560,7 @@ export namespace storage_v1beta2 {
 
 
   export class Resource$Bucketaccesscontrols {
-    root: Storage;
-    constructor(root: Storage) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -636,7 +620,7 @@ export namespace storage_v1beta2 {
         params,
         requiredParams: ['bucket', 'entity'],
         pathParams: ['bucket', 'entity'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -701,7 +685,7 @@ export namespace storage_v1beta2 {
         params,
         requiredParams: ['bucket', 'entity'],
         pathParams: ['bucket', 'entity'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$BucketAccessControl>(parameters, callback);
@@ -769,7 +753,7 @@ export namespace storage_v1beta2 {
         params,
         requiredParams: ['bucket'],
         pathParams: ['bucket'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$BucketAccessControl>(parameters, callback);
@@ -837,7 +821,7 @@ export namespace storage_v1beta2 {
         params,
         requiredParams: ['bucket'],
         pathParams: ['bucket'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$BucketAccessControls>(parameters, callback);
@@ -907,7 +891,7 @@ export namespace storage_v1beta2 {
         params,
         requiredParams: ['bucket', 'entity'],
         pathParams: ['bucket', 'entity'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$BucketAccessControl>(parameters, callback);
@@ -976,7 +960,7 @@ export namespace storage_v1beta2 {
         params,
         requiredParams: ['bucket', 'entity'],
         pathParams: ['bucket', 'entity'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$BucketAccessControl>(parameters, callback);
@@ -1096,15 +1080,7 @@ export namespace storage_v1beta2 {
 
 
   export class Resource$Buckets {
-    root: Storage;
-    constructor(root: Storage) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -1162,7 +1138,7 @@ export namespace storage_v1beta2 {
         params,
         requiredParams: ['bucket'],
         pathParams: ['bucket'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -1226,7 +1202,7 @@ export namespace storage_v1beta2 {
         params,
         requiredParams: ['bucket'],
         pathParams: ['bucket'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Bucket>(parameters, callback);
@@ -1292,7 +1268,7 @@ export namespace storage_v1beta2 {
         params,
         requiredParams: ['project'],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Bucket>(parameters, callback);
@@ -1359,7 +1335,7 @@ export namespace storage_v1beta2 {
         params,
         requiredParams: ['project'],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Buckets>(parameters, callback);
@@ -1427,7 +1403,7 @@ export namespace storage_v1beta2 {
         params,
         requiredParams: ['bucket'],
         pathParams: ['bucket'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Bucket>(parameters, callback);
@@ -1495,7 +1471,7 @@ export namespace storage_v1beta2 {
         params,
         requiredParams: ['bucket'],
         pathParams: ['bucket'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Bucket>(parameters, callback);
@@ -1660,15 +1636,7 @@ export namespace storage_v1beta2 {
 
 
   export class Resource$Channels {
-    root: Storage;
-    constructor(root: Storage) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -1724,7 +1692,7 @@ export namespace storage_v1beta2 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -1749,15 +1717,7 @@ export namespace storage_v1beta2 {
 
 
   export class Resource$Defaultobjectaccesscontrols {
-    root: Storage;
-    constructor(root: Storage) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -1818,7 +1778,7 @@ export namespace storage_v1beta2 {
         params,
         requiredParams: ['bucket', 'entity'],
         pathParams: ['bucket', 'entity'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -1884,7 +1844,7 @@ export namespace storage_v1beta2 {
         params,
         requiredParams: ['bucket', 'entity'],
         pathParams: ['bucket', 'entity'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ObjectAccessControl>(parameters, callback);
@@ -1952,7 +1912,7 @@ export namespace storage_v1beta2 {
         params,
         requiredParams: ['bucket'],
         pathParams: ['bucket'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ObjectAccessControl>(parameters, callback);
@@ -2022,7 +1982,7 @@ export namespace storage_v1beta2 {
         params,
         requiredParams: ['bucket'],
         pathParams: ['bucket'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ObjectAccessControls>(parameters, callback);
@@ -2093,7 +2053,7 @@ export namespace storage_v1beta2 {
         params,
         requiredParams: ['bucket', 'entity'],
         pathParams: ['bucket', 'entity'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ObjectAccessControl>(parameters, callback);
@@ -2163,7 +2123,7 @@ export namespace storage_v1beta2 {
         params,
         requiredParams: ['bucket', 'entity'],
         pathParams: ['bucket', 'entity'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ObjectAccessControl>(parameters, callback);
@@ -2293,15 +2253,7 @@ export namespace storage_v1beta2 {
 
 
   export class Resource$Objectaccesscontrols {
-    root: Storage;
-    constructor(root: Storage) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -2364,7 +2316,7 @@ export namespace storage_v1beta2 {
         params,
         requiredParams: ['bucket', 'object', 'entity'],
         pathParams: ['bucket', 'entity', 'object'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -2432,7 +2384,7 @@ export namespace storage_v1beta2 {
         params,
         requiredParams: ['bucket', 'object', 'entity'],
         pathParams: ['bucket', 'entity', 'object'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ObjectAccessControl>(parameters, callback);
@@ -2502,7 +2454,7 @@ export namespace storage_v1beta2 {
         params,
         requiredParams: ['bucket', 'object'],
         pathParams: ['bucket', 'object'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ObjectAccessControl>(parameters, callback);
@@ -2572,7 +2524,7 @@ export namespace storage_v1beta2 {
         params,
         requiredParams: ['bucket', 'object'],
         pathParams: ['bucket', 'object'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ObjectAccessControls>(parameters, callback);
@@ -2645,7 +2597,7 @@ export namespace storage_v1beta2 {
         params,
         requiredParams: ['bucket', 'object', 'entity'],
         pathParams: ['bucket', 'entity', 'object'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ObjectAccessControl>(parameters, callback);
@@ -2717,7 +2669,7 @@ export namespace storage_v1beta2 {
         params,
         requiredParams: ['bucket', 'object', 'entity'],
         pathParams: ['bucket', 'entity', 'object'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ObjectAccessControl>(parameters, callback);
@@ -2891,15 +2843,7 @@ export namespace storage_v1beta2 {
 
 
   export class Resource$Objects {
-    root: Storage;
-    constructor(root: Storage) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -2963,7 +2907,7 @@ export namespace storage_v1beta2 {
         params,
         requiredParams: ['destinationBucket', 'destinationObject'],
         pathParams: ['destinationBucket', 'destinationObject'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Object>(parameters, callback);
@@ -3050,7 +2994,7 @@ export namespace storage_v1beta2 {
           'destinationBucket', 'destinationObject', 'sourceBucket',
           'sourceObject'
         ],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Object>(parameters, callback);
@@ -3121,7 +3065,7 @@ export namespace storage_v1beta2 {
         params,
         requiredParams: ['bucket', 'object'],
         pathParams: ['bucket', 'object'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -3189,7 +3133,7 @@ export namespace storage_v1beta2 {
         params,
         requiredParams: ['bucket', 'object'],
         pathParams: ['bucket', 'object'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Object>(parameters, callback);
@@ -3265,7 +3209,7 @@ export namespace storage_v1beta2 {
                       .replace(/([^:]\/)\/+/g, '$1'),
         requiredParams: ['bucket'],
         pathParams: ['bucket'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Object>(parameters, callback);
@@ -3335,7 +3279,7 @@ export namespace storage_v1beta2 {
         params,
         requiredParams: ['bucket'],
         pathParams: ['bucket'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Objects>(parameters, callback);
@@ -3408,7 +3352,7 @@ export namespace storage_v1beta2 {
         params,
         requiredParams: ['bucket', 'object'],
         pathParams: ['bucket', 'object'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Object>(parameters, callback);
@@ -3480,7 +3424,7 @@ export namespace storage_v1beta2 {
         params,
         requiredParams: ['bucket', 'object'],
         pathParams: ['bucket', 'object'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Object>(parameters, callback);
@@ -3552,7 +3496,7 @@ export namespace storage_v1beta2 {
         params,
         requiredParams: ['bucket'],
         pathParams: ['bucket'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Channel>(parameters, callback);

--- a/src/apis/storagetransfer/v1.ts
+++ b/src/apis/storagetransfer/v1.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace storagetransfer_v1 {
   export interface Options extends GlobalOptions {
     version: 'v1';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -97,26 +99,16 @@ export namespace storagetransfer_v1 {
    * @param {object=} options Options for Storagetransfer
    */
   export class Storagetransfer {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     googleServiceAccounts: Resource$Googleserviceaccounts;
     transferJobs: Resource$Transferjobs;
     transferOperations: Resource$Transferoperations;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.googleServiceAccounts = new Resource$Googleserviceaccounts(this);
-      this.transferJobs = new Resource$Transferjobs(this);
-      this.transferOperations = new Resource$Transferoperations(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.googleServiceAccounts = new Resource$Googleserviceaccounts();
+      this.transferJobs = new Resource$Transferjobs();
+      this.transferOperations = new Resource$Transferoperations();
     }
   }
 
@@ -761,15 +753,7 @@ export namespace storagetransfer_v1 {
 
 
   export class Resource$Googleserviceaccounts {
-    root: Storagetransfer;
-    constructor(root: Storagetransfer) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -887,7 +871,7 @@ export namespace storagetransfer_v1 {
         params,
         requiredParams: ['projectId'],
         pathParams: ['projectId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleServiceAccount>(parameters, callback);
@@ -913,15 +897,7 @@ export namespace storagetransfer_v1 {
 
 
   export class Resource$Transferjobs {
-    root: Storagetransfer;
-    constructor(root: Storagetransfer) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -1035,7 +1011,7 @@ export namespace storagetransfer_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TransferJob>(parameters, callback);
@@ -1153,7 +1129,7 @@ export namespace storagetransfer_v1 {
         params,
         requiredParams: ['jobName'],
         pathParams: ['jobName'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TransferJob>(parameters, callback);
@@ -1286,7 +1262,7 @@ export namespace storagetransfer_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListTransferJobsResponse>(parameters, callback);
@@ -1416,7 +1392,7 @@ export namespace storagetransfer_v1 {
         params,
         requiredParams: ['jobName'],
         pathParams: ['jobName'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TransferJob>(parameters, callback);
@@ -1501,15 +1477,7 @@ export namespace storagetransfer_v1 {
 
 
   export class Resource$Transferoperations {
-    root: Storagetransfer;
-    constructor(root: Storagetransfer) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -1622,7 +1590,7 @@ export namespace storagetransfer_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -1740,7 +1708,7 @@ export namespace storagetransfer_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -1857,7 +1825,7 @@ export namespace storagetransfer_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -2003,7 +1971,7 @@ export namespace storagetransfer_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListOperationsResponse>(parameters, callback);
@@ -2127,7 +2095,7 @@ export namespace storagetransfer_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -2251,7 +2219,7 @@ export namespace storagetransfer_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);

--- a/src/apis/streetviewpublish/v1.ts
+++ b/src/apis/streetviewpublish/v1.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace streetviewpublish_v1 {
   export interface Options extends GlobalOptions {
     version: 'v1';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -98,24 +100,14 @@ export namespace streetviewpublish_v1 {
    * @param {object=} options Options for Streetviewpublish
    */
   export class Streetviewpublish {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     photo: Resource$Photo;
     photos: Resource$Photos;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.photo = new Resource$Photo(this);
-      this.photos = new Resource$Photos(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.photo = new Resource$Photo();
+      this.photos = new Resource$Photos();
     }
   }
 
@@ -521,15 +513,7 @@ export namespace streetviewpublish_v1 {
 
 
   export class Resource$Photo {
-    root: Streetviewpublish;
-    constructor(root: Streetviewpublish) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -597,7 +581,7 @@ export namespace streetviewpublish_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Photo>(parameters, callback);
@@ -665,7 +649,7 @@ export namespace streetviewpublish_v1 {
         params,
         requiredParams: ['photoId'],
         pathParams: ['photoId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -734,7 +718,7 @@ export namespace streetviewpublish_v1 {
         params,
         requiredParams: ['photoId'],
         pathParams: ['photoId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Photo>(parameters, callback);
@@ -814,7 +798,7 @@ export namespace streetviewpublish_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$UploadRef>(parameters, callback);
@@ -891,7 +875,7 @@ export namespace streetviewpublish_v1 {
         params,
         requiredParams: ['id'],
         pathParams: ['id'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Photo>(parameters, callback);
@@ -994,15 +978,7 @@ export namespace streetviewpublish_v1 {
 
 
   export class Resource$Photos {
-    root: Streetviewpublish;
-    constructor(root: Streetviewpublish) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -1071,7 +1047,7 @@ export namespace streetviewpublish_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$BatchDeletePhotosResponse>(
@@ -1147,7 +1123,7 @@ export namespace streetviewpublish_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$BatchGetPhotosResponse>(parameters, callback);
@@ -1228,7 +1204,7 @@ export namespace streetviewpublish_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$BatchUpdatePhotosResponse>(
@@ -1300,7 +1276,7 @@ export namespace streetviewpublish_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListPhotosResponse>(parameters, callback);

--- a/src/apis/surveys/v2.ts
+++ b/src/apis/surveys/v2.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace surveys_v2 {
   export interface Options extends GlobalOptions {
     version: 'v2';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -80,24 +82,14 @@ export namespace surveys_v2 {
    * @param {object=} options Options for Surveys
    */
   export class Surveys {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     results: Resource$Results;
     surveys: Resource$Surveys;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.results = new Resource$Results(this);
-      this.surveys = new Resource$Surveys(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.results = new Resource$Results();
+      this.surveys = new Resource$Surveys();
     }
   }
 
@@ -437,15 +429,7 @@ export namespace surveys_v2 {
 
 
   export class Resource$Results {
-    root: Surveys;
-    constructor(root: Surveys) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -503,7 +487,7 @@ export namespace surveys_v2 {
         params,
         requiredParams: ['surveyUrlId'],
         pathParams: ['surveyUrlId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$SurveyResults>(parameters, callback);
@@ -532,15 +516,7 @@ export namespace surveys_v2 {
 
 
   export class Resource$Surveys {
-    root: Surveys;
-    constructor(root: Surveys) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -599,7 +575,7 @@ export namespace surveys_v2 {
         params,
         requiredParams: ['surveyUrlId'],
         pathParams: ['surveyUrlId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$SurveysDeleteResponse>(parameters, callback);
@@ -660,7 +636,7 @@ export namespace surveys_v2 {
         params,
         requiredParams: ['surveyUrlId'],
         pathParams: ['surveyUrlId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Survey>(parameters, callback);
@@ -724,7 +700,7 @@ export namespace surveys_v2 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Survey>(parameters, callback);
@@ -791,7 +767,7 @@ export namespace surveys_v2 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$SurveysListResponse>(parameters, callback);
@@ -858,7 +834,7 @@ export namespace surveys_v2 {
         params,
         requiredParams: ['resourceId'],
         pathParams: ['resourceId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$SurveysStartResponse>(parameters, callback);
@@ -923,7 +899,7 @@ export namespace surveys_v2 {
         params,
         requiredParams: ['resourceId'],
         pathParams: ['resourceId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$SurveysStopResponse>(parameters, callback);
@@ -989,7 +965,7 @@ export namespace surveys_v2 {
         params,
         requiredParams: ['surveyUrlId'],
         pathParams: ['surveyUrlId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Survey>(parameters, callback);

--- a/src/apis/tagmanager/v1.ts
+++ b/src/apis/tagmanager/v1.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace tagmanager_v1 {
   export interface Options extends GlobalOptions {
     version: 'v1';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -79,22 +81,12 @@ export namespace tagmanager_v1 {
    * @param {object=} options Options for Tagmanager
    */
   export class Tagmanager {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     accounts: Resource$Accounts;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.accounts = new Resource$Accounts(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.accounts = new Resource$Accounts();
     }
   }
 
@@ -1046,18 +1038,11 @@ export namespace tagmanager_v1 {
 
 
   export class Resource$Accounts {
-    root: Tagmanager;
     containers: Resource$Accounts$Containers;
     permissions: Resource$Accounts$Permissions;
-    constructor(root: Tagmanager) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.containers = new Resource$Accounts$Containers(root);
-      this.permissions = new Resource$Accounts$Permissions(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.containers = new Resource$Accounts$Containers();
+      this.permissions = new Resource$Accounts$Permissions();
     }
 
 
@@ -1112,7 +1097,7 @@ export namespace tagmanager_v1 {
         params,
         requiredParams: ['accountId'],
         pathParams: ['accountId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Account>(parameters, callback);
@@ -1177,7 +1162,7 @@ export namespace tagmanager_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListAccountsResponse>(parameters, callback);
@@ -1243,7 +1228,7 @@ export namespace tagmanager_v1 {
         params,
         requiredParams: ['accountId'],
         pathParams: ['accountId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Account>(parameters, callback);
@@ -1293,7 +1278,6 @@ export namespace tagmanager_v1 {
   }
 
   export class Resource$Accounts$Containers {
-    root: Tagmanager;
     environments: Resource$Accounts$Containers$Environments;
     folders: Resource$Accounts$Containers$Folders;
     move_folders: Resource$Accounts$Containers$Move_folders;
@@ -1303,22 +1287,16 @@ export namespace tagmanager_v1 {
     triggers: Resource$Accounts$Containers$Triggers;
     variables: Resource$Accounts$Containers$Variables;
     versions: Resource$Accounts$Containers$Versions;
-    constructor(root: Tagmanager) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.environments = new Resource$Accounts$Containers$Environments(root);
-      this.folders = new Resource$Accounts$Containers$Folders(root);
-      this.move_folders = new Resource$Accounts$Containers$Move_folders(root);
+    constructor() {
+      this.environments = new Resource$Accounts$Containers$Environments();
+      this.folders = new Resource$Accounts$Containers$Folders();
+      this.move_folders = new Resource$Accounts$Containers$Move_folders();
       this.reauthorize_environments =
-          new Resource$Accounts$Containers$Reauthorize_environments(root);
-      this.tags = new Resource$Accounts$Containers$Tags(root);
-      this.triggers = new Resource$Accounts$Containers$Triggers(root);
-      this.variables = new Resource$Accounts$Containers$Variables(root);
-      this.versions = new Resource$Accounts$Containers$Versions(root);
-    }
-
-    getRoot() {
-      return this.root;
+          new Resource$Accounts$Containers$Reauthorize_environments();
+      this.tags = new Resource$Accounts$Containers$Tags();
+      this.triggers = new Resource$Accounts$Containers$Triggers();
+      this.variables = new Resource$Accounts$Containers$Variables();
+      this.versions = new Resource$Accounts$Containers$Versions();
     }
 
 
@@ -1380,7 +1358,7 @@ export namespace tagmanager_v1 {
         params,
         requiredParams: ['accountId'],
         pathParams: ['accountId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Container>(parameters, callback);
@@ -1448,7 +1426,7 @@ export namespace tagmanager_v1 {
         params,
         requiredParams: ['accountId', 'containerId'],
         pathParams: ['accountId', 'containerId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -1514,7 +1492,7 @@ export namespace tagmanager_v1 {
         params,
         requiredParams: ['accountId', 'containerId'],
         pathParams: ['accountId', 'containerId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Container>(parameters, callback);
@@ -1582,7 +1560,7 @@ export namespace tagmanager_v1 {
         params,
         requiredParams: ['accountId'],
         pathParams: ['accountId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListContainersResponse>(parameters, callback);
@@ -1654,7 +1632,7 @@ export namespace tagmanager_v1 {
         params,
         requiredParams: ['accountId', 'containerId'],
         pathParams: ['accountId', 'containerId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Container>(parameters, callback);
@@ -1753,15 +1731,7 @@ export namespace tagmanager_v1 {
   }
 
   export class Resource$Accounts$Containers$Environments {
-    root: Tagmanager;
-    constructor(root: Tagmanager) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -1826,7 +1796,7 @@ export namespace tagmanager_v1 {
         params,
         requiredParams: ['accountId', 'containerId'],
         pathParams: ['accountId', 'containerId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Environment>(parameters, callback);
@@ -1896,7 +1866,7 @@ export namespace tagmanager_v1 {
         params,
         requiredParams: ['accountId', 'containerId', 'environmentId'],
         pathParams: ['accountId', 'containerId', 'environmentId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -1963,7 +1933,7 @@ export namespace tagmanager_v1 {
         params,
         requiredParams: ['accountId', 'containerId', 'environmentId'],
         pathParams: ['accountId', 'containerId', 'environmentId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Environment>(parameters, callback);
@@ -2035,7 +2005,7 @@ export namespace tagmanager_v1 {
         params,
         requiredParams: ['accountId', 'containerId'],
         pathParams: ['accountId', 'containerId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListEnvironmentsResponse>(parameters, callback);
@@ -2109,7 +2079,7 @@ export namespace tagmanager_v1 {
         params,
         requiredParams: ['accountId', 'containerId', 'environmentId'],
         pathParams: ['accountId', 'containerId', 'environmentId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Environment>(parameters, callback);
@@ -2183,7 +2153,7 @@ export namespace tagmanager_v1 {
         params,
         requiredParams: ['accountId', 'containerId', 'environmentId'],
         pathParams: ['accountId', 'containerId', 'environmentId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Environment>(parameters, callback);
@@ -2333,16 +2303,9 @@ export namespace tagmanager_v1 {
 
 
   export class Resource$Accounts$Containers$Folders {
-    root: Tagmanager;
     entities: Resource$Accounts$Containers$Folders$Entities;
-    constructor(root: Tagmanager) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.entities = new Resource$Accounts$Containers$Folders$Entities(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.entities = new Resource$Accounts$Containers$Folders$Entities();
     }
 
 
@@ -2406,7 +2369,7 @@ export namespace tagmanager_v1 {
         params,
         requiredParams: ['accountId', 'containerId'],
         pathParams: ['accountId', 'containerId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Folder>(parameters, callback);
@@ -2475,7 +2438,7 @@ export namespace tagmanager_v1 {
         params,
         requiredParams: ['accountId', 'containerId', 'folderId'],
         pathParams: ['accountId', 'containerId', 'folderId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -2541,7 +2504,7 @@ export namespace tagmanager_v1 {
         params,
         requiredParams: ['accountId', 'containerId', 'folderId'],
         pathParams: ['accountId', 'containerId', 'folderId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Folder>(parameters, callback);
@@ -2611,7 +2574,7 @@ export namespace tagmanager_v1 {
         params,
         requiredParams: ['accountId', 'containerId'],
         pathParams: ['accountId', 'containerId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListFoldersResponse>(parameters, callback);
@@ -2683,7 +2646,7 @@ export namespace tagmanager_v1 {
         params,
         requiredParams: ['accountId', 'containerId', 'folderId'],
         pathParams: ['accountId', 'containerId', 'folderId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Folder>(parameters, callback);
@@ -2802,15 +2765,7 @@ export namespace tagmanager_v1 {
   }
 
   export class Resource$Accounts$Containers$Folders$Entities {
-    root: Tagmanager;
-    constructor(root: Tagmanager) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -2876,7 +2831,7 @@ export namespace tagmanager_v1 {
         params,
         requiredParams: ['accountId', 'containerId', 'folderId'],
         pathParams: ['accountId', 'containerId', 'folderId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$FolderEntities>(parameters, callback);
@@ -2910,15 +2865,7 @@ export namespace tagmanager_v1 {
 
 
   export class Resource$Accounts$Containers$Move_folders {
-    root: Tagmanager;
-    constructor(root: Tagmanager) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -2985,7 +2932,7 @@ export namespace tagmanager_v1 {
         params,
         requiredParams: ['accountId', 'containerId', 'folderId'],
         pathParams: ['accountId', 'containerId', 'folderId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -3035,15 +2982,7 @@ export namespace tagmanager_v1 {
 
 
   export class Resource$Accounts$Containers$Reauthorize_environments {
-    root: Tagmanager;
-    constructor(root: Tagmanager) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -3113,7 +3052,7 @@ export namespace tagmanager_v1 {
         params,
         requiredParams: ['accountId', 'containerId', 'environmentId'],
         pathParams: ['accountId', 'containerId', 'environmentId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Environment>(parameters, callback);
@@ -3151,15 +3090,7 @@ export namespace tagmanager_v1 {
 
 
   export class Resource$Accounts$Containers$Tags {
-    root: Tagmanager;
-    constructor(root: Tagmanager) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -3222,7 +3153,7 @@ export namespace tagmanager_v1 {
         params,
         requiredParams: ['accountId', 'containerId'],
         pathParams: ['accountId', 'containerId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Tag>(parameters, callback);
@@ -3291,7 +3222,7 @@ export namespace tagmanager_v1 {
         params,
         requiredParams: ['accountId', 'containerId', 'tagId'],
         pathParams: ['accountId', 'containerId', 'tagId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -3357,7 +3288,7 @@ export namespace tagmanager_v1 {
         params,
         requiredParams: ['accountId', 'containerId', 'tagId'],
         pathParams: ['accountId', 'containerId', 'tagId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Tag>(parameters, callback);
@@ -3427,7 +3358,7 @@ export namespace tagmanager_v1 {
         params,
         requiredParams: ['accountId', 'containerId'],
         pathParams: ['accountId', 'containerId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListTagsResponse>(parameters, callback);
@@ -3499,7 +3430,7 @@ export namespace tagmanager_v1 {
         params,
         requiredParams: ['accountId', 'containerId', 'tagId'],
         pathParams: ['accountId', 'containerId', 'tagId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Tag>(parameters, callback);
@@ -3619,15 +3550,7 @@ export namespace tagmanager_v1 {
 
 
   export class Resource$Accounts$Containers$Triggers {
-    root: Tagmanager;
-    constructor(root: Tagmanager) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -3690,7 +3613,7 @@ export namespace tagmanager_v1 {
         params,
         requiredParams: ['accountId', 'containerId'],
         pathParams: ['accountId', 'containerId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Trigger>(parameters, callback);
@@ -3759,7 +3682,7 @@ export namespace tagmanager_v1 {
         params,
         requiredParams: ['accountId', 'containerId', 'triggerId'],
         pathParams: ['accountId', 'containerId', 'triggerId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -3825,7 +3748,7 @@ export namespace tagmanager_v1 {
         params,
         requiredParams: ['accountId', 'containerId', 'triggerId'],
         pathParams: ['accountId', 'containerId', 'triggerId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Trigger>(parameters, callback);
@@ -3896,7 +3819,7 @@ export namespace tagmanager_v1 {
         params,
         requiredParams: ['accountId', 'containerId'],
         pathParams: ['accountId', 'containerId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListTriggersResponse>(parameters, callback);
@@ -3968,7 +3891,7 @@ export namespace tagmanager_v1 {
         params,
         requiredParams: ['accountId', 'containerId', 'triggerId'],
         pathParams: ['accountId', 'containerId', 'triggerId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Trigger>(parameters, callback);
@@ -4088,15 +4011,7 @@ export namespace tagmanager_v1 {
 
 
   export class Resource$Accounts$Containers$Variables {
-    root: Tagmanager;
-    constructor(root: Tagmanager) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -4159,7 +4074,7 @@ export namespace tagmanager_v1 {
         params,
         requiredParams: ['accountId', 'containerId'],
         pathParams: ['accountId', 'containerId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Variable>(parameters, callback);
@@ -4228,7 +4143,7 @@ export namespace tagmanager_v1 {
         params,
         requiredParams: ['accountId', 'containerId', 'variableId'],
         pathParams: ['accountId', 'containerId', 'variableId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -4294,7 +4209,7 @@ export namespace tagmanager_v1 {
         params,
         requiredParams: ['accountId', 'containerId', 'variableId'],
         pathParams: ['accountId', 'containerId', 'variableId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Variable>(parameters, callback);
@@ -4365,7 +4280,7 @@ export namespace tagmanager_v1 {
         params,
         requiredParams: ['accountId', 'containerId'],
         pathParams: ['accountId', 'containerId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListVariablesResponse>(parameters, callback);
@@ -4437,7 +4352,7 @@ export namespace tagmanager_v1 {
         params,
         requiredParams: ['accountId', 'containerId', 'variableId'],
         pathParams: ['accountId', 'containerId', 'variableId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Variable>(parameters, callback);
@@ -4557,15 +4472,7 @@ export namespace tagmanager_v1 {
 
 
   export class Resource$Accounts$Containers$Versions {
-    root: Tagmanager;
-    constructor(root: Tagmanager) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -4635,7 +4542,7 @@ export namespace tagmanager_v1 {
         params,
         requiredParams: ['accountId', 'containerId'],
         pathParams: ['accountId', 'containerId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$CreateContainerVersionResponse>(
@@ -4706,7 +4613,7 @@ export namespace tagmanager_v1 {
         params,
         requiredParams: ['accountId', 'containerId', 'containerVersionId'],
         pathParams: ['accountId', 'containerId', 'containerVersionId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -4773,7 +4680,7 @@ export namespace tagmanager_v1 {
         params,
         requiredParams: ['accountId', 'containerId', 'containerVersionId'],
         pathParams: ['accountId', 'containerId', 'containerVersionId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ContainerVersion>(parameters, callback);
@@ -4850,7 +4757,7 @@ export namespace tagmanager_v1 {
         params,
         requiredParams: ['accountId', 'containerId'],
         pathParams: ['accountId', 'containerId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListContainerVersionsResponse>(
@@ -4931,7 +4838,7 @@ export namespace tagmanager_v1 {
         params,
         requiredParams: ['accountId', 'containerId', 'containerVersionId'],
         pathParams: ['accountId', 'containerId', 'containerVersionId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$PublishContainerVersionResponse>(
@@ -5007,7 +4914,7 @@ export namespace tagmanager_v1 {
         params,
         requiredParams: ['accountId', 'containerId', 'containerVersionId'],
         pathParams: ['accountId', 'containerId', 'containerVersionId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ContainerVersion>(parameters, callback);
@@ -5079,7 +4986,7 @@ export namespace tagmanager_v1 {
         params,
         requiredParams: ['accountId', 'containerId', 'containerVersionId'],
         pathParams: ['accountId', 'containerId', 'containerVersionId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ContainerVersion>(parameters, callback);
@@ -5152,7 +5059,7 @@ export namespace tagmanager_v1 {
         params,
         requiredParams: ['accountId', 'containerId', 'containerVersionId'],
         pathParams: ['accountId', 'containerId', 'containerVersionId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ContainerVersion>(parameters, callback);
@@ -5347,15 +5254,7 @@ export namespace tagmanager_v1 {
 
 
   export class Resource$Accounts$Permissions {
-    root: Tagmanager;
-    constructor(root: Tagmanager) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -5416,7 +5315,7 @@ export namespace tagmanager_v1 {
         params,
         requiredParams: ['accountId'],
         pathParams: ['accountId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$UserAccess>(parameters, callback);
@@ -5485,7 +5384,7 @@ export namespace tagmanager_v1 {
         params,
         requiredParams: ['accountId', 'permissionId'],
         pathParams: ['accountId', 'permissionId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -5551,7 +5450,7 @@ export namespace tagmanager_v1 {
         params,
         requiredParams: ['accountId', 'permissionId'],
         pathParams: ['accountId', 'permissionId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$UserAccess>(parameters, callback);
@@ -5620,7 +5519,7 @@ export namespace tagmanager_v1 {
         params,
         requiredParams: ['accountId'],
         pathParams: ['accountId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListAccountUsersResponse>(parameters, callback);
@@ -5691,7 +5590,7 @@ export namespace tagmanager_v1 {
         params,
         requiredParams: ['accountId', 'permissionId'],
         pathParams: ['accountId', 'permissionId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$UserAccess>(parameters, callback);

--- a/src/apis/tagmanager/v2.ts
+++ b/src/apis/tagmanager/v2.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace tagmanager_v2 {
   export interface Options extends GlobalOptions {
     version: 'v2';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -79,22 +81,12 @@ export namespace tagmanager_v2 {
    * @param {object=} options Options for Tagmanager
    */
   export class Tagmanager {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     accounts: Resource$Accounts;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.accounts = new Resource$Accounts(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.accounts = new Resource$Accounts();
     }
   }
 
@@ -1631,18 +1623,11 @@ export namespace tagmanager_v2 {
 
 
   export class Resource$Accounts {
-    root: Tagmanager;
     containers: Resource$Accounts$Containers;
     user_permissions: Resource$Accounts$User_permissions;
-    constructor(root: Tagmanager) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.containers = new Resource$Accounts$Containers(root);
-      this.user_permissions = new Resource$Accounts$User_permissions(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.containers = new Resource$Accounts$Containers();
+      this.user_permissions = new Resource$Accounts$User_permissions();
     }
 
 
@@ -1697,7 +1682,7 @@ export namespace tagmanager_v2 {
         params,
         requiredParams: ['path'],
         pathParams: ['path'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Account>(parameters, callback);
@@ -1763,7 +1748,7 @@ export namespace tagmanager_v2 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListAccountsResponse>(parameters, callback);
@@ -1829,7 +1814,7 @@ export namespace tagmanager_v2 {
         params,
         requiredParams: ['path'],
         pathParams: ['path'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Account>(parameters, callback);
@@ -1884,23 +1869,15 @@ export namespace tagmanager_v2 {
   }
 
   export class Resource$Accounts$Containers {
-    root: Tagmanager;
     environments: Resource$Accounts$Containers$Environments;
     versions: Resource$Accounts$Containers$Versions;
     version_headers: Resource$Accounts$Containers$Version_headers;
     workspaces: Resource$Accounts$Containers$Workspaces;
-    constructor(root: Tagmanager) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.environments = new Resource$Accounts$Containers$Environments(root);
-      this.versions = new Resource$Accounts$Containers$Versions(root);
-      this.version_headers =
-          new Resource$Accounts$Containers$Version_headers(root);
-      this.workspaces = new Resource$Accounts$Containers$Workspaces(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.environments = new Resource$Accounts$Containers$Environments();
+      this.versions = new Resource$Accounts$Containers$Versions();
+      this.version_headers = new Resource$Accounts$Containers$Version_headers();
+      this.workspaces = new Resource$Accounts$Containers$Workspaces();
     }
 
 
@@ -1962,7 +1939,7 @@ export namespace tagmanager_v2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Container>(parameters, callback);
@@ -2027,7 +2004,7 @@ export namespace tagmanager_v2 {
         params,
         requiredParams: ['path'],
         pathParams: ['path'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -2090,7 +2067,7 @@ export namespace tagmanager_v2 {
         params,
         requiredParams: ['path'],
         pathParams: ['path'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Container>(parameters, callback);
@@ -2159,7 +2136,7 @@ export namespace tagmanager_v2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListContainersResponse>(parameters, callback);
@@ -2228,7 +2205,7 @@ export namespace tagmanager_v2 {
         params,
         requiredParams: ['path'],
         pathParams: ['path'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Container>(parameters, callback);
@@ -2322,15 +2299,7 @@ export namespace tagmanager_v2 {
   }
 
   export class Resource$Accounts$Containers$Environments {
-    root: Tagmanager;
-    constructor(root: Tagmanager) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -2392,7 +2361,7 @@ export namespace tagmanager_v2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Environment>(parameters, callback);
@@ -2458,7 +2427,7 @@ export namespace tagmanager_v2 {
         params,
         requiredParams: ['path'],
         pathParams: ['path'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -2521,7 +2490,7 @@ export namespace tagmanager_v2 {
         params,
         requiredParams: ['path'],
         pathParams: ['path'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Environment>(parameters, callback);
@@ -2591,7 +2560,7 @@ export namespace tagmanager_v2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListEnvironmentsResponse>(parameters, callback);
@@ -2661,7 +2630,7 @@ export namespace tagmanager_v2 {
         params,
         requiredParams: ['path'],
         pathParams: ['path'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Environment>(parameters, callback);
@@ -2731,7 +2700,7 @@ export namespace tagmanager_v2 {
         params,
         requiredParams: ['path'],
         pathParams: ['path'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Environment>(parameters, callback);
@@ -2801,7 +2770,7 @@ export namespace tagmanager_v2 {
         params,
         requiredParams: ['path'],
         pathParams: ['path'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Environment>(parameters, callback);
@@ -2939,15 +2908,7 @@ export namespace tagmanager_v2 {
 
 
   export class Resource$Accounts$Containers$Versions {
-    root: Tagmanager;
-    constructor(root: Tagmanager) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -3005,7 +2966,7 @@ export namespace tagmanager_v2 {
         params,
         requiredParams: ['path'],
         pathParams: ['path'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -3069,7 +3030,7 @@ export namespace tagmanager_v2 {
         params,
         requiredParams: ['path'],
         pathParams: ['path'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ContainerVersion>(parameters, callback);
@@ -3136,7 +3097,7 @@ export namespace tagmanager_v2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ContainerVersion>(parameters, callback);
@@ -3211,7 +3172,7 @@ export namespace tagmanager_v2 {
         params,
         requiredParams: ['path'],
         pathParams: ['path'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$PublishContainerVersionResponse>(
@@ -3282,7 +3243,7 @@ export namespace tagmanager_v2 {
         params,
         requiredParams: ['path'],
         pathParams: ['path'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ContainerVersion>(parameters, callback);
@@ -3350,7 +3311,7 @@ export namespace tagmanager_v2 {
         params,
         requiredParams: ['path'],
         pathParams: ['path'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ContainerVersion>(parameters, callback);
@@ -3419,7 +3380,7 @@ export namespace tagmanager_v2 {
         params,
         requiredParams: ['path'],
         pathParams: ['path'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ContainerVersion>(parameters, callback);
@@ -3543,15 +3504,7 @@ export namespace tagmanager_v2 {
 
 
   export class Resource$Accounts$Containers$Version_headers {
-    root: Tagmanager;
-    constructor(root: Tagmanager) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -3614,7 +3567,7 @@ export namespace tagmanager_v2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ContainerVersionHeader>(parameters, callback);
@@ -3689,7 +3642,7 @@ export namespace tagmanager_v2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListContainerVersionsResponse>(
@@ -3738,7 +3691,6 @@ export namespace tagmanager_v2 {
 
 
   export class Resource$Accounts$Containers$Workspaces {
-    root: Tagmanager;
     built_in_variables:
         Resource$Accounts$Containers$Workspaces$Built_in_variables;
     folders: Resource$Accounts$Containers$Workspaces$Folders;
@@ -3746,23 +3698,14 @@ export namespace tagmanager_v2 {
     tags: Resource$Accounts$Containers$Workspaces$Tags;
     triggers: Resource$Accounts$Containers$Workspaces$Triggers;
     variables: Resource$Accounts$Containers$Workspaces$Variables;
-    constructor(root: Tagmanager) {
-      this.root = root;
-      this.getRoot.bind(this);
+    constructor() {
       this.built_in_variables =
-          new Resource$Accounts$Containers$Workspaces$Built_in_variables(root);
-      this.folders = new Resource$Accounts$Containers$Workspaces$Folders(root);
-      this.proposal =
-          new Resource$Accounts$Containers$Workspaces$Proposal(root);
-      this.tags = new Resource$Accounts$Containers$Workspaces$Tags(root);
-      this.triggers =
-          new Resource$Accounts$Containers$Workspaces$Triggers(root);
-      this.variables =
-          new Resource$Accounts$Containers$Workspaces$Variables(root);
-    }
-
-    getRoot() {
-      return this.root;
+          new Resource$Accounts$Containers$Workspaces$Built_in_variables();
+      this.folders = new Resource$Accounts$Containers$Workspaces$Folders();
+      this.proposal = new Resource$Accounts$Containers$Workspaces$Proposal();
+      this.tags = new Resource$Accounts$Containers$Workspaces$Tags();
+      this.triggers = new Resource$Accounts$Containers$Workspaces$Triggers();
+      this.variables = new Resource$Accounts$Containers$Workspaces$Variables();
     }
 
 
@@ -3825,7 +3768,7 @@ export namespace tagmanager_v2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Workspace>(parameters, callback);
@@ -3903,7 +3846,7 @@ export namespace tagmanager_v2 {
         params,
         requiredParams: ['path'],
         pathParams: ['path'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$CreateContainerVersionResponse>(
@@ -3971,7 +3914,7 @@ export namespace tagmanager_v2 {
         params,
         requiredParams: ['path'],
         pathParams: ['path'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -4034,7 +3977,7 @@ export namespace tagmanager_v2 {
         params,
         requiredParams: ['path'],
         pathParams: ['path'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Workspace>(parameters, callback);
@@ -4103,7 +4046,7 @@ export namespace tagmanager_v2 {
         params,
         requiredParams: ['path'],
         pathParams: ['path'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$WorkspaceProposal>(parameters, callback);
@@ -4177,7 +4120,7 @@ export namespace tagmanager_v2 {
         params,
         requiredParams: ['path'],
         pathParams: ['path'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GetWorkspaceStatusResponse>(
@@ -4247,7 +4190,7 @@ export namespace tagmanager_v2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListWorkspacesResponse>(parameters, callback);
@@ -4319,7 +4262,7 @@ export namespace tagmanager_v2 {
         params,
         requiredParams: ['path'],
         pathParams: ['path'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$QuickPreviewResponse>(parameters, callback);
@@ -4390,7 +4333,7 @@ export namespace tagmanager_v2 {
         params,
         requiredParams: ['path'],
         pathParams: ['path'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -4460,7 +4403,7 @@ export namespace tagmanager_v2 {
         params,
         requiredParams: ['path'],
         pathParams: ['path'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$SyncWorkspaceResponse>(parameters, callback);
@@ -4530,7 +4473,7 @@ export namespace tagmanager_v2 {
         params,
         requiredParams: ['path'],
         pathParams: ['path'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Workspace>(parameters, callback);
@@ -4601,7 +4544,7 @@ export namespace tagmanager_v2 {
         params,
         requiredParams: ['path'],
         pathParams: ['path'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$WorkspaceProposal>(parameters, callback);
@@ -4808,15 +4751,7 @@ export namespace tagmanager_v2 {
   }
 
   export class Resource$Accounts$Containers$Workspaces$Built_in_variables {
-    root: Tagmanager;
-    constructor(root: Tagmanager) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -4889,7 +4824,7 @@ export namespace tagmanager_v2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$CreateBuiltInVariableResponse>(
@@ -4963,7 +4898,7 @@ export namespace tagmanager_v2 {
         params,
         requiredParams: ['path'],
         pathParams: ['path'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -5045,7 +4980,7 @@ export namespace tagmanager_v2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListEnabledBuiltInVariablesResponse>(
@@ -5128,7 +5063,7 @@ export namespace tagmanager_v2 {
         params,
         requiredParams: ['path'],
         pathParams: ['path'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$RevertBuiltInVariableResponse>(
@@ -5211,15 +5146,7 @@ export namespace tagmanager_v2 {
 
 
   export class Resource$Accounts$Containers$Workspaces$Folders {
-    root: Tagmanager;
-    constructor(root: Tagmanager) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -5281,7 +5208,7 @@ export namespace tagmanager_v2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Folder>(parameters, callback);
@@ -5348,7 +5275,7 @@ export namespace tagmanager_v2 {
         params,
         requiredParams: ['path'],
         pathParams: ['path'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -5419,7 +5346,7 @@ export namespace tagmanager_v2 {
         params,
         requiredParams: ['path'],
         pathParams: ['path'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$FolderEntities>(parameters, callback);
@@ -5483,7 +5410,7 @@ export namespace tagmanager_v2 {
         params,
         requiredParams: ['path'],
         pathParams: ['path'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Folder>(parameters, callback);
@@ -5553,7 +5480,7 @@ export namespace tagmanager_v2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListFoldersResponse>(parameters, callback);
@@ -5628,7 +5555,7 @@ export namespace tagmanager_v2 {
         params,
         requiredParams: ['path'],
         pathParams: ['path'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -5699,7 +5626,7 @@ export namespace tagmanager_v2 {
         params,
         requiredParams: ['path'],
         pathParams: ['path'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$RevertFolderResponse>(parameters, callback);
@@ -5769,7 +5696,7 @@ export namespace tagmanager_v2 {
         params,
         requiredParams: ['path'],
         pathParams: ['path'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Folder>(parameters, callback);
@@ -5931,15 +5858,7 @@ export namespace tagmanager_v2 {
 
 
   export class Resource$Accounts$Containers$Workspaces$Proposal {
-    root: Tagmanager;
-    constructor(root: Tagmanager) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -6002,7 +5921,7 @@ export namespace tagmanager_v2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$WorkspaceProposal>(parameters, callback);
@@ -6069,7 +5988,7 @@ export namespace tagmanager_v2 {
         params,
         requiredParams: ['path'],
         pathParams: ['path'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -6113,15 +6032,7 @@ export namespace tagmanager_v2 {
 
 
   export class Resource$Accounts$Containers$Workspaces$Tags {
-    root: Tagmanager;
-    constructor(root: Tagmanager) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -6183,7 +6094,7 @@ export namespace tagmanager_v2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Tag>(parameters, callback);
@@ -6250,7 +6161,7 @@ export namespace tagmanager_v2 {
         params,
         requiredParams: ['path'],
         pathParams: ['path'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -6313,7 +6224,7 @@ export namespace tagmanager_v2 {
         params,
         requiredParams: ['path'],
         pathParams: ['path'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Tag>(parameters, callback);
@@ -6382,7 +6293,7 @@ export namespace tagmanager_v2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListTagsResponse>(parameters, callback);
@@ -6452,7 +6363,7 @@ export namespace tagmanager_v2 {
         params,
         requiredParams: ['path'],
         pathParams: ['path'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$RevertTagResponse>(parameters, callback);
@@ -6522,7 +6433,7 @@ export namespace tagmanager_v2 {
         params,
         requiredParams: ['path'],
         pathParams: ['path'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Tag>(parameters, callback);
@@ -6637,15 +6548,7 @@ export namespace tagmanager_v2 {
 
 
   export class Resource$Accounts$Containers$Workspaces$Triggers {
-    root: Tagmanager;
-    constructor(root: Tagmanager) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -6707,7 +6610,7 @@ export namespace tagmanager_v2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Trigger>(parameters, callback);
@@ -6774,7 +6677,7 @@ export namespace tagmanager_v2 {
         params,
         requiredParams: ['path'],
         pathParams: ['path'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -6838,7 +6741,7 @@ export namespace tagmanager_v2 {
         params,
         requiredParams: ['path'],
         pathParams: ['path'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Trigger>(parameters, callback);
@@ -6909,7 +6812,7 @@ export namespace tagmanager_v2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListTriggersResponse>(parameters, callback);
@@ -6980,7 +6883,7 @@ export namespace tagmanager_v2 {
         params,
         requiredParams: ['path'],
         pathParams: ['path'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$RevertTriggerResponse>(parameters, callback);
@@ -7050,7 +6953,7 @@ export namespace tagmanager_v2 {
         params,
         requiredParams: ['path'],
         pathParams: ['path'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Trigger>(parameters, callback);
@@ -7165,15 +7068,7 @@ export namespace tagmanager_v2 {
 
 
   export class Resource$Accounts$Containers$Workspaces$Variables {
-    root: Tagmanager;
-    constructor(root: Tagmanager) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -7236,7 +7131,7 @@ export namespace tagmanager_v2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Variable>(parameters, callback);
@@ -7304,7 +7199,7 @@ export namespace tagmanager_v2 {
         params,
         requiredParams: ['path'],
         pathParams: ['path'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -7368,7 +7263,7 @@ export namespace tagmanager_v2 {
         params,
         requiredParams: ['path'],
         pathParams: ['path'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Variable>(parameters, callback);
@@ -7439,7 +7334,7 @@ export namespace tagmanager_v2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListVariablesResponse>(parameters, callback);
@@ -7511,7 +7406,7 @@ export namespace tagmanager_v2 {
         params,
         requiredParams: ['path'],
         pathParams: ['path'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$RevertVariableResponse>(parameters, callback);
@@ -7582,7 +7477,7 @@ export namespace tagmanager_v2 {
         params,
         requiredParams: ['path'],
         pathParams: ['path'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Variable>(parameters, callback);
@@ -7698,15 +7593,7 @@ export namespace tagmanager_v2 {
 
 
   export class Resource$Accounts$User_permissions {
-    root: Tagmanager;
-    constructor(root: Tagmanager) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -7767,7 +7654,7 @@ export namespace tagmanager_v2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$UserPermission>(parameters, callback);
@@ -7833,7 +7720,7 @@ export namespace tagmanager_v2 {
         params,
         requiredParams: ['path'],
         pathParams: ['path'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -7896,7 +7783,7 @@ export namespace tagmanager_v2 {
         params,
         requiredParams: ['path'],
         pathParams: ['path'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$UserPermission>(parameters, callback);
@@ -7970,7 +7857,7 @@ export namespace tagmanager_v2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListUserPermissionsResponse>(
@@ -8039,7 +7926,7 @@ export namespace tagmanager_v2 {
         params,
         requiredParams: ['path'],
         pathParams: ['path'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$UserPermission>(parameters, callback);

--- a/src/apis/tasks/v1.ts
+++ b/src/apis/tasks/v1.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace tasks_v1 {
   export interface Options extends GlobalOptions {
     version: 'v1';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -79,24 +81,14 @@ export namespace tasks_v1 {
    * @param {object=} options Options for Tasks
    */
   export class Tasks {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     tasklists: Resource$Tasklists;
     tasks: Resource$Tasks;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.tasklists = new Resource$Tasklists(this);
-      this.tasks = new Resource$Tasks(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.tasklists = new Resource$Tasklists();
+      this.tasks = new Resource$Tasks();
     }
   }
 
@@ -240,15 +232,7 @@ export namespace tasks_v1 {
 
 
   export class Resource$Tasklists {
-    root: Tasks;
-    constructor(root: Tasks) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -304,7 +288,7 @@ export namespace tasks_v1 {
         params,
         requiredParams: ['tasklist'],
         pathParams: ['tasklist'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -365,7 +349,7 @@ export namespace tasks_v1 {
         params,
         requiredParams: ['tasklist'],
         pathParams: ['tasklist'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TaskList>(parameters, callback);
@@ -430,7 +414,7 @@ export namespace tasks_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TaskList>(parameters, callback);
@@ -496,7 +480,7 @@ export namespace tasks_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TaskLists>(parameters, callback);
@@ -562,7 +546,7 @@ export namespace tasks_v1 {
         params,
         requiredParams: ['tasklist'],
         pathParams: ['tasklist'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TaskList>(parameters, callback);
@@ -627,7 +611,7 @@ export namespace tasks_v1 {
         params,
         requiredParams: ['tasklist'],
         pathParams: ['tasklist'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TaskList>(parameters, callback);
@@ -722,15 +706,7 @@ export namespace tasks_v1 {
 
 
   export class Resource$Tasks {
-    root: Tasks;
-    constructor(root: Tasks) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -788,7 +764,7 @@ export namespace tasks_v1 {
         params,
         requiredParams: ['tasklist'],
         pathParams: ['tasklist'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -852,7 +828,7 @@ export namespace tasks_v1 {
         params,
         requiredParams: ['tasklist', 'task'],
         pathParams: ['task', 'tasklist'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -914,7 +890,7 @@ export namespace tasks_v1 {
         params,
         requiredParams: ['tasklist', 'task'],
         pathParams: ['task', 'tasklist'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Task>(parameters, callback);
@@ -981,7 +957,7 @@ export namespace tasks_v1 {
         params,
         requiredParams: ['tasklist'],
         pathParams: ['tasklist'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Task>(parameters, callback);
@@ -1055,7 +1031,7 @@ export namespace tasks_v1 {
         params,
         requiredParams: ['tasklist'],
         pathParams: ['tasklist'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Tasks>(parameters, callback);
@@ -1124,7 +1100,7 @@ export namespace tasks_v1 {
         params,
         requiredParams: ['tasklist', 'task'],
         pathParams: ['task', 'tasklist'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Task>(parameters, callback);
@@ -1190,7 +1166,7 @@ export namespace tasks_v1 {
         params,
         requiredParams: ['tasklist', 'task'],
         pathParams: ['task', 'tasklist'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Task>(parameters, callback);
@@ -1256,7 +1232,7 @@ export namespace tasks_v1 {
         params,
         requiredParams: ['tasklist', 'task'],
         pathParams: ['task', 'tasklist'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Task>(parameters, callback);

--- a/src/apis/testing/v1.ts
+++ b/src/apis/testing/v1.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace testing_v1 {
   export interface Options extends GlobalOptions {
     version: 'v1';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -97,27 +99,16 @@ export namespace testing_v1 {
    * @param {object=} options Options for Testing
    */
   export class Testing {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     applicationDetailService: Resource$Applicationdetailservice;
     projects: Resource$Projects;
     testEnvironmentCatalog: Resource$Testenvironmentcatalog;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.applicationDetailService =
-          new Resource$Applicationdetailservice(this);
-      this.projects = new Resource$Projects(this);
-      this.testEnvironmentCatalog = new Resource$Testenvironmentcatalog(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.applicationDetailService = new Resource$Applicationdetailservice();
+      this.projects = new Resource$Projects();
+      this.testEnvironmentCatalog = new Resource$Testenvironmentcatalog();
     }
   }
 
@@ -1402,15 +1393,7 @@ export namespace testing_v1 {
 
 
   export class Resource$Applicationdetailservice {
-    root: Testing;
-    constructor(root: Testing) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -1473,7 +1456,7 @@ export namespace testing_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GetApkDetailsResponse>(parameters, callback);
@@ -1499,30 +1482,15 @@ export namespace testing_v1 {
 
 
   export class Resource$Projects {
-    root: Testing;
     testMatrices: Resource$Projects$Testmatrices;
-    constructor(root: Testing) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.testMatrices = new Resource$Projects$Testmatrices(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.testMatrices = new Resource$Projects$Testmatrices();
     }
   }
 
 
   export class Resource$Projects$Testmatrices {
-    root: Testing;
-    constructor(root: Testing) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -1592,7 +1560,7 @@ export namespace testing_v1 {
         params,
         requiredParams: ['projectId', 'testMatrixId'],
         pathParams: ['projectId', 'testMatrixId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$CancelTestMatrixResponse>(parameters, callback);
@@ -1667,7 +1635,7 @@ export namespace testing_v1 {
         params,
         requiredParams: ['projectId'],
         pathParams: ['projectId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TestMatrix>(parameters, callback);
@@ -1735,7 +1703,7 @@ export namespace testing_v1 {
         params,
         requiredParams: ['projectId', 'testMatrixId'],
         pathParams: ['projectId', 'testMatrixId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TestMatrix>(parameters, callback);
@@ -1804,15 +1772,7 @@ export namespace testing_v1 {
 
 
   export class Resource$Testenvironmentcatalog {
-    root: Testing;
-    constructor(root: Testing) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -1873,7 +1833,7 @@ export namespace testing_v1 {
         params,
         requiredParams: ['environmentType'],
         pathParams: ['environmentType'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TestEnvironmentCatalog>(parameters, callback);

--- a/src/apis/texttospeech/v1.ts
+++ b/src/apis/texttospeech/v1.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace texttospeech_v1 {
   export interface Options extends GlobalOptions {
     version: 'v1';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -97,24 +99,14 @@ export namespace texttospeech_v1 {
    * @param {object=} options Options for Texttospeech
    */
   export class Texttospeech {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     text: Resource$Text;
     voices: Resource$Voices;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.text = new Resource$Text(this);
-      this.voices = new Resource$Voices(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.text = new Resource$Text();
+      this.voices = new Resource$Voices();
     }
   }
 
@@ -277,15 +269,7 @@ export namespace texttospeech_v1 {
 
 
   export class Resource$Text {
-    root: Texttospeech;
-    constructor(root: Texttospeech) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -347,7 +331,7 @@ export namespace texttospeech_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$SynthesizeSpeechResponse>(parameters, callback);
@@ -372,15 +356,7 @@ export namespace texttospeech_v1 {
 
 
   export class Resource$Voices {
-    root: Texttospeech;
-    constructor(root: Texttospeech) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -437,7 +413,7 @@ export namespace texttospeech_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListVoicesResponse>(parameters, callback);

--- a/src/apis/texttospeech/v1beta1.ts
+++ b/src/apis/texttospeech/v1beta1.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace texttospeech_v1beta1 {
   export interface Options extends GlobalOptions {
     version: 'v1beta1';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -97,24 +99,14 @@ export namespace texttospeech_v1beta1 {
    * @param {object=} options Options for Texttospeech
    */
   export class Texttospeech {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     text: Resource$Text;
     voices: Resource$Voices;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.text = new Resource$Text(this);
-      this.voices = new Resource$Voices(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.text = new Resource$Text();
+      this.voices = new Resource$Voices();
     }
   }
 
@@ -283,15 +275,7 @@ export namespace texttospeech_v1beta1 {
 
 
   export class Resource$Text {
-    root: Texttospeech;
-    constructor(root: Texttospeech) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -353,7 +337,7 @@ export namespace texttospeech_v1beta1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$SynthesizeSpeechResponse>(parameters, callback);
@@ -378,15 +362,7 @@ export namespace texttospeech_v1beta1 {
 
 
   export class Resource$Voices {
-    root: Texttospeech;
-    constructor(root: Texttospeech) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -443,7 +419,7 @@ export namespace texttospeech_v1beta1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListVoicesResponse>(parameters, callback);

--- a/src/apis/toolresults/v1beta3.ts
+++ b/src/apis/toolresults/v1beta3.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace toolresults_v1beta3 {
   export interface Options extends GlobalOptions {
     version: 'v1beta3';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -79,22 +81,12 @@ export namespace toolresults_v1beta3 {
    * @param {object=} options Options for Toolresults
    */
   export class Toolresults {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     projects: Resource$Projects;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.projects = new Resource$Projects(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.projects = new Resource$Projects();
     }
   }
 
@@ -1406,16 +1398,9 @@ export namespace toolresults_v1beta3 {
 
 
   export class Resource$Projects {
-    root: Toolresults;
     histories: Resource$Projects$Histories;
-    constructor(root: Toolresults) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.histories = new Resource$Projects$Histories(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.histories = new Resource$Projects$Histories();
     }
 
 
@@ -1479,7 +1464,7 @@ export namespace toolresults_v1beta3 {
         params,
         requiredParams: ['projectId'],
         pathParams: ['projectId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ProjectSettings>(parameters, callback);
@@ -1568,7 +1553,7 @@ export namespace toolresults_v1beta3 {
         params,
         requiredParams: ['projectId'],
         pathParams: ['projectId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ProjectSettings>(parameters, callback);
@@ -1604,16 +1589,9 @@ export namespace toolresults_v1beta3 {
   }
 
   export class Resource$Projects$Histories {
-    root: Toolresults;
     executions: Resource$Projects$Histories$Executions;
-    constructor(root: Toolresults) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.executions = new Resource$Projects$Histories$Executions(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.executions = new Resource$Projects$Histories$Executions();
     }
 
 
@@ -1680,7 +1658,7 @@ export namespace toolresults_v1beta3 {
         params,
         requiredParams: ['projectId'],
         pathParams: ['projectId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$History>(parameters, callback);
@@ -1748,7 +1726,7 @@ export namespace toolresults_v1beta3 {
         params,
         requiredParams: ['projectId', 'historyId'],
         pathParams: ['historyId', 'projectId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$History>(parameters, callback);
@@ -1825,7 +1803,7 @@ export namespace toolresults_v1beta3 {
         params,
         requiredParams: ['projectId'],
         pathParams: ['projectId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListHistoriesResponse>(parameters, callback);
@@ -1901,18 +1879,11 @@ export namespace toolresults_v1beta3 {
   }
 
   export class Resource$Projects$Histories$Executions {
-    root: Toolresults;
     clusters: Resource$Projects$Histories$Executions$Clusters;
     steps: Resource$Projects$Histories$Executions$Steps;
-    constructor(root: Toolresults) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.clusters = new Resource$Projects$Histories$Executions$Clusters(root);
-      this.steps = new Resource$Projects$Histories$Executions$Steps(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.clusters = new Resource$Projects$Histories$Executions$Clusters();
+      this.steps = new Resource$Projects$Histories$Executions$Steps();
     }
 
 
@@ -1982,7 +1953,7 @@ export namespace toolresults_v1beta3 {
         params,
         requiredParams: ['projectId', 'historyId'],
         pathParams: ['historyId', 'projectId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Execution>(parameters, callback);
@@ -2052,7 +2023,7 @@ export namespace toolresults_v1beta3 {
         params,
         requiredParams: ['projectId', 'historyId', 'executionId'],
         pathParams: ['executionId', 'historyId', 'projectId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Execution>(parameters, callback);
@@ -2130,7 +2101,7 @@ export namespace toolresults_v1beta3 {
         params,
         requiredParams: ['projectId', 'historyId'],
         pathParams: ['historyId', 'projectId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListExecutionsResponse>(parameters, callback);
@@ -2208,7 +2179,7 @@ export namespace toolresults_v1beta3 {
         params,
         requiredParams: ['projectId', 'historyId', 'executionId'],
         pathParams: ['executionId', 'historyId', 'projectId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Execution>(parameters, callback);
@@ -2322,15 +2293,7 @@ export namespace toolresults_v1beta3 {
   }
 
   export class Resource$Projects$Histories$Executions$Clusters {
-    root: Toolresults;
-    constructor(root: Toolresults) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -2393,7 +2356,7 @@ export namespace toolresults_v1beta3 {
         params,
         requiredParams: ['projectId', 'historyId', 'executionId', 'clusterId'],
         pathParams: ['clusterId', 'executionId', 'historyId', 'projectId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ScreenshotCluster>(parameters, callback);
@@ -2477,7 +2440,7 @@ export namespace toolresults_v1beta3 {
         params,
         requiredParams: ['projectId', 'historyId', 'executionId'],
         pathParams: ['executionId', 'historyId', 'projectId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListScreenshotClustersResponse>(
@@ -2536,27 +2499,18 @@ export namespace toolresults_v1beta3 {
 
 
   export class Resource$Projects$Histories$Executions$Steps {
-    root: Toolresults;
     perfMetricsSummary:
         Resource$Projects$Histories$Executions$Steps$Perfmetricssummary;
     perfSampleSeries:
         Resource$Projects$Histories$Executions$Steps$Perfsampleseries;
     thumbnails: Resource$Projects$Histories$Executions$Steps$Thumbnails;
-    constructor(root: Toolresults) {
-      this.root = root;
-      this.getRoot.bind(this);
+    constructor() {
       this.perfMetricsSummary =
-          new Resource$Projects$Histories$Executions$Steps$Perfmetricssummary(
-              root);
+          new Resource$Projects$Histories$Executions$Steps$Perfmetricssummary();
       this.perfSampleSeries =
-          new Resource$Projects$Histories$Executions$Steps$Perfsampleseries(
-              root);
+          new Resource$Projects$Histories$Executions$Steps$Perfsampleseries();
       this.thumbnails =
-          new Resource$Projects$Histories$Executions$Steps$Thumbnails(root);
-    }
-
-    getRoot() {
-      return this.root;
+          new Resource$Projects$Histories$Executions$Steps$Thumbnails();
     }
 
 
@@ -2629,7 +2583,7 @@ export namespace toolresults_v1beta3 {
         params,
         requiredParams: ['projectId', 'historyId', 'executionId'],
         pathParams: ['executionId', 'historyId', 'projectId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Step>(parameters, callback);
@@ -2700,7 +2654,7 @@ export namespace toolresults_v1beta3 {
         params,
         requiredParams: ['projectId', 'historyId', 'executionId', 'stepId'],
         pathParams: ['executionId', 'historyId', 'projectId', 'stepId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Step>(parameters, callback);
@@ -2781,7 +2735,7 @@ export namespace toolresults_v1beta3 {
         params,
         requiredParams: ['projectId', 'historyId', 'executionId', 'stepId'],
         pathParams: ['executionId', 'historyId', 'projectId', 'stepId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$PerfMetricsSummary>(parameters, callback);
@@ -2862,7 +2816,7 @@ export namespace toolresults_v1beta3 {
         params,
         requiredParams: ['projectId', 'historyId', 'executionId'],
         pathParams: ['executionId', 'historyId', 'projectId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListStepsResponse>(parameters, callback);
@@ -2943,7 +2897,7 @@ export namespace toolresults_v1beta3 {
         params,
         requiredParams: ['projectId', 'historyId', 'executionId', 'stepId'],
         pathParams: ['executionId', 'historyId', 'projectId', 'stepId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Step>(parameters, callback);
@@ -3026,7 +2980,7 @@ export namespace toolresults_v1beta3 {
         params,
         requiredParams: ['projectId', 'historyId', 'executionId', 'stepId'],
         pathParams: ['executionId', 'historyId', 'projectId', 'stepId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Step>(parameters, callback);
@@ -3208,15 +3162,7 @@ export namespace toolresults_v1beta3 {
   }
 
   export class Resource$Projects$Histories$Executions$Steps$Perfmetricssummary {
-    root: Toolresults;
-    constructor(root: Toolresults) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -3290,7 +3236,7 @@ export namespace toolresults_v1beta3 {
         params,
         requiredParams: ['projectId', 'historyId', 'executionId', 'stepId'],
         pathParams: ['executionId', 'historyId', 'projectId', 'stepId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$PerfMetricsSummary>(parameters, callback);
@@ -3332,19 +3278,11 @@ export namespace toolresults_v1beta3 {
 
 
   export class Resource$Projects$Histories$Executions$Steps$Perfsampleseries {
-    root: Toolresults;
     samples:
         Resource$Projects$Histories$Executions$Steps$Perfsampleseries$Samples;
-    constructor(root: Toolresults) {
-      this.root = root;
-      this.getRoot.bind(this);
+    constructor() {
       this.samples =
-          new Resource$Projects$Histories$Executions$Steps$Perfsampleseries$Samples(
-              root);
-    }
-
-    getRoot() {
-      return this.root;
+          new Resource$Projects$Histories$Executions$Steps$Perfsampleseries$Samples();
     }
 
 
@@ -3419,7 +3357,7 @@ export namespace toolresults_v1beta3 {
         params,
         requiredParams: ['projectId', 'historyId', 'executionId', 'stepId'],
         pathParams: ['executionId', 'historyId', 'projectId', 'stepId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$PerfSampleSeries>(parameters, callback);
@@ -3499,7 +3437,7 @@ export namespace toolresults_v1beta3 {
         pathParams: [
           'executionId', 'historyId', 'projectId', 'sampleSeriesId', 'stepId'
         ],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$PerfSampleSeries>(parameters, callback);
@@ -3587,7 +3525,7 @@ export namespace toolresults_v1beta3 {
         params,
         requiredParams: ['projectId', 'historyId', 'executionId', 'stepId'],
         pathParams: ['executionId', 'historyId', 'projectId', 'stepId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListPerfSampleSeriesResponse>(
@@ -3688,15 +3626,7 @@ export namespace toolresults_v1beta3 {
 
   export class
       Resource$Projects$Histories$Executions$Steps$Perfsampleseries$Samples {
-    root: Toolresults;
-    constructor(root: Toolresults) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -3786,7 +3716,7 @@ export namespace toolresults_v1beta3 {
         pathParams: [
           'executionId', 'historyId', 'projectId', 'sampleSeriesId', 'stepId'
         ],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$BatchCreatePerfSamplesResponse>(
@@ -3882,7 +3812,7 @@ export namespace toolresults_v1beta3 {
         pathParams: [
           'executionId', 'historyId', 'projectId', 'sampleSeriesId', 'stepId'
         ],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListPerfSamplesResponse>(parameters, callback);
@@ -3966,15 +3896,7 @@ export namespace toolresults_v1beta3 {
 
 
   export class Resource$Projects$Histories$Executions$Steps$Thumbnails {
-    root: Toolresults;
-    constructor(root: Toolresults) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -4055,7 +3977,7 @@ export namespace toolresults_v1beta3 {
         params,
         requiredParams: ['projectId', 'historyId', 'executionId', 'stepId'],
         pathParams: ['executionId', 'historyId', 'projectId', 'stepId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListStepThumbnailsResponse>(

--- a/src/apis/tpu/v1.ts
+++ b/src/apis/tpu/v1.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace tpu_v1 {
   export interface Options extends GlobalOptions {
     version: 'v1';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -96,22 +98,12 @@ export namespace tpu_v1 {
    * @param {object=} options Options for Tpu
    */
   export class Tpu {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     projects: Resource$Projects;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.projects = new Resource$Projects(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.projects = new Resource$Projects();
     }
   }
 
@@ -496,39 +488,25 @@ export namespace tpu_v1 {
 
 
   export class Resource$Projects {
-    root: Tpu;
     locations: Resource$Projects$Locations;
-    constructor(root: Tpu) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.locations = new Resource$Projects$Locations(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.locations = new Resource$Projects$Locations();
     }
   }
 
 
   export class Resource$Projects$Locations {
-    root: Tpu;
     acceleratorTypes: Resource$Projects$Locations$Acceleratortypes;
     nodes: Resource$Projects$Locations$Nodes;
     operations: Resource$Projects$Locations$Operations;
     tensorflowVersions: Resource$Projects$Locations$Tensorflowversions;
-    constructor(root: Tpu) {
-      this.root = root;
-      this.getRoot.bind(this);
+    constructor() {
       this.acceleratorTypes =
-          new Resource$Projects$Locations$Acceleratortypes(root);
-      this.nodes = new Resource$Projects$Locations$Nodes(root);
-      this.operations = new Resource$Projects$Locations$Operations(root);
+          new Resource$Projects$Locations$Acceleratortypes();
+      this.nodes = new Resource$Projects$Locations$Nodes();
+      this.operations = new Resource$Projects$Locations$Operations();
       this.tensorflowVersions =
-          new Resource$Projects$Locations$Tensorflowversions(root);
-    }
-
-    getRoot() {
-      return this.root;
+          new Resource$Projects$Locations$Tensorflowversions();
     }
 
 
@@ -583,7 +561,7 @@ export namespace tpu_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Location>(parameters, callback);
@@ -654,7 +632,7 @@ export namespace tpu_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListLocationsResponse>(parameters, callback);
@@ -702,15 +680,7 @@ export namespace tpu_v1 {
   }
 
   export class Resource$Projects$Locations$Acceleratortypes {
-    root: Tpu;
-    constructor(root: Tpu) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -766,7 +736,7 @@ export namespace tpu_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$AcceleratorType>(parameters, callback);
@@ -843,7 +813,7 @@ export namespace tpu_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListAcceleratorTypesResponse>(
@@ -898,15 +868,7 @@ export namespace tpu_v1 {
 
 
   export class Resource$Projects$Locations$Nodes {
-    root: Tpu;
-    constructor(root: Tpu) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -968,7 +930,7 @@ export namespace tpu_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -1034,7 +996,7 @@ export namespace tpu_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -1095,7 +1057,7 @@ export namespace tpu_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Node>(parameters, callback);
@@ -1164,7 +1126,7 @@ export namespace tpu_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListNodesResponse>(parameters, callback);
@@ -1232,7 +1194,7 @@ export namespace tpu_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -1300,7 +1262,7 @@ export namespace tpu_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -1367,7 +1329,7 @@ export namespace tpu_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -1496,15 +1458,7 @@ export namespace tpu_v1 {
 
 
   export class Resource$Projects$Locations$Operations {
-    root: Tpu;
-    constructor(root: Tpu) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -1571,7 +1525,7 @@ export namespace tpu_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -1639,7 +1593,7 @@ export namespace tpu_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -1703,7 +1657,7 @@ export namespace tpu_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -1782,7 +1736,7 @@ export namespace tpu_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListOperationsResponse>(parameters, callback);
@@ -1855,15 +1809,7 @@ export namespace tpu_v1 {
 
 
   export class Resource$Projects$Locations$Tensorflowversions {
-    root: Tpu;
-    constructor(root: Tpu) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -1920,7 +1866,7 @@ export namespace tpu_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TensorFlowVersion>(parameters, callback);
@@ -1998,7 +1944,7 @@ export namespace tpu_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListTensorFlowVersionsResponse>(

--- a/src/apis/tpu/v1alpha1.ts
+++ b/src/apis/tpu/v1alpha1.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace tpu_v1alpha1 {
   export interface Options extends GlobalOptions {
     version: 'v1alpha1';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -96,22 +98,12 @@ export namespace tpu_v1alpha1 {
    * @param {object=} options Options for Tpu
    */
   export class Tpu {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     projects: Resource$Projects;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.projects = new Resource$Projects(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.projects = new Resource$Projects();
     }
   }
 
@@ -496,39 +488,25 @@ export namespace tpu_v1alpha1 {
 
 
   export class Resource$Projects {
-    root: Tpu;
     locations: Resource$Projects$Locations;
-    constructor(root: Tpu) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.locations = new Resource$Projects$Locations(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.locations = new Resource$Projects$Locations();
     }
   }
 
 
   export class Resource$Projects$Locations {
-    root: Tpu;
     acceleratorTypes: Resource$Projects$Locations$Acceleratortypes;
     nodes: Resource$Projects$Locations$Nodes;
     operations: Resource$Projects$Locations$Operations;
     tensorflowVersions: Resource$Projects$Locations$Tensorflowversions;
-    constructor(root: Tpu) {
-      this.root = root;
-      this.getRoot.bind(this);
+    constructor() {
       this.acceleratorTypes =
-          new Resource$Projects$Locations$Acceleratortypes(root);
-      this.nodes = new Resource$Projects$Locations$Nodes(root);
-      this.operations = new Resource$Projects$Locations$Operations(root);
+          new Resource$Projects$Locations$Acceleratortypes();
+      this.nodes = new Resource$Projects$Locations$Nodes();
+      this.operations = new Resource$Projects$Locations$Operations();
       this.tensorflowVersions =
-          new Resource$Projects$Locations$Tensorflowversions(root);
-    }
-
-    getRoot() {
-      return this.root;
+          new Resource$Projects$Locations$Tensorflowversions();
     }
 
 
@@ -584,7 +562,7 @@ export namespace tpu_v1alpha1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Location>(parameters, callback);
@@ -655,7 +633,7 @@ export namespace tpu_v1alpha1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListLocationsResponse>(parameters, callback);
@@ -703,15 +681,7 @@ export namespace tpu_v1alpha1 {
   }
 
   export class Resource$Projects$Locations$Acceleratortypes {
-    root: Tpu;
-    constructor(root: Tpu) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -768,7 +738,7 @@ export namespace tpu_v1alpha1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$AcceleratorType>(parameters, callback);
@@ -845,7 +815,7 @@ export namespace tpu_v1alpha1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListAcceleratorTypesResponse>(
@@ -900,15 +870,7 @@ export namespace tpu_v1alpha1 {
 
 
   export class Resource$Projects$Locations$Nodes {
-    root: Tpu;
-    constructor(root: Tpu) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -970,7 +932,7 @@ export namespace tpu_v1alpha1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -1037,7 +999,7 @@ export namespace tpu_v1alpha1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -1099,7 +1061,7 @@ export namespace tpu_v1alpha1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Node>(parameters, callback);
@@ -1168,7 +1130,7 @@ export namespace tpu_v1alpha1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListNodesResponse>(parameters, callback);
@@ -1236,7 +1198,7 @@ export namespace tpu_v1alpha1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -1304,7 +1266,7 @@ export namespace tpu_v1alpha1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -1372,7 +1334,7 @@ export namespace tpu_v1alpha1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -1501,15 +1463,7 @@ export namespace tpu_v1alpha1 {
 
 
   export class Resource$Projects$Locations$Operations {
-    root: Tpu;
-    constructor(root: Tpu) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -1576,7 +1530,7 @@ export namespace tpu_v1alpha1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -1645,7 +1599,7 @@ export namespace tpu_v1alpha1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -1710,7 +1664,7 @@ export namespace tpu_v1alpha1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -1789,7 +1743,7 @@ export namespace tpu_v1alpha1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListOperationsResponse>(parameters, callback);
@@ -1862,15 +1816,7 @@ export namespace tpu_v1alpha1 {
 
 
   export class Resource$Projects$Locations$Tensorflowversions {
-    root: Tpu;
-    constructor(root: Tpu) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -1928,7 +1874,7 @@ export namespace tpu_v1alpha1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TensorFlowVersion>(parameters, callback);
@@ -2006,7 +1952,7 @@ export namespace tpu_v1alpha1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListTensorFlowVersionsResponse>(

--- a/src/apis/translate/v2.ts
+++ b/src/apis/translate/v2.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace translate_v2 {
   export interface Options extends GlobalOptions {
     version: 'v2';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -105,26 +107,16 @@ export namespace translate_v2 {
    * @param {object=} options Options for Translate
    */
   export class Translate {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     detections: Resource$Detections;
     languages: Resource$Languages;
     translations: Resource$Translations;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.detections = new Resource$Detections(this);
-      this.languages = new Resource$Languages(this);
-      this.translations = new Resource$Translations(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.detections = new Resource$Detections();
+      this.languages = new Resource$Languages();
+      this.translations = new Resource$Translations();
     }
   }
 
@@ -246,15 +238,7 @@ export namespace translate_v2 {
 
 
   export class Resource$Detections {
-    root: Translate;
-    constructor(root: Translate) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -314,7 +298,7 @@ export namespace translate_v2 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$DetectionsListResponse>(parameters, callback);
@@ -380,7 +364,7 @@ export namespace translate_v2 {
         params,
         requiredParams: ['q'],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$DetectionsListResponse>(parameters, callback);
@@ -418,15 +402,7 @@ export namespace translate_v2 {
 
 
   export class Resource$Languages {
-    root: Translate;
-    constructor(root: Translate) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -486,7 +462,7 @@ export namespace translate_v2 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$LanguagesListResponse>(parameters, callback);
@@ -515,15 +491,7 @@ export namespace translate_v2 {
 
 
   export class Resource$Translations {
-    root: Translate;
-    constructor(root: Translate) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -588,7 +556,7 @@ export namespace translate_v2 {
         params,
         requiredParams: ['q', 'target'],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TranslationsListResponse>(parameters, callback);
@@ -657,7 +625,7 @@ export namespace translate_v2 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$TranslationsListResponse>(parameters, callback);

--- a/src/apis/urlshortener/v1.ts
+++ b/src/apis/urlshortener/v1.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace urlshortener_v1 {
   export interface Options extends GlobalOptions {
     version: 'v1';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -79,22 +81,12 @@ export namespace urlshortener_v1 {
    * @param {object=} options Options for Urlshortener
    */
   export class Urlshortener {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     url: Resource$Url;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.url = new Resource$Url(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.url = new Resource$Url();
     }
   }
 
@@ -224,15 +216,7 @@ export namespace urlshortener_v1 {
 
 
   export class Resource$Url {
-    root: Urlshortener;
-    constructor(root: Urlshortener) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -287,7 +271,7 @@ export namespace urlshortener_v1 {
         params,
         requiredParams: ['shortUrl'],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Url>(parameters, callback);
@@ -351,7 +335,7 @@ export namespace urlshortener_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Url>(parameters, callback);
@@ -417,7 +401,7 @@ export namespace urlshortener_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$UrlHistory>(parameters, callback);

--- a/src/apis/vault/v1.ts
+++ b/src/apis/vault/v1.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace vault_v1 {
   export interface Options extends GlobalOptions {
     version: 'v1';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -96,22 +98,12 @@ export namespace vault_v1 {
    * @param {object=} options Options for Vault
    */
   export class Vault {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     matters: Resource$Matters;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.matters = new Resource$Matters(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.matters = new Resource$Matters();
     }
   }
 
@@ -893,20 +885,13 @@ export namespace vault_v1 {
 
 
   export class Resource$Matters {
-    root: Vault;
     exports: Resource$Matters$Exports;
     holds: Resource$Matters$Holds;
     savedQueries: Resource$Matters$Savedqueries;
-    constructor(root: Vault) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.exports = new Resource$Matters$Exports(root);
-      this.holds = new Resource$Matters$Holds(root);
-      this.savedQueries = new Resource$Matters$Savedqueries(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.exports = new Resource$Matters$Exports();
+      this.holds = new Resource$Matters$Holds();
+      this.savedQueries = new Resource$Matters$Savedqueries();
     }
 
 
@@ -969,7 +954,7 @@ export namespace vault_v1 {
         params,
         requiredParams: ['matterId'],
         pathParams: ['matterId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$MatterPermission>(parameters, callback);
@@ -1035,7 +1020,7 @@ export namespace vault_v1 {
         params,
         requiredParams: ['matterId'],
         pathParams: ['matterId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$CloseMatterResponse>(parameters, callback);
@@ -1100,7 +1085,7 @@ export namespace vault_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Matter>(parameters, callback);
@@ -1164,7 +1149,7 @@ export namespace vault_v1 {
         params,
         requiredParams: ['matterId'],
         pathParams: ['matterId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Matter>(parameters, callback);
@@ -1226,7 +1211,7 @@ export namespace vault_v1 {
         params,
         requiredParams: ['matterId'],
         pathParams: ['matterId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Matter>(parameters, callback);
@@ -1293,7 +1278,7 @@ export namespace vault_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListMattersResponse>(parameters, callback);
@@ -1360,7 +1345,7 @@ export namespace vault_v1 {
         params,
         requiredParams: ['matterId'],
         pathParams: ['matterId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -1427,7 +1412,7 @@ export namespace vault_v1 {
         params,
         requiredParams: ['matterId'],
         pathParams: ['matterId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ReopenMatterResponse>(parameters, callback);
@@ -1493,7 +1478,7 @@ export namespace vault_v1 {
         params,
         requiredParams: ['matterId'],
         pathParams: ['matterId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Matter>(parameters, callback);
@@ -1560,7 +1545,7 @@ export namespace vault_v1 {
         params,
         requiredParams: ['matterId'],
         pathParams: ['matterId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Matter>(parameters, callback);
@@ -1733,15 +1718,7 @@ export namespace vault_v1 {
   }
 
   export class Resource$Matters$Exports {
-    root: Vault;
-    constructor(root: Vault) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -1801,7 +1778,7 @@ export namespace vault_v1 {
         params,
         requiredParams: ['matterId'],
         pathParams: ['matterId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Export>(parameters, callback);
@@ -1868,7 +1845,7 @@ export namespace vault_v1 {
         params,
         requiredParams: ['matterId', 'exportId'],
         pathParams: ['exportId', 'matterId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -1931,7 +1908,7 @@ export namespace vault_v1 {
         params,
         requiredParams: ['matterId', 'exportId'],
         pathParams: ['exportId', 'matterId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Export>(parameters, callback);
@@ -2000,7 +1977,7 @@ export namespace vault_v1 {
         params,
         requiredParams: ['matterId'],
         pathParams: ['matterId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListExportsResponse>(parameters, callback);
@@ -2082,16 +2059,9 @@ export namespace vault_v1 {
 
 
   export class Resource$Matters$Holds {
-    root: Vault;
     accounts: Resource$Matters$Holds$Accounts;
-    constructor(root: Vault) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.accounts = new Resource$Matters$Holds$Accounts(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.accounts = new Resource$Matters$Holds$Accounts();
     }
 
 
@@ -2159,7 +2129,7 @@ export namespace vault_v1 {
         params,
         requiredParams: ['matterId', 'holdId'],
         pathParams: ['holdId', 'matterId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$AddHeldAccountsResponse>(parameters, callback);
@@ -2226,7 +2196,7 @@ export namespace vault_v1 {
         params,
         requiredParams: ['matterId'],
         pathParams: ['matterId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Hold>(parameters, callback);
@@ -2294,7 +2264,7 @@ export namespace vault_v1 {
         params,
         requiredParams: ['matterId', 'holdId'],
         pathParams: ['holdId', 'matterId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -2358,7 +2328,7 @@ export namespace vault_v1 {
         params,
         requiredParams: ['matterId', 'holdId'],
         pathParams: ['holdId', 'matterId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Hold>(parameters, callback);
@@ -2428,7 +2398,7 @@ export namespace vault_v1 {
         params,
         requiredParams: ['matterId'],
         pathParams: ['matterId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListHoldsResponse>(parameters, callback);
@@ -2506,7 +2476,7 @@ export namespace vault_v1 {
         params,
         requiredParams: ['matterId', 'holdId'],
         pathParams: ['holdId', 'matterId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$RemoveHeldAccountsResponse>(
@@ -2577,7 +2547,7 @@ export namespace vault_v1 {
         params,
         requiredParams: ['matterId', 'holdId'],
         pathParams: ['holdId', 'matterId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Hold>(parameters, callback);
@@ -2731,15 +2701,7 @@ export namespace vault_v1 {
   }
 
   export class Resource$Matters$Holds$Accounts {
-    root: Vault;
-    constructor(root: Vault) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -2803,7 +2765,7 @@ export namespace vault_v1 {
         params,
         requiredParams: ['matterId', 'holdId'],
         pathParams: ['holdId', 'matterId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$HeldAccount>(parameters, callback);
@@ -2874,7 +2836,7 @@ export namespace vault_v1 {
         params,
         requiredParams: ['matterId', 'holdId', 'accountId'],
         pathParams: ['accountId', 'holdId', 'matterId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -2946,7 +2908,7 @@ export namespace vault_v1 {
         params,
         requiredParams: ['matterId', 'holdId'],
         pathParams: ['holdId', 'matterId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListHeldAccountsResponse>(parameters, callback);
@@ -3017,15 +2979,7 @@ export namespace vault_v1 {
 
 
   export class Resource$Matters$Savedqueries {
-    root: Vault;
-    constructor(root: Vault) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -3086,7 +3040,7 @@ export namespace vault_v1 {
         params,
         requiredParams: ['matterId'],
         pathParams: ['matterId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$SavedQuery>(parameters, callback);
@@ -3154,7 +3108,7 @@ export namespace vault_v1 {
         params,
         requiredParams: ['matterId', 'savedQueryId'],
         pathParams: ['matterId', 'savedQueryId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -3219,7 +3173,7 @@ export namespace vault_v1 {
         params,
         requiredParams: ['matterId', 'savedQueryId'],
         pathParams: ['matterId', 'savedQueryId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$SavedQuery>(parameters, callback);
@@ -3290,7 +3244,7 @@ export namespace vault_v1 {
         params,
         requiredParams: ['matterId'],
         pathParams: ['matterId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListSavedQueriesResponse>(parameters, callback);

--- a/src/apis/videointelligence/v1.ts
+++ b/src/apis/videointelligence/v1.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace videointelligence_v1 {
   export interface Options extends GlobalOptions {
     version: 'v1';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -97,24 +99,14 @@ export namespace videointelligence_v1 {
    * @param {object=} options Options for Videointelligence
    */
   export class Videointelligence {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     operations: Resource$Operations;
     videos: Resource$Videos;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.operations = new Resource$Operations(this);
-      this.videos = new Resource$Videos(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.operations = new Resource$Operations();
+      this.videos = new Resource$Videos();
     }
   }
 
@@ -1738,15 +1730,7 @@ export namespace videointelligence_v1 {
 
 
   export class Resource$Operations {
-    root: Videointelligence;
-    constructor(root: Videointelligence) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -1816,7 +1800,7 @@ export namespace videointelligence_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleProtobuf_Empty>(parameters, callback);
@@ -1887,7 +1871,7 @@ export namespace videointelligence_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleProtobuf_Empty>(parameters, callback);
@@ -1956,7 +1940,7 @@ export namespace videointelligence_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleLongrunning_Operation>(
@@ -2038,7 +2022,7 @@ export namespace videointelligence_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleLongrunning_ListOperationsResponse>(
@@ -2116,15 +2100,7 @@ export namespace videointelligence_v1 {
 
 
   export class Resource$Videos {
-    root: Videointelligence;
-    constructor(root: Videointelligence) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -2191,7 +2167,7 @@ export namespace videointelligence_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleLongrunning_Operation>(

--- a/src/apis/videointelligence/v1beta2.ts
+++ b/src/apis/videointelligence/v1beta2.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace videointelligence_v1beta2 {
   export interface Options extends GlobalOptions {
     version: 'v1beta2';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -97,22 +99,12 @@ export namespace videointelligence_v1beta2 {
    * @param {object=} options Options for Videointelligence
    */
   export class Videointelligence {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     videos: Resource$Videos;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.videos = new Resource$Videos(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.videos = new Resource$Videos();
     }
   }
 
@@ -1711,15 +1703,7 @@ export namespace videointelligence_v1beta2 {
 
 
   export class Resource$Videos {
-    root: Videointelligence;
-    constructor(root: Videointelligence) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -1786,7 +1770,7 @@ export namespace videointelligence_v1beta2 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleLongrunning_Operation>(

--- a/src/apis/videointelligence/v1p1beta1.ts
+++ b/src/apis/videointelligence/v1p1beta1.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace videointelligence_v1p1beta1 {
   export interface Options extends GlobalOptions {
     version: 'v1p1beta1';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -97,22 +99,12 @@ export namespace videointelligence_v1p1beta1 {
    * @param {object=} options Options for Videointelligence
    */
   export class Videointelligence {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     videos: Resource$Videos;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.videos = new Resource$Videos(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.videos = new Resource$Videos();
     }
   }
 
@@ -1712,15 +1704,7 @@ export namespace videointelligence_v1p1beta1 {
 
 
   export class Resource$Videos {
-    root: Videointelligence;
-    constructor(root: Videointelligence) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -1787,7 +1771,7 @@ export namespace videointelligence_v1p1beta1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleLongrunning_Operation>(

--- a/src/apis/vision/v1.ts
+++ b/src/apis/vision/v1.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace vision_v1 {
   export interface Options extends GlobalOptions {
     version: 'v1';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -98,10 +100,6 @@ export namespace vision_v1 {
    * @param {object=} options Options for Vision
    */
   export class Vision {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     files: Resource$Files;
     images: Resource$Images;
     locations: Resource$Locations;
@@ -109,19 +107,13 @@ export namespace vision_v1 {
     projects: Resource$Projects;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.files = new Resource$Files(this);
-      this.images = new Resource$Images(this);
-      this.locations = new Resource$Locations(this);
-      this.operations = new Resource$Operations(this);
-      this.projects = new Resource$Projects(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.files = new Resource$Files();
+      this.images = new Resource$Images();
+      this.locations = new Resource$Locations();
+      this.operations = new Resource$Operations();
+      this.projects = new Resource$Projects();
     }
   }
 
@@ -4801,15 +4793,7 @@ export namespace vision_v1 {
 
 
   export class Resource$Files {
-    root: Vision;
-    constructor(root: Vision) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -4874,7 +4858,7 @@ export namespace vision_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -4900,15 +4884,7 @@ export namespace vision_v1 {
 
 
   export class Resource$Images {
-    root: Vision;
-    constructor(root: Vision) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -5025,7 +5001,7 @@ export namespace vision_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$BatchAnnotateImagesResponse>(
@@ -5051,30 +5027,15 @@ export namespace vision_v1 {
 
 
   export class Resource$Locations {
-    root: Vision;
     operations: Resource$Locations$Operations;
-    constructor(root: Vision) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.operations = new Resource$Locations$Operations(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.operations = new Resource$Locations$Operations();
     }
   }
 
 
   export class Resource$Locations$Operations {
-    root: Vision;
-    constructor(root: Vision) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -5131,7 +5092,7 @@ export namespace vision_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -5157,15 +5118,7 @@ export namespace vision_v1 {
 
 
   export class Resource$Operations {
-    root: Vision;
-    constructor(root: Vision) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -5232,7 +5185,7 @@ export namespace vision_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -5299,7 +5252,7 @@ export namespace vision_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -5362,7 +5315,7 @@ export namespace vision_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -5438,7 +5391,7 @@ export namespace vision_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListOperationsResponse>(parameters, callback);
@@ -5514,49 +5467,28 @@ export namespace vision_v1 {
 
 
   export class Resource$Projects {
-    root: Vision;
     locations: Resource$Projects$Locations;
-    constructor(root: Vision) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.locations = new Resource$Projects$Locations(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.locations = new Resource$Projects$Locations();
     }
   }
 
 
   export class Resource$Projects$Locations {
-    root: Vision;
     products: Resource$Projects$Locations$Products;
     productSets: Resource$Projects$Locations$Productsets;
-    constructor(root: Vision) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.products = new Resource$Projects$Locations$Products(root);
-      this.productSets = new Resource$Projects$Locations$Productsets(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.products = new Resource$Projects$Locations$Products();
+      this.productSets = new Resource$Projects$Locations$Productsets();
     }
   }
 
 
   export class Resource$Projects$Locations$Products {
-    root: Vision;
     referenceImages: Resource$Projects$Locations$Products$Referenceimages;
-    constructor(root: Vision) {
-      this.root = root;
-      this.getRoot.bind(this);
+    constructor() {
       this.referenceImages =
-          new Resource$Projects$Locations$Products$Referenceimages(root);
-    }
-
-    getRoot() {
-      return this.root;
+          new Resource$Projects$Locations$Products$Referenceimages();
     }
 
 
@@ -5622,7 +5554,7 @@ export namespace vision_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Product>(parameters, callback);
@@ -5691,7 +5623,7 @@ export namespace vision_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -5753,7 +5685,7 @@ export namespace vision_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Product>(parameters, callback);
@@ -5824,7 +5756,7 @@ export namespace vision_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListProductsResponse>(parameters, callback);
@@ -5899,7 +5831,7 @@ export namespace vision_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Product>(parameters, callback);
@@ -6008,15 +5940,7 @@ export namespace vision_v1 {
   }
 
   export class Resource$Projects$Locations$Products$Referenceimages {
-    root: Vision;
-    constructor(root: Vision) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -6095,7 +6019,7 @@ export namespace vision_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ReferenceImage>(parameters, callback);
@@ -6169,7 +6093,7 @@ export namespace vision_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -6235,7 +6159,7 @@ export namespace vision_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ReferenceImage>(parameters, callback);
@@ -6316,7 +6240,7 @@ export namespace vision_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListReferenceImagesResponse>(
@@ -6405,17 +6329,9 @@ export namespace vision_v1 {
 
 
   export class Resource$Projects$Locations$Productsets {
-    root: Vision;
     products: Resource$Projects$Locations$Productsets$Products;
-    constructor(root: Vision) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.products =
-          new Resource$Projects$Locations$Productsets$Products(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.products = new Resource$Projects$Locations$Productsets$Products();
     }
 
 
@@ -6481,7 +6397,7 @@ export namespace vision_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -6553,7 +6469,7 @@ export namespace vision_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ProductSet>(parameters, callback);
@@ -6622,7 +6538,7 @@ export namespace vision_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -6685,7 +6601,7 @@ export namespace vision_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ProductSet>(parameters, callback);
@@ -6732,7 +6648,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Locations$Productsets$Import|
     options = {};
                                                                                                                                                                                                                                                                                                }
 
-                                                                                                                                                                                                                                                                                               const rootUrl = options.rootUrl || 'https://vision.googleapis.com/'; const parameters = {options: Object.assign({url: (rootUrl + '/v1/{+parent}/productSets:import').replace(/([^:]\/)\/+/g, '$1'), method: 'POST'}, options), params, requiredParams: ['parent'], pathParams: ['parent'], context: this.getRoot()}; if(callback) {
+                                                                                                                                                                                                                                                                                               const rootUrl = options.rootUrl || 'https://vision.googleapis.com/'; const parameters = {options: Object.assign({url: (rootUrl + '/v1/{+parent}/productSets:import').replace(/([^:]\/)\/+/g, '$1'), method: 'POST'}, options), params, requiredParams: ['parent'], pathParams: ['parent'], context}; if(callback) {
     createAPIRequest<Schema$Operation>(parameters, callback);
                                                                                                                                                                                                                                                                                                } else {
     return createAPIRequest<Schema$Operation>(parameters);
@@ -6797,7 +6713,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Locations$Productsets$Import|
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListProductSetsResponse>(parameters, callback);
@@ -6869,7 +6785,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Locations$Productsets$Import|
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ProductSet>(parameters, callback);
@@ -6939,7 +6855,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Locations$Productsets$Import|
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -7102,15 +7018,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Locations$Productsets$Import|
   }
 
   export class Resource$Projects$Locations$Productsets$Products {
-    root: Vision;
-    constructor(root: Vision) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -7186,7 +7094,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Locations$Productsets$Import|
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListProductsInProductSetResponse>(

--- a/src/apis/vision/v1p1beta1.ts
+++ b/src/apis/vision/v1p1beta1.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace vision_v1p1beta1 {
   export interface Options extends GlobalOptions {
     version: 'v1p1beta1';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -98,24 +100,14 @@ export namespace vision_v1p1beta1 {
    * @param {object=} options Options for Vision
    */
   export class Vision {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     files: Resource$Files;
     images: Resource$Images;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.files = new Resource$Files(this);
-      this.images = new Resource$Images(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.files = new Resource$Files();
+      this.images = new Resource$Images();
     }
   }
 
@@ -4599,15 +4591,7 @@ export namespace vision_v1p1beta1 {
 
 
   export class Resource$Files {
-    root: Vision;
-    constructor(root: Vision) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -4672,7 +4656,7 @@ export namespace vision_v1p1beta1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -4699,15 +4683,7 @@ export namespace vision_v1p1beta1 {
 
 
   export class Resource$Images {
-    root: Vision;
-    constructor(root: Vision) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -4775,7 +4751,7 @@ export namespace vision_v1p1beta1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<

--- a/src/apis/vision/v1p2beta1.ts
+++ b/src/apis/vision/v1p2beta1.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace vision_v1p2beta1 {
   export interface Options extends GlobalOptions {
     version: 'v1p2beta1';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -98,24 +100,14 @@ export namespace vision_v1p2beta1 {
    * @param {object=} options Options for Vision
    */
   export class Vision {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     files: Resource$Files;
     images: Resource$Images;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.files = new Resource$Files(this);
-      this.images = new Resource$Images(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.files = new Resource$Files();
+      this.images = new Resource$Images();
     }
   }
 
@@ -4599,15 +4591,7 @@ export namespace vision_v1p2beta1 {
 
 
   export class Resource$Files {
-    root: Vision;
-    constructor(root: Vision) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -4672,7 +4656,7 @@ export namespace vision_v1p2beta1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -4699,15 +4683,7 @@ export namespace vision_v1p2beta1 {
 
 
   export class Resource$Images {
-    root: Vision;
-    constructor(root: Vision) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -4775,7 +4751,7 @@ export namespace vision_v1p2beta1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<

--- a/src/apis/webfonts/v1.ts
+++ b/src/apis/webfonts/v1.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace webfonts_v1 {
   export interface Options extends GlobalOptions {
     version: 'v1';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -81,22 +83,12 @@ export namespace webfonts_v1 {
    * @param {object=} options Options for Webfonts
    */
   export class Webfonts {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     webfonts: Resource$Webfonts;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.webfonts = new Resource$Webfonts(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.webfonts = new Resource$Webfonts();
     }
   }
 
@@ -149,15 +141,7 @@ export namespace webfonts_v1 {
 
 
   export class Resource$Webfonts {
-    root: Webfonts;
-    constructor(root: Webfonts) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -216,7 +200,7 @@ export namespace webfonts_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$WebfontList>(parameters, callback);

--- a/src/apis/webmasters/v3.ts
+++ b/src/apis/webmasters/v3.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace webmasters_v3 {
   export interface Options extends GlobalOptions {
     version: 'v3';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -79,10 +81,6 @@ export namespace webmasters_v3 {
    * @param {object=} options Options for Webmasters
    */
   export class Webmasters {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     searchanalytics: Resource$Searchanalytics;
     sitemaps: Resource$Sitemaps;
     sites: Resource$Sites;
@@ -90,19 +88,13 @@ export namespace webmasters_v3 {
     urlcrawlerrorssamples: Resource$Urlcrawlerrorssamples;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.searchanalytics = new Resource$Searchanalytics(this);
-      this.sitemaps = new Resource$Sitemaps(this);
-      this.sites = new Resource$Sites(this);
-      this.urlcrawlerrorscounts = new Resource$Urlcrawlerrorscounts(this);
-      this.urlcrawlerrorssamples = new Resource$Urlcrawlerrorssamples(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.searchanalytics = new Resource$Searchanalytics();
+      this.sitemaps = new Resource$Sitemaps();
+      this.sites = new Resource$Sites();
+      this.urlcrawlerrorscounts = new Resource$Urlcrawlerrorscounts();
+      this.urlcrawlerrorssamples = new Resource$Urlcrawlerrorssamples();
     }
   }
 
@@ -383,15 +375,7 @@ export namespace webmasters_v3 {
 
 
   export class Resource$Searchanalytics {
-    root: Webmasters;
-    constructor(root: Webmasters) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -463,7 +447,7 @@ export namespace webmasters_v3 {
         params,
         requiredParams: ['siteUrl'],
         pathParams: ['siteUrl'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$SearchAnalyticsQueryResponse>(
@@ -495,15 +479,7 @@ export namespace webmasters_v3 {
 
 
   export class Resource$Sitemaps {
-    root: Webmasters;
-    constructor(root: Webmasters) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -561,7 +537,7 @@ export namespace webmasters_v3 {
         params,
         requiredParams: ['siteUrl', 'feedpath'],
         pathParams: ['feedpath', 'siteUrl'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -625,7 +601,7 @@ export namespace webmasters_v3 {
         params,
         requiredParams: ['siteUrl', 'feedpath'],
         pathParams: ['feedpath', 'siteUrl'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$WmxSitemap>(parameters, callback);
@@ -693,7 +669,7 @@ export namespace webmasters_v3 {
         params,
         requiredParams: ['siteUrl'],
         pathParams: ['siteUrl'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$SitemapsListResponse>(parameters, callback);
@@ -758,7 +734,7 @@ export namespace webmasters_v3 {
         params,
         requiredParams: ['siteUrl', 'feedpath'],
         pathParams: ['feedpath', 'siteUrl'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -835,15 +811,7 @@ export namespace webmasters_v3 {
 
 
   export class Resource$Sites {
-    root: Webmasters;
-    constructor(root: Webmasters) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -895,7 +863,7 @@ export namespace webmasters_v3 {
         params,
         requiredParams: ['siteUrl'],
         pathParams: ['siteUrl'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -958,7 +926,7 @@ export namespace webmasters_v3 {
         params,
         requiredParams: ['siteUrl'],
         pathParams: ['siteUrl'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -1019,7 +987,7 @@ export namespace webmasters_v3 {
         params,
         requiredParams: ['siteUrl'],
         pathParams: ['siteUrl'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$WmxSite>(parameters, callback);
@@ -1083,7 +1051,7 @@ export namespace webmasters_v3 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$SitesListResponse>(parameters, callback);
@@ -1141,15 +1109,7 @@ export namespace webmasters_v3 {
 
 
   export class Resource$Urlcrawlerrorscounts {
-    root: Webmasters;
-    constructor(root: Webmasters) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -1223,7 +1183,7 @@ export namespace webmasters_v3 {
         params,
         requiredParams: ['siteUrl'],
         pathParams: ['siteUrl'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$UrlCrawlErrorsCountsQueryResponse>(
@@ -1264,15 +1224,7 @@ export namespace webmasters_v3 {
 
 
   export class Resource$Urlcrawlerrorssamples {
-    root: Webmasters;
-    constructor(root: Webmasters) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -1334,7 +1286,7 @@ export namespace webmasters_v3 {
         params,
         requiredParams: ['siteUrl', 'url', 'category', 'platform'],
         pathParams: ['siteUrl', 'url'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$UrlCrawlErrorsSample>(parameters, callback);
@@ -1414,7 +1366,7 @@ export namespace webmasters_v3 {
         params,
         requiredParams: ['siteUrl', 'category', 'platform'],
         pathParams: ['siteUrl'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$UrlCrawlErrorsSamplesListResponse>(
@@ -1487,7 +1439,7 @@ export namespace webmasters_v3 {
         params,
         requiredParams: ['siteUrl', 'url', 'category', 'platform'],
         pathParams: ['siteUrl', 'url'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);

--- a/src/apis/websecurityscanner/v1alpha.ts
+++ b/src/apis/websecurityscanner/v1alpha.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace websecurityscanner_v1alpha {
   export interface Options extends GlobalOptions {
     version: 'v1alpha';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -96,22 +98,12 @@ export namespace websecurityscanner_v1alpha {
    * @param {object=} options Options for Websecurityscanner
    */
   export class Websecurityscanner {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     projects: Resource$Projects;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.projects = new Resource$Projects(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.projects = new Resource$Projects();
     }
   }
 
@@ -556,31 +548,17 @@ export namespace websecurityscanner_v1alpha {
 
 
   export class Resource$Projects {
-    root: Websecurityscanner;
     scanConfigs: Resource$Projects$Scanconfigs;
-    constructor(root: Websecurityscanner) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.scanConfigs = new Resource$Projects$Scanconfigs(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.scanConfigs = new Resource$Projects$Scanconfigs();
     }
   }
 
 
   export class Resource$Projects$Scanconfigs {
-    root: Websecurityscanner;
     scanRuns: Resource$Projects$Scanconfigs$Scanruns;
-    constructor(root: Websecurityscanner) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.scanRuns = new Resource$Projects$Scanconfigs$Scanruns(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.scanRuns = new Resource$Projects$Scanconfigs$Scanruns();
     }
 
 
@@ -643,7 +621,7 @@ export namespace websecurityscanner_v1alpha {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ScanConfig>(parameters, callback);
@@ -709,7 +687,7 @@ export namespace websecurityscanner_v1alpha {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -772,7 +750,7 @@ export namespace websecurityscanner_v1alpha {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ScanConfig>(parameters, callback);
@@ -843,7 +821,7 @@ export namespace websecurityscanner_v1alpha {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListScanConfigsResponse>(parameters, callback);
@@ -913,7 +891,7 @@ export namespace websecurityscanner_v1alpha {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ScanConfig>(parameters, callback);
@@ -981,7 +959,7 @@ export namespace websecurityscanner_v1alpha {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ScanRun>(parameters, callback);
@@ -1105,22 +1083,15 @@ export namespace websecurityscanner_v1alpha {
   }
 
   export class Resource$Projects$Scanconfigs$Scanruns {
-    root: Websecurityscanner;
     crawledUrls: Resource$Projects$Scanconfigs$Scanruns$Crawledurls;
     findings: Resource$Projects$Scanconfigs$Scanruns$Findings;
     findingTypeStats: Resource$Projects$Scanconfigs$Scanruns$Findingtypestats;
-    constructor(root: Websecurityscanner) {
-      this.root = root;
-      this.getRoot.bind(this);
+    constructor() {
       this.crawledUrls =
-          new Resource$Projects$Scanconfigs$Scanruns$Crawledurls(root);
-      this.findings = new Resource$Projects$Scanconfigs$Scanruns$Findings(root);
+          new Resource$Projects$Scanconfigs$Scanruns$Crawledurls();
+      this.findings = new Resource$Projects$Scanconfigs$Scanruns$Findings();
       this.findingTypeStats =
-          new Resource$Projects$Scanconfigs$Scanruns$Findingtypestats(root);
-    }
-
-    getRoot() {
-      return this.root;
+          new Resource$Projects$Scanconfigs$Scanruns$Findingtypestats();
     }
 
 
@@ -1176,7 +1147,7 @@ export namespace websecurityscanner_v1alpha {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ScanRun>(parameters, callback);
@@ -1248,7 +1219,7 @@ export namespace websecurityscanner_v1alpha {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListScanRunsResponse>(parameters, callback);
@@ -1316,7 +1287,7 @@ export namespace websecurityscanner_v1alpha {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ScanRun>(parameters, callback);
@@ -1386,15 +1357,7 @@ export namespace websecurityscanner_v1alpha {
   }
 
   export class Resource$Projects$Scanconfigs$Scanruns$Crawledurls {
-    root: Websecurityscanner;
-    constructor(root: Websecurityscanner) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -1460,7 +1423,7 @@ export namespace websecurityscanner_v1alpha {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListCrawledUrlsResponse>(parameters, callback);
@@ -1499,15 +1462,7 @@ export namespace websecurityscanner_v1alpha {
 
 
   export class Resource$Projects$Scanconfigs$Scanruns$Findings {
-    root: Websecurityscanner;
-    constructor(root: Websecurityscanner) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -1564,7 +1519,7 @@ export namespace websecurityscanner_v1alpha {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Finding>(parameters, callback);
@@ -1638,7 +1593,7 @@ export namespace websecurityscanner_v1alpha {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListFindingsResponse>(parameters, callback);
@@ -1697,15 +1652,7 @@ export namespace websecurityscanner_v1alpha {
 
 
   export class Resource$Projects$Scanconfigs$Scanruns$Findingtypestats {
-    root: Websecurityscanner;
-    constructor(root: Websecurityscanner) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -1777,7 +1724,7 @@ export namespace websecurityscanner_v1alpha {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListFindingTypeStatsResponse>(

--- a/src/apis/youtube/v3.ts
+++ b/src/apis/youtube/v3.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace youtube_v3 {
   export interface Options extends GlobalOptions {
     version: 'v3';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -80,10 +82,6 @@ export namespace youtube_v3 {
    * @param {object=} options Options for Youtube
    */
   export class Youtube {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     activities: Resource$Activities;
     captions: Resource$Captions;
     channelBanners: Resource$Channelbanners;
@@ -112,40 +110,34 @@ export namespace youtube_v3 {
     watermarks: Resource$Watermarks;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.activities = new Resource$Activities(this);
-      this.captions = new Resource$Captions(this);
-      this.channelBanners = new Resource$Channelbanners(this);
-      this.channels = new Resource$Channels(this);
-      this.channelSections = new Resource$Channelsections(this);
-      this.comments = new Resource$Comments(this);
-      this.commentThreads = new Resource$Commentthreads(this);
-      this.guideCategories = new Resource$Guidecategories(this);
-      this.i18nLanguages = new Resource$I18nlanguages(this);
-      this.i18nRegions = new Resource$I18nregions(this);
-      this.liveBroadcasts = new Resource$Livebroadcasts(this);
-      this.liveChatBans = new Resource$Livechatbans(this);
-      this.liveChatMessages = new Resource$Livechatmessages(this);
-      this.liveChatModerators = new Resource$Livechatmoderators(this);
-      this.liveStreams = new Resource$Livestreams(this);
-      this.playlistItems = new Resource$Playlistitems(this);
-      this.playlists = new Resource$Playlists(this);
-      this.search = new Resource$Search(this);
-      this.sponsors = new Resource$Sponsors(this);
-      this.subscriptions = new Resource$Subscriptions(this);
-      this.superChatEvents = new Resource$Superchatevents(this);
-      this.thumbnails = new Resource$Thumbnails(this);
-      this.videoAbuseReportReasons = new Resource$Videoabusereportreasons(this);
-      this.videoCategories = new Resource$Videocategories(this);
-      this.videos = new Resource$Videos(this);
-      this.watermarks = new Resource$Watermarks(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.activities = new Resource$Activities();
+      this.captions = new Resource$Captions();
+      this.channelBanners = new Resource$Channelbanners();
+      this.channels = new Resource$Channels();
+      this.channelSections = new Resource$Channelsections();
+      this.comments = new Resource$Comments();
+      this.commentThreads = new Resource$Commentthreads();
+      this.guideCategories = new Resource$Guidecategories();
+      this.i18nLanguages = new Resource$I18nlanguages();
+      this.i18nRegions = new Resource$I18nregions();
+      this.liveBroadcasts = new Resource$Livebroadcasts();
+      this.liveChatBans = new Resource$Livechatbans();
+      this.liveChatMessages = new Resource$Livechatmessages();
+      this.liveChatModerators = new Resource$Livechatmoderators();
+      this.liveStreams = new Resource$Livestreams();
+      this.playlistItems = new Resource$Playlistitems();
+      this.playlists = new Resource$Playlists();
+      this.search = new Resource$Search();
+      this.sponsors = new Resource$Sponsors();
+      this.subscriptions = new Resource$Subscriptions();
+      this.superChatEvents = new Resource$Superchatevents();
+      this.thumbnails = new Resource$Thumbnails();
+      this.videoAbuseReportReasons = new Resource$Videoabusereportreasons();
+      this.videoCategories = new Resource$Videocategories();
+      this.videos = new Resource$Videos();
+      this.watermarks = new Resource$Watermarks();
     }
   }
 
@@ -4987,15 +4979,7 @@ export namespace youtube_v3 {
 
 
   export class Resource$Activities {
-    root: Youtube;
-    constructor(root: Youtube) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -5060,7 +5044,7 @@ export namespace youtube_v3 {
         params,
         requiredParams: ['part'],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Activity>(parameters, callback);
@@ -5138,7 +5122,7 @@ export namespace youtube_v3 {
         params,
         requiredParams: ['part'],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ActivityListResponse>(parameters, callback);
@@ -5238,15 +5222,7 @@ export namespace youtube_v3 {
 
 
   export class Resource$Captions {
-    root: Youtube;
-    constructor(root: Youtube) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -5304,7 +5280,7 @@ export namespace youtube_v3 {
         params,
         requiredParams: ['id'],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -5376,7 +5352,7 @@ export namespace youtube_v3 {
         params,
         requiredParams: ['id'],
         pathParams: ['id'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -5449,7 +5425,7 @@ export namespace youtube_v3 {
                       .replace(/([^:]\/)\/+/g, '$1'),
         requiredParams: ['part'],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Caption>(parameters, callback);
@@ -5521,7 +5497,7 @@ export namespace youtube_v3 {
         params,
         requiredParams: ['part', 'videoId'],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$CaptionListResponse>(parameters, callback);
@@ -5596,7 +5572,7 @@ export namespace youtube_v3 {
                       .replace(/([^:]\/)\/+/g, '$1'),
         requiredParams: ['part'],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Caption>(parameters, callback);
@@ -5848,15 +5824,7 @@ export namespace youtube_v3 {
 
 
   export class Resource$Channelbanners {
-    root: Youtube;
-    constructor(root: Youtube) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -5932,7 +5900,7 @@ export namespace youtube_v3 {
                       .replace(/([^:]\/)\/+/g, '$1'),
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ChannelBannerResource>(parameters, callback);
@@ -5997,15 +5965,7 @@ export namespace youtube_v3 {
 
 
   export class Resource$Channels {
-    root: Youtube;
-    constructor(root: Youtube) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -6074,7 +6034,7 @@ export namespace youtube_v3 {
         params,
         requiredParams: ['part'],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ChannelListResponse>(parameters, callback);
@@ -6142,7 +6102,7 @@ export namespace youtube_v3 {
         params,
         requiredParams: ['part'],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Channel>(parameters, callback);
@@ -6270,15 +6230,7 @@ export namespace youtube_v3 {
 
 
   export class Resource$Channelsections {
-    root: Youtube;
-    constructor(root: Youtube) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -6337,7 +6289,7 @@ export namespace youtube_v3 {
         params,
         requiredParams: ['id'],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -6407,7 +6359,7 @@ export namespace youtube_v3 {
         params,
         requiredParams: ['part'],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ChannelSection>(parameters, callback);
@@ -6484,7 +6436,7 @@ export namespace youtube_v3 {
         params,
         requiredParams: ['part'],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ChannelSectionListResponse>(
@@ -6554,7 +6506,7 @@ export namespace youtube_v3 {
         params,
         requiredParams: ['part'],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ChannelSection>(parameters, callback);
@@ -6739,15 +6691,7 @@ export namespace youtube_v3 {
 
 
   export class Resource$Comments {
-    root: Youtube;
-    constructor(root: Youtube) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -6803,7 +6747,7 @@ export namespace youtube_v3 {
         params,
         requiredParams: ['id'],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -6869,7 +6813,7 @@ export namespace youtube_v3 {
         params,
         requiredParams: ['part'],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Comment>(parameters, callback);
@@ -6939,7 +6883,7 @@ export namespace youtube_v3 {
         params,
         requiredParams: ['part'],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$CommentListResponse>(parameters, callback);
@@ -7005,7 +6949,7 @@ export namespace youtube_v3 {
         params,
         requiredParams: ['id'],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -7074,7 +7018,7 @@ export namespace youtube_v3 {
         params,
         requiredParams: ['id', 'moderationStatus'],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -7139,7 +7083,7 @@ export namespace youtube_v3 {
         params,
         requiredParams: ['part'],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Comment>(parameters, callback);
@@ -7281,15 +7225,7 @@ export namespace youtube_v3 {
 
 
   export class Resource$Commentthreads {
-    root: Youtube;
-    constructor(root: Youtube) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -7351,7 +7287,7 @@ export namespace youtube_v3 {
         params,
         requiredParams: ['part'],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$CommentThread>(parameters, callback);
@@ -7430,7 +7366,7 @@ export namespace youtube_v3 {
         params,
         requiredParams: ['part'],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$CommentThreadListResponse>(
@@ -7499,7 +7435,7 @@ export namespace youtube_v3 {
         params,
         requiredParams: ['part'],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$CommentThread>(parameters, callback);
@@ -7625,15 +7561,7 @@ export namespace youtube_v3 {
 
 
   export class Resource$Guidecategories {
-    root: Youtube;
-    constructor(root: Youtube) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -7699,7 +7627,7 @@ export namespace youtube_v3 {
         params,
         requiredParams: ['part'],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GuideCategoryListResponse>(
@@ -7744,15 +7672,7 @@ export namespace youtube_v3 {
 
 
   export class Resource$I18nlanguages {
-    root: Youtube;
-    constructor(root: Youtube) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -7814,7 +7734,7 @@ export namespace youtube_v3 {
         params,
         requiredParams: ['part'],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$I18nLanguageListResponse>(parameters, callback);
@@ -7845,15 +7765,7 @@ export namespace youtube_v3 {
 
 
   export class Resource$I18nregions {
-    root: Youtube;
-    constructor(root: Youtube) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -7914,7 +7826,7 @@ export namespace youtube_v3 {
         params,
         requiredParams: ['part'],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$I18nRegionListResponse>(parameters, callback);
@@ -7944,15 +7856,7 @@ export namespace youtube_v3 {
 
 
   export class Resource$Livebroadcasts {
-    root: Youtube;
-    constructor(root: Youtube) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -8018,7 +7922,7 @@ export namespace youtube_v3 {
         params,
         requiredParams: ['id', 'part'],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$LiveBroadcast>(parameters, callback);
@@ -8092,7 +7996,7 @@ export namespace youtube_v3 {
         params,
         requiredParams: ['id', 'part'],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$LiveBroadcast>(parameters, callback);
@@ -8159,7 +8063,7 @@ export namespace youtube_v3 {
         params,
         requiredParams: ['id'],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -8229,7 +8133,7 @@ export namespace youtube_v3 {
         params,
         requiredParams: ['part'],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$LiveBroadcast>(parameters, callback);
@@ -8306,7 +8210,7 @@ export namespace youtube_v3 {
         params,
         requiredParams: ['part'],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$LiveBroadcastListResponse>(
@@ -8383,7 +8287,7 @@ export namespace youtube_v3 {
         params,
         requiredParams: ['broadcastStatus', 'id', 'part'],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$LiveBroadcast>(parameters, callback);
@@ -8454,7 +8358,7 @@ export namespace youtube_v3 {
         params,
         requiredParams: ['part'],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$LiveBroadcast>(parameters, callback);
@@ -8900,15 +8804,7 @@ export namespace youtube_v3 {
 
 
   export class Resource$Livechatbans {
-    root: Youtube;
-    constructor(root: Youtube) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -8966,7 +8862,7 @@ export namespace youtube_v3 {
         params,
         requiredParams: ['id'],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -9034,7 +8930,7 @@ export namespace youtube_v3 {
         params,
         requiredParams: ['part'],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$LiveChatBan>(parameters, callback);
@@ -9080,15 +8976,7 @@ export namespace youtube_v3 {
 
 
   export class Resource$Livechatmessages {
-    root: Youtube;
-    constructor(root: Youtube) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -9146,7 +9034,7 @@ export namespace youtube_v3 {
         params,
         requiredParams: ['id'],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -9214,7 +9102,7 @@ export namespace youtube_v3 {
         params,
         requiredParams: ['part'],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$LiveChatMessage>(parameters, callback);
@@ -9291,7 +9179,7 @@ export namespace youtube_v3 {
         params,
         requiredParams: ['liveChatId', 'part'],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$LiveChatMessageListResponse>(
@@ -9382,15 +9270,7 @@ export namespace youtube_v3 {
 
 
   export class Resource$Livechatmoderators {
-    root: Youtube;
-    constructor(root: Youtube) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -9448,7 +9328,7 @@ export namespace youtube_v3 {
         params,
         requiredParams: ['id'],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -9516,7 +9396,7 @@ export namespace youtube_v3 {
         params,
         requiredParams: ['part'],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$LiveChatModerator>(parameters, callback);
@@ -9591,7 +9471,7 @@ export namespace youtube_v3 {
         params,
         requiredParams: ['liveChatId', 'part'],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$LiveChatModeratorListResponse>(
@@ -9668,15 +9548,7 @@ export namespace youtube_v3 {
 
 
   export class Resource$Livestreams {
-    root: Youtube;
-    constructor(root: Youtube) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -9736,7 +9608,7 @@ export namespace youtube_v3 {
         params,
         requiredParams: ['id'],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -9807,7 +9679,7 @@ export namespace youtube_v3 {
         params,
         requiredParams: ['part'],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$LiveStream>(parameters, callback);
@@ -9880,7 +9752,7 @@ export namespace youtube_v3 {
         params,
         requiredParams: ['part'],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$LiveStreamListResponse>(parameters, callback);
@@ -9952,7 +9824,7 @@ export namespace youtube_v3 {
         params,
         requiredParams: ['part'],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$LiveStream>(parameters, callback);
@@ -10187,15 +10059,7 @@ export namespace youtube_v3 {
 
 
   export class Resource$Playlistitems {
-    root: Youtube;
-    constructor(root: Youtube) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -10254,7 +10118,7 @@ export namespace youtube_v3 {
         params,
         requiredParams: ['id'],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -10323,7 +10187,7 @@ export namespace youtube_v3 {
         params,
         requiredParams: ['part'],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$PlaylistItem>(parameters, callback);
@@ -10398,7 +10262,7 @@ export namespace youtube_v3 {
         params,
         requiredParams: ['part'],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$PlaylistItemListResponse>(parameters, callback);
@@ -10468,7 +10332,7 @@ export namespace youtube_v3 {
         params,
         requiredParams: ['part'],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$PlaylistItem>(parameters, callback);
@@ -10642,15 +10506,7 @@ export namespace youtube_v3 {
 
 
   export class Resource$Playlists {
-    root: Youtube;
-    constructor(root: Youtube) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -10707,7 +10563,7 @@ export namespace youtube_v3 {
         params,
         requiredParams: ['id'],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -10774,7 +10630,7 @@ export namespace youtube_v3 {
         params,
         requiredParams: ['part'],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Playlist>(parameters, callback);
@@ -10851,7 +10707,7 @@ export namespace youtube_v3 {
         params,
         requiredParams: ['part'],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$PlaylistListResponse>(parameters, callback);
@@ -10918,7 +10774,7 @@ export namespace youtube_v3 {
         params,
         requiredParams: ['part'],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Playlist>(parameters, callback);
@@ -11125,15 +10981,7 @@ export namespace youtube_v3 {
 
 
   export class Resource$Search {
-    root: Youtube;
-    constructor(root: Youtube) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -11224,7 +11072,7 @@ export namespace youtube_v3 {
         params,
         requiredParams: ['part'],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$SearchListResponse>(parameters, callback);
@@ -11464,15 +11312,7 @@ export namespace youtube_v3 {
 
 
   export class Resource$Sponsors {
-    root: Youtube;
-    constructor(root: Youtube) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -11533,7 +11373,7 @@ export namespace youtube_v3 {
         params,
         requiredParams: ['part'],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$SponsorListResponse>(parameters, callback);
@@ -11573,15 +11413,7 @@ export namespace youtube_v3 {
 
 
   export class Resource$Subscriptions {
-    root: Youtube;
-    constructor(root: Youtube) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -11639,7 +11471,7 @@ export namespace youtube_v3 {
         params,
         requiredParams: ['id'],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -11707,7 +11539,7 @@ export namespace youtube_v3 {
         params,
         requiredParams: ['part'],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Subscription>(parameters, callback);
@@ -11785,7 +11617,7 @@ export namespace youtube_v3 {
         params,
         requiredParams: ['part'],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$SubscriptionListResponse>(parameters, callback);
@@ -11930,15 +11762,7 @@ export namespace youtube_v3 {
 
 
   export class Resource$Superchatevents {
-    root: Youtube;
-    constructor(root: Youtube) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -12005,7 +11829,7 @@ export namespace youtube_v3 {
         params,
         requiredParams: ['part'],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$SuperChatEventListResponse>(
@@ -12054,15 +11878,7 @@ export namespace youtube_v3 {
 
 
   export class Resource$Thumbnails {
-    root: Youtube;
-    constructor(root: Youtube) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -12125,7 +11941,7 @@ export namespace youtube_v3 {
                       .replace(/([^:]\/)\/+/g, '$1'),
         requiredParams: ['videoId'],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ThumbnailSetResponse>(parameters, callback);
@@ -12179,15 +11995,7 @@ export namespace youtube_v3 {
 
 
   export class Resource$Videoabusereportreasons {
-    root: Youtube;
-    constructor(root: Youtube) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -12258,7 +12066,7 @@ export namespace youtube_v3 {
         params,
         requiredParams: ['part'],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$VideoAbuseReportReasonListResponse>(
@@ -12291,15 +12099,7 @@ export namespace youtube_v3 {
 
 
   export class Resource$Videocategories {
-    root: Youtube;
-    constructor(root: Youtube) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -12365,7 +12165,7 @@ export namespace youtube_v3 {
         params,
         requiredParams: ['part'],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$VideoCategoryListResponse>(
@@ -12408,15 +12208,7 @@ export namespace youtube_v3 {
 
 
   export class Resource$Videos {
-    root: Youtube;
-    constructor(root: Youtube) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -12473,7 +12265,7 @@ export namespace youtube_v3 {
         params,
         requiredParams: ['id'],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -12543,7 +12335,7 @@ export namespace youtube_v3 {
         params,
         requiredParams: ['id'],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$VideoGetRatingResponse>(parameters, callback);
@@ -12619,7 +12411,7 @@ export namespace youtube_v3 {
                       .replace(/([^:]\/)\/+/g, '$1'),
         requiredParams: ['part'],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Video>(parameters, callback);
@@ -12696,7 +12488,7 @@ export namespace youtube_v3 {
         params,
         requiredParams: ['part'],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$VideoListResponse>(parameters, callback);
@@ -12761,7 +12553,7 @@ export namespace youtube_v3 {
         params,
         requiredParams: ['id', 'rating'],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -12827,7 +12619,7 @@ export namespace youtube_v3 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -12893,7 +12685,7 @@ export namespace youtube_v3 {
         params,
         requiredParams: ['part'],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Video>(parameters, callback);
@@ -13236,15 +13028,7 @@ export namespace youtube_v3 {
 
 
   export class Resource$Watermarks {
-    root: Youtube;
-    constructor(root: Youtube) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -13304,7 +13088,7 @@ export namespace youtube_v3 {
                       .replace(/([^:]\/)\/+/g, '$1'),
         requiredParams: ['channelId'],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -13368,7 +13152,7 @@ export namespace youtube_v3 {
         params,
         requiredParams: ['channelId'],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);

--- a/src/apis/youtubeAnalytics/v1.ts
+++ b/src/apis/youtubeAnalytics/v1.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace youtubeAnalytics_v1 {
   export interface Options extends GlobalOptions {
     version: 'v1';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -79,26 +81,16 @@ export namespace youtubeAnalytics_v1 {
    * @param {object=} options Options for Youtubeanalytics
    */
   export class Youtubeanalytics {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     groupItems: Resource$Groupitems;
     groups: Resource$Groups;
     reports: Resource$Reports;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.groupItems = new Resource$Groupitems(this);
-      this.groups = new Resource$Groups(this);
-      this.reports = new Resource$Reports(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.groupItems = new Resource$Groupitems();
+      this.groups = new Resource$Groups();
+      this.reports = new Resource$Reports();
     }
   }
 
@@ -176,15 +168,7 @@ export namespace youtubeAnalytics_v1 {
 
 
   export class Resource$Groupitems {
-    root: Youtubeanalytics;
-    constructor(root: Youtubeanalytics) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -242,7 +226,7 @@ export namespace youtubeAnalytics_v1 {
         params,
         requiredParams: ['id'],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -309,7 +293,7 @@ export namespace youtubeAnalytics_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GroupItem>(parameters, callback);
@@ -377,7 +361,7 @@ export namespace youtubeAnalytics_v1 {
         params,
         requiredParams: ['groupId'],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GroupItemListResponse>(parameters, callback);
@@ -467,15 +451,7 @@ export namespace youtubeAnalytics_v1 {
 
 
   export class Resource$Groups {
-    root: Youtubeanalytics;
-    constructor(root: Youtubeanalytics) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -532,7 +508,7 @@ export namespace youtubeAnalytics_v1 {
         params,
         requiredParams: ['id'],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -597,7 +573,7 @@ export namespace youtubeAnalytics_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Group>(parameters, callback);
@@ -668,7 +644,7 @@ export namespace youtubeAnalytics_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GroupListResponse>(parameters, callback);
@@ -733,7 +709,7 @@ export namespace youtubeAnalytics_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Group>(parameters, callback);
@@ -858,15 +834,7 @@ export namespace youtubeAnalytics_v1 {
 
 
   export class Resource$Reports {
-    root: Youtubeanalytics;
-    constructor(root: Youtubeanalytics) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -934,7 +902,7 @@ export namespace youtubeAnalytics_v1 {
         params,
         requiredParams: ['ids', 'start-date', 'end-date', 'metrics'],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ResultTable>(parameters, callback);

--- a/src/apis/youtubeAnalytics/v1beta1.ts
+++ b/src/apis/youtubeAnalytics/v1beta1.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace youtubeAnalytics_v1beta1 {
   export interface Options extends GlobalOptions {
     version: 'v1beta1';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -79,26 +81,16 @@ export namespace youtubeAnalytics_v1beta1 {
    * @param {object=} options Options for Youtubeanalytics
    */
   export class Youtubeanalytics {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     groupItems: Resource$Groupitems;
     groups: Resource$Groups;
     reports: Resource$Reports;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.groupItems = new Resource$Groupitems(this);
-      this.groups = new Resource$Groups(this);
-      this.reports = new Resource$Reports(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.groupItems = new Resource$Groupitems();
+      this.groups = new Resource$Groups();
+      this.reports = new Resource$Reports();
     }
   }
 
@@ -176,15 +168,7 @@ export namespace youtubeAnalytics_v1beta1 {
 
 
   export class Resource$Groupitems {
-    root: Youtubeanalytics;
-    constructor(root: Youtubeanalytics) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -242,7 +226,7 @@ export namespace youtubeAnalytics_v1beta1 {
         params,
         requiredParams: ['id'],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -309,7 +293,7 @@ export namespace youtubeAnalytics_v1beta1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GroupItem>(parameters, callback);
@@ -377,7 +361,7 @@ export namespace youtubeAnalytics_v1beta1 {
         params,
         requiredParams: ['groupId'],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GroupItemListResponse>(parameters, callback);
@@ -467,15 +451,7 @@ export namespace youtubeAnalytics_v1beta1 {
 
 
   export class Resource$Groups {
-    root: Youtubeanalytics;
-    constructor(root: Youtubeanalytics) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -532,7 +508,7 @@ export namespace youtubeAnalytics_v1beta1 {
         params,
         requiredParams: ['id'],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -597,7 +573,7 @@ export namespace youtubeAnalytics_v1beta1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Group>(parameters, callback);
@@ -668,7 +644,7 @@ export namespace youtubeAnalytics_v1beta1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GroupListResponse>(parameters, callback);
@@ -733,7 +709,7 @@ export namespace youtubeAnalytics_v1beta1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Group>(parameters, callback);
@@ -858,15 +834,7 @@ export namespace youtubeAnalytics_v1beta1 {
 
 
   export class Resource$Reports {
-    root: Youtubeanalytics;
-    constructor(root: Youtubeanalytics) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -934,7 +902,7 @@ export namespace youtubeAnalytics_v1beta1 {
         params,
         requiredParams: ['ids', 'start-date', 'end-date', 'metrics'],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ResultTable>(parameters, callback);

--- a/src/apis/youtubeAnalytics/v2.ts
+++ b/src/apis/youtubeAnalytics/v2.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace youtubeAnalytics_v2 {
   export interface Options extends GlobalOptions {
     version: 'v2';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -96,26 +98,16 @@ export namespace youtubeAnalytics_v2 {
    * @param {object=} options Options for Youtubeanalytics
    */
   export class Youtubeanalytics {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     groupItems: Resource$Groupitems;
     groups: Resource$Groups;
     reports: Resource$Reports;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.groupItems = new Resource$Groupitems(this);
-      this.groups = new Resource$Groups(this);
-      this.reports = new Resource$Reports(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.groupItems = new Resource$Groupitems();
+      this.groups = new Resource$Groups();
+      this.reports = new Resource$Reports();
     }
   }
 
@@ -415,15 +407,7 @@ export namespace youtubeAnalytics_v2 {
 
 
   export class Resource$Groupitems {
-    root: Youtubeanalytics;
-    constructor(root: Youtubeanalytics) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -483,7 +467,7 @@ export namespace youtubeAnalytics_v2 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$EmptyResponse>(parameters, callback);
@@ -550,7 +534,7 @@ export namespace youtubeAnalytics_v2 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GroupItem>(parameters, callback);
@@ -618,7 +602,7 @@ export namespace youtubeAnalytics_v2 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListGroupItemsResponse>(parameters, callback);
@@ -708,15 +692,7 @@ export namespace youtubeAnalytics_v2 {
 
 
   export class Resource$Groups {
-    root: Youtubeanalytics;
-    constructor(root: Youtubeanalytics) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -775,7 +751,7 @@ export namespace youtubeAnalytics_v2 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$EmptyResponse>(parameters, callback);
@@ -840,7 +816,7 @@ export namespace youtubeAnalytics_v2 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Group>(parameters, callback);
@@ -911,7 +887,7 @@ export namespace youtubeAnalytics_v2 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListGroupsResponse>(parameters, callback);
@@ -976,7 +952,7 @@ export namespace youtubeAnalytics_v2 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Group>(parameters, callback);
@@ -1105,15 +1081,7 @@ export namespace youtubeAnalytics_v2 {
 
 
   export class Resource$Reports {
-    root: Youtubeanalytics;
-    constructor(root: Youtubeanalytics) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -1181,7 +1149,7 @@ export namespace youtubeAnalytics_v2 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$QueryResponse>(parameters, callback);

--- a/src/apis/youtubereporting/v1.ts
+++ b/src/apis/youtubereporting/v1.ts
@@ -16,7 +16,7 @@
 
 import {AxiosPromise} from 'axios';
 import {Compute, JWT, OAuth2Client, UserRefreshClient} from 'google-auth-library';
-import {BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
+import {APIRequestContext, BodyResponseCallback, createAPIRequest, GlobalOptions, GoogleConfigurable, MethodOptions} from 'googleapis-common';
 
 // tslint:disable: no-any
 // tslint:disable: class-name
@@ -28,6 +28,8 @@ export namespace youtubereporting_v1 {
   export interface Options extends GlobalOptions {
     version: 'v1';
   }
+
+  let context: APIRequestContext;
 
   interface StandardParameters {
     /**
@@ -97,26 +99,16 @@ export namespace youtubereporting_v1 {
    * @param {object=} options Options for Youtubereporting
    */
   export class Youtubereporting {
-    _options: GlobalOptions;
-    google?: GoogleConfigurable;
-    root = this;
-
     jobs: Resource$Jobs;
     media: Resource$Media;
     reportTypes: Resource$Reporttypes;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      this._options = options || {};
-      this.google = google;
-      this.getRoot.bind(this);
+      context = {_options: options || {}, google};
 
-      this.jobs = new Resource$Jobs(this);
-      this.media = new Resource$Media(this);
-      this.reportTypes = new Resource$Reporttypes(this);
-    }
-
-    getRoot() {
-      return this.root;
+      this.jobs = new Resource$Jobs();
+      this.media = new Resource$Media();
+      this.reportTypes = new Resource$Reporttypes();
     }
   }
 
@@ -598,16 +590,9 @@ export namespace youtubereporting_v1 {
 
 
   export class Resource$Jobs {
-    root: Youtubereporting;
     reports: Resource$Jobs$Reports;
-    constructor(root: Youtubereporting) {
-      this.root = root;
-      this.getRoot.bind(this);
-      this.reports = new Resource$Jobs$Reports(root);
-    }
-
-    getRoot() {
-      return this.root;
+    constructor() {
+      this.reports = new Resource$Jobs$Reports();
     }
 
 
@@ -666,7 +651,7 @@ export namespace youtubereporting_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Job>(parameters, callback);
@@ -731,7 +716,7 @@ export namespace youtubereporting_v1 {
         params,
         requiredParams: ['jobId'],
         pathParams: ['jobId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -793,7 +778,7 @@ export namespace youtubereporting_v1 {
         params,
         requiredParams: ['jobId'],
         pathParams: ['jobId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Job>(parameters, callback);
@@ -861,7 +846,7 @@ export namespace youtubereporting_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListJobsResponse>(parameters, callback);
@@ -951,15 +936,7 @@ export namespace youtubereporting_v1 {
   }
 
   export class Resource$Jobs$Reports {
-    root: Youtubereporting;
-    constructor(root: Youtubereporting) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -1016,7 +993,7 @@ export namespace youtubereporting_v1 {
         params,
         requiredParams: ['jobId', 'reportId'],
         pathParams: ['jobId', 'reportId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$Report>(parameters, callback);
@@ -1090,7 +1067,7 @@ export namespace youtubereporting_v1 {
         params,
         requiredParams: ['jobId'],
         pathParams: ['jobId'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListReportsResponse>(parameters, callback);
@@ -1166,15 +1143,7 @@ export namespace youtubereporting_v1 {
 
 
   export class Resource$Media {
-    root: Youtubereporting;
-    constructor(root: Youtubereporting) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -1234,7 +1203,7 @@ export namespace youtubereporting_v1 {
         params,
         requiredParams: ['resourceName'],
         pathParams: ['resourceName'],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$GdataMedia>(parameters, callback);
@@ -1258,15 +1227,7 @@ export namespace youtubereporting_v1 {
 
 
   export class Resource$Reporttypes {
-    root: Youtubereporting;
-    constructor(root: Youtubereporting) {
-      this.root = root;
-      this.getRoot.bind(this);
-    }
-
-    getRoot() {
-      return this.root;
-    }
+    constructor() {}
 
 
     /**
@@ -1328,7 +1289,7 @@ export namespace youtubereporting_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context: this.getRoot()
+        context
       };
       if (callback) {
         createAPIRequest<Schema$ListReportTypesResponse>(parameters, callback);

--- a/src/generator/templates/api-endpoint.njk
+++ b/src/generator/templates/api-endpoint.njk
@@ -19,7 +19,7 @@
  */
 
 import { OAuth2Client, JWT, Compute, UserRefreshClient } from 'google-auth-library';
-import { GoogleConfigurable, createAPIRequest, MethodOptions, GlobalOptions, BodyResponseCallback } from 'googleapis-common';
+import { GoogleConfigurable, createAPIRequest, MethodOptions, GlobalOptions, BodyResponseCallback, APIRequestContext } from 'googleapis-common';
 import { AxiosPromise } from 'axios';
 
 // tslint:disable: no-any
@@ -39,6 +39,8 @@ export namespace {{api.name}}_{{api.version|replace('\.', '_')}} {
 export interface Options extends GlobalOptions {
   version: '{{api.version|replace('\.', '_')}}';
 }
+
+let context: APIRequestContext;
 
 interface StandardParameters {
   {% for pname, p in api.parameters|dictsort %}
@@ -66,10 +68,6 @@ interface StandardParameters {
  */
 export class {{ Name }} {
 
-  _options: GlobalOptions;
-  google?: GoogleConfigurable;
-  root = this;
-
   {% if api.resources %}
     {% for rname, r in api.resources|dictsort %}
       {{ rname }}: Resource${{ rname|capitalize }};
@@ -77,19 +75,16 @@ export class {{ Name }} {
   {% endif %}
 
   constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-    this._options = options || {};
-    this.google = google;
-    this.getRoot.bind(this);
+    context = {
+      _options: options || {},
+      google
+    };
 
     {% if api.resources %}
       {% for rname, r in api.resources|dictsort %}
-        this.{{ rname }} = new Resource${{ rname|capitalize }}(this);
+        this.{{ rname }} = new Resource${{ rname|capitalize }}();
       {% endfor %}
     {% endif %}
-  }
-
-  getRoot() {
-    return this.root;
   }
 
 {% if api.methods %}

--- a/src/generator/templates/method-partial.njk
+++ b/src/generator/templates/method-partial.njk
@@ -68,7 +68,7 @@
     {% if m.mediaUpload.protocols.simple.path %}mediaUrl: (rootUrl + {{ ('/' + m.mediaUpload.protocols.simple.path)|buildurl|safe }}).replace(/([^:]\/)\/+/g, '$1'),{% endif %}
     requiredParams: [{% if m.parameterOrder.length %}'{{ m.parameterOrder|join("', '")|safe }}'{% endif %}],
     pathParams: [{% if pathParams.length %}'{{ pathParams|join("', '")|safe }}'{% endif %}],
-    context: this.getRoot()
+    context
   };
   {% set responseType = "Schema$" + m.response.$ref|default() %}
   if (callback) {

--- a/src/generator/templates/resource-partial.njk
+++ b/src/generator/templates/resource-partial.njk
@@ -1,30 +1,22 @@
 {% import "method-partial.njk" as method %}
 {% macro render(api, rootApi, classPath) %}
-{% set rootName = rootApi.name|capitalize %}
 {% if api.resources %}
   {% for rname, r in api.resources|dictsort %}
     {% set ClassName = classPath + rname|capitalize %}
     export class {{ ClassName }} {
-      root: {{ rootName }};
       {% if r.resources %}
         {% for rname, r2 in r.resources|dictsort %}
           {% set innerClassName = ClassName + "$" + rname|capitalize %}
           {{ rname }}: {{ innerClassName }};
         {% endfor %}
       {% endif %}
-      constructor(root: {{ rootName }}) {
-        this.root = root;
-        this.getRoot.bind(this);
+      constructor() {
         {% if r.resources %}
           {% for rname, r2 in r.resources|dictsort %}
             {% set innerClassName = ClassName + "$" + rname|capitalize %}
-            this.{{ rname }} = new {{ innerClassName }}(root);
+            this.{{ rname }} = new {{ innerClassName }}();
           {% endfor %}
         {% endif %}
-      }
-
-      getRoot() {
-        return this.root;
       }
 
       {% if r.methods %}

--- a/test/test.drive.v2.ts
+++ b/test/test.drive.v2.ts
@@ -14,9 +14,7 @@
 import * as assert from 'assert';
 import {APIEndpoint} from 'googleapis-common';
 import * as nock from 'nock';
-
 import {drive_v2, GoogleApis} from '../src';
-
 import {Utils} from './utils';
 
 const googleapis = new GoogleApis();
@@ -113,18 +111,6 @@ describe('drive:v2', () => {
         req = remoteDrive.files.get({fileId: '123'}, Utils.noop);
         assert.strictEqual(req, undefined);
       });
-    });
-  });
-
-  describe('._options', () => {
-    it('should exist', () => {
-      assert.notEqual(typeof localDrive._options, 'undefined');
-      assert.notEqual(typeof remoteDrive._options, 'undefined');
-    });
-
-    it('should be an object', () => {
-      assert.strictEqual(typeof localDrive._options, 'object');
-      assert.strictEqual(typeof remoteDrive._options, 'object');
     });
   });
 


### PR DESCRIPTION
This gets rid of some generated code that was responsible for helping preserve context across parent/child objects.  Turns out, it probably wasn't really needed.