### PR TITLE
fix: convert method names to camelCase

### DIFF
--- a/src/generator/templates/method-partial.njk
+++ b/src/generator/templates/method-partial.njk
@@ -39,17 +39,17 @@
  * @param {callback} callback The callback that handles the response.
  * @return {object} Request object
  */
-{{ mname }}(params?: Params${{ClassName}}${{mname|capitalize}}, options?: MethodOptions): AxiosPromise<{{ ("Schema$"+m.response.$ref) if m.response.$ref else "void" }}>;
-{{ mname }}(params: Params${{ClassName}}${{mname|capitalize}}, options: MethodOptions|BodyResponseCallback<{{ ("Schema$"+m.response.$ref) if m.response.$ref else "void" }}>, callback: BodyResponseCallback<{{ ("Schema$"+m.response.$ref) if m.response.$ref else "void" }}>): void;
-{{ mname }}(params: Params${{ClassName}}${{mname|capitalize}}, callback: BodyResponseCallback<{{ ("Schema$"+m.response.$ref) if m.response.$ref else "void" }}>): void;
-{{ mname }}(callback: BodyResponseCallback<{{ ("Schema$"+m.response.$ref) if m.response.$ref else "void" }}>): void;
-{{ mname }}(paramsOrCallback?: Params${{ClassName}}${{mname|capitalize}}|BodyResponseCallback<{{ ("Schema$"+m.response.$ref) if m.response.$ref else "void" }}>, optionsOrCallback?: MethodOptions|BodyResponseCallback<{{ ("Schema$"+m.response.$ref) if m.response.$ref else "void" }}>, callback?: BodyResponseCallback<{{ ("Schema$"+m.response.$ref) if m.response.$ref else "void" }}>): void|AxiosPromise<{{ ("Schema$"+m.response.$ref) if m.response.$ref else "void" }}> {
-  let params = (paramsOrCallback || {}) as Params${{ClassName}}${{mname|capitalize}};
+{{ mname|camelify }}(params?: Params${{ClassName}}${{mname|camelify|capitalize}}, options?: MethodOptions): AxiosPromise<{{ ("Schema$"+m.response.$ref) if m.response.$ref else "void" }}>;
+{{ mname|camelify }}(params: Params${{ClassName}}${{mname|camelify|capitalize}}, options: MethodOptions|BodyResponseCallback<{{ ("Schema$"+m.response.$ref) if m.response.$ref else "void" }}>, callback: BodyResponseCallback<{{ ("Schema$"+m.response.$ref) if m.response.$ref else "void" }}>): void;
+{{ mname|camelify }}(params: Params${{ClassName}}${{mname|camelify|capitalize}}, callback: BodyResponseCallback<{{ ("Schema$"+m.response.$ref) if m.response.$ref else "void" }}>): void;
+{{ mname|camelify }}(callback: BodyResponseCallback<{{ ("Schema$"+m.response.$ref) if m.response.$ref else "void" }}>): void;
+{{ mname|camelify }}(paramsOrCallback?: Params${{ClassName}}${{mname|camelify|capitalize}}|BodyResponseCallback<{{ ("Schema$"+m.response.$ref) if m.response.$ref else "void" }}>, optionsOrCallback?: MethodOptions|BodyResponseCallback<{{ ("Schema$"+m.response.$ref) if m.response.$ref else "void" }}>, callback?: BodyResponseCallback<{{ ("Schema$"+m.response.$ref) if m.response.$ref else "void" }}>): void|AxiosPromise<{{ ("Schema$"+m.response.$ref) if m.response.$ref else "void" }}> {
+  let params = (paramsOrCallback || {}) as Params${{ClassName}}${{mname|camelify|capitalize}};
   let options = (optionsOrCallback || {}) as MethodOptions;
 
   if (typeof paramsOrCallback === 'function') {
     callback = paramsOrCallback;
-    params = {} as Params${{ClassName}}${{mname|capitalize}};
+    params = {} as Params${{ClassName}}${{mname|camelify|capitalize}};
     options = {};
   }
 

--- a/src/generator/templates/resource-partial.njk
+++ b/src/generator/templates/resource-partial.njk
@@ -28,7 +28,7 @@
 
     {% if r.methods %}
       {% for mname, m in r.methods|dictsort %}
-        export interface Params${{ClassName}}${{ mname|capitalize }} extends StandardParameters {
+        export interface Params${{ClassName}}${{ mname|camelify|capitalize }} extends StandardParameters {
           /**
            * Auth client or API Key for the request
            */


### PR DESCRIPTION
Some APIs now contain dashes in method names ([example](https://container.googleapis.com/$discovery/rest?version=v1)). Fixing that by changing all method names to camelCase.

- [x] Tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
