### PR TITLE
Use people API instead of plus API

### DIFF
--- a/samples/people/me.js
+++ b/samples/people/me.js
@@ -16,19 +16,22 @@
 const {google} = require('googleapis');
 const sampleClient = require('../sampleclient');
 
-const plus = google.plus({
+const people = google.people({
   version: 'v1',
   auth: sampleClient.oAuth2Client,
 });
 
 async function runSample() {
-  const res = await plus.people.get({userId: 'me'});
+  // See documentation of personFields at
+  // https://developers.google.com/people/api/rest/v1/people/get
+  const res = await people.people.get({
+    resourceName: 'people/me',
+    personFields: 'emailAddresses,names,photos'
+  });
   console.log(res.data);
 }
 
 const scopes = [
-  'https://www.googleapis.com/auth/plus.login',
-  'https://www.googleapis.com/auth/plus.me',
   'https://www.googleapis.com/auth/userinfo.email',
   'https://www.googleapis.com/auth/userinfo.profile',
 ];

--- a/samples/people/me.js
+++ b/samples/people/me.js
@@ -26,7 +26,7 @@ async function runSample() {
   // https://developers.google.com/people/api/rest/v1/people/get
   const res = await people.people.get({
     resourceName: 'people/me',
-    personFields: 'emailAddresses,names,photos'
+    personFields: 'emailAddresses,names,photos',
   });
   console.log(res.data);
 }


### PR DESCRIPTION
The plus API is being deprecated. This updates the sample code to use the people API instead.

Fixes #1600.

- [x] Tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
