### PR TITLE
docs: Remove "releasing" ToC from CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,6 @@
 * [Contributor License Agreements](#contributor-license-agreements)
 * [Contributing a patch](#contributing-a-patch)
 * [Running the tests](#running-the-tests)
-* [Releasing the library](#releasing-the-library)
 
 ## Contributor License Agreements
 


### PR DESCRIPTION
## Remove "releasing" ToC from CONTRIBUTING.md
Why?
- Link does not exist.
- Releasing shouldn't be done by contributors anyways.
