### PR TITLE
fix: move context from namespace to class scope

### DIFF
--- a/src/apis/abusiveexperiencereport/v1.ts
+++ b/src/apis/abusiveexperiencereport/v1.ts
@@ -29,8 +29,6 @@ export namespace abusiveexperiencereport_v1 {
     version: 'v1';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * V1 error format.
@@ -99,14 +97,15 @@ export namespace abusiveexperiencereport_v1 {
    * @param {object=} options Options for Abusiveexperiencereport
    */
   export class Abusiveexperiencereport {
+    context: APIRequestContext;
     sites: Resource$Sites;
     violatingSites: Resource$Violatingsites;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.sites = new Resource$Sites();
-      this.violatingSites = new Resource$Violatingsites();
+      this.sites = new Resource$Sites(this.context);
+      this.violatingSites = new Resource$Violatingsites(this.context);
     }
   }
 
@@ -155,7 +154,10 @@ export namespace abusiveexperiencereport_v1 {
 
 
   export class Resource$Sites {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -210,7 +212,7 @@ export namespace abusiveexperiencereport_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$SiteSummaryResponse>(parameters, callback);
@@ -241,7 +243,10 @@ export namespace abusiveexperiencereport_v1 {
 
 
   export class Resource$Violatingsites {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -301,7 +306,7 @@ export namespace abusiveexperiencereport_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ViolatingSitesResponse>(parameters, callback);

--- a/src/apis/acceleratedmobilepageurl/v1.ts
+++ b/src/apis/acceleratedmobilepageurl/v1.ts
@@ -29,8 +29,6 @@ export namespace acceleratedmobilepageurl_v1 {
     version: 'v1';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * V1 error format.
@@ -99,12 +97,13 @@ export namespace acceleratedmobilepageurl_v1 {
    * @param {object=} options Options for Acceleratedmobilepageurl
    */
   export class Acceleratedmobilepageurl {
+    context: APIRequestContext;
     ampUrls: Resource$Ampurls;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.ampUrls = new Resource$Ampurls();
+      this.ampUrls = new Resource$Ampurls(this.context);
     }
   }
 
@@ -177,7 +176,10 @@ export namespace acceleratedmobilepageurl_v1 {
 
 
   export class Resource$Ampurls {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -240,7 +242,7 @@ export namespace acceleratedmobilepageurl_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$BatchGetAmpUrlsResponse>(parameters, callback);

--- a/src/apis/accesscontextmanager/v1.ts
+++ b/src/apis/accesscontextmanager/v1.ts
@@ -29,8 +29,6 @@ export namespace accesscontextmanager_v1 {
     version: 'v1';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * V1 error format.
@@ -99,14 +97,15 @@ export namespace accesscontextmanager_v1 {
    * @param {object=} options Options for Accesscontextmanager
    */
   export class Accesscontextmanager {
+    context: APIRequestContext;
     accessPolicies: Resource$Accesspolicies;
     operations: Resource$Operations;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.accessPolicies = new Resource$Accesspolicies();
-      this.operations = new Resource$Operations();
+      this.accessPolicies = new Resource$Accesspolicies(this.context);
+      this.operations = new Resource$Operations(this.context);
     }
   }
 
@@ -548,11 +547,15 @@ export namespace accesscontextmanager_v1 {
 
 
   export class Resource$Accesspolicies {
+    context: APIRequestContext;
     accessLevels: Resource$Accesspolicies$Accesslevels;
     servicePerimeters: Resource$Accesspolicies$Serviceperimeters;
-    constructor() {
-      this.accessLevels = new Resource$Accesspolicies$Accesslevels();
-      this.servicePerimeters = new Resource$Accesspolicies$Serviceperimeters();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.accessLevels =
+          new Resource$Accesspolicies$Accesslevels(this.context);
+      this.servicePerimeters =
+          new Resource$Accesspolicies$Serviceperimeters(this.context);
     }
 
 
@@ -618,7 +621,7 @@ export namespace accesscontextmanager_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -687,7 +690,7 @@ export namespace accesscontextmanager_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -750,7 +753,7 @@ export namespace accesscontextmanager_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AccessPolicy>(parameters, callback);
@@ -823,7 +826,7 @@ export namespace accesscontextmanager_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListAccessPoliciesResponse>(
@@ -896,7 +899,7 @@ export namespace accesscontextmanager_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -991,7 +994,10 @@ export namespace accesscontextmanager_v1 {
   }
 
   export class Resource$Accesspolicies$Accesslevels {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1056,7 +1062,7 @@ export namespace accesscontextmanager_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -1125,7 +1131,7 @@ export namespace accesscontextmanager_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -1189,7 +1195,7 @@ export namespace accesscontextmanager_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AccessLevel>(parameters, callback);
@@ -1262,7 +1268,7 @@ export namespace accesscontextmanager_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListAccessLevelsResponse>(parameters, callback);
@@ -1334,7 +1340,7 @@ export namespace accesscontextmanager_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -1451,7 +1457,10 @@ export namespace accesscontextmanager_v1 {
 
 
   export class Resource$Accesspolicies$Serviceperimeters {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1517,7 +1526,7 @@ export namespace accesscontextmanager_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -1587,7 +1596,7 @@ export namespace accesscontextmanager_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -1650,7 +1659,7 @@ export namespace accesscontextmanager_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ServicePerimeter>(parameters, callback);
@@ -1726,7 +1735,7 @@ export namespace accesscontextmanager_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListServicePerimetersResponse>(
@@ -1802,7 +1811,7 @@ export namespace accesscontextmanager_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -1905,7 +1914,10 @@ export namespace accesscontextmanager_v1 {
 
 
   export class Resource$Operations {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1973,7 +1985,7 @@ export namespace accesscontextmanager_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -2041,7 +2053,7 @@ export namespace accesscontextmanager_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -2105,7 +2117,7 @@ export namespace accesscontextmanager_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -2182,7 +2194,7 @@ export namespace accesscontextmanager_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListOperationsResponse>(parameters, callback);

--- a/src/apis/accesscontextmanager/v1beta.ts
+++ b/src/apis/accesscontextmanager/v1beta.ts
@@ -29,8 +29,6 @@ export namespace accesscontextmanager_v1beta {
     version: 'v1beta';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * V1 error format.
@@ -99,14 +97,15 @@ export namespace accesscontextmanager_v1beta {
    * @param {object=} options Options for Accesscontextmanager
    */
   export class Accesscontextmanager {
+    context: APIRequestContext;
     accessPolicies: Resource$Accesspolicies;
     operations: Resource$Operations;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.accessPolicies = new Resource$Accesspolicies();
-      this.operations = new Resource$Operations();
+      this.accessPolicies = new Resource$Accesspolicies(this.context);
+      this.operations = new Resource$Operations(this.context);
     }
   }
 
@@ -530,11 +529,15 @@ export namespace accesscontextmanager_v1beta {
 
 
   export class Resource$Accesspolicies {
+    context: APIRequestContext;
     accessLevels: Resource$Accesspolicies$Accesslevels;
     servicePerimeters: Resource$Accesspolicies$Serviceperimeters;
-    constructor() {
-      this.accessLevels = new Resource$Accesspolicies$Accesslevels();
-      this.servicePerimeters = new Resource$Accesspolicies$Serviceperimeters();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.accessLevels =
+          new Resource$Accesspolicies$Accesslevels(this.context);
+      this.servicePerimeters =
+          new Resource$Accesspolicies$Serviceperimeters(this.context);
     }
 
 
@@ -600,7 +603,7 @@ export namespace accesscontextmanager_v1beta {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -669,7 +672,7 @@ export namespace accesscontextmanager_v1beta {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -732,7 +735,7 @@ export namespace accesscontextmanager_v1beta {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AccessPolicy>(parameters, callback);
@@ -805,7 +808,7 @@ export namespace accesscontextmanager_v1beta {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListAccessPoliciesResponse>(
@@ -878,7 +881,7 @@ export namespace accesscontextmanager_v1beta {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -973,7 +976,10 @@ export namespace accesscontextmanager_v1beta {
   }
 
   export class Resource$Accesspolicies$Accesslevels {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1038,7 +1044,7 @@ export namespace accesscontextmanager_v1beta {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -1107,7 +1113,7 @@ export namespace accesscontextmanager_v1beta {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -1171,7 +1177,7 @@ export namespace accesscontextmanager_v1beta {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AccessLevel>(parameters, callback);
@@ -1244,7 +1250,7 @@ export namespace accesscontextmanager_v1beta {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListAccessLevelsResponse>(parameters, callback);
@@ -1316,7 +1322,7 @@ export namespace accesscontextmanager_v1beta {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -1433,7 +1439,10 @@ export namespace accesscontextmanager_v1beta {
 
 
   export class Resource$Accesspolicies$Serviceperimeters {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1499,7 +1508,7 @@ export namespace accesscontextmanager_v1beta {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -1569,7 +1578,7 @@ export namespace accesscontextmanager_v1beta {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -1632,7 +1641,7 @@ export namespace accesscontextmanager_v1beta {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ServicePerimeter>(parameters, callback);
@@ -1708,7 +1717,7 @@ export namespace accesscontextmanager_v1beta {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListServicePerimetersResponse>(
@@ -1784,7 +1793,7 @@ export namespace accesscontextmanager_v1beta {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -1887,7 +1896,10 @@ export namespace accesscontextmanager_v1beta {
 
 
   export class Resource$Operations {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1944,7 +1956,7 @@ export namespace accesscontextmanager_v1beta {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);

--- a/src/apis/adexchangebuyer/v1.2.ts
+++ b/src/apis/adexchangebuyer/v1.2.ts
@@ -29,8 +29,6 @@ export namespace adexchangebuyer_v1_2 {
     version: 'v1_2';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * Data format for the response.
@@ -83,14 +81,15 @@ export namespace adexchangebuyer_v1_2 {
    * @param {object=} options Options for Adexchangebuyer
    */
   export class Adexchangebuyer {
+    context: APIRequestContext;
     accounts: Resource$Accounts;
     creatives: Resource$Creatives;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.accounts = new Resource$Accounts();
-      this.creatives = new Resource$Creatives();
+      this.accounts = new Resource$Accounts(this.context);
+      this.creatives = new Resource$Creatives(this.context);
     }
   }
 
@@ -290,7 +289,10 @@ export namespace adexchangebuyer_v1_2 {
 
 
   export class Resource$Accounts {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -344,7 +346,7 @@ export namespace adexchangebuyer_v1_2 {
         params,
         requiredParams: ['id'],
         pathParams: ['id'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Account>(parameters, callback);
@@ -408,7 +410,7 @@ export namespace adexchangebuyer_v1_2 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AccountsList>(parameters, callback);
@@ -473,7 +475,7 @@ export namespace adexchangebuyer_v1_2 {
         params,
         requiredParams: ['id'],
         pathParams: ['id'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Account>(parameters, callback);
@@ -538,7 +540,7 @@ export namespace adexchangebuyer_v1_2 {
         params,
         requiredParams: ['id'],
         pathParams: ['id'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Account>(parameters, callback);
@@ -600,7 +602,10 @@ export namespace adexchangebuyer_v1_2 {
 
 
   export class Resource$Creatives {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -658,7 +663,7 @@ export namespace adexchangebuyer_v1_2 {
         params,
         requiredParams: ['accountId', 'buyerCreativeId'],
         pathParams: ['accountId', 'buyerCreativeId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Creative>(parameters, callback);
@@ -722,7 +727,7 @@ export namespace adexchangebuyer_v1_2 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Creative>(parameters, callback);
@@ -790,7 +795,7 @@ export namespace adexchangebuyer_v1_2 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$CreativesList>(parameters, callback);

--- a/src/apis/adexchangebuyer/v1.3.ts
+++ b/src/apis/adexchangebuyer/v1.3.ts
@@ -29,8 +29,6 @@ export namespace adexchangebuyer_v1_3 {
     version: 'v1_3';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * Data format for the response.
@@ -83,6 +81,7 @@ export namespace adexchangebuyer_v1_3 {
    * @param {object=} options Options for Adexchangebuyer
    */
   export class Adexchangebuyer {
+    context: APIRequestContext;
     accounts: Resource$Accounts;
     billingInfo: Resource$Billinginfo;
     budget: Resource$Budget;
@@ -92,15 +91,15 @@ export namespace adexchangebuyer_v1_3 {
     pretargetingConfig: Resource$Pretargetingconfig;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.accounts = new Resource$Accounts();
-      this.billingInfo = new Resource$Billinginfo();
-      this.budget = new Resource$Budget();
-      this.creatives = new Resource$Creatives();
-      this.directDeals = new Resource$Directdeals();
-      this.performanceReport = new Resource$Performancereport();
-      this.pretargetingConfig = new Resource$Pretargetingconfig();
+      this.accounts = new Resource$Accounts(this.context);
+      this.billingInfo = new Resource$Billinginfo(this.context);
+      this.budget = new Resource$Budget(this.context);
+      this.creatives = new Resource$Creatives(this.context);
+      this.directDeals = new Resource$Directdeals(this.context);
+      this.performanceReport = new Resource$Performancereport(this.context);
+      this.pretargetingConfig = new Resource$Pretargetingconfig(this.context);
     }
   }
 
@@ -712,7 +711,10 @@ export namespace adexchangebuyer_v1_3 {
 
 
   export class Resource$Accounts {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -766,7 +768,7 @@ export namespace adexchangebuyer_v1_3 {
         params,
         requiredParams: ['id'],
         pathParams: ['id'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Account>(parameters, callback);
@@ -830,7 +832,7 @@ export namespace adexchangebuyer_v1_3 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AccountsList>(parameters, callback);
@@ -895,7 +897,7 @@ export namespace adexchangebuyer_v1_3 {
         params,
         requiredParams: ['id'],
         pathParams: ['id'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Account>(parameters, callback);
@@ -960,7 +962,7 @@ export namespace adexchangebuyer_v1_3 {
         params,
         requiredParams: ['id'],
         pathParams: ['id'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Account>(parameters, callback);
@@ -1022,7 +1024,10 @@ export namespace adexchangebuyer_v1_3 {
 
 
   export class Resource$Billinginfo {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1078,7 +1083,7 @@ export namespace adexchangebuyer_v1_3 {
         params,
         requiredParams: ['accountId'],
         pathParams: ['accountId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$BillingInfo>(parameters, callback);
@@ -1143,7 +1148,7 @@ export namespace adexchangebuyer_v1_3 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$BillingInfoList>(parameters, callback);
@@ -1173,7 +1178,10 @@ export namespace adexchangebuyer_v1_3 {
 
 
   export class Resource$Budget {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1230,7 +1238,7 @@ export namespace adexchangebuyer_v1_3 {
         params,
         requiredParams: ['accountId', 'billingId'],
         pathParams: ['accountId', 'billingId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Budget>(parameters, callback);
@@ -1299,7 +1307,7 @@ export namespace adexchangebuyer_v1_3 {
         params,
         requiredParams: ['accountId', 'billingId'],
         pathParams: ['accountId', 'billingId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Budget>(parameters, callback);
@@ -1367,7 +1375,7 @@ export namespace adexchangebuyer_v1_3 {
         params,
         requiredParams: ['accountId', 'billingId'],
         pathParams: ['accountId', 'billingId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Budget>(parameters, callback);
@@ -1435,7 +1443,10 @@ export namespace adexchangebuyer_v1_3 {
 
 
   export class Resource$Creatives {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1493,7 +1504,7 @@ export namespace adexchangebuyer_v1_3 {
         params,
         requiredParams: ['accountId', 'buyerCreativeId'],
         pathParams: ['accountId', 'buyerCreativeId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Creative>(parameters, callback);
@@ -1557,7 +1568,7 @@ export namespace adexchangebuyer_v1_3 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Creative>(parameters, callback);
@@ -1627,7 +1638,7 @@ export namespace adexchangebuyer_v1_3 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$CreativesList>(parameters, callback);
@@ -1698,7 +1709,10 @@ export namespace adexchangebuyer_v1_3 {
 
 
   export class Resource$Directdeals {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1753,7 +1767,7 @@ export namespace adexchangebuyer_v1_3 {
         params,
         requiredParams: ['id'],
         pathParams: ['id'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$DirectDeal>(parameters, callback);
@@ -1817,7 +1831,7 @@ export namespace adexchangebuyer_v1_3 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$DirectDealsList>(parameters, callback);
@@ -1847,7 +1861,10 @@ export namespace adexchangebuyer_v1_3 {
 
 
   export class Resource$Performancereport {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1912,7 +1929,7 @@ export namespace adexchangebuyer_v1_3 {
         params,
         requiredParams: ['accountId', 'endDateTime', 'startDateTime'],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$PerformanceReportList>(parameters, callback);
@@ -1956,7 +1973,10 @@ export namespace adexchangebuyer_v1_3 {
 
 
   export class Resource$Pretargetingconfig {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -2017,7 +2037,7 @@ export namespace adexchangebuyer_v1_3 {
         params,
         requiredParams: ['accountId', 'configId'],
         pathParams: ['accountId', 'configId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -2083,7 +2103,7 @@ export namespace adexchangebuyer_v1_3 {
         params,
         requiredParams: ['accountId', 'configId'],
         pathParams: ['accountId', 'configId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$PretargetingConfig>(parameters, callback);
@@ -2152,7 +2172,7 @@ export namespace adexchangebuyer_v1_3 {
         params,
         requiredParams: ['accountId'],
         pathParams: ['accountId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$PretargetingConfig>(parameters, callback);
@@ -2222,7 +2242,7 @@ export namespace adexchangebuyer_v1_3 {
         params,
         requiredParams: ['accountId'],
         pathParams: ['accountId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$PretargetingConfigList>(parameters, callback);
@@ -2294,7 +2314,7 @@ export namespace adexchangebuyer_v1_3 {
         params,
         requiredParams: ['accountId', 'configId'],
         pathParams: ['accountId', 'configId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$PretargetingConfig>(parameters, callback);
@@ -2365,7 +2385,7 @@ export namespace adexchangebuyer_v1_3 {
         params,
         requiredParams: ['accountId', 'configId'],
         pathParams: ['accountId', 'configId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$PretargetingConfig>(parameters, callback);

--- a/src/apis/adexchangebuyer/v1.4.ts
+++ b/src/apis/adexchangebuyer/v1.4.ts
@@ -29,8 +29,6 @@ export namespace adexchangebuyer_v1_4 {
     version: 'v1_4';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * Data format for the response.
@@ -83,6 +81,7 @@ export namespace adexchangebuyer_v1_4 {
    * @param {object=} options Options for Adexchangebuyer
    */
   export class Adexchangebuyer {
+    context: APIRequestContext;
     accounts: Resource$Accounts;
     billingInfo: Resource$Billinginfo;
     budget: Resource$Budget;
@@ -97,20 +96,21 @@ export namespace adexchangebuyer_v1_4 {
     pubprofiles: Resource$Pubprofiles;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.accounts = new Resource$Accounts();
-      this.billingInfo = new Resource$Billinginfo();
-      this.budget = new Resource$Budget();
-      this.creatives = new Resource$Creatives();
-      this.marketplacedeals = new Resource$Marketplacedeals();
-      this.marketplacenotes = new Resource$Marketplacenotes();
-      this.marketplaceprivateauction = new Resource$Marketplaceprivateauction();
-      this.performanceReport = new Resource$Performancereport();
-      this.pretargetingConfig = new Resource$Pretargetingconfig();
-      this.products = new Resource$Products();
-      this.proposals = new Resource$Proposals();
-      this.pubprofiles = new Resource$Pubprofiles();
+      this.accounts = new Resource$Accounts(this.context);
+      this.billingInfo = new Resource$Billinginfo(this.context);
+      this.budget = new Resource$Budget(this.context);
+      this.creatives = new Resource$Creatives(this.context);
+      this.marketplacedeals = new Resource$Marketplacedeals(this.context);
+      this.marketplacenotes = new Resource$Marketplacenotes(this.context);
+      this.marketplaceprivateauction =
+          new Resource$Marketplaceprivateauction(this.context);
+      this.performanceReport = new Resource$Performancereport(this.context);
+      this.pretargetingConfig = new Resource$Pretargetingconfig(this.context);
+      this.products = new Resource$Products(this.context);
+      this.proposals = new Resource$Proposals(this.context);
+      this.pubprofiles = new Resource$Pubprofiles(this.context);
     }
   }
 
@@ -1826,7 +1826,10 @@ export namespace adexchangebuyer_v1_4 {
 
 
   export class Resource$Accounts {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1880,7 +1883,7 @@ export namespace adexchangebuyer_v1_4 {
         params,
         requiredParams: ['id'],
         pathParams: ['id'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Account>(parameters, callback);
@@ -1944,7 +1947,7 @@ export namespace adexchangebuyer_v1_4 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AccountsList>(parameters, callback);
@@ -2010,7 +2013,7 @@ export namespace adexchangebuyer_v1_4 {
         params,
         requiredParams: ['id'],
         pathParams: ['id'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Account>(parameters, callback);
@@ -2076,7 +2079,7 @@ export namespace adexchangebuyer_v1_4 {
         params,
         requiredParams: ['id'],
         pathParams: ['id'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Account>(parameters, callback);
@@ -2146,7 +2149,10 @@ export namespace adexchangebuyer_v1_4 {
 
 
   export class Resource$Billinginfo {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -2202,7 +2208,7 @@ export namespace adexchangebuyer_v1_4 {
         params,
         requiredParams: ['accountId'],
         pathParams: ['accountId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$BillingInfo>(parameters, callback);
@@ -2267,7 +2273,7 @@ export namespace adexchangebuyer_v1_4 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$BillingInfoList>(parameters, callback);
@@ -2297,7 +2303,10 @@ export namespace adexchangebuyer_v1_4 {
 
 
   export class Resource$Budget {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -2354,7 +2363,7 @@ export namespace adexchangebuyer_v1_4 {
         params,
         requiredParams: ['accountId', 'billingId'],
         pathParams: ['accountId', 'billingId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Budget>(parameters, callback);
@@ -2423,7 +2432,7 @@ export namespace adexchangebuyer_v1_4 {
         params,
         requiredParams: ['accountId', 'billingId'],
         pathParams: ['accountId', 'billingId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Budget>(parameters, callback);
@@ -2491,7 +2500,7 @@ export namespace adexchangebuyer_v1_4 {
         params,
         requiredParams: ['accountId', 'billingId'],
         pathParams: ['accountId', 'billingId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Budget>(parameters, callback);
@@ -2559,7 +2568,10 @@ export namespace adexchangebuyer_v1_4 {
 
 
   export class Resource$Creatives {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -2621,7 +2633,7 @@ export namespace adexchangebuyer_v1_4 {
         params,
         requiredParams: ['accountId', 'buyerCreativeId', 'dealId'],
         pathParams: ['accountId', 'buyerCreativeId', 'dealId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -2686,7 +2698,7 @@ export namespace adexchangebuyer_v1_4 {
         params,
         requiredParams: ['accountId', 'buyerCreativeId'],
         pathParams: ['accountId', 'buyerCreativeId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Creative>(parameters, callback);
@@ -2750,7 +2762,7 @@ export namespace adexchangebuyer_v1_4 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Creative>(parameters, callback);
@@ -2821,7 +2833,7 @@ export namespace adexchangebuyer_v1_4 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$CreativesList>(parameters, callback);
@@ -2891,7 +2903,7 @@ export namespace adexchangebuyer_v1_4 {
         params,
         requiredParams: ['accountId', 'buyerCreativeId'],
         pathParams: ['accountId', 'buyerCreativeId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$CreativeDealIds>(parameters, callback);
@@ -2960,7 +2972,7 @@ export namespace adexchangebuyer_v1_4 {
         params,
         requiredParams: ['accountId', 'buyerCreativeId', 'dealId'],
         pathParams: ['accountId', 'buyerCreativeId', 'dealId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -3093,7 +3105,10 @@ export namespace adexchangebuyer_v1_4 {
 
 
   export class Resource$Marketplacedeals {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -3158,7 +3173,7 @@ export namespace adexchangebuyer_v1_4 {
         params,
         requiredParams: ['proposalId'],
         pathParams: ['proposalId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$DeleteOrderDealsResponse>(parameters, callback);
@@ -3228,7 +3243,7 @@ export namespace adexchangebuyer_v1_4 {
         params,
         requiredParams: ['proposalId'],
         pathParams: ['proposalId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AddOrderDealsResponse>(parameters, callback);
@@ -3298,7 +3313,7 @@ export namespace adexchangebuyer_v1_4 {
         params,
         requiredParams: ['proposalId'],
         pathParams: ['proposalId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GetOrderDealsResponse>(parameters, callback);
@@ -3370,7 +3385,7 @@ export namespace adexchangebuyer_v1_4 {
         params,
         requiredParams: ['proposalId'],
         pathParams: ['proposalId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$EditAllOrderDealsResponse>(
@@ -3452,7 +3467,10 @@ export namespace adexchangebuyer_v1_4 {
 
 
   export class Resource$Marketplacenotes {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -3515,7 +3533,7 @@ export namespace adexchangebuyer_v1_4 {
         params,
         requiredParams: ['proposalId'],
         pathParams: ['proposalId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AddOrderNotesResponse>(parameters, callback);
@@ -3585,7 +3603,7 @@ export namespace adexchangebuyer_v1_4 {
         params,
         requiredParams: ['proposalId'],
         pathParams: ['proposalId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GetOrderNotesResponse>(parameters, callback);
@@ -3634,7 +3652,10 @@ export namespace adexchangebuyer_v1_4 {
 
 
   export class Resource$Marketplaceprivateauction {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -3696,7 +3717,7 @@ export namespace adexchangebuyer_v1_4 {
         params,
         requiredParams: ['privateAuctionId'],
         pathParams: ['privateAuctionId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -3726,7 +3747,10 @@ export namespace adexchangebuyer_v1_4 {
 
 
   export class Resource$Performancereport {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -3791,7 +3815,7 @@ export namespace adexchangebuyer_v1_4 {
         params,
         requiredParams: ['accountId', 'endDateTime', 'startDateTime'],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$PerformanceReportList>(parameters, callback);
@@ -3835,7 +3859,10 @@ export namespace adexchangebuyer_v1_4 {
 
 
   export class Resource$Pretargetingconfig {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -3896,7 +3923,7 @@ export namespace adexchangebuyer_v1_4 {
         params,
         requiredParams: ['accountId', 'configId'],
         pathParams: ['accountId', 'configId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -3962,7 +3989,7 @@ export namespace adexchangebuyer_v1_4 {
         params,
         requiredParams: ['accountId', 'configId'],
         pathParams: ['accountId', 'configId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$PretargetingConfig>(parameters, callback);
@@ -4031,7 +4058,7 @@ export namespace adexchangebuyer_v1_4 {
         params,
         requiredParams: ['accountId'],
         pathParams: ['accountId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$PretargetingConfig>(parameters, callback);
@@ -4101,7 +4128,7 @@ export namespace adexchangebuyer_v1_4 {
         params,
         requiredParams: ['accountId'],
         pathParams: ['accountId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$PretargetingConfigList>(parameters, callback);
@@ -4173,7 +4200,7 @@ export namespace adexchangebuyer_v1_4 {
         params,
         requiredParams: ['accountId', 'configId'],
         pathParams: ['accountId', 'configId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$PretargetingConfig>(parameters, callback);
@@ -4244,7 +4271,7 @@ export namespace adexchangebuyer_v1_4 {
         params,
         requiredParams: ['accountId', 'configId'],
         pathParams: ['accountId', 'configId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$PretargetingConfig>(parameters, callback);
@@ -4360,7 +4387,10 @@ export namespace adexchangebuyer_v1_4 {
 
 
   export class Resource$Products {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -4414,7 +4444,7 @@ export namespace adexchangebuyer_v1_4 {
         params,
         requiredParams: ['productId'],
         pathParams: ['productId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Product>(parameters, callback);
@@ -4479,7 +4509,7 @@ export namespace adexchangebuyer_v1_4 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GetOffersResponse>(parameters, callback);
@@ -4514,7 +4544,10 @@ export namespace adexchangebuyer_v1_4 {
 
 
   export class Resource$Proposals {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -4568,7 +4601,7 @@ export namespace adexchangebuyer_v1_4 {
         params,
         requiredParams: ['proposalId'],
         pathParams: ['proposalId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Proposal>(parameters, callback);
@@ -4634,7 +4667,7 @@ export namespace adexchangebuyer_v1_4 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$CreateOrdersResponse>(parameters, callback);
@@ -4703,7 +4736,7 @@ export namespace adexchangebuyer_v1_4 {
         params,
         requiredParams: ['proposalId', 'revisionNumber', 'updateAction'],
         pathParams: ['proposalId', 'revisionNumber', 'updateAction'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Proposal>(parameters, callback);
@@ -4768,7 +4801,7 @@ export namespace adexchangebuyer_v1_4 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GetOrdersResponse>(parameters, callback);
@@ -4836,7 +4869,7 @@ export namespace adexchangebuyer_v1_4 {
         params,
         requiredParams: ['proposalId'],
         pathParams: ['proposalId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -4905,7 +4938,7 @@ export namespace adexchangebuyer_v1_4 {
         params,
         requiredParams: ['proposalId', 'revisionNumber', 'updateAction'],
         pathParams: ['proposalId', 'revisionNumber', 'updateAction'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Proposal>(parameters, callback);
@@ -5020,7 +5053,10 @@ export namespace adexchangebuyer_v1_4 {
 
 
   export class Resource$Pubprofiles {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -5084,7 +5120,7 @@ export namespace adexchangebuyer_v1_4 {
         params,
         requiredParams: ['accountId'],
         pathParams: ['accountId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GetPublisherProfilesByAccountIdResponse>(

--- a/src/apis/adexchangebuyer2/v2beta1.ts
+++ b/src/apis/adexchangebuyer2/v2beta1.ts
@@ -29,8 +29,6 @@ export namespace adexchangebuyer2_v2beta1 {
     version: 'v2beta1';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * V1 error format.
@@ -100,14 +98,15 @@ export namespace adexchangebuyer2_v2beta1 {
    * @param {object=} options Options for Adexchangebuyer2
    */
   export class Adexchangebuyer2 {
+    context: APIRequestContext;
     accounts: Resource$Accounts;
     bidders: Resource$Bidders;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.accounts = new Resource$Accounts();
-      this.bidders = new Resource$Bidders();
+      this.accounts = new Resource$Accounts(this.context);
+      this.bidders = new Resource$Bidders(this.context);
     }
   }
 
@@ -2504,29 +2503,36 @@ export namespace adexchangebuyer2_v2beta1 {
 
 
   export class Resource$Accounts {
+    context: APIRequestContext;
     clients: Resource$Accounts$Clients;
     creatives: Resource$Accounts$Creatives;
     finalizedProposals: Resource$Accounts$Finalizedproposals;
     products: Resource$Accounts$Products;
     proposals: Resource$Accounts$Proposals;
     publisherProfiles: Resource$Accounts$Publisherprofiles;
-    constructor() {
-      this.clients = new Resource$Accounts$Clients();
-      this.creatives = new Resource$Accounts$Creatives();
-      this.finalizedProposals = new Resource$Accounts$Finalizedproposals();
-      this.products = new Resource$Accounts$Products();
-      this.proposals = new Resource$Accounts$Proposals();
-      this.publisherProfiles = new Resource$Accounts$Publisherprofiles();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.clients = new Resource$Accounts$Clients(this.context);
+      this.creatives = new Resource$Accounts$Creatives(this.context);
+      this.finalizedProposals =
+          new Resource$Accounts$Finalizedproposals(this.context);
+      this.products = new Resource$Accounts$Products(this.context);
+      this.proposals = new Resource$Accounts$Proposals(this.context);
+      this.publisherProfiles =
+          new Resource$Accounts$Publisherprofiles(this.context);
     }
   }
 
 
   export class Resource$Accounts$Clients {
+    context: APIRequestContext;
     invitations: Resource$Accounts$Clients$Invitations;
     users: Resource$Accounts$Clients$Users;
-    constructor() {
-      this.invitations = new Resource$Accounts$Clients$Invitations();
-      this.users = new Resource$Accounts$Clients$Users();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.invitations =
+          new Resource$Accounts$Clients$Invitations(this.context);
+      this.users = new Resource$Accounts$Clients$Users(this.context);
     }
 
 
@@ -2588,7 +2594,7 @@ export namespace adexchangebuyer2_v2beta1 {
         params,
         requiredParams: ['accountId'],
         pathParams: ['accountId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Client>(parameters, callback);
@@ -2653,7 +2659,7 @@ export namespace adexchangebuyer2_v2beta1 {
         params,
         requiredParams: ['accountId', 'clientAccountId'],
         pathParams: ['accountId', 'clientAccountId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Client>(parameters, callback);
@@ -2724,7 +2730,7 @@ export namespace adexchangebuyer2_v2beta1 {
         params,
         requiredParams: ['accountId'],
         pathParams: ['accountId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListClientsResponse>(parameters, callback);
@@ -2794,7 +2800,7 @@ export namespace adexchangebuyer2_v2beta1 {
         params,
         requiredParams: ['accountId', 'clientAccountId'],
         pathParams: ['accountId', 'clientAccountId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Client>(parameters, callback);
@@ -2891,7 +2897,10 @@ export namespace adexchangebuyer2_v2beta1 {
   }
 
   export class Resource$Accounts$Clients$Invitations {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -2958,7 +2967,7 @@ export namespace adexchangebuyer2_v2beta1 {
         params,
         requiredParams: ['accountId', 'clientAccountId'],
         pathParams: ['accountId', 'clientAccountId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ClientUserInvitation>(parameters, callback);
@@ -3027,7 +3036,7 @@ export namespace adexchangebuyer2_v2beta1 {
         params,
         requiredParams: ['accountId', 'clientAccountId', 'invitationId'],
         pathParams: ['accountId', 'clientAccountId', 'invitationId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ClientUserInvitation>(parameters, callback);
@@ -3110,7 +3119,7 @@ export namespace adexchangebuyer2_v2beta1 {
         params,
         requiredParams: ['accountId', 'clientAccountId'],
         pathParams: ['accountId', 'clientAccountId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListClientUserInvitationsResponse>(
@@ -3199,7 +3208,10 @@ export namespace adexchangebuyer2_v2beta1 {
 
 
   export class Resource$Accounts$Clients$Users {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -3260,7 +3272,7 @@ export namespace adexchangebuyer2_v2beta1 {
         params,
         requiredParams: ['accountId', 'clientAccountId', 'userId'],
         pathParams: ['accountId', 'clientAccountId', 'userId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ClientUser>(parameters, callback);
@@ -3335,7 +3347,7 @@ export namespace adexchangebuyer2_v2beta1 {
         params,
         requiredParams: ['accountId', 'clientAccountId'],
         pathParams: ['accountId', 'clientAccountId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListClientUsersResponse>(parameters, callback);
@@ -3409,7 +3421,7 @@ export namespace adexchangebuyer2_v2beta1 {
         params,
         requiredParams: ['accountId', 'clientAccountId', 'userId'],
         pathParams: ['accountId', 'clientAccountId', 'userId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ClientUser>(parameters, callback);
@@ -3502,10 +3514,12 @@ export namespace adexchangebuyer2_v2beta1 {
 
 
   export class Resource$Accounts$Creatives {
+    context: APIRequestContext;
     dealAssociations: Resource$Accounts$Creatives$Dealassociations;
-    constructor() {
+    constructor(context: APIRequestContext) {
+      this.context = context;
       this.dealAssociations =
-          new Resource$Accounts$Creatives$Dealassociations();
+          new Resource$Accounts$Creatives$Dealassociations(this.context);
     }
 
 
@@ -3568,7 +3582,7 @@ export namespace adexchangebuyer2_v2beta1 {
         params,
         requiredParams: ['accountId'],
         pathParams: ['accountId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Creative>(parameters, callback);
@@ -3633,7 +3647,7 @@ export namespace adexchangebuyer2_v2beta1 {
         params,
         requiredParams: ['accountId', 'creativeId'],
         pathParams: ['accountId', 'creativeId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Creative>(parameters, callback);
@@ -3705,7 +3719,7 @@ export namespace adexchangebuyer2_v2beta1 {
         params,
         requiredParams: ['accountId'],
         pathParams: ['accountId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListCreativesResponse>(parameters, callback);
@@ -3777,7 +3791,7 @@ export namespace adexchangebuyer2_v2beta1 {
         params,
         requiredParams: ['accountId', 'creativeId'],
         pathParams: ['accountId', 'creativeId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -3847,7 +3861,7 @@ export namespace adexchangebuyer2_v2beta1 {
         params,
         requiredParams: ['accountId', 'creativeId'],
         pathParams: ['accountId', 'creativeId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Creative>(parameters, callback);
@@ -3919,7 +3933,7 @@ export namespace adexchangebuyer2_v2beta1 {
         params,
         requiredParams: ['accountId', 'creativeId'],
         pathParams: ['accountId', 'creativeId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -4078,7 +4092,10 @@ export namespace adexchangebuyer2_v2beta1 {
   }
 
   export class Resource$Accounts$Creatives$Dealassociations {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -4139,7 +4156,7 @@ export namespace adexchangebuyer2_v2beta1 {
         params,
         requiredParams: ['accountId', 'creativeId'],
         pathParams: ['accountId', 'creativeId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -4219,7 +4236,7 @@ export namespace adexchangebuyer2_v2beta1 {
         params,
         requiredParams: ['accountId', 'creativeId'],
         pathParams: ['accountId', 'creativeId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListDealAssociationsResponse>(
@@ -4294,7 +4311,7 @@ export namespace adexchangebuyer2_v2beta1 {
         params,
         requiredParams: ['accountId', 'creativeId'],
         pathParams: ['accountId', 'creativeId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -4391,7 +4408,10 @@ export namespace adexchangebuyer2_v2beta1 {
 
 
   export class Resource$Accounts$Finalizedproposals {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -4460,7 +4480,7 @@ export namespace adexchangebuyer2_v2beta1 {
         params,
         requiredParams: ['accountId'],
         pathParams: ['accountId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListProposalsResponse>(parameters, callback);
@@ -4505,7 +4525,10 @@ export namespace adexchangebuyer2_v2beta1 {
 
 
   export class Resource$Accounts$Products {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -4563,7 +4586,7 @@ export namespace adexchangebuyer2_v2beta1 {
         params,
         requiredParams: ['accountId', 'productId'],
         pathParams: ['accountId', 'productId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Product>(parameters, callback);
@@ -4636,7 +4659,7 @@ export namespace adexchangebuyer2_v2beta1 {
         params,
         requiredParams: ['accountId'],
         pathParams: ['accountId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListProductsResponse>(parameters, callback);
@@ -4693,7 +4716,10 @@ export namespace adexchangebuyer2_v2beta1 {
 
 
   export class Resource$Accounts$Proposals {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -4760,7 +4786,7 @@ export namespace adexchangebuyer2_v2beta1 {
         params,
         requiredParams: ['accountId', 'proposalId'],
         pathParams: ['accountId', 'proposalId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Proposal>(parameters, callback);
@@ -4833,7 +4859,7 @@ export namespace adexchangebuyer2_v2beta1 {
         params,
         requiredParams: ['accountId', 'proposalId'],
         pathParams: ['accountId', 'proposalId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Note>(parameters, callback);
@@ -4906,7 +4932,7 @@ export namespace adexchangebuyer2_v2beta1 {
         params,
         requiredParams: ['accountId', 'proposalId'],
         pathParams: ['accountId', 'proposalId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Proposal>(parameters, callback);
@@ -4983,7 +5009,7 @@ export namespace adexchangebuyer2_v2beta1 {
         params,
         requiredParams: ['accountId', 'proposalId'],
         pathParams: ['accountId', 'proposalId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Proposal>(parameters, callback);
@@ -5052,7 +5078,7 @@ export namespace adexchangebuyer2_v2beta1 {
         params,
         requiredParams: ['accountId'],
         pathParams: ['accountId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Proposal>(parameters, callback);
@@ -5118,7 +5144,7 @@ export namespace adexchangebuyer2_v2beta1 {
         params,
         requiredParams: ['accountId', 'proposalId'],
         pathParams: ['accountId', 'proposalId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Proposal>(parameters, callback);
@@ -5196,7 +5222,7 @@ export namespace adexchangebuyer2_v2beta1 {
         params,
         requiredParams: ['accountId'],
         pathParams: ['accountId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListProposalsResponse>(parameters, callback);
@@ -5271,7 +5297,7 @@ export namespace adexchangebuyer2_v2beta1 {
         params,
         requiredParams: ['accountId', 'proposalId'],
         pathParams: ['accountId', 'proposalId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Proposal>(parameters, callback);
@@ -5347,7 +5373,7 @@ export namespace adexchangebuyer2_v2beta1 {
         params,
         requiredParams: ['accountId', 'proposalId'],
         pathParams: ['accountId', 'proposalId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Proposal>(parameters, callback);
@@ -5426,7 +5452,7 @@ export namespace adexchangebuyer2_v2beta1 {
         params,
         requiredParams: ['accountId', 'proposalId'],
         pathParams: ['accountId', 'proposalId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Proposal>(parameters, callback);
@@ -5651,7 +5677,10 @@ export namespace adexchangebuyer2_v2beta1 {
 
 
   export class Resource$Accounts$Publisherprofiles {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -5711,7 +5740,7 @@ export namespace adexchangebuyer2_v2beta1 {
         params,
         requiredParams: ['accountId', 'publisherProfileId'],
         pathParams: ['accountId', 'publisherProfileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$PublisherProfile>(parameters, callback);
@@ -5786,7 +5815,7 @@ export namespace adexchangebuyer2_v2beta1 {
         params,
         requiredParams: ['accountId'],
         pathParams: ['accountId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListPublisherProfilesResponse>(
@@ -5838,27 +5867,34 @@ export namespace adexchangebuyer2_v2beta1 {
 
 
   export class Resource$Bidders {
+    context: APIRequestContext;
     accounts: Resource$Bidders$Accounts;
     filterSets: Resource$Bidders$Filtersets;
-    constructor() {
-      this.accounts = new Resource$Bidders$Accounts();
-      this.filterSets = new Resource$Bidders$Filtersets();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.accounts = new Resource$Bidders$Accounts(this.context);
+      this.filterSets = new Resource$Bidders$Filtersets(this.context);
     }
   }
 
 
   export class Resource$Bidders$Accounts {
+    context: APIRequestContext;
     creatives: Resource$Bidders$Accounts$Creatives;
     filterSets: Resource$Bidders$Accounts$Filtersets;
-    constructor() {
-      this.creatives = new Resource$Bidders$Accounts$Creatives();
-      this.filterSets = new Resource$Bidders$Accounts$Filtersets();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.creatives = new Resource$Bidders$Accounts$Creatives(this.context);
+      this.filterSets = new Resource$Bidders$Accounts$Filtersets(this.context);
     }
   }
 
 
   export class Resource$Bidders$Accounts$Creatives {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -5922,7 +5958,7 @@ export namespace adexchangebuyer2_v2beta1 {
         params,
         requiredParams: ['ownerName', 'creativeId'],
         pathParams: ['creativeId', 'ownerName'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -5955,6 +5991,7 @@ export namespace adexchangebuyer2_v2beta1 {
 
 
   export class Resource$Bidders$Accounts$Filtersets {
+    context: APIRequestContext;
     bidMetrics: Resource$Bidders$Accounts$Filtersets$Bidmetrics;
     bidResponseErrors: Resource$Bidders$Accounts$Filtersets$Bidresponseerrors;
     bidResponsesWithoutBids:
@@ -5966,21 +6003,29 @@ export namespace adexchangebuyer2_v2beta1 {
     losingBids: Resource$Bidders$Accounts$Filtersets$Losingbids;
     nonBillableWinningBids:
         Resource$Bidders$Accounts$Filtersets$Nonbillablewinningbids;
-    constructor() {
-      this.bidMetrics = new Resource$Bidders$Accounts$Filtersets$Bidmetrics();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.bidMetrics =
+          new Resource$Bidders$Accounts$Filtersets$Bidmetrics(this.context);
       this.bidResponseErrors =
-          new Resource$Bidders$Accounts$Filtersets$Bidresponseerrors();
+          new Resource$Bidders$Accounts$Filtersets$Bidresponseerrors(
+              this.context);
       this.bidResponsesWithoutBids =
-          new Resource$Bidders$Accounts$Filtersets$Bidresponseswithoutbids();
+          new Resource$Bidders$Accounts$Filtersets$Bidresponseswithoutbids(
+              this.context);
       this.filteredBidRequests =
-          new Resource$Bidders$Accounts$Filtersets$Filteredbidrequests();
+          new Resource$Bidders$Accounts$Filtersets$Filteredbidrequests(
+              this.context);
       this.filteredBids =
-          new Resource$Bidders$Accounts$Filtersets$Filteredbids();
+          new Resource$Bidders$Accounts$Filtersets$Filteredbids(this.context);
       this.impressionMetrics =
-          new Resource$Bidders$Accounts$Filtersets$Impressionmetrics();
-      this.losingBids = new Resource$Bidders$Accounts$Filtersets$Losingbids();
+          new Resource$Bidders$Accounts$Filtersets$Impressionmetrics(
+              this.context);
+      this.losingBids =
+          new Resource$Bidders$Accounts$Filtersets$Losingbids(this.context);
       this.nonBillableWinningBids =
-          new Resource$Bidders$Accounts$Filtersets$Nonbillablewinningbids();
+          new Resource$Bidders$Accounts$Filtersets$Nonbillablewinningbids(
+              this.context);
     }
 
 
@@ -6045,7 +6090,7 @@ export namespace adexchangebuyer2_v2beta1 {
         params,
         requiredParams: ['ownerName'],
         pathParams: ['ownerName'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$FilterSet>(parameters, callback);
@@ -6112,7 +6157,7 @@ export namespace adexchangebuyer2_v2beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -6176,7 +6221,7 @@ export namespace adexchangebuyer2_v2beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$FilterSet>(parameters, callback);
@@ -6247,7 +6292,7 @@ export namespace adexchangebuyer2_v2beta1 {
         params,
         requiredParams: ['ownerName'],
         pathParams: ['ownerName'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListFilterSetsResponse>(parameters, callback);
@@ -6349,7 +6394,10 @@ export namespace adexchangebuyer2_v2beta1 {
   }
 
   export class Resource$Bidders$Accounts$Filtersets$Bidmetrics {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -6415,7 +6463,7 @@ export namespace adexchangebuyer2_v2beta1 {
         params,
         requiredParams: ['filterSetName'],
         pathParams: ['filterSetName'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListBidMetricsResponse>(parameters, callback);
@@ -6457,7 +6505,10 @@ export namespace adexchangebuyer2_v2beta1 {
 
 
   export class Resource$Bidders$Accounts$Filtersets$Bidresponseerrors {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -6532,7 +6583,7 @@ export namespace adexchangebuyer2_v2beta1 {
         params,
         requiredParams: ['filterSetName'],
         pathParams: ['filterSetName'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListBidResponseErrorsResponse>(
@@ -6577,7 +6628,10 @@ export namespace adexchangebuyer2_v2beta1 {
 
 
   export class Resource$Bidders$Accounts$Filtersets$Bidresponseswithoutbids {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -6658,7 +6712,7 @@ export namespace adexchangebuyer2_v2beta1 {
         params,
         requiredParams: ['filterSetName'],
         pathParams: ['filterSetName'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListBidResponsesWithoutBidsResponse>(
@@ -6703,7 +6757,10 @@ export namespace adexchangebuyer2_v2beta1 {
 
 
   export class Resource$Bidders$Accounts$Filtersets$Filteredbidrequests {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -6780,7 +6837,7 @@ export namespace adexchangebuyer2_v2beta1 {
         params,
         requiredParams: ['filterSetName'],
         pathParams: ['filterSetName'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListFilteredBidRequestsResponse>(
@@ -6825,13 +6882,17 @@ export namespace adexchangebuyer2_v2beta1 {
 
 
   export class Resource$Bidders$Accounts$Filtersets$Filteredbids {
+    context: APIRequestContext;
     creatives: Resource$Bidders$Accounts$Filtersets$Filteredbids$Creatives;
     details: Resource$Bidders$Accounts$Filtersets$Filteredbids$Details;
-    constructor() {
+    constructor(context: APIRequestContext) {
+      this.context = context;
       this.creatives =
-          new Resource$Bidders$Accounts$Filtersets$Filteredbids$Creatives();
+          new Resource$Bidders$Accounts$Filtersets$Filteredbids$Creatives(
+              this.context);
       this.details =
-          new Resource$Bidders$Accounts$Filtersets$Filteredbids$Details();
+          new Resource$Bidders$Accounts$Filtersets$Filteredbids$Details(
+              this.context);
     }
 
 
@@ -6900,7 +6961,7 @@ export namespace adexchangebuyer2_v2beta1 {
         params,
         requiredParams: ['filterSetName'],
         pathParams: ['filterSetName'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListFilteredBidsResponse>(parameters, callback);
@@ -6941,7 +7002,10 @@ export namespace adexchangebuyer2_v2beta1 {
   }
 
   export class Resource$Bidders$Accounts$Filtersets$Filteredbids$Creatives {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -7021,7 +7085,7 @@ export namespace adexchangebuyer2_v2beta1 {
         params,
         requiredParams: ['filterSetName', 'creativeStatusId'],
         pathParams: ['creativeStatusId', 'filterSetName'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListCreativeStatusBreakdownByCreativeResponse>(
@@ -7072,7 +7136,10 @@ export namespace adexchangebuyer2_v2beta1 {
 
 
   export class Resource$Bidders$Accounts$Filtersets$Filteredbids$Details {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -7152,7 +7219,7 @@ export namespace adexchangebuyer2_v2beta1 {
         params,
         requiredParams: ['filterSetName', 'creativeStatusId'],
         pathParams: ['creativeStatusId', 'filterSetName'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListCreativeStatusBreakdownByDetailResponse>(
@@ -7206,7 +7273,10 @@ export namespace adexchangebuyer2_v2beta1 {
 
 
   export class Resource$Bidders$Accounts$Filtersets$Impressionmetrics {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -7281,7 +7351,7 @@ export namespace adexchangebuyer2_v2beta1 {
         params,
         requiredParams: ['filterSetName'],
         pathParams: ['filterSetName'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListImpressionMetricsResponse>(
@@ -7326,7 +7396,10 @@ export namespace adexchangebuyer2_v2beta1 {
 
 
   export class Resource$Bidders$Accounts$Filtersets$Losingbids {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -7393,7 +7466,7 @@ export namespace adexchangebuyer2_v2beta1 {
         params,
         requiredParams: ['filterSetName'],
         pathParams: ['filterSetName'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListLosingBidsResponse>(parameters, callback);
@@ -7435,7 +7508,10 @@ export namespace adexchangebuyer2_v2beta1 {
 
 
   export class Resource$Bidders$Accounts$Filtersets$Nonbillablewinningbids {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -7515,7 +7591,7 @@ export namespace adexchangebuyer2_v2beta1 {
         params,
         requiredParams: ['filterSetName'],
         pathParams: ['filterSetName'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListNonBillableWinningBidsResponse>(
@@ -7561,6 +7637,7 @@ export namespace adexchangebuyer2_v2beta1 {
 
 
   export class Resource$Bidders$Filtersets {
+    context: APIRequestContext;
     bidMetrics: Resource$Bidders$Filtersets$Bidmetrics;
     bidResponseErrors: Resource$Bidders$Filtersets$Bidresponseerrors;
     bidResponsesWithoutBids:
@@ -7570,20 +7647,24 @@ export namespace adexchangebuyer2_v2beta1 {
     impressionMetrics: Resource$Bidders$Filtersets$Impressionmetrics;
     losingBids: Resource$Bidders$Filtersets$Losingbids;
     nonBillableWinningBids: Resource$Bidders$Filtersets$Nonbillablewinningbids;
-    constructor() {
-      this.bidMetrics = new Resource$Bidders$Filtersets$Bidmetrics();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.bidMetrics =
+          new Resource$Bidders$Filtersets$Bidmetrics(this.context);
       this.bidResponseErrors =
-          new Resource$Bidders$Filtersets$Bidresponseerrors();
+          new Resource$Bidders$Filtersets$Bidresponseerrors(this.context);
       this.bidResponsesWithoutBids =
-          new Resource$Bidders$Filtersets$Bidresponseswithoutbids();
+          new Resource$Bidders$Filtersets$Bidresponseswithoutbids(this.context);
       this.filteredBidRequests =
-          new Resource$Bidders$Filtersets$Filteredbidrequests();
-      this.filteredBids = new Resource$Bidders$Filtersets$Filteredbids();
+          new Resource$Bidders$Filtersets$Filteredbidrequests(this.context);
+      this.filteredBids =
+          new Resource$Bidders$Filtersets$Filteredbids(this.context);
       this.impressionMetrics =
-          new Resource$Bidders$Filtersets$Impressionmetrics();
-      this.losingBids = new Resource$Bidders$Filtersets$Losingbids();
+          new Resource$Bidders$Filtersets$Impressionmetrics(this.context);
+      this.losingBids =
+          new Resource$Bidders$Filtersets$Losingbids(this.context);
       this.nonBillableWinningBids =
-          new Resource$Bidders$Filtersets$Nonbillablewinningbids();
+          new Resource$Bidders$Filtersets$Nonbillablewinningbids(this.context);
     }
 
 
@@ -7648,7 +7729,7 @@ export namespace adexchangebuyer2_v2beta1 {
         params,
         requiredParams: ['ownerName'],
         pathParams: ['ownerName'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$FilterSet>(parameters, callback);
@@ -7715,7 +7796,7 @@ export namespace adexchangebuyer2_v2beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -7779,7 +7860,7 @@ export namespace adexchangebuyer2_v2beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$FilterSet>(parameters, callback);
@@ -7850,7 +7931,7 @@ export namespace adexchangebuyer2_v2beta1 {
         params,
         requiredParams: ['ownerName'],
         pathParams: ['ownerName'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListFilterSetsResponse>(parameters, callback);
@@ -7952,7 +8033,10 @@ export namespace adexchangebuyer2_v2beta1 {
   }
 
   export class Resource$Bidders$Filtersets$Bidmetrics {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -8016,7 +8100,7 @@ export namespace adexchangebuyer2_v2beta1 {
         params,
         requiredParams: ['filterSetName'],
         pathParams: ['filterSetName'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListBidMetricsResponse>(parameters, callback);
@@ -8058,7 +8142,10 @@ export namespace adexchangebuyer2_v2beta1 {
 
 
   export class Resource$Bidders$Filtersets$Bidresponseerrors {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -8129,7 +8216,7 @@ export namespace adexchangebuyer2_v2beta1 {
         params,
         requiredParams: ['filterSetName'],
         pathParams: ['filterSetName'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListBidResponseErrorsResponse>(
@@ -8174,7 +8261,10 @@ export namespace adexchangebuyer2_v2beta1 {
 
 
   export class Resource$Bidders$Filtersets$Bidresponseswithoutbids {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -8252,7 +8342,7 @@ export namespace adexchangebuyer2_v2beta1 {
         params,
         requiredParams: ['filterSetName'],
         pathParams: ['filterSetName'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListBidResponsesWithoutBidsResponse>(
@@ -8297,7 +8387,10 @@ export namespace adexchangebuyer2_v2beta1 {
 
 
   export class Resource$Bidders$Filtersets$Filteredbidrequests {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -8370,7 +8463,7 @@ export namespace adexchangebuyer2_v2beta1 {
         params,
         requiredParams: ['filterSetName'],
         pathParams: ['filterSetName'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListFilteredBidRequestsResponse>(
@@ -8415,11 +8508,15 @@ export namespace adexchangebuyer2_v2beta1 {
 
 
   export class Resource$Bidders$Filtersets$Filteredbids {
+    context: APIRequestContext;
     creatives: Resource$Bidders$Filtersets$Filteredbids$Creatives;
     details: Resource$Bidders$Filtersets$Filteredbids$Details;
-    constructor() {
-      this.creatives = new Resource$Bidders$Filtersets$Filteredbids$Creatives();
-      this.details = new Resource$Bidders$Filtersets$Filteredbids$Details();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.creatives =
+          new Resource$Bidders$Filtersets$Filteredbids$Creatives(this.context);
+      this.details =
+          new Resource$Bidders$Filtersets$Filteredbids$Details(this.context);
     }
 
 
@@ -8486,7 +8583,7 @@ export namespace adexchangebuyer2_v2beta1 {
         params,
         requiredParams: ['filterSetName'],
         pathParams: ['filterSetName'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListFilteredBidsResponse>(parameters, callback);
@@ -8527,7 +8624,10 @@ export namespace adexchangebuyer2_v2beta1 {
   }
 
   export class Resource$Bidders$Filtersets$Filteredbids$Creatives {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -8603,7 +8703,7 @@ export namespace adexchangebuyer2_v2beta1 {
         params,
         requiredParams: ['filterSetName', 'creativeStatusId'],
         pathParams: ['creativeStatusId', 'filterSetName'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListCreativeStatusBreakdownByCreativeResponse>(
@@ -8654,7 +8754,10 @@ export namespace adexchangebuyer2_v2beta1 {
 
 
   export class Resource$Bidders$Filtersets$Filteredbids$Details {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -8730,7 +8833,7 @@ export namespace adexchangebuyer2_v2beta1 {
         params,
         requiredParams: ['filterSetName', 'creativeStatusId'],
         pathParams: ['creativeStatusId', 'filterSetName'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListCreativeStatusBreakdownByDetailResponse>(
@@ -8784,7 +8887,10 @@ export namespace adexchangebuyer2_v2beta1 {
 
 
   export class Resource$Bidders$Filtersets$Impressionmetrics {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -8855,7 +8961,7 @@ export namespace adexchangebuyer2_v2beta1 {
         params,
         requiredParams: ['filterSetName'],
         pathParams: ['filterSetName'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListImpressionMetricsResponse>(
@@ -8900,7 +9006,10 @@ export namespace adexchangebuyer2_v2beta1 {
 
 
   export class Resource$Bidders$Filtersets$Losingbids {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -8965,7 +9074,7 @@ export namespace adexchangebuyer2_v2beta1 {
         params,
         requiredParams: ['filterSetName'],
         pathParams: ['filterSetName'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListLosingBidsResponse>(parameters, callback);
@@ -9007,7 +9116,10 @@ export namespace adexchangebuyer2_v2beta1 {
 
 
   export class Resource$Bidders$Filtersets$Nonbillablewinningbids {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -9083,7 +9195,7 @@ export namespace adexchangebuyer2_v2beta1 {
         params,
         requiredParams: ['filterSetName'],
         pathParams: ['filterSetName'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListNonBillableWinningBidsResponse>(

--- a/src/apis/adexperiencereport/v1.ts
+++ b/src/apis/adexperiencereport/v1.ts
@@ -29,8 +29,6 @@ export namespace adexperiencereport_v1 {
     version: 'v1';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * V1 error format.
@@ -99,14 +97,15 @@ export namespace adexperiencereport_v1 {
    * @param {object=} options Options for Adexperiencereport
    */
   export class Adexperiencereport {
+    context: APIRequestContext;
     sites: Resource$Sites;
     violatingSites: Resource$Violatingsites;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.sites = new Resource$Sites();
-      this.violatingSites = new Resource$Violatingsites();
+      this.sites = new Resource$Sites(this.context);
+      this.violatingSites = new Resource$Violatingsites(this.context);
     }
   }
 
@@ -172,7 +171,10 @@ export namespace adexperiencereport_v1 {
 
 
   export class Resource$Sites {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -227,7 +229,7 @@ export namespace adexperiencereport_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$SiteSummaryResponse>(parameters, callback);
@@ -258,7 +260,10 @@ export namespace adexperiencereport_v1 {
 
 
   export class Resource$Violatingsites {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -319,7 +324,7 @@ export namespace adexperiencereport_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ViolatingSitesResponse>(parameters, callback);

--- a/src/apis/admin/datatransfer_v1.ts
+++ b/src/apis/admin/datatransfer_v1.ts
@@ -29,8 +29,6 @@ export namespace admin_datatransfer_v1 {
     version: 'datatransfer_v1';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * Data format for the response.
@@ -81,14 +79,15 @@ export namespace admin_datatransfer_v1 {
    * @param {object=} options Options for Admin
    */
   export class Admin {
+    context: APIRequestContext;
     applications: Resource$Applications;
     transfers: Resource$Transfers;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.applications = new Resource$Applications();
-      this.transfers = new Resource$Transfers();
+      this.applications = new Resource$Applications(this.context);
+      this.transfers = new Resource$Transfers(this.context);
     }
   }
 
@@ -238,7 +237,10 @@ export namespace admin_datatransfer_v1 {
 
 
   export class Resource$Applications {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -295,7 +297,7 @@ export namespace admin_datatransfer_v1 {
         params,
         requiredParams: ['applicationId'],
         pathParams: ['applicationId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Application>(parameters, callback);
@@ -364,7 +366,7 @@ export namespace admin_datatransfer_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ApplicationsListResponse>(parameters, callback);
@@ -408,7 +410,10 @@ export namespace admin_datatransfer_v1 {
 
 
   export class Resource$Transfers {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -464,7 +469,7 @@ export namespace admin_datatransfer_v1 {
         params,
         requiredParams: ['dataTransferId'],
         pathParams: ['dataTransferId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$DataTransfer>(parameters, callback);
@@ -529,7 +534,7 @@ export namespace admin_datatransfer_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$DataTransfer>(parameters, callback);
@@ -602,7 +607,7 @@ export namespace admin_datatransfer_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$DataTransfersListResponse>(

--- a/src/apis/admin/directory_v1.ts
+++ b/src/apis/admin/directory_v1.ts
@@ -29,8 +29,6 @@ export namespace admin_directory_v1 {
     version: 'directory_v1';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * Data format for the response.
@@ -82,6 +80,7 @@ export namespace admin_directory_v1 {
    * @param {object=} options Options for Admin
    */
   export class Admin {
+    context: APIRequestContext;
     asps: Resource$Asps;
     channels: Resource$Channels;
     chromeosdevices: Resource$Chromeosdevices;
@@ -104,28 +103,29 @@ export namespace admin_directory_v1 {
     verificationCodes: Resource$Verificationcodes;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.asps = new Resource$Asps();
-      this.channels = new Resource$Channels();
-      this.chromeosdevices = new Resource$Chromeosdevices();
-      this.customers = new Resource$Customers();
-      this.domainAliases = new Resource$Domainaliases();
-      this.domains = new Resource$Domains();
-      this.groups = new Resource$Groups();
-      this.members = new Resource$Members();
-      this.mobiledevices = new Resource$Mobiledevices();
-      this.notifications = new Resource$Notifications();
-      this.orgunits = new Resource$Orgunits();
-      this.privileges = new Resource$Privileges();
-      this.resolvedAppAccessSettings = new Resource$Resolvedappaccesssettings();
-      this.resources = new Resource$Resources();
-      this.roleAssignments = new Resource$Roleassignments();
-      this.roles = new Resource$Roles();
-      this.schemas = new Resource$Schemas();
-      this.tokens = new Resource$Tokens();
-      this.users = new Resource$Users();
-      this.verificationCodes = new Resource$Verificationcodes();
+      this.asps = new Resource$Asps(this.context);
+      this.channels = new Resource$Channels(this.context);
+      this.chromeosdevices = new Resource$Chromeosdevices(this.context);
+      this.customers = new Resource$Customers(this.context);
+      this.domainAliases = new Resource$Domainaliases(this.context);
+      this.domains = new Resource$Domains(this.context);
+      this.groups = new Resource$Groups(this.context);
+      this.members = new Resource$Members(this.context);
+      this.mobiledevices = new Resource$Mobiledevices(this.context);
+      this.notifications = new Resource$Notifications(this.context);
+      this.orgunits = new Resource$Orgunits(this.context);
+      this.privileges = new Resource$Privileges(this.context);
+      this.resolvedAppAccessSettings =
+          new Resource$Resolvedappaccesssettings(this.context);
+      this.resources = new Resource$Resources(this.context);
+      this.roleAssignments = new Resource$Roleassignments(this.context);
+      this.roles = new Resource$Roles(this.context);
+      this.schemas = new Resource$Schemas(this.context);
+      this.tokens = new Resource$Tokens(this.context);
+      this.users = new Resource$Users(this.context);
+      this.verificationCodes = new Resource$Verificationcodes(this.context);
     }
   }
 
@@ -2491,7 +2491,10 @@ export namespace admin_directory_v1 {
 
 
   export class Resource$Asps {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -2549,7 +2552,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['userKey', 'codeId'],
         pathParams: ['codeId', 'userKey'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -2612,7 +2615,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['userKey', 'codeId'],
         pathParams: ['codeId', 'userKey'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Asp>(parameters, callback);
@@ -2676,7 +2679,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['userKey'],
         pathParams: ['userKey'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Asps>(parameters, callback);
@@ -2733,7 +2736,10 @@ export namespace admin_directory_v1 {
 
 
   export class Resource$Channels {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -2790,7 +2796,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -2815,7 +2821,10 @@ export namespace admin_directory_v1 {
 
 
   export class Resource$Chromeosdevices {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -2877,7 +2886,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['customerId', 'resourceId'],
         pathParams: ['customerId', 'resourceId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -2944,7 +2953,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['customerId', 'deviceId'],
         pathParams: ['customerId', 'deviceId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ChromeOsDevice>(parameters, callback);
@@ -3020,7 +3029,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['customerId'],
         pathParams: ['customerId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ChromeOsDevices>(parameters, callback);
@@ -3089,7 +3098,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['customerId', 'orgUnitPath'],
         pathParams: ['customerId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -3161,7 +3170,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['customerId', 'deviceId'],
         pathParams: ['customerId', 'deviceId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ChromeOsDevice>(parameters, callback);
@@ -3233,7 +3242,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['customerId', 'deviceId'],
         pathParams: ['customerId', 'deviceId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ChromeOsDevice>(parameters, callback);
@@ -3400,7 +3409,10 @@ export namespace admin_directory_v1 {
 
 
   export class Resource$Customers {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -3454,7 +3466,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['customerKey'],
         pathParams: ['customerKey'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Customer>(parameters, callback);
@@ -3519,7 +3531,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['customerKey'],
         pathParams: ['customerKey'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Customer>(parameters, callback);
@@ -3584,7 +3596,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['customerKey'],
         pathParams: ['customerKey'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Customer>(parameters, callback);
@@ -3640,7 +3652,10 @@ export namespace admin_directory_v1 {
 
 
   export class Resource$Domainaliases {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -3701,7 +3716,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['customer', 'domainAliasName'],
         pathParams: ['customer', 'domainAliasName'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -3767,7 +3782,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['customer', 'domainAliasName'],
         pathParams: ['customer', 'domainAliasName'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$DomainAlias>(parameters, callback);
@@ -3836,7 +3851,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['customer'],
         pathParams: ['customer'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$DomainAlias>(parameters, callback);
@@ -3904,7 +3919,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['customer'],
         pathParams: ['customer'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$DomainAliases>(parameters, callback);
@@ -3982,7 +3997,10 @@ export namespace admin_directory_v1 {
 
 
   export class Resource$Domains {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -4041,7 +4059,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['customer', 'domainName'],
         pathParams: ['customer', 'domainName'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -4105,7 +4123,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['customer', 'domainName'],
         pathParams: ['customer', 'domainName'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Domains>(parameters, callback);
@@ -4170,7 +4188,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['customer'],
         pathParams: ['customer'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Domains>(parameters, callback);
@@ -4234,7 +4252,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['customer'],
         pathParams: ['customer'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Domains2>(parameters, callback);
@@ -4304,9 +4322,11 @@ export namespace admin_directory_v1 {
 
 
   export class Resource$Groups {
+    context: APIRequestContext;
     aliases: Resource$Groups$Aliases;
-    constructor() {
-      this.aliases = new Resource$Groups$Aliases();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.aliases = new Resource$Groups$Aliases(this.context);
     }
 
 
@@ -4363,7 +4383,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['groupKey'],
         pathParams: ['groupKey'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -4424,7 +4444,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['groupKey'],
         pathParams: ['groupKey'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Group>(parameters, callback);
@@ -4488,7 +4508,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Group>(parameters, callback);
@@ -4560,7 +4580,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Groups>(parameters, callback);
@@ -4625,7 +4645,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['groupKey'],
         pathParams: ['groupKey'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Group>(parameters, callback);
@@ -4690,7 +4710,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['groupKey'],
         pathParams: ['groupKey'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Group>(parameters, callback);
@@ -4816,7 +4836,10 @@ export namespace admin_directory_v1 {
   }
 
   export class Resource$Groups$Aliases {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -4876,7 +4899,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['groupKey', 'alias'],
         pathParams: ['alias', 'groupKey'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -4943,7 +4966,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['groupKey'],
         pathParams: ['groupKey'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Alias>(parameters, callback);
@@ -5008,7 +5031,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['groupKey'],
         pathParams: ['groupKey'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Aliases>(parameters, callback);
@@ -5067,7 +5090,10 @@ export namespace admin_directory_v1 {
 
 
   export class Resource$Members {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -5125,7 +5151,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['groupKey', 'memberKey'],
         pathParams: ['groupKey', 'memberKey'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -5188,7 +5214,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['groupKey', 'memberKey'],
         pathParams: ['groupKey', 'memberKey'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Member>(parameters, callback);
@@ -5259,7 +5285,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['groupKey', 'memberKey'],
         pathParams: ['groupKey', 'memberKey'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$MembersHasMember>(parameters, callback);
@@ -5324,7 +5350,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['groupKey'],
         pathParams: ['groupKey'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Member>(parameters, callback);
@@ -5392,7 +5418,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['groupKey'],
         pathParams: ['groupKey'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Members>(parameters, callback);
@@ -5460,7 +5486,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['groupKey', 'memberKey'],
         pathParams: ['groupKey', 'memberKey'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Member>(parameters, callback);
@@ -5527,7 +5553,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['groupKey', 'memberKey'],
         pathParams: ['groupKey', 'memberKey'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Member>(parameters, callback);
@@ -5675,7 +5701,10 @@ export namespace admin_directory_v1 {
 
 
   export class Resource$Mobiledevices {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -5737,7 +5766,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['customerId', 'resourceId'],
         pathParams: ['customerId', 'resourceId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -5805,7 +5834,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['customerId', 'resourceId'],
         pathParams: ['customerId', 'resourceId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -5872,7 +5901,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['customerId', 'resourceId'],
         pathParams: ['customerId', 'resourceId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$MobileDevice>(parameters, callback);
@@ -5945,7 +5974,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['customerId'],
         pathParams: ['customerId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$MobileDevices>(parameters, callback);
@@ -6053,7 +6082,10 @@ export namespace admin_directory_v1 {
 
 
   export class Resource$Notifications {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -6114,7 +6146,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['customer', 'notificationId'],
         pathParams: ['customer', 'notificationId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -6180,7 +6212,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['customer', 'notificationId'],
         pathParams: ['customer', 'notificationId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Notification>(parameters, callback);
@@ -6250,7 +6282,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['customer'],
         pathParams: ['customer'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Notifications>(parameters, callback);
@@ -6321,7 +6353,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['customer', 'notificationId'],
         pathParams: ['customer', 'notificationId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Notification>(parameters, callback);
@@ -6392,7 +6424,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['customer', 'notificationId'],
         pathParams: ['customer', 'notificationId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Notification>(parameters, callback);
@@ -6506,7 +6538,10 @@ export namespace admin_directory_v1 {
 
 
   export class Resource$Orgunits {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -6565,7 +6600,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['customerId', 'orgUnitPath'],
         pathParams: ['customerId', 'orgUnitPath'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -6629,7 +6664,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['customerId', 'orgUnitPath'],
         pathParams: ['customerId', 'orgUnitPath'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$OrgUnit>(parameters, callback);
@@ -6695,7 +6730,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['customerId'],
         pathParams: ['customerId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$OrgUnit>(parameters, callback);
@@ -6762,7 +6797,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['customerId'],
         pathParams: ['customerId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$OrgUnits>(parameters, callback);
@@ -6830,7 +6865,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['customerId', 'orgUnitPath'],
         pathParams: ['customerId', 'orgUnitPath'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$OrgUnit>(parameters, callback);
@@ -6898,7 +6933,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['customerId', 'orgUnitPath'],
         pathParams: ['customerId', 'orgUnitPath'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$OrgUnit>(parameters, callback);
@@ -7016,7 +7051,10 @@ export namespace admin_directory_v1 {
 
 
   export class Resource$Privileges {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -7076,7 +7114,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['customer'],
         pathParams: ['customer'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Privileges>(parameters, callback);
@@ -7100,7 +7138,10 @@ export namespace admin_directory_v1 {
 
 
   export class Resource$Resolvedappaccesssettings {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -7162,7 +7203,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AppAccessCollections>(parameters, callback);
@@ -7231,7 +7272,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TrustedApps>(parameters, callback);
@@ -7258,19 +7299,24 @@ export namespace admin_directory_v1 {
 
 
   export class Resource$Resources {
+    context: APIRequestContext;
     buildings: Resource$Resources$Buildings;
     calendars: Resource$Resources$Calendars;
     features: Resource$Resources$Features;
-    constructor() {
-      this.buildings = new Resource$Resources$Buildings();
-      this.calendars = new Resource$Resources$Calendars();
-      this.features = new Resource$Resources$Features();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.buildings = new Resource$Resources$Buildings(this.context);
+      this.calendars = new Resource$Resources$Calendars(this.context);
+      this.features = new Resource$Resources$Features(this.context);
     }
   }
 
 
   export class Resource$Resources$Buildings {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -7331,7 +7377,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['customer', 'buildingId'],
         pathParams: ['buildingId', 'customer'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -7396,7 +7442,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['customer', 'buildingId'],
         pathParams: ['buildingId', 'customer'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Building>(parameters, callback);
@@ -7466,7 +7512,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['customer'],
         pathParams: ['customer'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Building>(parameters, callback);
@@ -7537,7 +7583,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['customer'],
         pathParams: ['customer'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Buildings>(parameters, callback);
@@ -7608,7 +7654,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['customer', 'buildingId'],
         pathParams: ['buildingId', 'customer'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Building>(parameters, callback);
@@ -7679,7 +7725,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['customer', 'buildingId'],
         pathParams: ['buildingId', 'customer'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Building>(parameters, callback);
@@ -7827,7 +7873,10 @@ export namespace admin_directory_v1 {
 
 
   export class Resource$Resources$Calendars {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -7888,7 +7937,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['customer', 'calendarResourceId'],
         pathParams: ['calendarResourceId', 'customer'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -7954,7 +8003,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['customer', 'calendarResourceId'],
         pathParams: ['calendarResourceId', 'customer'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$CalendarResource>(parameters, callback);
@@ -8024,7 +8073,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['customer'],
         pathParams: ['customer'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$CalendarResource>(parameters, callback);
@@ -8097,7 +8146,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['customer'],
         pathParams: ['customer'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$CalendarResources>(parameters, callback);
@@ -8171,7 +8220,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['customer', 'calendarResourceId'],
         pathParams: ['calendarResourceId', 'customer'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$CalendarResource>(parameters, callback);
@@ -8244,7 +8293,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['customer', 'calendarResourceId'],
         pathParams: ['calendarResourceId', 'customer'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$CalendarResource>(parameters, callback);
@@ -8400,7 +8449,10 @@ export namespace admin_directory_v1 {
 
 
   export class Resource$Resources$Features {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -8461,7 +8513,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['customer', 'featureKey'],
         pathParams: ['customer', 'featureKey'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -8526,7 +8578,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['customer', 'featureKey'],
         pathParams: ['customer', 'featureKey'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Feature>(parameters, callback);
@@ -8595,7 +8647,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['customer'],
         pathParams: ['customer'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Feature>(parameters, callback);
@@ -8665,7 +8717,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['customer'],
         pathParams: ['customer'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Features>(parameters, callback);
@@ -8735,7 +8787,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['customer', 'featureKey'],
         pathParams: ['customer', 'featureKey'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Feature>(parameters, callback);
@@ -8804,7 +8856,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['customer', 'oldName'],
         pathParams: ['customer', 'oldName'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -8874,7 +8926,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['customer', 'featureKey'],
         pathParams: ['customer', 'featureKey'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Feature>(parameters, callback);
@@ -9034,7 +9086,10 @@ export namespace admin_directory_v1 {
 
 
   export class Resource$Roleassignments {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -9095,7 +9150,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['customer', 'roleAssignmentId'],
         pathParams: ['customer', 'roleAssignmentId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -9161,7 +9216,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['customer', 'roleAssignmentId'],
         pathParams: ['customer', 'roleAssignmentId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$RoleAssignment>(parameters, callback);
@@ -9230,7 +9285,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['customer'],
         pathParams: ['customer'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$RoleAssignment>(parameters, callback);
@@ -9302,7 +9357,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['customer'],
         pathParams: ['customer'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$RoleAssignments>(parameters, callback);
@@ -9394,7 +9449,10 @@ export namespace admin_directory_v1 {
 
 
   export class Resource$Roles {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -9452,7 +9510,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['customer', 'roleId'],
         pathParams: ['customer', 'roleId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -9515,7 +9573,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['customer', 'roleId'],
         pathParams: ['customer', 'roleId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Role>(parameters, callback);
@@ -9580,7 +9638,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['customer'],
         pathParams: ['customer'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Role>(parameters, callback);
@@ -9646,7 +9704,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['customer'],
         pathParams: ['customer'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Roles>(parameters, callback);
@@ -9713,7 +9771,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['customer', 'roleId'],
         pathParams: ['customer', 'roleId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Role>(parameters, callback);
@@ -9780,7 +9838,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['customer', 'roleId'],
         pathParams: ['customer', 'roleId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Role>(parameters, callback);
@@ -9898,7 +9956,10 @@ export namespace admin_directory_v1 {
 
 
   export class Resource$Schemas {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -9957,7 +10018,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['customerId', 'schemaKey'],
         pathParams: ['customerId', 'schemaKey'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -10021,7 +10082,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['customerId', 'schemaKey'],
         pathParams: ['customerId', 'schemaKey'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Schema>(parameters, callback);
@@ -10087,7 +10148,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['customerId'],
         pathParams: ['customerId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Schema>(parameters, callback);
@@ -10152,7 +10213,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['customerId'],
         pathParams: ['customerId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Schemas>(parameters, callback);
@@ -10220,7 +10281,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['customerId', 'schemaKey'],
         pathParams: ['customerId', 'schemaKey'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Schema>(parameters, callback);
@@ -10288,7 +10349,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['customerId', 'schemaKey'],
         pathParams: ['customerId', 'schemaKey'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Schema>(parameters, callback);
@@ -10398,7 +10459,10 @@ export namespace admin_directory_v1 {
 
 
   export class Resource$Tokens {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -10456,7 +10520,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['userKey', 'clientId'],
         pathParams: ['clientId', 'userKey'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -10519,7 +10583,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['userKey', 'clientId'],
         pathParams: ['clientId', 'userKey'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Token>(parameters, callback);
@@ -10584,7 +10648,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['userKey'],
         pathParams: ['userKey'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Tokens>(parameters, callback);
@@ -10641,11 +10705,13 @@ export namespace admin_directory_v1 {
 
 
   export class Resource$Users {
+    context: APIRequestContext;
     aliases: Resource$Users$Aliases;
     photos: Resource$Users$Photos;
-    constructor() {
-      this.aliases = new Resource$Users$Aliases();
-      this.photos = new Resource$Users$Photos();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.aliases = new Resource$Users$Aliases(this.context);
+      this.photos = new Resource$Users$Photos(this.context);
     }
 
 
@@ -10702,7 +10768,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['userKey'],
         pathParams: ['userKey'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -10766,7 +10832,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['userKey'],
         pathParams: ['userKey'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$User>(parameters, callback);
@@ -10830,7 +10896,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$User>(parameters, callback);
@@ -10905,7 +10971,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Users>(parameters, callback);
@@ -10970,7 +11036,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['userKey'],
         pathParams: ['userKey'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -11035,7 +11101,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['userKey'],
         pathParams: ['userKey'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$User>(parameters, callback);
@@ -11099,7 +11165,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['userKey'],
         pathParams: ['userKey'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -11164,7 +11230,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['userKey'],
         pathParams: ['userKey'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$User>(parameters, callback);
@@ -11240,7 +11306,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Channel>(parameters, callback);
@@ -11490,7 +11556,10 @@ export namespace admin_directory_v1 {
   }
 
   export class Resource$Users$Aliases {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -11550,7 +11619,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['userKey', 'alias'],
         pathParams: ['alias', 'userKey'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -11617,7 +11686,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['userKey'],
         pathParams: ['userKey'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Alias>(parameters, callback);
@@ -11683,7 +11752,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['userKey'],
         pathParams: ['userKey'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Aliases>(parameters, callback);
@@ -11752,7 +11821,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['userKey'],
         pathParams: ['userKey'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Channel>(parameters, callback);
@@ -11835,7 +11904,10 @@ export namespace admin_directory_v1 {
 
 
   export class Resource$Users$Photos {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -11894,7 +11966,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['userKey'],
         pathParams: ['userKey'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -11957,7 +12029,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['userKey'],
         pathParams: ['userKey'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$UserPhoto>(parameters, callback);
@@ -12025,7 +12097,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['userKey'],
         pathParams: ['userKey'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$UserPhoto>(parameters, callback);
@@ -12094,7 +12166,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['userKey'],
         pathParams: ['userKey'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$UserPhoto>(parameters, callback);
@@ -12165,7 +12237,10 @@ export namespace admin_directory_v1 {
 
 
   export class Resource$Verificationcodes {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -12225,7 +12300,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['userKey'],
         pathParams: ['userKey'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -12292,7 +12367,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['userKey'],
         pathParams: ['userKey'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -12361,7 +12436,7 @@ export namespace admin_directory_v1 {
         params,
         requiredParams: ['userKey'],
         pathParams: ['userKey'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$VerificationCodes>(parameters, callback);

--- a/src/apis/admin/reports_v1.ts
+++ b/src/apis/admin/reports_v1.ts
@@ -29,8 +29,6 @@ export namespace admin_reports_v1 {
     version: 'reports_v1';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * Data format for the response.
@@ -82,6 +80,7 @@ export namespace admin_reports_v1 {
    * @param {object=} options Options for Admin
    */
   export class Admin {
+    context: APIRequestContext;
     activities: Resource$Activities;
     channels: Resource$Channels;
     customerUsageReports: Resource$Customerusagereports;
@@ -89,13 +88,14 @@ export namespace admin_reports_v1 {
     userUsageReport: Resource$Userusagereport;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.activities = new Resource$Activities();
-      this.channels = new Resource$Channels();
-      this.customerUsageReports = new Resource$Customerusagereports();
-      this.entityUsageReports = new Resource$Entityusagereports();
-      this.userUsageReport = new Resource$Userusagereport();
+      this.activities = new Resource$Activities(this.context);
+      this.channels = new Resource$Channels(this.context);
+      this.customerUsageReports =
+          new Resource$Customerusagereports(this.context);
+      this.entityUsageReports = new Resource$Entityusagereports(this.context);
+      this.userUsageReport = new Resource$Userusagereport(this.context);
     }
   }
 
@@ -293,7 +293,10 @@ export namespace admin_reports_v1 {
 
 
   export class Resource$Activities {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -364,7 +367,7 @@ export namespace admin_reports_v1 {
         params,
         requiredParams: ['userKey', 'applicationName'],
         pathParams: ['applicationName', 'userKey'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Activities>(parameters, callback);
@@ -441,7 +444,7 @@ export namespace admin_reports_v1 {
         params,
         requiredParams: ['userKey', 'applicationName'],
         pathParams: ['applicationName', 'userKey'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Channel>(parameters, callback);
@@ -571,7 +574,10 @@ export namespace admin_reports_v1 {
 
 
   export class Resource$Channels {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -628,7 +634,7 @@ export namespace admin_reports_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -653,7 +659,10 @@ export namespace admin_reports_v1 {
 
 
   export class Resource$Customerusagereports {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -713,7 +722,7 @@ export namespace admin_reports_v1 {
         params,
         requiredParams: ['date'],
         pathParams: ['date'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$UsageReports>(parameters, callback);
@@ -752,7 +761,10 @@ export namespace admin_reports_v1 {
 
 
   export class Resource$Entityusagereports {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -818,7 +830,7 @@ export namespace admin_reports_v1 {
         params,
         requiredParams: ['entityType', 'entityKey', 'date'],
         pathParams: ['date', 'entityKey', 'entityType'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$UsageReports>(parameters, callback);
@@ -873,7 +885,10 @@ export namespace admin_reports_v1 {
 
 
   export class Resource$Userusagereport {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -938,7 +953,7 @@ export namespace admin_reports_v1 {
         params,
         requiredParams: ['userKey', 'date'],
         pathParams: ['date', 'userKey'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$UsageReports>(parameters, callback);

--- a/src/apis/adsense/v1.4.ts
+++ b/src/apis/adsense/v1.4.ts
@@ -29,8 +29,6 @@ export namespace adsense_v1_4 {
     version: 'v1_4';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * Data format for the response.
@@ -82,6 +80,7 @@ export namespace adsense_v1_4 {
    * @param {object=} options Options for Adsense
    */
   export class Adsense {
+    context: APIRequestContext;
     accounts: Resource$Accounts;
     adclients: Resource$Adclients;
     adunits: Resource$Adunits;
@@ -94,18 +93,18 @@ export namespace adsense_v1_4 {
     urlchannels: Resource$Urlchannels;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.accounts = new Resource$Accounts();
-      this.adclients = new Resource$Adclients();
-      this.adunits = new Resource$Adunits();
-      this.alerts = new Resource$Alerts();
-      this.customchannels = new Resource$Customchannels();
-      this.metadata = new Resource$Metadata();
-      this.payments = new Resource$Payments();
-      this.reports = new Resource$Reports();
-      this.savedadstyles = new Resource$Savedadstyles();
-      this.urlchannels = new Resource$Urlchannels();
+      this.accounts = new Resource$Accounts(this.context);
+      this.adclients = new Resource$Adclients(this.context);
+      this.adunits = new Resource$Adunits(this.context);
+      this.alerts = new Resource$Alerts(this.context);
+      this.customchannels = new Resource$Customchannels(this.context);
+      this.metadata = new Resource$Metadata(this.context);
+      this.payments = new Resource$Payments(this.context);
+      this.reports = new Resource$Reports(this.context);
+      this.savedadstyles = new Resource$Savedadstyles(this.context);
+      this.urlchannels = new Resource$Urlchannels(this.context);
     }
   }
 
@@ -658,6 +657,7 @@ export namespace adsense_v1_4 {
 
 
   export class Resource$Accounts {
+    context: APIRequestContext;
     adclients: Resource$Accounts$Adclients;
     adunits: Resource$Accounts$Adunits;
     alerts: Resource$Accounts$Alerts;
@@ -666,15 +666,16 @@ export namespace adsense_v1_4 {
     reports: Resource$Accounts$Reports;
     savedadstyles: Resource$Accounts$Savedadstyles;
     urlchannels: Resource$Accounts$Urlchannels;
-    constructor() {
-      this.adclients = new Resource$Accounts$Adclients();
-      this.adunits = new Resource$Accounts$Adunits();
-      this.alerts = new Resource$Accounts$Alerts();
-      this.customchannels = new Resource$Accounts$Customchannels();
-      this.payments = new Resource$Accounts$Payments();
-      this.reports = new Resource$Accounts$Reports();
-      this.savedadstyles = new Resource$Accounts$Savedadstyles();
-      this.urlchannels = new Resource$Accounts$Urlchannels();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.adclients = new Resource$Accounts$Adclients(this.context);
+      this.adunits = new Resource$Accounts$Adunits(this.context);
+      this.alerts = new Resource$Accounts$Alerts(this.context);
+      this.customchannels = new Resource$Accounts$Customchannels(this.context);
+      this.payments = new Resource$Accounts$Payments(this.context);
+      this.reports = new Resource$Accounts$Reports(this.context);
+      this.savedadstyles = new Resource$Accounts$Savedadstyles(this.context);
+      this.urlchannels = new Resource$Accounts$Urlchannels(this.context);
     }
 
 
@@ -730,7 +731,7 @@ export namespace adsense_v1_4 {
         params,
         requiredParams: ['accountId'],
         pathParams: ['accountId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Account>(parameters, callback);
@@ -795,7 +796,7 @@ export namespace adsense_v1_4 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Accounts>(parameters, callback);
@@ -840,7 +841,10 @@ export namespace adsense_v1_4 {
   }
 
   export class Resource$Accounts$Adclients {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -902,7 +906,7 @@ export namespace adsense_v1_4 {
         params,
         requiredParams: ['accountId', 'adClientId'],
         pathParams: ['accountId', 'adClientId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AdCode>(parameters, callback);
@@ -971,7 +975,7 @@ export namespace adsense_v1_4 {
         params,
         requiredParams: ['accountId'],
         pathParams: ['accountId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AdClients>(parameters, callback);
@@ -1023,9 +1027,12 @@ export namespace adsense_v1_4 {
 
 
   export class Resource$Accounts$Adunits {
+    context: APIRequestContext;
     customchannels: Resource$Accounts$Adunits$Customchannels;
-    constructor() {
-      this.customchannels = new Resource$Accounts$Adunits$Customchannels();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.customchannels =
+          new Resource$Accounts$Adunits$Customchannels(this.context);
     }
 
 
@@ -1086,7 +1093,7 @@ export namespace adsense_v1_4 {
         params,
         requiredParams: ['accountId', 'adClientId', 'adUnitId'],
         pathParams: ['accountId', 'adClientId', 'adUnitId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AdUnit>(parameters, callback);
@@ -1156,7 +1163,7 @@ export namespace adsense_v1_4 {
         params,
         requiredParams: ['accountId', 'adClientId', 'adUnitId'],
         pathParams: ['accountId', 'adClientId', 'adUnitId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AdCode>(parameters, callback);
@@ -1229,7 +1236,7 @@ export namespace adsense_v1_4 {
         params,
         requiredParams: ['accountId', 'adClientId'],
         pathParams: ['accountId', 'adClientId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AdUnits>(parameters, callback);
@@ -1312,7 +1319,10 @@ export namespace adsense_v1_4 {
   }
 
   export class Resource$Accounts$Adunits$Customchannels {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1378,7 +1388,7 @@ export namespace adsense_v1_4 {
         params,
         requiredParams: ['accountId', 'adClientId', 'adUnitId'],
         pathParams: ['accountId', 'adClientId', 'adUnitId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$CustomChannels>(parameters, callback);
@@ -1423,7 +1433,10 @@ export namespace adsense_v1_4 {
 
 
   export class Resource$Accounts$Alerts {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1484,7 +1497,7 @@ export namespace adsense_v1_4 {
         params,
         requiredParams: ['accountId', 'alertId'],
         pathParams: ['accountId', 'alertId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -1551,7 +1564,7 @@ export namespace adsense_v1_4 {
         params,
         requiredParams: ['accountId'],
         pathParams: ['accountId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Alerts>(parameters, callback);
@@ -1598,9 +1611,11 @@ export namespace adsense_v1_4 {
 
 
   export class Resource$Accounts$Customchannels {
+    context: APIRequestContext;
     adunits: Resource$Accounts$Customchannels$Adunits;
-    constructor() {
-      this.adunits = new Resource$Accounts$Customchannels$Adunits();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.adunits = new Resource$Accounts$Customchannels$Adunits(this.context);
     }
 
 
@@ -1662,7 +1677,7 @@ export namespace adsense_v1_4 {
         params,
         requiredParams: ['accountId', 'adClientId', 'customChannelId'],
         pathParams: ['accountId', 'adClientId', 'customChannelId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$CustomChannel>(parameters, callback);
@@ -1735,7 +1750,7 @@ export namespace adsense_v1_4 {
         params,
         requiredParams: ['accountId', 'adClientId'],
         pathParams: ['accountId', 'adClientId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$CustomChannels>(parameters, callback);
@@ -1794,7 +1809,10 @@ export namespace adsense_v1_4 {
   }
 
   export class Resource$Accounts$Customchannels$Adunits {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1860,7 +1878,7 @@ export namespace adsense_v1_4 {
         params,
         requiredParams: ['accountId', 'adClientId', 'customChannelId'],
         pathParams: ['accountId', 'adClientId', 'customChannelId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AdUnits>(parameters, callback);
@@ -1909,7 +1927,10 @@ export namespace adsense_v1_4 {
 
 
   export class Resource$Accounts$Payments {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1968,7 +1989,7 @@ export namespace adsense_v1_4 {
         params,
         requiredParams: ['accountId'],
         pathParams: ['accountId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Payments>(parameters, callback);
@@ -1993,9 +2014,11 @@ export namespace adsense_v1_4 {
 
 
   export class Resource$Accounts$Reports {
+    context: APIRequestContext;
     saved: Resource$Accounts$Reports$Saved;
-    constructor() {
-      this.saved = new Resource$Accounts$Reports$Saved();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.saved = new Resource$Accounts$Reports$Saved(this.context);
     }
 
 
@@ -2075,7 +2098,7 @@ export namespace adsense_v1_4 {
         params,
         requiredParams: ['accountId', 'startDate', 'endDate'],
         pathParams: ['accountId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AdsenseReportsGenerateResponse>(
@@ -2150,7 +2173,10 @@ export namespace adsense_v1_4 {
   }
 
   export class Resource$Accounts$Reports$Saved {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -2223,7 +2249,7 @@ export namespace adsense_v1_4 {
         params,
         requiredParams: ['accountId', 'savedReportId'],
         pathParams: ['accountId', 'savedReportId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AdsenseReportsGenerateResponse>(
@@ -2295,7 +2321,7 @@ export namespace adsense_v1_4 {
         params,
         requiredParams: ['accountId'],
         pathParams: ['accountId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$SavedReports>(parameters, callback);
@@ -2361,7 +2387,10 @@ export namespace adsense_v1_4 {
 
 
   export class Resource$Accounts$Savedadstyles {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -2420,7 +2449,7 @@ export namespace adsense_v1_4 {
         params,
         requiredParams: ['accountId', 'savedAdStyleId'],
         pathParams: ['accountId', 'savedAdStyleId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$SavedAdStyle>(parameters, callback);
@@ -2490,7 +2519,7 @@ export namespace adsense_v1_4 {
         params,
         requiredParams: ['accountId'],
         pathParams: ['accountId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$SavedAdStyles>(parameters, callback);
@@ -2542,7 +2571,10 @@ export namespace adsense_v1_4 {
 
 
   export class Resource$Accounts$Urlchannels {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -2608,7 +2640,7 @@ export namespace adsense_v1_4 {
         params,
         requiredParams: ['accountId', 'adClientId'],
         pathParams: ['accountId', 'adClientId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$UrlChannels>(parameters, callback);
@@ -2649,7 +2681,10 @@ export namespace adsense_v1_4 {
 
 
   export class Resource$Adclients {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -2708,7 +2743,7 @@ export namespace adsense_v1_4 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AdClients>(parameters, callback);
@@ -2739,9 +2774,11 @@ export namespace adsense_v1_4 {
 
 
   export class Resource$Adunits {
+    context: APIRequestContext;
     customchannels: Resource$Adunits$Customchannels;
-    constructor() {
-      this.customchannels = new Resource$Adunits$Customchannels();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.customchannels = new Resource$Adunits$Customchannels(this.context);
     }
 
 
@@ -2798,7 +2835,7 @@ export namespace adsense_v1_4 {
         params,
         requiredParams: ['adClientId', 'adUnitId'],
         pathParams: ['adClientId', 'adUnitId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AdUnit>(parameters, callback);
@@ -2867,7 +2904,7 @@ export namespace adsense_v1_4 {
         params,
         requiredParams: ['adClientId', 'adUnitId'],
         pathParams: ['adClientId', 'adUnitId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AdCode>(parameters, callback);
@@ -2935,7 +2972,7 @@ export namespace adsense_v1_4 {
         params,
         requiredParams: ['adClientId'],
         pathParams: ['adClientId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AdUnits>(parameters, callback);
@@ -3004,7 +3041,10 @@ export namespace adsense_v1_4 {
   }
 
   export class Resource$Adunits$Customchannels {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -3069,7 +3109,7 @@ export namespace adsense_v1_4 {
         params,
         requiredParams: ['adClientId', 'adUnitId'],
         pathParams: ['adClientId', 'adUnitId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$CustomChannels>(parameters, callback);
@@ -3110,7 +3150,10 @@ export namespace adsense_v1_4 {
 
 
   export class Resource$Alerts {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -3167,7 +3210,7 @@ export namespace adsense_v1_4 {
         params,
         requiredParams: ['alertId'],
         pathParams: ['alertId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -3231,7 +3274,7 @@ export namespace adsense_v1_4 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Alerts>(parameters, callback);
@@ -3268,9 +3311,11 @@ export namespace adsense_v1_4 {
 
 
   export class Resource$Customchannels {
+    context: APIRequestContext;
     adunits: Resource$Customchannels$Adunits;
-    constructor() {
-      this.adunits = new Resource$Customchannels$Adunits();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.adunits = new Resource$Customchannels$Adunits(this.context);
     }
 
 
@@ -3330,7 +3375,7 @@ export namespace adsense_v1_4 {
         params,
         requiredParams: ['adClientId', 'customChannelId'],
         pathParams: ['adClientId', 'customChannelId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$CustomChannel>(parameters, callback);
@@ -3400,7 +3445,7 @@ export namespace adsense_v1_4 {
         params,
         requiredParams: ['adClientId'],
         pathParams: ['adClientId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$CustomChannels>(parameters, callback);
@@ -3451,7 +3496,10 @@ export namespace adsense_v1_4 {
   }
 
   export class Resource$Customchannels$Adunits {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -3516,7 +3564,7 @@ export namespace adsense_v1_4 {
         params,
         requiredParams: ['adClientId', 'customChannelId'],
         pathParams: ['adClientId', 'customChannelId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AdUnits>(parameters, callback);
@@ -3561,17 +3609,22 @@ export namespace adsense_v1_4 {
 
 
   export class Resource$Metadata {
+    context: APIRequestContext;
     dimensions: Resource$Metadata$Dimensions;
     metrics: Resource$Metadata$Metrics;
-    constructor() {
-      this.dimensions = new Resource$Metadata$Dimensions();
-      this.metrics = new Resource$Metadata$Metrics();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.dimensions = new Resource$Metadata$Dimensions(this.context);
+      this.metrics = new Resource$Metadata$Metrics(this.context);
     }
   }
 
 
   export class Resource$Metadata$Dimensions {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -3630,7 +3683,7 @@ export namespace adsense_v1_4 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Metadata>(parameters, callback);
@@ -3650,7 +3703,10 @@ export namespace adsense_v1_4 {
 
 
   export class Resource$Metadata$Metrics {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -3709,7 +3765,7 @@ export namespace adsense_v1_4 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Metadata>(parameters, callback);
@@ -3730,7 +3786,10 @@ export namespace adsense_v1_4 {
 
 
   export class Resource$Payments {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -3786,7 +3845,7 @@ export namespace adsense_v1_4 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Payments>(parameters, callback);
@@ -3805,9 +3864,11 @@ export namespace adsense_v1_4 {
 
 
   export class Resource$Reports {
+    context: APIRequestContext;
     saved: Resource$Reports$Saved;
-    constructor() {
-      this.saved = new Resource$Reports$Saved();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.saved = new Resource$Reports$Saved(this.context);
     }
 
 
@@ -3885,7 +3946,7 @@ export namespace adsense_v1_4 {
         params,
         requiredParams: ['startDate', 'endDate'],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AdsenseReportsGenerateResponse>(
@@ -3959,7 +4020,10 @@ export namespace adsense_v1_4 {
   }
 
   export class Resource$Reports$Saved {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -4029,7 +4093,7 @@ export namespace adsense_v1_4 {
         params,
         requiredParams: ['savedReportId'],
         pathParams: ['savedReportId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AdsenseReportsGenerateResponse>(
@@ -4098,7 +4162,7 @@ export namespace adsense_v1_4 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$SavedReports>(parameters, callback);
@@ -4156,7 +4220,10 @@ export namespace adsense_v1_4 {
 
 
   export class Resource$Savedadstyles {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -4212,7 +4279,7 @@ export namespace adsense_v1_4 {
         params,
         requiredParams: ['savedAdStyleId'],
         pathParams: ['savedAdStyleId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$SavedAdStyle>(parameters, callback);
@@ -4279,7 +4346,7 @@ export namespace adsense_v1_4 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$SavedAdStyles>(parameters, callback);
@@ -4323,7 +4390,10 @@ export namespace adsense_v1_4 {
 
 
   export class Resource$Urlchannels {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -4385,7 +4455,7 @@ export namespace adsense_v1_4 {
         params,
         requiredParams: ['adClientId'],
         pathParams: ['adClientId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$UrlChannels>(parameters, callback);

--- a/src/apis/adsensehost/v4.1.ts
+++ b/src/apis/adsensehost/v4.1.ts
@@ -29,8 +29,6 @@ export namespace adsensehost_v4_1 {
     version: 'v4_1';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * Data format for the response.
@@ -82,6 +80,7 @@ export namespace adsensehost_v4_1 {
    * @param {object=} options Options for Adsensehost
    */
   export class Adsensehost {
+    context: APIRequestContext;
     accounts: Resource$Accounts;
     adclients: Resource$Adclients;
     associationsessions: Resource$Associationsessions;
@@ -90,14 +89,14 @@ export namespace adsensehost_v4_1 {
     urlchannels: Resource$Urlchannels;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.accounts = new Resource$Accounts();
-      this.adclients = new Resource$Adclients();
-      this.associationsessions = new Resource$Associationsessions();
-      this.customchannels = new Resource$Customchannels();
-      this.reports = new Resource$Reports();
-      this.urlchannels = new Resource$Urlchannels();
+      this.accounts = new Resource$Accounts(this.context);
+      this.adclients = new Resource$Adclients(this.context);
+      this.associationsessions = new Resource$Associationsessions(this.context);
+      this.customchannels = new Resource$Customchannels(this.context);
+      this.reports = new Resource$Reports(this.context);
+      this.urlchannels = new Resource$Urlchannels(this.context);
     }
   }
 
@@ -444,13 +443,15 @@ export namespace adsensehost_v4_1 {
 
 
   export class Resource$Accounts {
+    context: APIRequestContext;
     adclients: Resource$Accounts$Adclients;
     adunits: Resource$Accounts$Adunits;
     reports: Resource$Accounts$Reports;
-    constructor() {
-      this.adclients = new Resource$Accounts$Adclients();
-      this.adunits = new Resource$Accounts$Adunits();
-      this.reports = new Resource$Accounts$Reports();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.adclients = new Resource$Accounts$Adclients(this.context);
+      this.adunits = new Resource$Accounts$Adunits(this.context);
+      this.reports = new Resource$Accounts$Reports(this.context);
     }
 
 
@@ -505,7 +506,7 @@ export namespace adsensehost_v4_1 {
         params,
         requiredParams: ['accountId'],
         pathParams: ['accountId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Account>(parameters, callback);
@@ -570,7 +571,7 @@ export namespace adsensehost_v4_1 {
         params,
         requiredParams: ['filterAdClientId'],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Accounts>(parameters, callback);
@@ -604,7 +605,10 @@ export namespace adsensehost_v4_1 {
   }
 
   export class Resource$Accounts$Adclients {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -663,7 +667,7 @@ export namespace adsensehost_v4_1 {
         params,
         requiredParams: ['accountId', 'adClientId'],
         pathParams: ['accountId', 'adClientId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AdClient>(parameters, callback);
@@ -733,7 +737,7 @@ export namespace adsensehost_v4_1 {
         params,
         requiredParams: ['accountId'],
         pathParams: ['accountId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AdClients>(parameters, callback);
@@ -785,7 +789,10 @@ export namespace adsensehost_v4_1 {
 
 
   export class Resource$Accounts$Adunits {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -849,7 +856,7 @@ export namespace adsensehost_v4_1 {
         params,
         requiredParams: ['accountId', 'adClientId', 'adUnitId'],
         pathParams: ['accountId', 'adClientId', 'adUnitId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AdUnit>(parameters, callback);
@@ -915,7 +922,7 @@ export namespace adsensehost_v4_1 {
         params,
         requiredParams: ['accountId', 'adClientId', 'adUnitId'],
         pathParams: ['accountId', 'adClientId', 'adUnitId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AdUnit>(parameters, callback);
@@ -987,7 +994,7 @@ export namespace adsensehost_v4_1 {
         params,
         requiredParams: ['accountId', 'adClientId', 'adUnitId'],
         pathParams: ['accountId', 'adClientId', 'adUnitId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AdCode>(parameters, callback);
@@ -1058,7 +1065,7 @@ export namespace adsensehost_v4_1 {
         params,
         requiredParams: ['accountId', 'adClientId'],
         pathParams: ['accountId', 'adClientId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AdUnit>(parameters, callback);
@@ -1130,7 +1137,7 @@ export namespace adsensehost_v4_1 {
         params,
         requiredParams: ['accountId', 'adClientId'],
         pathParams: ['accountId', 'adClientId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AdUnits>(parameters, callback);
@@ -1202,7 +1209,7 @@ export namespace adsensehost_v4_1 {
         params,
         requiredParams: ['accountId', 'adClientId', 'adUnitId'],
         pathParams: ['accountId', 'adClientId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AdUnit>(parameters, callback);
@@ -1273,7 +1280,7 @@ export namespace adsensehost_v4_1 {
         params,
         requiredParams: ['accountId', 'adClientId'],
         pathParams: ['accountId', 'adClientId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AdUnit>(parameters, callback);
@@ -1448,7 +1455,10 @@ export namespace adsensehost_v4_1 {
 
 
   export class Resource$Accounts$Reports {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1518,7 +1528,7 @@ export namespace adsensehost_v4_1 {
         params,
         requiredParams: ['accountId', 'startDate', 'endDate'],
         pathParams: ['accountId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Report>(parameters, callback);
@@ -1583,7 +1593,10 @@ export namespace adsensehost_v4_1 {
 
 
   export class Resource$Adclients {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1638,7 +1651,7 @@ export namespace adsensehost_v4_1 {
         params,
         requiredParams: ['adClientId'],
         pathParams: ['adClientId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AdClient>(parameters, callback);
@@ -1704,7 +1717,7 @@ export namespace adsensehost_v4_1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AdClients>(parameters, callback);
@@ -1746,7 +1759,10 @@ export namespace adsensehost_v4_1 {
 
 
   export class Resource$Associationsessions {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1810,7 +1826,7 @@ export namespace adsensehost_v4_1 {
         params,
         requiredParams: ['productCode', 'websiteUrl'],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AssociationSession>(parameters, callback);
@@ -1878,7 +1894,7 @@ export namespace adsensehost_v4_1 {
         params,
         requiredParams: ['token'],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AssociationSession>(parameters, callback);
@@ -1927,7 +1943,10 @@ export namespace adsensehost_v4_1 {
 
 
   export class Resource$Customchannels {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1990,7 +2009,7 @@ export namespace adsensehost_v4_1 {
         params,
         requiredParams: ['adClientId', 'customChannelId'],
         pathParams: ['adClientId', 'customChannelId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$CustomChannel>(parameters, callback);
@@ -2056,7 +2075,7 @@ export namespace adsensehost_v4_1 {
         params,
         requiredParams: ['adClientId', 'customChannelId'],
         pathParams: ['adClientId', 'customChannelId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$CustomChannel>(parameters, callback);
@@ -2125,7 +2144,7 @@ export namespace adsensehost_v4_1 {
         params,
         requiredParams: ['adClientId'],
         pathParams: ['adClientId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$CustomChannel>(parameters, callback);
@@ -2194,7 +2213,7 @@ export namespace adsensehost_v4_1 {
         params,
         requiredParams: ['adClientId'],
         pathParams: ['adClientId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$CustomChannels>(parameters, callback);
@@ -2265,7 +2284,7 @@ export namespace adsensehost_v4_1 {
         params,
         requiredParams: ['adClientId', 'customChannelId'],
         pathParams: ['adClientId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$CustomChannel>(parameters, callback);
@@ -2334,7 +2353,7 @@ export namespace adsensehost_v4_1 {
         params,
         requiredParams: ['adClientId'],
         pathParams: ['adClientId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$CustomChannel>(parameters, callback);
@@ -2457,7 +2476,10 @@ export namespace adsensehost_v4_1 {
 
 
   export class Resource$Reports {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -2525,7 +2547,7 @@ export namespace adsensehost_v4_1 {
         params,
         requiredParams: ['startDate', 'endDate'],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Report>(parameters, callback);
@@ -2584,7 +2606,10 @@ export namespace adsensehost_v4_1 {
 
 
   export class Resource$Urlchannels {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -2647,7 +2672,7 @@ export namespace adsensehost_v4_1 {
         params,
         requiredParams: ['adClientId', 'urlChannelId'],
         pathParams: ['adClientId', 'urlChannelId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$UrlChannel>(parameters, callback);
@@ -2716,7 +2741,7 @@ export namespace adsensehost_v4_1 {
         params,
         requiredParams: ['adClientId'],
         pathParams: ['adClientId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$UrlChannel>(parameters, callback);
@@ -2784,7 +2809,7 @@ export namespace adsensehost_v4_1 {
         params,
         requiredParams: ['adClientId'],
         pathParams: ['adClientId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$UrlChannels>(parameters, callback);

--- a/src/apis/alertcenter/v1beta1.ts
+++ b/src/apis/alertcenter/v1beta1.ts
@@ -29,8 +29,6 @@ export namespace alertcenter_v1beta1 {
     version: 'v1beta1';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * V1 error format.
@@ -98,14 +96,15 @@ export namespace alertcenter_v1beta1 {
    * @param {object=} options Options for Alertcenter
    */
   export class Alertcenter {
+    context: APIRequestContext;
     alerts: Resource$Alerts;
     v1beta1: Resource$V1beta1;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.alerts = new Resource$Alerts();
-      this.v1beta1 = new Resource$V1beta1();
+      this.alerts = new Resource$Alerts(this.context);
+      this.v1beta1 = new Resource$V1beta1(this.context);
     }
   }
 
@@ -619,9 +618,11 @@ export namespace alertcenter_v1beta1 {
 
 
   export class Resource$Alerts {
+    context: APIRequestContext;
     feedback: Resource$Alerts$Feedback;
-    constructor() {
-      this.feedback = new Resource$Alerts$Feedback();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.feedback = new Resource$Alerts$Feedback(this.context);
     }
 
 
@@ -684,7 +685,7 @@ export namespace alertcenter_v1beta1 {
         params,
         requiredParams: ['alertId'],
         pathParams: ['alertId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -747,7 +748,7 @@ export namespace alertcenter_v1beta1 {
         params,
         requiredParams: ['alertId'],
         pathParams: ['alertId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Alert>(parameters, callback);
@@ -815,7 +816,7 @@ export namespace alertcenter_v1beta1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListAlertsResponse>(parameters, callback);
@@ -885,7 +886,7 @@ export namespace alertcenter_v1beta1 {
         params,
         requiredParams: ['alertId'],
         pathParams: ['alertId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Alert>(parameters, callback);
@@ -986,7 +987,10 @@ export namespace alertcenter_v1beta1 {
   }
 
   export class Resource$Alerts$Feedback {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1049,7 +1053,7 @@ export namespace alertcenter_v1beta1 {
         params,
         requiredParams: ['alertId'],
         pathParams: ['alertId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AlertFeedback>(parameters, callback);
@@ -1121,7 +1125,7 @@ export namespace alertcenter_v1beta1 {
         params,
         requiredParams: ['alertId'],
         pathParams: ['alertId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListAlertFeedbackResponse>(
@@ -1185,7 +1189,10 @@ export namespace alertcenter_v1beta1 {
 
 
   export class Resource$V1beta1 {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1244,7 +1251,7 @@ export namespace alertcenter_v1beta1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Settings>(parameters, callback);
@@ -1311,7 +1318,7 @@ export namespace alertcenter_v1beta1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Settings>(parameters, callback);

--- a/src/apis/analytics/v2.4.ts
+++ b/src/apis/analytics/v2.4.ts
@@ -29,8 +29,6 @@ export namespace analytics_v2_4 {
     version: 'v2_4';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * Data format for the response.
@@ -81,21 +79,25 @@ export namespace analytics_v2_4 {
    * @param {object=} options Options for Analytics
    */
   export class Analytics {
+    context: APIRequestContext;
     data: Resource$Data;
     management: Resource$Management;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.data = new Resource$Data();
-      this.management = new Resource$Management();
+      this.data = new Resource$Data(this.context);
+      this.management = new Resource$Management(this.context);
     }
   }
 
 
 
   export class Resource$Data {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -156,7 +158,7 @@ export namespace analytics_v2_4 {
         params,
         requiredParams: ['ids', 'start-date', 'end-date', 'metrics'],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -225,23 +227,28 @@ export namespace analytics_v2_4 {
 
 
   export class Resource$Management {
+    context: APIRequestContext;
     accounts: Resource$Management$Accounts;
     goals: Resource$Management$Goals;
     profiles: Resource$Management$Profiles;
     segments: Resource$Management$Segments;
     webproperties: Resource$Management$Webproperties;
-    constructor() {
-      this.accounts = new Resource$Management$Accounts();
-      this.goals = new Resource$Management$Goals();
-      this.profiles = new Resource$Management$Profiles();
-      this.segments = new Resource$Management$Segments();
-      this.webproperties = new Resource$Management$Webproperties();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.accounts = new Resource$Management$Accounts(this.context);
+      this.goals = new Resource$Management$Goals(this.context);
+      this.profiles = new Resource$Management$Profiles(this.context);
+      this.segments = new Resource$Management$Segments(this.context);
+      this.webproperties = new Resource$Management$Webproperties(this.context);
     }
   }
 
 
   export class Resource$Management$Accounts {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -300,7 +307,7 @@ export namespace analytics_v2_4 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -330,7 +337,10 @@ export namespace analytics_v2_4 {
 
 
   export class Resource$Management$Goals {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -394,7 +404,7 @@ export namespace analytics_v2_4 {
         params,
         requiredParams: ['accountId', 'webPropertyId', 'profileId'],
         pathParams: ['accountId', 'profileId', 'webPropertyId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -441,7 +451,10 @@ export namespace analytics_v2_4 {
 
 
   export class Resource$Management$Profiles {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -504,7 +517,7 @@ export namespace analytics_v2_4 {
         params,
         requiredParams: ['accountId', 'webPropertyId'],
         pathParams: ['accountId', 'webPropertyId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -546,7 +559,10 @@ export namespace analytics_v2_4 {
 
 
   export class Resource$Management$Segments {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -605,7 +621,7 @@ export namespace analytics_v2_4 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -635,7 +651,10 @@ export namespace analytics_v2_4 {
 
 
   export class Resource$Management$Webproperties {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -697,7 +716,7 @@ export namespace analytics_v2_4 {
         params,
         requiredParams: ['accountId'],
         pathParams: ['accountId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);

--- a/src/apis/analytics/v3.ts
+++ b/src/apis/analytics/v3.ts
@@ -29,8 +29,6 @@ export namespace analytics_v3 {
     version: 'v3';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * Data format for the response.
@@ -81,6 +79,7 @@ export namespace analytics_v3 {
    * @param {object=} options Options for Analytics
    */
   export class Analytics {
+    context: APIRequestContext;
     data: Resource$Data;
     management: Resource$Management;
     metadata: Resource$Metadata;
@@ -88,13 +87,13 @@ export namespace analytics_v3 {
     userDeletion: Resource$Userdeletion;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.data = new Resource$Data();
-      this.management = new Resource$Management();
-      this.metadata = new Resource$Metadata();
-      this.provisioning = new Resource$Provisioning();
-      this.userDeletion = new Resource$Userdeletion();
+      this.data = new Resource$Data(this.context);
+      this.management = new Resource$Management(this.context);
+      this.metadata = new Resource$Metadata(this.context);
+      this.provisioning = new Resource$Provisioning(this.context);
+      this.userDeletion = new Resource$Userdeletion(this.context);
     }
   }
 
@@ -2781,19 +2780,24 @@ export namespace analytics_v3 {
 
 
   export class Resource$Data {
+    context: APIRequestContext;
     ga: Resource$Data$Ga;
     mcf: Resource$Data$Mcf;
     realtime: Resource$Data$Realtime;
-    constructor() {
-      this.ga = new Resource$Data$Ga();
-      this.mcf = new Resource$Data$Mcf();
-      this.realtime = new Resource$Data$Realtime();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.ga = new Resource$Data$Ga(this.context);
+      this.mcf = new Resource$Data$Mcf(this.context);
+      this.realtime = new Resource$Data$Realtime(this.context);
     }
   }
 
 
   export class Resource$Data$Ga {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -2859,7 +2863,7 @@ export namespace analytics_v3 {
         params,
         requiredParams: ['ids', 'start-date', 'end-date', 'metrics'],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GaData>(parameters, callback);
@@ -2942,7 +2946,10 @@ export namespace analytics_v3 {
 
 
   export class Resource$Data$Mcf {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -3005,7 +3012,7 @@ export namespace analytics_v3 {
         params,
         requiredParams: ['ids', 'start-date', 'end-date', 'metrics'],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$McfData>(parameters, callback);
@@ -3076,7 +3083,10 @@ export namespace analytics_v3 {
 
 
   export class Resource$Data$Realtime {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -3137,7 +3147,7 @@ export namespace analytics_v3 {
         params,
         requiredParams: ['ids', 'metrics'],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$RealtimeData>(parameters, callback);
@@ -3188,6 +3198,7 @@ export namespace analytics_v3 {
 
 
   export class Resource$Management {
+    context: APIRequestContext;
     accounts: Resource$Management$Accounts;
     accountSummaries: Resource$Management$Accountsummaries;
     accountUserLinks: Resource$Management$Accountuserlinks;
@@ -3208,35 +3219,47 @@ export namespace analytics_v3 {
     webproperties: Resource$Management$Webproperties;
     webPropertyAdWordsLinks: Resource$Management$Webpropertyadwordslinks;
     webpropertyUserLinks: Resource$Management$Webpropertyuserlinks;
-    constructor() {
-      this.accounts = new Resource$Management$Accounts();
-      this.accountSummaries = new Resource$Management$Accountsummaries();
-      this.accountUserLinks = new Resource$Management$Accountuserlinks();
-      this.clientId = new Resource$Management$Clientid();
-      this.customDataSources = new Resource$Management$Customdatasources();
-      this.customDimensions = new Resource$Management$Customdimensions();
-      this.customMetrics = new Resource$Management$Custommetrics();
-      this.experiments = new Resource$Management$Experiments();
-      this.filters = new Resource$Management$Filters();
-      this.goals = new Resource$Management$Goals();
-      this.profileFilterLinks = new Resource$Management$Profilefilterlinks();
-      this.profiles = new Resource$Management$Profiles();
-      this.profileUserLinks = new Resource$Management$Profileuserlinks();
-      this.remarketingAudience = new Resource$Management$Remarketingaudience();
-      this.segments = new Resource$Management$Segments();
-      this.unsampledReports = new Resource$Management$Unsampledreports();
-      this.uploads = new Resource$Management$Uploads();
-      this.webproperties = new Resource$Management$Webproperties();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.accounts = new Resource$Management$Accounts(this.context);
+      this.accountSummaries =
+          new Resource$Management$Accountsummaries(this.context);
+      this.accountUserLinks =
+          new Resource$Management$Accountuserlinks(this.context);
+      this.clientId = new Resource$Management$Clientid(this.context);
+      this.customDataSources =
+          new Resource$Management$Customdatasources(this.context);
+      this.customDimensions =
+          new Resource$Management$Customdimensions(this.context);
+      this.customMetrics = new Resource$Management$Custommetrics(this.context);
+      this.experiments = new Resource$Management$Experiments(this.context);
+      this.filters = new Resource$Management$Filters(this.context);
+      this.goals = new Resource$Management$Goals(this.context);
+      this.profileFilterLinks =
+          new Resource$Management$Profilefilterlinks(this.context);
+      this.profiles = new Resource$Management$Profiles(this.context);
+      this.profileUserLinks =
+          new Resource$Management$Profileuserlinks(this.context);
+      this.remarketingAudience =
+          new Resource$Management$Remarketingaudience(this.context);
+      this.segments = new Resource$Management$Segments(this.context);
+      this.unsampledReports =
+          new Resource$Management$Unsampledreports(this.context);
+      this.uploads = new Resource$Management$Uploads(this.context);
+      this.webproperties = new Resource$Management$Webproperties(this.context);
       this.webPropertyAdWordsLinks =
-          new Resource$Management$Webpropertyadwordslinks();
+          new Resource$Management$Webpropertyadwordslinks(this.context);
       this.webpropertyUserLinks =
-          new Resource$Management$Webpropertyuserlinks();
+          new Resource$Management$Webpropertyuserlinks(this.context);
     }
   }
 
 
   export class Resource$Management$Accounts {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -3296,7 +3319,7 @@ export namespace analytics_v3 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Accounts>(parameters, callback);
@@ -3326,7 +3349,10 @@ export namespace analytics_v3 {
 
 
   export class Resource$Management$Accountsummaries {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -3388,7 +3414,7 @@ export namespace analytics_v3 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AccountSummaries>(parameters, callback);
@@ -3419,7 +3445,10 @@ export namespace analytics_v3 {
 
 
   export class Resource$Management$Accountuserlinks {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -3480,7 +3509,7 @@ export namespace analytics_v3 {
         params,
         requiredParams: ['accountId', 'linkId'],
         pathParams: ['accountId', 'linkId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -3550,7 +3579,7 @@ export namespace analytics_v3 {
         params,
         requiredParams: ['accountId'],
         pathParams: ['accountId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$EntityUserLink>(parameters, callback);
@@ -3621,7 +3650,7 @@ export namespace analytics_v3 {
         params,
         requiredParams: ['accountId'],
         pathParams: ['accountId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$EntityUserLinks>(parameters, callback);
@@ -3692,7 +3721,7 @@ export namespace analytics_v3 {
         params,
         requiredParams: ['accountId', 'linkId'],
         pathParams: ['accountId', 'linkId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$EntityUserLink>(parameters, callback);
@@ -3780,7 +3809,10 @@ export namespace analytics_v3 {
 
 
   export class Resource$Management$Clientid {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -3842,7 +3874,7 @@ export namespace analytics_v3 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$HashClientIdResponse>(parameters, callback);
@@ -3868,7 +3900,10 @@ export namespace analytics_v3 {
 
 
   export class Resource$Management$Customdatasources {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -3933,7 +3968,7 @@ export namespace analytics_v3 {
         params,
         requiredParams: ['accountId', 'webPropertyId'],
         pathParams: ['accountId', 'webPropertyId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$CustomDataSources>(parameters, callback);
@@ -3971,7 +4006,10 @@ export namespace analytics_v3 {
 
 
   export class Resource$Management$Customdimensions {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -4031,7 +4069,7 @@ export namespace analytics_v3 {
         params,
         requiredParams: ['accountId', 'webPropertyId', 'customDimensionId'],
         pathParams: ['accountId', 'customDimensionId', 'webPropertyId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$CustomDimension>(parameters, callback);
@@ -4102,7 +4140,7 @@ export namespace analytics_v3 {
         params,
         requiredParams: ['accountId', 'webPropertyId'],
         pathParams: ['accountId', 'webPropertyId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$CustomDimension>(parameters, callback);
@@ -4174,7 +4212,7 @@ export namespace analytics_v3 {
         params,
         requiredParams: ['accountId', 'webPropertyId'],
         pathParams: ['accountId', 'webPropertyId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$CustomDimensions>(parameters, callback);
@@ -4248,7 +4286,7 @@ export namespace analytics_v3 {
         params,
         requiredParams: ['accountId', 'webPropertyId', 'customDimensionId'],
         pathParams: ['accountId', 'customDimensionId', 'webPropertyId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$CustomDimension>(parameters, callback);
@@ -4321,7 +4359,7 @@ export namespace analytics_v3 {
         params,
         requiredParams: ['accountId', 'webPropertyId', 'customDimensionId'],
         pathParams: ['accountId', 'customDimensionId', 'webPropertyId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$CustomDimension>(parameters, callback);
@@ -4460,7 +4498,10 @@ export namespace analytics_v3 {
 
 
   export class Resource$Management$Custommetrics {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -4520,7 +4561,7 @@ export namespace analytics_v3 {
         params,
         requiredParams: ['accountId', 'webPropertyId', 'customMetricId'],
         pathParams: ['accountId', 'customMetricId', 'webPropertyId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$CustomMetric>(parameters, callback);
@@ -4591,7 +4632,7 @@ export namespace analytics_v3 {
         params,
         requiredParams: ['accountId', 'webPropertyId'],
         pathParams: ['accountId', 'webPropertyId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$CustomMetric>(parameters, callback);
@@ -4663,7 +4704,7 @@ export namespace analytics_v3 {
         params,
         requiredParams: ['accountId', 'webPropertyId'],
         pathParams: ['accountId', 'webPropertyId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$CustomMetrics>(parameters, callback);
@@ -4737,7 +4778,7 @@ export namespace analytics_v3 {
         params,
         requiredParams: ['accountId', 'webPropertyId', 'customMetricId'],
         pathParams: ['accountId', 'customMetricId', 'webPropertyId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$CustomMetric>(parameters, callback);
@@ -4810,7 +4851,7 @@ export namespace analytics_v3 {
         params,
         requiredParams: ['accountId', 'webPropertyId', 'customMetricId'],
         pathParams: ['accountId', 'customMetricId', 'webPropertyId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$CustomMetric>(parameters, callback);
@@ -4949,7 +4990,10 @@ export namespace analytics_v3 {
 
 
   export class Resource$Management$Experiments {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -5013,7 +5057,7 @@ export namespace analytics_v3 {
         requiredParams:
             ['accountId', 'webPropertyId', 'profileId', 'experimentId'],
         pathParams: ['accountId', 'experimentId', 'profileId', 'webPropertyId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -5082,7 +5126,7 @@ export namespace analytics_v3 {
         requiredParams:
             ['accountId', 'webPropertyId', 'profileId', 'experimentId'],
         pathParams: ['accountId', 'experimentId', 'profileId', 'webPropertyId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Experiment>(parameters, callback);
@@ -5154,7 +5198,7 @@ export namespace analytics_v3 {
         params,
         requiredParams: ['accountId', 'webPropertyId', 'profileId'],
         pathParams: ['accountId', 'profileId', 'webPropertyId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Experiment>(parameters, callback);
@@ -5227,7 +5271,7 @@ export namespace analytics_v3 {
         params,
         requiredParams: ['accountId', 'webPropertyId', 'profileId'],
         pathParams: ['accountId', 'profileId', 'webPropertyId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Experiments>(parameters, callback);
@@ -5302,7 +5346,7 @@ export namespace analytics_v3 {
         requiredParams:
             ['accountId', 'webPropertyId', 'profileId', 'experimentId'],
         pathParams: ['accountId', 'experimentId', 'profileId', 'webPropertyId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Experiment>(parameters, callback);
@@ -5376,7 +5420,7 @@ export namespace analytics_v3 {
         requiredParams:
             ['accountId', 'webPropertyId', 'profileId', 'experimentId'],
         pathParams: ['accountId', 'experimentId', 'profileId', 'webPropertyId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Experiment>(parameters, callback);
@@ -5549,7 +5593,10 @@ export namespace analytics_v3 {
 
 
   export class Resource$Management$Filters {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -5611,7 +5658,7 @@ export namespace analytics_v3 {
         params,
         requiredParams: ['accountId', 'filterId'],
         pathParams: ['accountId', 'filterId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Filter>(parameters, callback);
@@ -5676,7 +5723,7 @@ export namespace analytics_v3 {
         params,
         requiredParams: ['accountId', 'filterId'],
         pathParams: ['accountId', 'filterId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Filter>(parameters, callback);
@@ -5744,7 +5791,7 @@ export namespace analytics_v3 {
         params,
         requiredParams: ['accountId'],
         pathParams: ['accountId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Filter>(parameters, callback);
@@ -5813,7 +5860,7 @@ export namespace analytics_v3 {
         params,
         requiredParams: ['accountId'],
         pathParams: ['accountId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Filters>(parameters, callback);
@@ -5883,7 +5930,7 @@ export namespace analytics_v3 {
         params,
         requiredParams: ['accountId', 'filterId'],
         pathParams: ['accountId', 'filterId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Filter>(parameters, callback);
@@ -5953,7 +6000,7 @@ export namespace analytics_v3 {
         params,
         requiredParams: ['accountId', 'filterId'],
         pathParams: ['accountId', 'filterId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Filter>(parameters, callback);
@@ -6078,7 +6125,10 @@ export namespace analytics_v3 {
 
 
   export class Resource$Management$Goals {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -6138,7 +6188,7 @@ export namespace analytics_v3 {
         params,
         requiredParams: ['accountId', 'webPropertyId', 'profileId', 'goalId'],
         pathParams: ['accountId', 'goalId', 'profileId', 'webPropertyId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Goal>(parameters, callback);
@@ -6209,7 +6259,7 @@ export namespace analytics_v3 {
         params,
         requiredParams: ['accountId', 'webPropertyId', 'profileId'],
         pathParams: ['accountId', 'profileId', 'webPropertyId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Goal>(parameters, callback);
@@ -6281,7 +6331,7 @@ export namespace analytics_v3 {
         params,
         requiredParams: ['accountId', 'webPropertyId', 'profileId'],
         pathParams: ['accountId', 'profileId', 'webPropertyId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Goals>(parameters, callback);
@@ -6353,7 +6403,7 @@ export namespace analytics_v3 {
         params,
         requiredParams: ['accountId', 'webPropertyId', 'profileId', 'goalId'],
         pathParams: ['accountId', 'goalId', 'profileId', 'webPropertyId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Goal>(parameters, callback);
@@ -6425,7 +6475,7 @@ export namespace analytics_v3 {
         params,
         requiredParams: ['accountId', 'webPropertyId', 'profileId', 'goalId'],
         pathParams: ['accountId', 'goalId', 'profileId', 'webPropertyId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Goal>(parameters, callback);
@@ -6579,7 +6629,10 @@ export namespace analytics_v3 {
 
 
   export class Resource$Management$Profilefilterlinks {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -6642,7 +6695,7 @@ export namespace analytics_v3 {
         params,
         requiredParams: ['accountId', 'webPropertyId', 'profileId', 'linkId'],
         pathParams: ['accountId', 'linkId', 'profileId', 'webPropertyId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -6710,7 +6763,7 @@ export namespace analytics_v3 {
         params,
         requiredParams: ['accountId', 'webPropertyId', 'profileId', 'linkId'],
         pathParams: ['accountId', 'linkId', 'profileId', 'webPropertyId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ProfileFilterLink>(parameters, callback);
@@ -6782,7 +6835,7 @@ export namespace analytics_v3 {
         params,
         requiredParams: ['accountId', 'webPropertyId', 'profileId'],
         pathParams: ['accountId', 'profileId', 'webPropertyId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ProfileFilterLink>(parameters, callback);
@@ -6855,7 +6908,7 @@ export namespace analytics_v3 {
         params,
         requiredParams: ['accountId', 'webPropertyId', 'profileId'],
         pathParams: ['accountId', 'profileId', 'webPropertyId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ProfileFilterLinks>(parameters, callback);
@@ -6929,7 +6982,7 @@ export namespace analytics_v3 {
         params,
         requiredParams: ['accountId', 'webPropertyId', 'profileId', 'linkId'],
         pathParams: ['accountId', 'linkId', 'profileId', 'webPropertyId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ProfileFilterLink>(parameters, callback);
@@ -7002,7 +7055,7 @@ export namespace analytics_v3 {
         params,
         requiredParams: ['accountId', 'webPropertyId', 'profileId', 'linkId'],
         pathParams: ['accountId', 'linkId', 'profileId', 'webPropertyId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ProfileFilterLink>(parameters, callback);
@@ -7178,7 +7231,10 @@ export namespace analytics_v3 {
 
 
   export class Resource$Management$Profiles {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -7240,7 +7296,7 @@ export namespace analytics_v3 {
         params,
         requiredParams: ['accountId', 'webPropertyId', 'profileId'],
         pathParams: ['accountId', 'profileId', 'webPropertyId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -7306,7 +7362,7 @@ export namespace analytics_v3 {
         params,
         requiredParams: ['accountId', 'webPropertyId', 'profileId'],
         pathParams: ['accountId', 'profileId', 'webPropertyId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Profile>(parameters, callback);
@@ -7376,7 +7432,7 @@ export namespace analytics_v3 {
         params,
         requiredParams: ['accountId', 'webPropertyId'],
         pathParams: ['accountId', 'webPropertyId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Profile>(parameters, callback);
@@ -7447,7 +7503,7 @@ export namespace analytics_v3 {
         params,
         requiredParams: ['accountId', 'webPropertyId'],
         pathParams: ['accountId', 'webPropertyId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Profiles>(parameters, callback);
@@ -7519,7 +7575,7 @@ export namespace analytics_v3 {
         params,
         requiredParams: ['accountId', 'webPropertyId', 'profileId'],
         pathParams: ['accountId', 'profileId', 'webPropertyId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Profile>(parameters, callback);
@@ -7590,7 +7646,7 @@ export namespace analytics_v3 {
         params,
         requiredParams: ['accountId', 'webPropertyId', 'profileId'],
         pathParams: ['accountId', 'profileId', 'webPropertyId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Profile>(parameters, callback);
@@ -7743,7 +7799,10 @@ export namespace analytics_v3 {
 
 
   export class Resource$Management$Profileuserlinks {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -7806,7 +7865,7 @@ export namespace analytics_v3 {
         params,
         requiredParams: ['accountId', 'webPropertyId', 'profileId', 'linkId'],
         pathParams: ['accountId', 'linkId', 'profileId', 'webPropertyId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -7878,7 +7937,7 @@ export namespace analytics_v3 {
         params,
         requiredParams: ['accountId', 'webPropertyId', 'profileId'],
         pathParams: ['accountId', 'profileId', 'webPropertyId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$EntityUserLink>(parameters, callback);
@@ -7951,7 +8010,7 @@ export namespace analytics_v3 {
         params,
         requiredParams: ['accountId', 'webPropertyId', 'profileId'],
         pathParams: ['accountId', 'profileId', 'webPropertyId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$EntityUserLinks>(parameters, callback);
@@ -8025,7 +8084,7 @@ export namespace analytics_v3 {
         params,
         requiredParams: ['accountId', 'webPropertyId', 'profileId', 'linkId'],
         pathParams: ['accountId', 'linkId', 'profileId', 'webPropertyId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$EntityUserLink>(parameters, callback);
@@ -8149,7 +8208,10 @@ export namespace analytics_v3 {
 
 
   export class Resource$Management$Remarketingaudience {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -8212,7 +8274,7 @@ export namespace analytics_v3 {
         params,
         requiredParams: ['accountId', 'webPropertyId', 'remarketingAudienceId'],
         pathParams: ['accountId', 'remarketingAudienceId', 'webPropertyId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -8279,7 +8341,7 @@ export namespace analytics_v3 {
         params,
         requiredParams: ['accountId', 'webPropertyId', 'remarketingAudienceId'],
         pathParams: ['accountId', 'remarketingAudienceId', 'webPropertyId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$RemarketingAudience>(parameters, callback);
@@ -8351,7 +8413,7 @@ export namespace analytics_v3 {
         params,
         requiredParams: ['accountId', 'webPropertyId'],
         pathParams: ['accountId', 'webPropertyId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$RemarketingAudience>(parameters, callback);
@@ -8425,7 +8487,7 @@ export namespace analytics_v3 {
         params,
         requiredParams: ['accountId', 'webPropertyId'],
         pathParams: ['accountId', 'webPropertyId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$RemarketingAudiences>(parameters, callback);
@@ -8498,7 +8560,7 @@ export namespace analytics_v3 {
         params,
         requiredParams: ['accountId', 'webPropertyId', 'remarketingAudienceId'],
         pathParams: ['accountId', 'remarketingAudienceId', 'webPropertyId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$RemarketingAudience>(parameters, callback);
@@ -8571,7 +8633,7 @@ export namespace analytics_v3 {
         params,
         requiredParams: ['accountId', 'webPropertyId', 'remarketingAudienceId'],
         pathParams: ['accountId', 'remarketingAudienceId', 'webPropertyId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$RemarketingAudience>(parameters, callback);
@@ -8724,7 +8786,10 @@ export namespace analytics_v3 {
 
 
   export class Resource$Management$Segments {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -8784,7 +8849,7 @@ export namespace analytics_v3 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Segments>(parameters, callback);
@@ -8814,7 +8879,10 @@ export namespace analytics_v3 {
 
 
   export class Resource$Management$Unsampledreports {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -8879,7 +8947,7 @@ export namespace analytics_v3 {
             ['accountId', 'webPropertyId', 'profileId', 'unsampledReportId'],
         pathParams:
             ['accountId', 'profileId', 'unsampledReportId', 'webPropertyId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -8949,7 +9017,7 @@ export namespace analytics_v3 {
             ['accountId', 'webPropertyId', 'profileId', 'unsampledReportId'],
         pathParams:
             ['accountId', 'profileId', 'unsampledReportId', 'webPropertyId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$UnsampledReport>(parameters, callback);
@@ -9021,7 +9089,7 @@ export namespace analytics_v3 {
         params,
         requiredParams: ['accountId', 'webPropertyId', 'profileId'],
         pathParams: ['accountId', 'profileId', 'webPropertyId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$UnsampledReport>(parameters, callback);
@@ -9094,7 +9162,7 @@ export namespace analytics_v3 {
         params,
         requiredParams: ['accountId', 'webPropertyId', 'profileId'],
         pathParams: ['accountId', 'profileId', 'webPropertyId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$UnsampledReports>(parameters, callback);
@@ -9212,7 +9280,10 @@ export namespace analytics_v3 {
 
 
   export class Resource$Management$Uploads {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -9275,7 +9346,7 @@ export namespace analytics_v3 {
         params,
         requiredParams: ['accountId', 'webPropertyId', 'customDataSourceId'],
         pathParams: ['accountId', 'customDataSourceId', 'webPropertyId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -9344,7 +9415,7 @@ export namespace analytics_v3 {
             ['accountId', 'webPropertyId', 'customDataSourceId', 'uploadId'],
         pathParams:
             ['accountId', 'customDataSourceId', 'uploadId', 'webPropertyId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Upload>(parameters, callback);
@@ -9416,7 +9487,7 @@ export namespace analytics_v3 {
         params,
         requiredParams: ['accountId', 'webPropertyId', 'customDataSourceId'],
         pathParams: ['accountId', 'customDataSourceId', 'webPropertyId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Uploads>(parameters, callback);
@@ -9493,7 +9564,7 @@ export namespace analytics_v3 {
                 .replace(/([^:]\/)\/+/g, '$1'),
         requiredParams: ['accountId', 'webPropertyId', 'customDataSourceId'],
         pathParams: ['accountId', 'customDataSourceId', 'webPropertyId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Upload>(parameters, callback);
@@ -9620,7 +9691,10 @@ export namespace analytics_v3 {
 
 
   export class Resource$Management$Webproperties {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -9679,7 +9753,7 @@ export namespace analytics_v3 {
         params,
         requiredParams: ['accountId', 'webPropertyId'],
         pathParams: ['accountId', 'webPropertyId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Webproperty>(parameters, callback);
@@ -9751,7 +9825,7 @@ export namespace analytics_v3 {
         params,
         requiredParams: ['accountId'],
         pathParams: ['accountId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Webproperty>(parameters, callback);
@@ -9822,7 +9896,7 @@ export namespace analytics_v3 {
         params,
         requiredParams: ['accountId'],
         pathParams: ['accountId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Webproperties>(parameters, callback);
@@ -9894,7 +9968,7 @@ export namespace analytics_v3 {
         params,
         requiredParams: ['accountId', 'webPropertyId'],
         pathParams: ['accountId', 'webPropertyId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Webproperty>(parameters, callback);
@@ -9965,7 +10039,7 @@ export namespace analytics_v3 {
         params,
         requiredParams: ['accountId', 'webPropertyId'],
         pathParams: ['accountId', 'webPropertyId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Webproperty>(parameters, callback);
@@ -10076,7 +10150,10 @@ export namespace analytics_v3 {
 
 
   export class Resource$Management$Webpropertyadwordslinks {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -10141,7 +10218,7 @@ export namespace analytics_v3 {
         requiredParams:
             ['accountId', 'webPropertyId', 'webPropertyAdWordsLinkId'],
         pathParams: ['accountId', 'webPropertyAdWordsLinkId', 'webPropertyId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -10211,7 +10288,7 @@ export namespace analytics_v3 {
         requiredParams:
             ['accountId', 'webPropertyId', 'webPropertyAdWordsLinkId'],
         pathParams: ['accountId', 'webPropertyAdWordsLinkId', 'webPropertyId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$EntityAdWordsLink>(parameters, callback);
@@ -10284,7 +10361,7 @@ export namespace analytics_v3 {
         params,
         requiredParams: ['accountId', 'webPropertyId'],
         pathParams: ['accountId', 'webPropertyId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$EntityAdWordsLink>(parameters, callback);
@@ -10357,7 +10434,7 @@ export namespace analytics_v3 {
         params,
         requiredParams: ['accountId', 'webPropertyId'],
         pathParams: ['accountId', 'webPropertyId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$EntityAdWordsLinks>(parameters, callback);
@@ -10432,7 +10509,7 @@ export namespace analytics_v3 {
         requiredParams:
             ['accountId', 'webPropertyId', 'webPropertyAdWordsLinkId'],
         pathParams: ['accountId', 'webPropertyAdWordsLinkId', 'webPropertyId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$EntityAdWordsLink>(parameters, callback);
@@ -10507,7 +10584,7 @@ export namespace analytics_v3 {
         requiredParams:
             ['accountId', 'webPropertyId', 'webPropertyAdWordsLinkId'],
         pathParams: ['accountId', 'webPropertyAdWordsLinkId', 'webPropertyId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$EntityAdWordsLink>(parameters, callback);
@@ -10657,7 +10734,10 @@ export namespace analytics_v3 {
 
 
   export class Resource$Management$Webpropertyuserlinks {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -10720,7 +10800,7 @@ export namespace analytics_v3 {
         params,
         requiredParams: ['accountId', 'webPropertyId', 'linkId'],
         pathParams: ['accountId', 'linkId', 'webPropertyId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -10792,7 +10872,7 @@ export namespace analytics_v3 {
         params,
         requiredParams: ['accountId', 'webPropertyId'],
         pathParams: ['accountId', 'webPropertyId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$EntityUserLink>(parameters, callback);
@@ -10864,7 +10944,7 @@ export namespace analytics_v3 {
         params,
         requiredParams: ['accountId', 'webPropertyId'],
         pathParams: ['accountId', 'webPropertyId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$EntityUserLinks>(parameters, callback);
@@ -10937,7 +11017,7 @@ export namespace analytics_v3 {
         params,
         requiredParams: ['accountId', 'webPropertyId', 'linkId'],
         pathParams: ['accountId', 'linkId', 'webPropertyId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$EntityUserLink>(parameters, callback);
@@ -11044,15 +11124,20 @@ export namespace analytics_v3 {
 
 
   export class Resource$Metadata {
+    context: APIRequestContext;
     columns: Resource$Metadata$Columns;
-    constructor() {
-      this.columns = new Resource$Metadata$Columns();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.columns = new Resource$Metadata$Columns(this.context);
     }
   }
 
 
   export class Resource$Metadata$Columns {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -11111,7 +11196,7 @@ export namespace analytics_v3 {
         params,
         requiredParams: ['reportType'],
         pathParams: ['reportType'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Columns>(parameters, callback);
@@ -11138,7 +11223,10 @@ export namespace analytics_v3 {
 
 
   export class Resource$Provisioning {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -11199,7 +11287,7 @@ export namespace analytics_v3 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AccountTicket>(parameters, callback);
@@ -11267,7 +11355,7 @@ export namespace analytics_v3 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AccountTreeResponse>(parameters, callback);
@@ -11306,16 +11394,21 @@ export namespace analytics_v3 {
 
 
   export class Resource$Userdeletion {
+    context: APIRequestContext;
     userDeletionRequest: Resource$Userdeletion$Userdeletionrequest;
-    constructor() {
+    constructor(context: APIRequestContext) {
+      this.context = context;
       this.userDeletionRequest =
-          new Resource$Userdeletion$Userdeletionrequest();
+          new Resource$Userdeletion$Userdeletionrequest(this.context);
     }
   }
 
 
   export class Resource$Userdeletion$Userdeletionrequest {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -11377,7 +11470,7 @@ export namespace analytics_v3 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$UserDeletionRequest>(parameters, callback);

--- a/src/apis/analyticsreporting/v4.ts
+++ b/src/apis/analyticsreporting/v4.ts
@@ -29,8 +29,6 @@ export namespace analyticsreporting_v4 {
     version: 'v4';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * V1 error format.
@@ -98,14 +96,15 @@ export namespace analyticsreporting_v4 {
    * @param {object=} options Options for Analyticsreporting
    */
   export class Analyticsreporting {
+    context: APIRequestContext;
     reports: Resource$Reports;
     userActivity: Resource$Useractivity;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.reports = new Resource$Reports();
-      this.userActivity = new Resource$Useractivity();
+      this.reports = new Resource$Reports(this.context);
+      this.userActivity = new Resource$Useractivity(this.context);
     }
   }
 
@@ -1395,7 +1394,10 @@ export namespace analyticsreporting_v4 {
 
 
   export class Resource$Reports {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1455,7 +1457,7 @@ export namespace analyticsreporting_v4 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GetReportsResponse>(parameters, callback);
@@ -1480,7 +1482,10 @@ export namespace analyticsreporting_v4 {
 
 
   export class Resource$Useractivity {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1545,7 +1550,7 @@ export namespace analyticsreporting_v4 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$SearchUserActivityResponse>(

--- a/src/apis/androiddeviceprovisioning/v1.ts
+++ b/src/apis/androiddeviceprovisioning/v1.ts
@@ -29,8 +29,6 @@ export namespace androiddeviceprovisioning_v1 {
     version: 'v1';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * V1 error format.
@@ -99,16 +97,17 @@ export namespace androiddeviceprovisioning_v1 {
    * @param {object=} options Options for Androiddeviceprovisioning
    */
   export class Androiddeviceprovisioning {
+    context: APIRequestContext;
     customers: Resource$Customers;
     operations: Resource$Operations;
     partners: Resource$Partners;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.customers = new Resource$Customers();
-      this.operations = new Resource$Operations();
-      this.partners = new Resource$Partners();
+      this.customers = new Resource$Customers(this.context);
+      this.operations = new Resource$Operations(this.context);
+      this.partners = new Resource$Partners(this.context);
     }
   }
 
@@ -922,13 +921,15 @@ export namespace androiddeviceprovisioning_v1 {
 
 
   export class Resource$Customers {
+    context: APIRequestContext;
     configurations: Resource$Customers$Configurations;
     devices: Resource$Customers$Devices;
     dpcs: Resource$Customers$Dpcs;
-    constructor() {
-      this.configurations = new Resource$Customers$Configurations();
-      this.devices = new Resource$Customers$Devices();
-      this.dpcs = new Resource$Customers$Dpcs();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.configurations = new Resource$Customers$Configurations(this.context);
+      this.devices = new Resource$Customers$Devices(this.context);
+      this.dpcs = new Resource$Customers$Dpcs(this.context);
     }
 
 
@@ -992,7 +993,7 @@ export namespace androiddeviceprovisioning_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$CustomerListCustomersResponse>(
@@ -1022,7 +1023,10 @@ export namespace androiddeviceprovisioning_v1 {
   }
 
   export class Resource$Customers$Configurations {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1085,7 +1089,7 @@ export namespace androiddeviceprovisioning_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Configuration>(parameters, callback);
@@ -1152,7 +1156,7 @@ export namespace androiddeviceprovisioning_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -1215,7 +1219,7 @@ export namespace androiddeviceprovisioning_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Configuration>(parameters, callback);
@@ -1292,7 +1296,7 @@ export namespace androiddeviceprovisioning_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$CustomerListConfigurationsResponse>(
@@ -1363,7 +1367,7 @@ export namespace androiddeviceprovisioning_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Configuration>(parameters, callback);
@@ -1460,7 +1464,10 @@ export namespace androiddeviceprovisioning_v1 {
 
 
   export class Resource$Customers$Devices {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1524,7 +1531,7 @@ export namespace androiddeviceprovisioning_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -1586,7 +1593,7 @@ export namespace androiddeviceprovisioning_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Device>(parameters, callback);
@@ -1661,7 +1668,7 @@ export namespace androiddeviceprovisioning_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$CustomerListDevicesResponse>(
@@ -1731,7 +1738,7 @@ export namespace androiddeviceprovisioning_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -1801,7 +1808,7 @@ export namespace androiddeviceprovisioning_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -1903,7 +1910,10 @@ export namespace androiddeviceprovisioning_v1 {
 
 
   export class Resource$Customers$Dpcs {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1965,7 +1975,7 @@ export namespace androiddeviceprovisioning_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$CustomerListDpcsResponse>(parameters, callback);
@@ -1992,7 +2002,10 @@ export namespace androiddeviceprovisioning_v1 {
 
 
   export class Resource$Operations {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -2049,7 +2062,7 @@ export namespace androiddeviceprovisioning_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -2073,19 +2086,24 @@ export namespace androiddeviceprovisioning_v1 {
 
 
   export class Resource$Partners {
+    context: APIRequestContext;
     customers: Resource$Partners$Customers;
     devices: Resource$Partners$Devices;
     vendors: Resource$Partners$Vendors;
-    constructor() {
-      this.customers = new Resource$Partners$Customers();
-      this.devices = new Resource$Partners$Devices();
-      this.vendors = new Resource$Partners$Vendors();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.customers = new Resource$Partners$Customers(this.context);
+      this.devices = new Resource$Partners$Devices(this.context);
+      this.vendors = new Resource$Partners$Vendors(this.context);
     }
   }
 
 
   export class Resource$Partners$Customers {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -2150,7 +2168,7 @@ export namespace androiddeviceprovisioning_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Company>(parameters, callback);
@@ -2223,7 +2241,7 @@ export namespace androiddeviceprovisioning_v1 {
         params,
         requiredParams: ['partnerId'],
         pathParams: ['partnerId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListCustomersResponse>(parameters, callback);
@@ -2275,7 +2293,10 @@ export namespace androiddeviceprovisioning_v1 {
 
 
   export class Resource$Partners$Devices {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -2339,7 +2360,7 @@ export namespace androiddeviceprovisioning_v1 {
         params,
         requiredParams: ['partnerId'],
         pathParams: ['partnerId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ClaimDeviceResponse>(parameters, callback);
@@ -2410,7 +2431,7 @@ export namespace androiddeviceprovisioning_v1 {
         params,
         requiredParams: ['partnerId'],
         pathParams: ['partnerId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -2490,7 +2511,7 @@ export namespace androiddeviceprovisioning_v1 {
         params,
         requiredParams: ['partnerId'],
         pathParams: ['partnerId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$FindDevicesByDeviceIdentifierResponse>(
@@ -2570,7 +2591,7 @@ export namespace androiddeviceprovisioning_v1 {
         params,
         requiredParams: ['partnerId'],
         pathParams: ['partnerId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$FindDevicesByOwnerResponse>(
@@ -2633,7 +2654,7 @@ export namespace androiddeviceprovisioning_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Device>(parameters, callback);
@@ -2705,7 +2726,7 @@ export namespace androiddeviceprovisioning_v1 {
         params,
         requiredParams: ['metadataOwnerId', 'deviceId'],
         pathParams: ['deviceId', 'metadataOwnerId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$DeviceMetadata>(parameters, callback);
@@ -2774,7 +2795,7 @@ export namespace androiddeviceprovisioning_v1 {
         params,
         requiredParams: ['partnerId'],
         pathParams: ['partnerId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -2845,7 +2866,7 @@ export namespace androiddeviceprovisioning_v1 {
         params,
         requiredParams: ['partnerId'],
         pathParams: ['partnerId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -2918,7 +2939,7 @@ export namespace androiddeviceprovisioning_v1 {
         params,
         requiredParams: ['partnerId'],
         pathParams: ['partnerId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -3085,9 +3106,11 @@ export namespace androiddeviceprovisioning_v1 {
 
 
   export class Resource$Partners$Vendors {
+    context: APIRequestContext;
     customers: Resource$Partners$Vendors$Customers;
-    constructor() {
-      this.customers = new Resource$Partners$Vendors$Customers();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.customers = new Resource$Partners$Vendors$Customers(this.context);
     }
 
 
@@ -3151,7 +3174,7 @@ export namespace androiddeviceprovisioning_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListVendorsResponse>(parameters, callback);
@@ -3183,7 +3206,10 @@ export namespace androiddeviceprovisioning_v1 {
   }
 
   export class Resource$Partners$Vendors$Customers {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -3251,7 +3277,7 @@ export namespace androiddeviceprovisioning_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListVendorCustomersResponse>(

--- a/src/apis/androidenterprise/v1.ts
+++ b/src/apis/androidenterprise/v1.ts
@@ -29,8 +29,6 @@ export namespace androidenterprise_v1 {
     version: 'v1';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * Data format for the response.
@@ -81,6 +79,7 @@ export namespace androidenterprise_v1 {
    * @param {object=} options Options for Androidenterprise
    */
   export class Androidenterprise {
+    context: APIRequestContext;
     devices: Resource$Devices;
     enterprises: Resource$Enterprises;
     entitlements: Resource$Entitlements;
@@ -99,27 +98,27 @@ export namespace androidenterprise_v1 {
     webapps: Resource$Webapps;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.devices = new Resource$Devices();
-      this.enterprises = new Resource$Enterprises();
-      this.entitlements = new Resource$Entitlements();
-      this.grouplicenses = new Resource$Grouplicenses();
-      this.grouplicenseusers = new Resource$Grouplicenseusers();
-      this.installs = new Resource$Installs();
+      this.devices = new Resource$Devices(this.context);
+      this.enterprises = new Resource$Enterprises(this.context);
+      this.entitlements = new Resource$Entitlements(this.context);
+      this.grouplicenses = new Resource$Grouplicenses(this.context);
+      this.grouplicenseusers = new Resource$Grouplicenseusers(this.context);
+      this.installs = new Resource$Installs(this.context);
       this.managedconfigurationsfordevice =
-          new Resource$Managedconfigurationsfordevice();
+          new Resource$Managedconfigurationsfordevice(this.context);
       this.managedconfigurationsforuser =
-          new Resource$Managedconfigurationsforuser();
+          new Resource$Managedconfigurationsforuser(this.context);
       this.managedconfigurationssettings =
-          new Resource$Managedconfigurationssettings();
-      this.permissions = new Resource$Permissions();
-      this.products = new Resource$Products();
-      this.serviceaccountkeys = new Resource$Serviceaccountkeys();
-      this.storelayoutclusters = new Resource$Storelayoutclusters();
-      this.storelayoutpages = new Resource$Storelayoutpages();
-      this.users = new Resource$Users();
-      this.webapps = new Resource$Webapps();
+          new Resource$Managedconfigurationssettings(this.context);
+      this.permissions = new Resource$Permissions(this.context);
+      this.products = new Resource$Products(this.context);
+      this.serviceaccountkeys = new Resource$Serviceaccountkeys(this.context);
+      this.storelayoutclusters = new Resource$Storelayoutclusters(this.context);
+      this.storelayoutpages = new Resource$Storelayoutpages(this.context);
+      this.users = new Resource$Users(this.context);
+      this.webapps = new Resource$Webapps(this.context);
     }
   }
 
@@ -1972,7 +1971,10 @@ export namespace androidenterprise_v1 {
 
 
   export class Resource$Devices {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -2030,7 +2032,7 @@ export namespace androidenterprise_v1 {
         params,
         requiredParams: ['enterpriseId', 'userId', 'deviceId'],
         pathParams: ['deviceId', 'enterpriseId', 'userId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Device>(parameters, callback);
@@ -2104,7 +2106,7 @@ export namespace androidenterprise_v1 {
         params,
         requiredParams: ['enterpriseId', 'userId', 'deviceId'],
         pathParams: ['deviceId', 'enterpriseId', 'userId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$DeviceState>(parameters, callback);
@@ -2172,7 +2174,7 @@ export namespace androidenterprise_v1 {
         params,
         requiredParams: ['enterpriseId', 'userId'],
         pathParams: ['enterpriseId', 'userId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$DevicesListResponse>(parameters, callback);
@@ -2242,7 +2244,7 @@ export namespace androidenterprise_v1 {
         params,
         requiredParams: ['enterpriseId', 'userId', 'deviceId'],
         pathParams: ['deviceId', 'enterpriseId', 'userId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Device>(parameters, callback);
@@ -2317,7 +2319,7 @@ export namespace androidenterprise_v1 {
         params,
         requiredParams: ['enterpriseId', 'userId', 'deviceId'],
         pathParams: ['deviceId', 'enterpriseId', 'userId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$DeviceState>(parameters, callback);
@@ -2387,7 +2389,7 @@ export namespace androidenterprise_v1 {
         params,
         requiredParams: ['enterpriseId', 'userId', 'deviceId'],
         pathParams: ['deviceId', 'enterpriseId', 'userId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Device>(parameters, callback);
@@ -2537,7 +2539,10 @@ export namespace androidenterprise_v1 {
 
 
   export class Resource$Enterprises {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -2600,7 +2605,7 @@ export namespace androidenterprise_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -2671,7 +2676,7 @@ export namespace androidenterprise_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Enterprise>(parameters, callback);
@@ -2746,7 +2751,7 @@ export namespace androidenterprise_v1 {
         params,
         requiredParams: ['enterpriseId'],
         pathParams: ['enterpriseId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AdministratorWebToken>(parameters, callback);
@@ -2814,7 +2819,7 @@ export namespace androidenterprise_v1 {
         params,
         requiredParams: ['token'],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Enterprise>(parameters, callback);
@@ -2881,7 +2886,7 @@ export namespace androidenterprise_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$SignupInfo>(parameters, callback);
@@ -2944,7 +2949,7 @@ export namespace androidenterprise_v1 {
         params,
         requiredParams: ['enterpriseId'],
         pathParams: ['enterpriseId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Enterprise>(parameters, callback);
@@ -3025,7 +3030,7 @@ export namespace androidenterprise_v1 {
         params,
         requiredParams: ['enterpriseId'],
         pathParams: ['enterpriseId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ServiceAccount>(parameters, callback);
@@ -3096,7 +3101,7 @@ export namespace androidenterprise_v1 {
         params,
         requiredParams: ['enterpriseId'],
         pathParams: ['enterpriseId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$StoreLayout>(parameters, callback);
@@ -3166,7 +3171,7 @@ export namespace androidenterprise_v1 {
         params,
         requiredParams: ['domain'],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$EnterprisesListResponse>(parameters, callback);
@@ -3248,7 +3253,7 @@ export namespace androidenterprise_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$NotificationSet>(parameters, callback);
@@ -3326,7 +3331,7 @@ export namespace androidenterprise_v1 {
         params,
         requiredParams: ['enterpriseId'],
         pathParams: ['enterpriseId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$EnterprisesSendTestPushNotificationResponse>(
@@ -3398,7 +3403,7 @@ export namespace androidenterprise_v1 {
         params,
         requiredParams: ['enterpriseId'],
         pathParams: ['enterpriseId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$EnterpriseAccount>(parameters, callback);
@@ -3472,7 +3477,7 @@ export namespace androidenterprise_v1 {
         params,
         requiredParams: ['enterpriseId'],
         pathParams: ['enterpriseId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AndroidDevicePolicyConfig>(
@@ -3550,7 +3555,7 @@ export namespace androidenterprise_v1 {
         params,
         requiredParams: ['enterpriseId'],
         pathParams: ['enterpriseId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$StoreLayout>(parameters, callback);
@@ -3616,7 +3621,7 @@ export namespace androidenterprise_v1 {
         params,
         requiredParams: ['enterpriseId'],
         pathParams: ['enterpriseId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -3853,7 +3858,10 @@ export namespace androidenterprise_v1 {
 
 
   export class Resource$Entitlements {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -3915,7 +3923,7 @@ export namespace androidenterprise_v1 {
         params,
         requiredParams: ['enterpriseId', 'userId', 'entitlementId'],
         pathParams: ['enterpriseId', 'entitlementId', 'userId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -3981,7 +3989,7 @@ export namespace androidenterprise_v1 {
         params,
         requiredParams: ['enterpriseId', 'userId', 'entitlementId'],
         pathParams: ['enterpriseId', 'entitlementId', 'userId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Entitlement>(parameters, callback);
@@ -4051,7 +4059,7 @@ export namespace androidenterprise_v1 {
         params,
         requiredParams: ['enterpriseId', 'userId'],
         pathParams: ['enterpriseId', 'userId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$EntitlementsListResponse>(parameters, callback);
@@ -4124,7 +4132,7 @@ export namespace androidenterprise_v1 {
         params,
         requiredParams: ['enterpriseId', 'userId', 'entitlementId'],
         pathParams: ['enterpriseId', 'entitlementId', 'userId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Entitlement>(parameters, callback);
@@ -4197,7 +4205,7 @@ export namespace androidenterprise_v1 {
         params,
         requiredParams: ['enterpriseId', 'userId', 'entitlementId'],
         pathParams: ['enterpriseId', 'entitlementId', 'userId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Entitlement>(parameters, callback);
@@ -4333,7 +4341,10 @@ export namespace androidenterprise_v1 {
 
 
   export class Resource$Grouplicenses {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -4392,7 +4403,7 @@ export namespace androidenterprise_v1 {
         params,
         requiredParams: ['enterpriseId', 'groupLicenseId'],
         pathParams: ['enterpriseId', 'groupLicenseId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GroupLicense>(parameters, callback);
@@ -4463,7 +4474,7 @@ export namespace androidenterprise_v1 {
         params,
         requiredParams: ['enterpriseId'],
         pathParams: ['enterpriseId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GroupLicensesListResponse>(
@@ -4506,7 +4517,10 @@ export namespace androidenterprise_v1 {
 
 
   export class Resource$Grouplicenseusers {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -4575,7 +4589,7 @@ export namespace androidenterprise_v1 {
         params,
         requiredParams: ['enterpriseId', 'groupLicenseId'],
         pathParams: ['enterpriseId', 'groupLicenseId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GroupLicenseUsersListResponse>(
@@ -4607,7 +4621,10 @@ export namespace androidenterprise_v1 {
 
 
   export class Resource$Installs {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -4670,7 +4687,7 @@ export namespace androidenterprise_v1 {
         params,
         requiredParams: ['enterpriseId', 'userId', 'deviceId', 'installId'],
         pathParams: ['deviceId', 'enterpriseId', 'installId', 'userId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -4736,7 +4753,7 @@ export namespace androidenterprise_v1 {
         params,
         requiredParams: ['enterpriseId', 'userId', 'deviceId', 'installId'],
         pathParams: ['deviceId', 'enterpriseId', 'installId', 'userId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Install>(parameters, callback);
@@ -4807,7 +4824,7 @@ export namespace androidenterprise_v1 {
         params,
         requiredParams: ['enterpriseId', 'userId', 'deviceId'],
         pathParams: ['deviceId', 'enterpriseId', 'userId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$InstallsListResponse>(parameters, callback);
@@ -4879,7 +4896,7 @@ export namespace androidenterprise_v1 {
         params,
         requiredParams: ['enterpriseId', 'userId', 'deviceId', 'installId'],
         pathParams: ['deviceId', 'enterpriseId', 'installId', 'userId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Install>(parameters, callback);
@@ -4951,7 +4968,7 @@ export namespace androidenterprise_v1 {
         params,
         requiredParams: ['enterpriseId', 'userId', 'deviceId', 'installId'],
         pathParams: ['deviceId', 'enterpriseId', 'installId', 'userId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Install>(parameters, callback);
@@ -5089,7 +5106,10 @@ export namespace androidenterprise_v1 {
 
 
   export class Resource$Managedconfigurationsfordevice {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -5160,7 +5180,7 @@ export namespace androidenterprise_v1 {
           'deviceId', 'enterpriseId', 'managedConfigurationForDeviceId',
           'userId'
         ],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -5235,7 +5255,7 @@ export namespace androidenterprise_v1 {
           'deviceId', 'enterpriseId', 'managedConfigurationForDeviceId',
           'userId'
         ],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ManagedConfiguration>(parameters, callback);
@@ -5313,7 +5333,7 @@ export namespace androidenterprise_v1 {
         params,
         requiredParams: ['enterpriseId', 'userId', 'deviceId'],
         pathParams: ['deviceId', 'enterpriseId', 'userId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ManagedConfigurationsForDeviceListResponse>(
@@ -5396,7 +5416,7 @@ export namespace androidenterprise_v1 {
           'deviceId', 'enterpriseId', 'managedConfigurationForDeviceId',
           'userId'
         ],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ManagedConfiguration>(parameters, callback);
@@ -5478,7 +5498,7 @@ export namespace androidenterprise_v1 {
           'deviceId', 'enterpriseId', 'managedConfigurationForDeviceId',
           'userId'
         ],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ManagedConfiguration>(parameters, callback);
@@ -5621,7 +5641,10 @@ export namespace androidenterprise_v1 {
 
 
   export class Resource$Managedconfigurationsforuser {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -5685,7 +5708,7 @@ export namespace androidenterprise_v1 {
         requiredParams:
             ['enterpriseId', 'userId', 'managedConfigurationForUserId'],
         pathParams: ['enterpriseId', 'managedConfigurationForUserId', 'userId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -5755,7 +5778,7 @@ export namespace androidenterprise_v1 {
         requiredParams:
             ['enterpriseId', 'userId', 'managedConfigurationForUserId'],
         pathParams: ['enterpriseId', 'managedConfigurationForUserId', 'userId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ManagedConfiguration>(parameters, callback);
@@ -5832,7 +5855,7 @@ export namespace androidenterprise_v1 {
         params,
         requiredParams: ['enterpriseId', 'userId'],
         pathParams: ['enterpriseId', 'userId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ManagedConfigurationsForUserListResponse>(
@@ -5913,7 +5936,7 @@ export namespace androidenterprise_v1 {
         requiredParams:
             ['enterpriseId', 'userId', 'managedConfigurationForUserId'],
         pathParams: ['enterpriseId', 'managedConfigurationForUserId', 'userId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ManagedConfiguration>(parameters, callback);
@@ -5992,7 +6015,7 @@ export namespace androidenterprise_v1 {
         requiredParams:
             ['enterpriseId', 'userId', 'managedConfigurationForUserId'],
         pathParams: ['enterpriseId', 'managedConfigurationForUserId', 'userId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ManagedConfiguration>(parameters, callback);
@@ -6115,7 +6138,10 @@ export namespace androidenterprise_v1 {
 
 
   export class Resource$Managedconfigurationssettings {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -6185,7 +6211,7 @@ export namespace androidenterprise_v1 {
         params,
         requiredParams: ['enterpriseId', 'productId'],
         pathParams: ['enterpriseId', 'productId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ManagedConfigurationsSettingsListResponse>(
@@ -6217,7 +6243,10 @@ export namespace androidenterprise_v1 {
 
 
   export class Resource$Permissions {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -6275,7 +6304,7 @@ export namespace androidenterprise_v1 {
         params,
         requiredParams: ['permissionId'],
         pathParams: ['permissionId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Permission>(parameters, callback);
@@ -6303,7 +6332,10 @@ export namespace androidenterprise_v1 {
 
 
   export class Resource$Products {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -6367,7 +6399,7 @@ export namespace androidenterprise_v1 {
         params,
         requiredParams: ['enterpriseId', 'productId'],
         pathParams: ['enterpriseId', 'productId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -6455,7 +6487,7 @@ export namespace androidenterprise_v1 {
         params,
         requiredParams: ['enterpriseId', 'productId'],
         pathParams: ['enterpriseId', 'productId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ProductsGenerateApprovalUrlResponse>(
@@ -6522,7 +6554,7 @@ export namespace androidenterprise_v1 {
         params,
         requiredParams: ['enterpriseId', 'productId'],
         pathParams: ['enterpriseId', 'productId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Product>(parameters, callback);
@@ -6600,7 +6632,7 @@ export namespace androidenterprise_v1 {
         params,
         requiredParams: ['enterpriseId', 'productId'],
         pathParams: ['enterpriseId', 'productId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AppRestrictionsSchema>(parameters, callback);
@@ -6671,7 +6703,7 @@ export namespace androidenterprise_v1 {
         params,
         requiredParams: ['enterpriseId', 'productId'],
         pathParams: ['enterpriseId', 'productId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ProductPermissions>(parameters, callback);
@@ -6744,7 +6776,7 @@ export namespace androidenterprise_v1 {
         params,
         requiredParams: ['enterpriseId'],
         pathParams: ['enterpriseId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ProductsListResponse>(parameters, callback);
@@ -6813,7 +6845,7 @@ export namespace androidenterprise_v1 {
         params,
         requiredParams: ['enterpriseId', 'productId'],
         pathParams: ['enterpriseId', 'productId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -6981,7 +7013,10 @@ export namespace androidenterprise_v1 {
 
 
   export class Resource$Serviceaccountkeys {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -7046,7 +7081,7 @@ export namespace androidenterprise_v1 {
         params,
         requiredParams: ['enterpriseId', 'keyId'],
         pathParams: ['enterpriseId', 'keyId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -7120,7 +7155,7 @@ export namespace androidenterprise_v1 {
         params,
         requiredParams: ['enterpriseId'],
         pathParams: ['enterpriseId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ServiceAccountKey>(parameters, callback);
@@ -7198,7 +7233,7 @@ export namespace androidenterprise_v1 {
         params,
         requiredParams: ['enterpriseId'],
         pathParams: ['enterpriseId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ServiceAccountKeysListResponse>(
@@ -7258,7 +7293,10 @@ export namespace androidenterprise_v1 {
 
 
   export class Resource$Storelayoutclusters {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -7320,7 +7358,7 @@ export namespace androidenterprise_v1 {
         params,
         requiredParams: ['enterpriseId', 'pageId', 'clusterId'],
         pathParams: ['clusterId', 'enterpriseId', 'pageId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -7387,7 +7425,7 @@ export namespace androidenterprise_v1 {
         params,
         requiredParams: ['enterpriseId', 'pageId', 'clusterId'],
         pathParams: ['clusterId', 'enterpriseId', 'pageId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$StoreCluster>(parameters, callback);
@@ -7458,7 +7496,7 @@ export namespace androidenterprise_v1 {
         params,
         requiredParams: ['enterpriseId', 'pageId'],
         pathParams: ['enterpriseId', 'pageId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$StoreCluster>(parameters, callback);
@@ -7535,7 +7573,7 @@ export namespace androidenterprise_v1 {
         params,
         requiredParams: ['enterpriseId', 'pageId'],
         pathParams: ['enterpriseId', 'pageId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$StoreLayoutClustersListResponse>(
@@ -7609,7 +7647,7 @@ export namespace androidenterprise_v1 {
         params,
         requiredParams: ['enterpriseId', 'pageId', 'clusterId'],
         pathParams: ['clusterId', 'enterpriseId', 'pageId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$StoreCluster>(parameters, callback);
@@ -7681,7 +7719,7 @@ export namespace androidenterprise_v1 {
         params,
         requiredParams: ['enterpriseId', 'pageId', 'clusterId'],
         pathParams: ['clusterId', 'enterpriseId', 'pageId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$StoreCluster>(parameters, callback);
@@ -7821,7 +7859,10 @@ export namespace androidenterprise_v1 {
 
 
   export class Resource$Storelayoutpages {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -7882,7 +7923,7 @@ export namespace androidenterprise_v1 {
         params,
         requiredParams: ['enterpriseId', 'pageId'],
         pathParams: ['enterpriseId', 'pageId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -7948,7 +7989,7 @@ export namespace androidenterprise_v1 {
         params,
         requiredParams: ['enterpriseId', 'pageId'],
         pathParams: ['enterpriseId', 'pageId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$StorePage>(parameters, callback);
@@ -8018,7 +8059,7 @@ export namespace androidenterprise_v1 {
         params,
         requiredParams: ['enterpriseId'],
         pathParams: ['enterpriseId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$StorePage>(parameters, callback);
@@ -8092,7 +8133,7 @@ export namespace androidenterprise_v1 {
         params,
         requiredParams: ['enterpriseId'],
         pathParams: ['enterpriseId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$StoreLayoutPagesListResponse>(
@@ -8166,7 +8207,7 @@ export namespace androidenterprise_v1 {
         params,
         requiredParams: ['enterpriseId', 'pageId'],
         pathParams: ['enterpriseId', 'pageId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$StorePage>(parameters, callback);
@@ -8237,7 +8278,7 @@ export namespace androidenterprise_v1 {
         params,
         requiredParams: ['enterpriseId', 'pageId'],
         pathParams: ['enterpriseId', 'pageId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$StorePage>(parameters, callback);
@@ -8353,7 +8394,10 @@ export namespace androidenterprise_v1 {
 
 
   export class Resource$Users {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -8412,7 +8456,7 @@ export namespace androidenterprise_v1 {
         params,
         requiredParams: ['enterpriseId', 'userId'],
         pathParams: ['enterpriseId', 'userId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -8487,7 +8531,7 @@ export namespace androidenterprise_v1 {
         params,
         requiredParams: ['enterpriseId', 'userId'],
         pathParams: ['enterpriseId', 'userId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AuthenticationToken>(parameters, callback);
@@ -8559,7 +8603,7 @@ export namespace androidenterprise_v1 {
         params,
         requiredParams: ['enterpriseId', 'userId'],
         pathParams: ['enterpriseId', 'userId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$UserToken>(parameters, callback);
@@ -8623,7 +8667,7 @@ export namespace androidenterprise_v1 {
         params,
         requiredParams: ['enterpriseId', 'userId'],
         pathParams: ['enterpriseId', 'userId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$User>(parameters, callback);
@@ -8694,7 +8738,7 @@ export namespace androidenterprise_v1 {
         params,
         requiredParams: ['enterpriseId', 'userId'],
         pathParams: ['enterpriseId', 'userId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ProductSet>(parameters, callback);
@@ -8764,7 +8808,7 @@ export namespace androidenterprise_v1 {
         params,
         requiredParams: ['enterpriseId'],
         pathParams: ['enterpriseId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$User>(parameters, callback);
@@ -8834,7 +8878,7 @@ export namespace androidenterprise_v1 {
         params,
         requiredParams: ['enterpriseId', 'email'],
         pathParams: ['enterpriseId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$UsersListResponse>(parameters, callback);
@@ -8906,7 +8950,7 @@ export namespace androidenterprise_v1 {
         params,
         requiredParams: ['enterpriseId', 'userId'],
         pathParams: ['enterpriseId', 'userId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$User>(parameters, callback);
@@ -8976,7 +9020,7 @@ export namespace androidenterprise_v1 {
         params,
         requiredParams: ['enterpriseId', 'userId'],
         pathParams: ['enterpriseId', 'userId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -9045,7 +9089,7 @@ export namespace androidenterprise_v1 {
         params,
         requiredParams: ['enterpriseId', 'userId'],
         pathParams: ['enterpriseId', 'userId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -9120,7 +9164,7 @@ export namespace androidenterprise_v1 {
         params,
         requiredParams: ['enterpriseId', 'userId'],
         pathParams: ['enterpriseId', 'userId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ProductSet>(parameters, callback);
@@ -9192,7 +9236,7 @@ export namespace androidenterprise_v1 {
         params,
         requiredParams: ['enterpriseId', 'userId'],
         pathParams: ['enterpriseId', 'userId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$User>(parameters, callback);
@@ -9407,7 +9451,10 @@ export namespace androidenterprise_v1 {
 
 
   export class Resource$Webapps {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -9466,7 +9513,7 @@ export namespace androidenterprise_v1 {
         params,
         requiredParams: ['enterpriseId', 'webAppId'],
         pathParams: ['enterpriseId', 'webAppId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -9530,7 +9577,7 @@ export namespace androidenterprise_v1 {
         params,
         requiredParams: ['enterpriseId', 'webAppId'],
         pathParams: ['enterpriseId', 'webAppId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$WebApp>(parameters, callback);
@@ -9596,7 +9643,7 @@ export namespace androidenterprise_v1 {
         params,
         requiredParams: ['enterpriseId'],
         pathParams: ['enterpriseId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$WebApp>(parameters, callback);
@@ -9662,7 +9709,7 @@ export namespace androidenterprise_v1 {
         params,
         requiredParams: ['enterpriseId'],
         pathParams: ['enterpriseId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$WebAppsListResponse>(parameters, callback);
@@ -9730,7 +9777,7 @@ export namespace androidenterprise_v1 {
         params,
         requiredParams: ['enterpriseId', 'webAppId'],
         pathParams: ['enterpriseId', 'webAppId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$WebApp>(parameters, callback);
@@ -9798,7 +9845,7 @@ export namespace androidenterprise_v1 {
         params,
         requiredParams: ['enterpriseId', 'webAppId'],
         pathParams: ['enterpriseId', 'webAppId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$WebApp>(parameters, callback);

--- a/src/apis/androidmanagement/v1.ts
+++ b/src/apis/androidmanagement/v1.ts
@@ -29,8 +29,6 @@ export namespace androidmanagement_v1 {
     version: 'v1';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * V1 error format.
@@ -99,14 +97,15 @@ export namespace androidmanagement_v1 {
    * @param {object=} options Options for Androidmanagement
    */
   export class Androidmanagement {
+    context: APIRequestContext;
     enterprises: Resource$Enterprises;
     signupUrls: Resource$Signupurls;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.enterprises = new Resource$Enterprises();
-      this.signupUrls = new Resource$Signupurls();
+      this.enterprises = new Resource$Enterprises(this.context);
+      this.signupUrls = new Resource$Signupurls(this.context);
     }
   }
 
@@ -1978,17 +1977,20 @@ export namespace androidmanagement_v1 {
 
 
   export class Resource$Enterprises {
+    context: APIRequestContext;
     applications: Resource$Enterprises$Applications;
     devices: Resource$Enterprises$Devices;
     enrollmentTokens: Resource$Enterprises$Enrollmenttokens;
     policies: Resource$Enterprises$Policies;
     webTokens: Resource$Enterprises$Webtokens;
-    constructor() {
-      this.applications = new Resource$Enterprises$Applications();
-      this.devices = new Resource$Enterprises$Devices();
-      this.enrollmentTokens = new Resource$Enterprises$Enrollmenttokens();
-      this.policies = new Resource$Enterprises$Policies();
-      this.webTokens = new Resource$Enterprises$Webtokens();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.applications = new Resource$Enterprises$Applications(this.context);
+      this.devices = new Resource$Enterprises$Devices(this.context);
+      this.enrollmentTokens =
+          new Resource$Enterprises$Enrollmenttokens(this.context);
+      this.policies = new Resource$Enterprises$Policies(this.context);
+      this.webTokens = new Resource$Enterprises$Webtokens(this.context);
     }
 
 
@@ -2053,7 +2055,7 @@ export namespace androidmanagement_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Enterprise>(parameters, callback);
@@ -2115,7 +2117,7 @@ export namespace androidmanagement_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Enterprise>(parameters, callback);
@@ -2183,7 +2185,7 @@ export namespace androidmanagement_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Enterprise>(parameters, callback);
@@ -2254,7 +2256,10 @@ export namespace androidmanagement_v1 {
   }
 
   export class Resource$Enterprises$Applications {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -2311,7 +2316,7 @@ export namespace androidmanagement_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Application>(parameters, callback);
@@ -2343,9 +2348,12 @@ export namespace androidmanagement_v1 {
 
 
   export class Resource$Enterprises$Devices {
+    context: APIRequestContext;
     operations: Resource$Enterprises$Devices$Operations;
-    constructor() {
-      this.operations = new Resource$Enterprises$Devices$Operations();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.operations =
+          new Resource$Enterprises$Devices$Operations(this.context);
     }
 
 
@@ -2406,7 +2414,7 @@ export namespace androidmanagement_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -2468,7 +2476,7 @@ export namespace androidmanagement_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Device>(parameters, callback);
@@ -2539,7 +2547,7 @@ export namespace androidmanagement_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -2609,7 +2617,7 @@ export namespace androidmanagement_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListDevicesResponse>(parameters, callback);
@@ -2677,7 +2685,7 @@ export namespace androidmanagement_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Device>(parameters, callback);
@@ -2781,7 +2789,10 @@ export namespace androidmanagement_v1 {
   }
 
   export class Resource$Enterprises$Devices$Operations {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -2850,7 +2861,7 @@ export namespace androidmanagement_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -2920,7 +2931,7 @@ export namespace androidmanagement_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -2985,7 +2996,7 @@ export namespace androidmanagement_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -3064,7 +3075,7 @@ export namespace androidmanagement_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListOperationsResponse>(parameters, callback);
@@ -3138,7 +3149,10 @@ export namespace androidmanagement_v1 {
 
 
   export class Resource$Enterprises$Enrollmenttokens {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -3200,7 +3214,7 @@ export namespace androidmanagement_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$EnrollmentToken>(parameters, callback);
@@ -3267,7 +3281,7 @@ export namespace androidmanagement_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -3310,7 +3324,10 @@ export namespace androidmanagement_v1 {
 
 
   export class Resource$Enterprises$Policies {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -3370,7 +3387,7 @@ export namespace androidmanagement_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -3432,7 +3449,7 @@ export namespace androidmanagement_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -3503,7 +3520,7 @@ export namespace androidmanagement_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListPoliciesResponse>(parameters, callback);
@@ -3571,7 +3588,7 @@ export namespace androidmanagement_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -3654,7 +3671,10 @@ export namespace androidmanagement_v1 {
 
 
   export class Resource$Enterprises$Webtokens {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -3716,7 +3736,7 @@ export namespace androidmanagement_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$WebToken>(parameters, callback);
@@ -3747,7 +3767,10 @@ export namespace androidmanagement_v1 {
 
 
   export class Resource$Signupurls {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -3807,7 +3830,7 @@ export namespace androidmanagement_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$SignupUrl>(parameters, callback);

--- a/src/apis/androidpublisher/v1.1.ts
+++ b/src/apis/androidpublisher/v1.1.ts
@@ -29,8 +29,6 @@ export namespace androidpublisher_v1_1 {
     version: 'v1_1';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * Data format for the response.
@@ -81,14 +79,15 @@ export namespace androidpublisher_v1_1 {
    * @param {object=} options Options for Androidpublisher
    */
   export class Androidpublisher {
+    context: APIRequestContext;
     inapppurchases: Resource$Inapppurchases;
     purchases: Resource$Purchases;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.inapppurchases = new Resource$Inapppurchases();
-      this.purchases = new Resource$Purchases();
+      this.inapppurchases = new Resource$Inapppurchases(this.context);
+      this.purchases = new Resource$Purchases(this.context);
     }
   }
 
@@ -164,7 +163,10 @@ export namespace androidpublisher_v1_1 {
 
 
   export class Resource$Inapppurchases {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -224,7 +226,7 @@ export namespace androidpublisher_v1_1 {
         params,
         requiredParams: ['packageName', 'productId', 'token'],
         pathParams: ['packageName', 'productId', 'token'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$InappPurchase>(parameters, callback);
@@ -259,7 +261,10 @@ export namespace androidpublisher_v1_1 {
 
 
   export class Resource$Purchases {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -320,7 +325,7 @@ export namespace androidpublisher_v1_1 {
         params,
         requiredParams: ['packageName', 'subscriptionId', 'token'],
         pathParams: ['packageName', 'subscriptionId', 'token'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -388,7 +393,7 @@ export namespace androidpublisher_v1_1 {
         params,
         requiredParams: ['packageName', 'subscriptionId', 'token'],
         pathParams: ['packageName', 'subscriptionId', 'token'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$SubscriptionPurchase>(parameters, callback);

--- a/src/apis/androidpublisher/v1.ts
+++ b/src/apis/androidpublisher/v1.ts
@@ -29,8 +29,6 @@ export namespace androidpublisher_v1 {
     version: 'v1';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * Data format for the response.
@@ -81,12 +79,13 @@ export namespace androidpublisher_v1 {
    * @param {object=} options Options for Androidpublisher
    */
   export class Androidpublisher {
+    context: APIRequestContext;
     purchases: Resource$Purchases;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.purchases = new Resource$Purchases();
+      this.purchases = new Resource$Purchases(this.context);
     }
   }
 
@@ -119,7 +118,10 @@ export namespace androidpublisher_v1 {
 
 
   export class Resource$Purchases {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -180,7 +182,7 @@ export namespace androidpublisher_v1 {
         params,
         requiredParams: ['packageName', 'subscriptionId', 'token'],
         pathParams: ['packageName', 'subscriptionId', 'token'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -248,7 +250,7 @@ export namespace androidpublisher_v1 {
         params,
         requiredParams: ['packageName', 'subscriptionId', 'token'],
         pathParams: ['packageName', 'subscriptionId', 'token'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$SubscriptionPurchase>(parameters, callback);

--- a/src/apis/androidpublisher/v2.ts
+++ b/src/apis/androidpublisher/v2.ts
@@ -29,8 +29,6 @@ export namespace androidpublisher_v2 {
     version: 'v2';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * Data format for the response.
@@ -81,6 +79,7 @@ export namespace androidpublisher_v2 {
    * @param {object=} options Options for Androidpublisher
    */
   export class Androidpublisher {
+    context: APIRequestContext;
     edits: Resource$Edits;
     inappproducts: Resource$Inappproducts;
     orders: Resource$Orders;
@@ -88,13 +87,13 @@ export namespace androidpublisher_v2 {
     reviews: Resource$Reviews;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.edits = new Resource$Edits();
-      this.inappproducts = new Resource$Inappproducts();
-      this.orders = new Resource$Orders();
-      this.purchases = new Resource$Purchases();
-      this.reviews = new Resource$Reviews();
+      this.edits = new Resource$Edits(this.context);
+      this.inappproducts = new Resource$Inappproducts(this.context);
+      this.orders = new Resource$Orders(this.context);
+      this.purchases = new Resource$Purchases(this.context);
+      this.reviews = new Resource$Reviews(this.context);
     }
   }
 
@@ -990,6 +989,7 @@ export namespace androidpublisher_v2 {
 
 
   export class Resource$Edits {
+    context: APIRequestContext;
     apklistings: Resource$Edits$Apklistings;
     apks: Resource$Edits$Apks;
     bundles: Resource$Edits$Bundles;
@@ -1000,17 +1000,19 @@ export namespace androidpublisher_v2 {
     listings: Resource$Edits$Listings;
     testers: Resource$Edits$Testers;
     tracks: Resource$Edits$Tracks;
-    constructor() {
-      this.apklistings = new Resource$Edits$Apklistings();
-      this.apks = new Resource$Edits$Apks();
-      this.bundles = new Resource$Edits$Bundles();
-      this.deobfuscationfiles = new Resource$Edits$Deobfuscationfiles();
-      this.details = new Resource$Edits$Details();
-      this.expansionfiles = new Resource$Edits$Expansionfiles();
-      this.images = new Resource$Edits$Images();
-      this.listings = new Resource$Edits$Listings();
-      this.testers = new Resource$Edits$Testers();
-      this.tracks = new Resource$Edits$Tracks();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.apklistings = new Resource$Edits$Apklistings(this.context);
+      this.apks = new Resource$Edits$Apks(this.context);
+      this.bundles = new Resource$Edits$Bundles(this.context);
+      this.deobfuscationfiles =
+          new Resource$Edits$Deobfuscationfiles(this.context);
+      this.details = new Resource$Edits$Details(this.context);
+      this.expansionfiles = new Resource$Edits$Expansionfiles(this.context);
+      this.images = new Resource$Edits$Images(this.context);
+      this.listings = new Resource$Edits$Listings(this.context);
+      this.testers = new Resource$Edits$Testers(this.context);
+      this.tracks = new Resource$Edits$Tracks(this.context);
     }
 
 
@@ -1071,7 +1073,7 @@ export namespace androidpublisher_v2 {
         params,
         requiredParams: ['packageName', 'editId'],
         pathParams: ['editId', 'packageName'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AppEdit>(parameters, callback);
@@ -1139,7 +1141,7 @@ export namespace androidpublisher_v2 {
         params,
         requiredParams: ['packageName', 'editId'],
         pathParams: ['editId', 'packageName'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -1205,7 +1207,7 @@ export namespace androidpublisher_v2 {
         params,
         requiredParams: ['packageName', 'editId'],
         pathParams: ['editId', 'packageName'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AppEdit>(parameters, callback);
@@ -1272,7 +1274,7 @@ export namespace androidpublisher_v2 {
         params,
         requiredParams: ['packageName'],
         pathParams: ['packageName'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AppEdit>(parameters, callback);
@@ -1340,7 +1342,7 @@ export namespace androidpublisher_v2 {
         params,
         requiredParams: ['packageName', 'editId'],
         pathParams: ['editId', 'packageName'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AppEdit>(parameters, callback);
@@ -1433,7 +1435,10 @@ export namespace androidpublisher_v2 {
   }
 
   export class Resource$Edits$Apklistings {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1497,7 +1502,7 @@ export namespace androidpublisher_v2 {
         params,
         requiredParams: ['packageName', 'editId', 'apkVersionCode', 'language'],
         pathParams: ['apkVersionCode', 'editId', 'language', 'packageName'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -1567,7 +1572,7 @@ export namespace androidpublisher_v2 {
         params,
         requiredParams: ['packageName', 'editId', 'apkVersionCode'],
         pathParams: ['apkVersionCode', 'editId', 'packageName'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -1636,7 +1641,7 @@ export namespace androidpublisher_v2 {
         params,
         requiredParams: ['packageName', 'editId', 'apkVersionCode', 'language'],
         pathParams: ['apkVersionCode', 'editId', 'language', 'packageName'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ApkListing>(parameters, callback);
@@ -1708,7 +1713,7 @@ export namespace androidpublisher_v2 {
         params,
         requiredParams: ['packageName', 'editId', 'apkVersionCode'],
         pathParams: ['apkVersionCode', 'editId', 'packageName'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ApkListingsListResponse>(parameters, callback);
@@ -1782,7 +1787,7 @@ export namespace androidpublisher_v2 {
         params,
         requiredParams: ['packageName', 'editId', 'apkVersionCode', 'language'],
         pathParams: ['apkVersionCode', 'editId', 'language', 'packageName'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ApkListing>(parameters, callback);
@@ -1856,7 +1861,7 @@ export namespace androidpublisher_v2 {
         params,
         requiredParams: ['packageName', 'editId', 'apkVersionCode', 'language'],
         pathParams: ['apkVersionCode', 'editId', 'language', 'packageName'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ApkListing>(parameters, callback);
@@ -2035,7 +2040,10 @@ export namespace androidpublisher_v2 {
 
 
   export class Resource$Edits$Apks {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -2109,7 +2117,7 @@ export namespace androidpublisher_v2 {
         params,
         requiredParams: ['packageName', 'editId'],
         pathParams: ['editId', 'packageName'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ApksAddExternallyHostedResponse>(
@@ -2178,7 +2186,7 @@ export namespace androidpublisher_v2 {
         params,
         requiredParams: ['packageName', 'editId'],
         pathParams: ['editId', 'packageName'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ApksListResponse>(parameters, callback);
@@ -2252,7 +2260,7 @@ export namespace androidpublisher_v2 {
                 .replace(/([^:]\/)\/+/g, '$1'),
         requiredParams: ['packageName', 'editId'],
         pathParams: ['editId', 'packageName'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Apk>(parameters, callback);
@@ -2336,7 +2344,10 @@ export namespace androidpublisher_v2 {
 
 
   export class Resource$Edits$Bundles {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -2397,7 +2408,7 @@ export namespace androidpublisher_v2 {
         params,
         requiredParams: ['packageName', 'editId'],
         pathParams: ['editId', 'packageName'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$BundlesListResponse>(parameters, callback);
@@ -2479,7 +2490,7 @@ export namespace androidpublisher_v2 {
                 .replace(/([^:]\/)\/+/g, '$1'),
         requiredParams: ['packageName', 'editId'],
         pathParams: ['editId', 'packageName'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Bundle>(parameters, callback);
@@ -2548,7 +2559,10 @@ export namespace androidpublisher_v2 {
 
 
   export class Resource$Edits$Deobfuscationfiles {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -2634,7 +2648,7 @@ export namespace androidpublisher_v2 {
         pathParams: [
           'apkVersionCode', 'deobfuscationFileType', 'editId', 'packageName'
         ],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$DeobfuscationFilesUploadResponse>(
@@ -2690,7 +2704,10 @@ export namespace androidpublisher_v2 {
 
 
   export class Resource$Edits$Details {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -2750,7 +2767,7 @@ export namespace androidpublisher_v2 {
         params,
         requiredParams: ['packageName', 'editId'],
         pathParams: ['editId', 'packageName'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AppDetails>(parameters, callback);
@@ -2822,7 +2839,7 @@ export namespace androidpublisher_v2 {
         params,
         requiredParams: ['packageName', 'editId'],
         pathParams: ['editId', 'packageName'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AppDetails>(parameters, callback);
@@ -2893,7 +2910,7 @@ export namespace androidpublisher_v2 {
         params,
         requiredParams: ['packageName', 'editId'],
         pathParams: ['editId', 'packageName'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AppDetails>(parameters, callback);
@@ -2967,7 +2984,10 @@ export namespace androidpublisher_v2 {
 
 
   export class Resource$Edits$Expansionfiles {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -3030,7 +3050,7 @@ export namespace androidpublisher_v2 {
             ['packageName', 'editId', 'apkVersionCode', 'expansionFileType'],
         pathParams:
             ['apkVersionCode', 'editId', 'expansionFileType', 'packageName'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ExpansionFile>(parameters, callback);
@@ -3107,7 +3127,7 @@ export namespace androidpublisher_v2 {
             ['packageName', 'editId', 'apkVersionCode', 'expansionFileType'],
         pathParams:
             ['apkVersionCode', 'editId', 'expansionFileType', 'packageName'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ExpansionFile>(parameters, callback);
@@ -3183,7 +3203,7 @@ export namespace androidpublisher_v2 {
             ['packageName', 'editId', 'apkVersionCode', 'expansionFileType'],
         pathParams:
             ['apkVersionCode', 'editId', 'expansionFileType', 'packageName'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ExpansionFile>(parameters, callback);
@@ -3269,7 +3289,7 @@ export namespace androidpublisher_v2 {
             ['packageName', 'editId', 'apkVersionCode', 'expansionFileType'],
         pathParams:
             ['apkVersionCode', 'editId', 'expansionFileType', 'packageName'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ExpansionFilesUploadResponse>(
@@ -3414,7 +3434,10 @@ export namespace androidpublisher_v2 {
 
 
   export class Resource$Edits$Images {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -3480,7 +3503,7 @@ export namespace androidpublisher_v2 {
             ['packageName', 'editId', 'language', 'imageType', 'imageId'],
         pathParams:
             ['editId', 'imageId', 'imageType', 'language', 'packageName'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -3554,7 +3577,7 @@ export namespace androidpublisher_v2 {
         params,
         requiredParams: ['packageName', 'editId', 'language', 'imageType'],
         pathParams: ['editId', 'imageType', 'language', 'packageName'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ImagesDeleteAllResponse>(parameters, callback);
@@ -3625,7 +3648,7 @@ export namespace androidpublisher_v2 {
         params,
         requiredParams: ['packageName', 'editId', 'language', 'imageType'],
         pathParams: ['editId', 'imageType', 'language', 'packageName'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ImagesListResponse>(parameters, callback);
@@ -3706,7 +3729,7 @@ export namespace androidpublisher_v2 {
                 .replace(/([^:]\/)\/+/g, '$1'),
         requiredParams: ['packageName', 'editId', 'language', 'imageType'],
         pathParams: ['editId', 'imageType', 'language', 'packageName'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ImagesUploadResponse>(parameters, callback);
@@ -3848,7 +3871,10 @@ export namespace androidpublisher_v2 {
 
 
   export class Resource$Edits$Listings {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -3910,7 +3936,7 @@ export namespace androidpublisher_v2 {
         params,
         requiredParams: ['packageName', 'editId', 'language'],
         pathParams: ['editId', 'language', 'packageName'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -3978,7 +4004,7 @@ export namespace androidpublisher_v2 {
         params,
         requiredParams: ['packageName', 'editId'],
         pathParams: ['editId', 'packageName'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -4044,7 +4070,7 @@ export namespace androidpublisher_v2 {
         params,
         requiredParams: ['packageName', 'editId', 'language'],
         pathParams: ['editId', 'language', 'packageName'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Listing>(parameters, callback);
@@ -4114,7 +4140,7 @@ export namespace androidpublisher_v2 {
         params,
         requiredParams: ['packageName', 'editId'],
         pathParams: ['editId', 'packageName'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListingsListResponse>(parameters, callback);
@@ -4186,7 +4212,7 @@ export namespace androidpublisher_v2 {
         params,
         requiredParams: ['packageName', 'editId', 'language'],
         pathParams: ['editId', 'language', 'packageName'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Listing>(parameters, callback);
@@ -4257,7 +4283,7 @@ export namespace androidpublisher_v2 {
         params,
         requiredParams: ['packageName', 'editId', 'language'],
         pathParams: ['editId', 'language', 'packageName'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Listing>(parameters, callback);
@@ -4402,7 +4428,10 @@ export namespace androidpublisher_v2 {
 
 
   export class Resource$Edits$Testers {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -4460,7 +4489,7 @@ export namespace androidpublisher_v2 {
         params,
         requiredParams: ['packageName', 'editId', 'track'],
         pathParams: ['editId', 'packageName', 'track'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Testers>(parameters, callback);
@@ -4530,7 +4559,7 @@ export namespace androidpublisher_v2 {
         params,
         requiredParams: ['packageName', 'editId', 'track'],
         pathParams: ['editId', 'packageName', 'track'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Testers>(parameters, callback);
@@ -4600,7 +4629,7 @@ export namespace androidpublisher_v2 {
         params,
         requiredParams: ['packageName', 'editId', 'track'],
         pathParams: ['editId', 'packageName', 'track'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Testers>(parameters, callback);
@@ -4689,7 +4718,10 @@ export namespace androidpublisher_v2 {
 
 
   export class Resource$Edits$Tracks {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -4748,7 +4780,7 @@ export namespace androidpublisher_v2 {
         params,
         requiredParams: ['packageName', 'editId', 'track'],
         pathParams: ['editId', 'packageName', 'track'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Track>(parameters, callback);
@@ -4817,7 +4849,7 @@ export namespace androidpublisher_v2 {
         params,
         requiredParams: ['packageName', 'editId'],
         pathParams: ['editId', 'packageName'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TracksListResponse>(parameters, callback);
@@ -4890,7 +4922,7 @@ export namespace androidpublisher_v2 {
         params,
         requiredParams: ['packageName', 'editId', 'track'],
         pathParams: ['editId', 'packageName', 'track'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Track>(parameters, callback);
@@ -4963,7 +4995,7 @@ export namespace androidpublisher_v2 {
         params,
         requiredParams: ['packageName', 'editId', 'track'],
         pathParams: ['editId', 'packageName', 'track'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Track>(parameters, callback);
@@ -5066,7 +5098,10 @@ export namespace androidpublisher_v2 {
 
 
   export class Resource$Inappproducts {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -5127,7 +5162,7 @@ export namespace androidpublisher_v2 {
         params,
         requiredParams: ['packageName', 'sku'],
         pathParams: ['packageName', 'sku'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -5193,7 +5228,7 @@ export namespace androidpublisher_v2 {
         params,
         requiredParams: ['packageName', 'sku'],
         pathParams: ['packageName', 'sku'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$InAppProduct>(parameters, callback);
@@ -5264,7 +5299,7 @@ export namespace androidpublisher_v2 {
         params,
         requiredParams: ['packageName'],
         pathParams: ['packageName'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$InAppProduct>(parameters, callback);
@@ -5338,7 +5373,7 @@ export namespace androidpublisher_v2 {
         params,
         requiredParams: ['packageName'],
         pathParams: ['packageName'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$InappproductsListResponse>(
@@ -5412,7 +5447,7 @@ export namespace androidpublisher_v2 {
         params,
         requiredParams: ['packageName', 'sku'],
         pathParams: ['packageName', 'sku'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$InAppProduct>(parameters, callback);
@@ -5484,7 +5519,7 @@ export namespace androidpublisher_v2 {
         params,
         requiredParams: ['packageName', 'sku'],
         pathParams: ['packageName', 'sku'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$InAppProduct>(parameters, callback);
@@ -5634,7 +5669,10 @@ export namespace androidpublisher_v2 {
 
 
   export class Resource$Orders {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -5694,7 +5732,7 @@ export namespace androidpublisher_v2 {
         params,
         requiredParams: ['packageName', 'orderId'],
         pathParams: ['orderId', 'packageName'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -5731,19 +5769,25 @@ export namespace androidpublisher_v2 {
 
 
   export class Resource$Purchases {
+    context: APIRequestContext;
     products: Resource$Purchases$Products;
     subscriptions: Resource$Purchases$Subscriptions;
     voidedpurchases: Resource$Purchases$Voidedpurchases;
-    constructor() {
-      this.products = new Resource$Purchases$Products();
-      this.subscriptions = new Resource$Purchases$Subscriptions();
-      this.voidedpurchases = new Resource$Purchases$Voidedpurchases();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.products = new Resource$Purchases$Products(this.context);
+      this.subscriptions = new Resource$Purchases$Subscriptions(this.context);
+      this.voidedpurchases =
+          new Resource$Purchases$Voidedpurchases(this.context);
     }
   }
 
 
   export class Resource$Purchases$Products {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -5803,7 +5847,7 @@ export namespace androidpublisher_v2 {
         params,
         requiredParams: ['packageName', 'productId', 'token'],
         pathParams: ['packageName', 'productId', 'token'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ProductPurchase>(parameters, callback);
@@ -5838,7 +5882,10 @@ export namespace androidpublisher_v2 {
 
 
   export class Resource$Purchases$Subscriptions {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -5901,7 +5948,7 @@ export namespace androidpublisher_v2 {
         params,
         requiredParams: ['packageName', 'subscriptionId', 'token'],
         pathParams: ['packageName', 'subscriptionId', 'token'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -5983,7 +6030,7 @@ export namespace androidpublisher_v2 {
         params,
         requiredParams: ['packageName', 'subscriptionId', 'token'],
         pathParams: ['packageName', 'subscriptionId', 'token'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$SubscriptionPurchasesDeferResponse>(
@@ -6054,7 +6101,7 @@ export namespace androidpublisher_v2 {
         params,
         requiredParams: ['packageName', 'subscriptionId', 'token'],
         pathParams: ['packageName', 'subscriptionId', 'token'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$SubscriptionPurchase>(parameters, callback);
@@ -6124,7 +6171,7 @@ export namespace androidpublisher_v2 {
         params,
         requiredParams: ['packageName', 'subscriptionId', 'token'],
         pathParams: ['packageName', 'subscriptionId', 'token'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -6195,7 +6242,7 @@ export namespace androidpublisher_v2 {
         params,
         requiredParams: ['packageName', 'subscriptionId', 'token'],
         pathParams: ['packageName', 'subscriptionId', 'token'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -6323,7 +6370,10 @@ export namespace androidpublisher_v2 {
 
 
   export class Resource$Purchases$Voidedpurchases {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -6395,7 +6445,7 @@ export namespace androidpublisher_v2 {
         params,
         requiredParams: ['packageName'],
         pathParams: ['packageName'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$VoidedPurchasesListResponse>(
@@ -6453,7 +6503,10 @@ export namespace androidpublisher_v2 {
 
 
   export class Resource$Reviews {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -6511,7 +6564,7 @@ export namespace androidpublisher_v2 {
         params,
         requiredParams: ['packageName', 'reviewId'],
         pathParams: ['packageName', 'reviewId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Review>(parameters, callback);
@@ -6582,7 +6635,7 @@ export namespace androidpublisher_v2 {
         params,
         requiredParams: ['packageName'],
         pathParams: ['packageName'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ReviewsListResponse>(parameters, callback);
@@ -6652,7 +6705,7 @@ export namespace androidpublisher_v2 {
         params,
         requiredParams: ['packageName', 'reviewId'],
         pathParams: ['packageName', 'reviewId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ReviewsReplyResponse>(parameters, callback);

--- a/src/apis/androidpublisher/v3.ts
+++ b/src/apis/androidpublisher/v3.ts
@@ -29,8 +29,6 @@ export namespace androidpublisher_v3 {
     version: 'v3';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * Data format for the response.
@@ -81,6 +79,7 @@ export namespace androidpublisher_v3 {
    * @param {object=} options Options for Androidpublisher
    */
   export class Androidpublisher {
+    context: APIRequestContext;
     edits: Resource$Edits;
     inappproducts: Resource$Inappproducts;
     orders: Resource$Orders;
@@ -88,13 +87,13 @@ export namespace androidpublisher_v3 {
     reviews: Resource$Reviews;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.edits = new Resource$Edits();
-      this.inappproducts = new Resource$Inappproducts();
-      this.orders = new Resource$Orders();
-      this.purchases = new Resource$Purchases();
-      this.reviews = new Resource$Reviews();
+      this.edits = new Resource$Edits(this.context);
+      this.inappproducts = new Resource$Inappproducts(this.context);
+      this.orders = new Resource$Orders(this.context);
+      this.purchases = new Resource$Purchases(this.context);
+      this.reviews = new Resource$Reviews(this.context);
     }
   }
 
@@ -1015,6 +1014,7 @@ export namespace androidpublisher_v3 {
 
 
   export class Resource$Edits {
+    context: APIRequestContext;
     apks: Resource$Edits$Apks;
     bundles: Resource$Edits$Bundles;
     deobfuscationfiles: Resource$Edits$Deobfuscationfiles;
@@ -1024,16 +1024,18 @@ export namespace androidpublisher_v3 {
     listings: Resource$Edits$Listings;
     testers: Resource$Edits$Testers;
     tracks: Resource$Edits$Tracks;
-    constructor() {
-      this.apks = new Resource$Edits$Apks();
-      this.bundles = new Resource$Edits$Bundles();
-      this.deobfuscationfiles = new Resource$Edits$Deobfuscationfiles();
-      this.details = new Resource$Edits$Details();
-      this.expansionfiles = new Resource$Edits$Expansionfiles();
-      this.images = new Resource$Edits$Images();
-      this.listings = new Resource$Edits$Listings();
-      this.testers = new Resource$Edits$Testers();
-      this.tracks = new Resource$Edits$Tracks();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.apks = new Resource$Edits$Apks(this.context);
+      this.bundles = new Resource$Edits$Bundles(this.context);
+      this.deobfuscationfiles =
+          new Resource$Edits$Deobfuscationfiles(this.context);
+      this.details = new Resource$Edits$Details(this.context);
+      this.expansionfiles = new Resource$Edits$Expansionfiles(this.context);
+      this.images = new Resource$Edits$Images(this.context);
+      this.listings = new Resource$Edits$Listings(this.context);
+      this.testers = new Resource$Edits$Testers(this.context);
+      this.tracks = new Resource$Edits$Tracks(this.context);
     }
 
 
@@ -1094,7 +1096,7 @@ export namespace androidpublisher_v3 {
         params,
         requiredParams: ['packageName', 'editId'],
         pathParams: ['editId', 'packageName'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AppEdit>(parameters, callback);
@@ -1162,7 +1164,7 @@ export namespace androidpublisher_v3 {
         params,
         requiredParams: ['packageName', 'editId'],
         pathParams: ['editId', 'packageName'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -1228,7 +1230,7 @@ export namespace androidpublisher_v3 {
         params,
         requiredParams: ['packageName', 'editId'],
         pathParams: ['editId', 'packageName'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AppEdit>(parameters, callback);
@@ -1295,7 +1297,7 @@ export namespace androidpublisher_v3 {
         params,
         requiredParams: ['packageName'],
         pathParams: ['packageName'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AppEdit>(parameters, callback);
@@ -1363,7 +1365,7 @@ export namespace androidpublisher_v3 {
         params,
         requiredParams: ['packageName', 'editId'],
         pathParams: ['editId', 'packageName'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AppEdit>(parameters, callback);
@@ -1456,7 +1458,10 @@ export namespace androidpublisher_v3 {
   }
 
   export class Resource$Edits$Apks {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1530,7 +1535,7 @@ export namespace androidpublisher_v3 {
         params,
         requiredParams: ['packageName', 'editId'],
         pathParams: ['editId', 'packageName'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ApksAddExternallyHostedResponse>(
@@ -1599,7 +1604,7 @@ export namespace androidpublisher_v3 {
         params,
         requiredParams: ['packageName', 'editId'],
         pathParams: ['editId', 'packageName'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ApksListResponse>(parameters, callback);
@@ -1673,7 +1678,7 @@ export namespace androidpublisher_v3 {
                 .replace(/([^:]\/)\/+/g, '$1'),
         requiredParams: ['packageName', 'editId'],
         pathParams: ['editId', 'packageName'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Apk>(parameters, callback);
@@ -1757,7 +1762,10 @@ export namespace androidpublisher_v3 {
 
 
   export class Resource$Edits$Bundles {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1818,7 +1826,7 @@ export namespace androidpublisher_v3 {
         params,
         requiredParams: ['packageName', 'editId'],
         pathParams: ['editId', 'packageName'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$BundlesListResponse>(parameters, callback);
@@ -1900,7 +1908,7 @@ export namespace androidpublisher_v3 {
                 .replace(/([^:]\/)\/+/g, '$1'),
         requiredParams: ['packageName', 'editId'],
         pathParams: ['editId', 'packageName'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Bundle>(parameters, callback);
@@ -1969,7 +1977,10 @@ export namespace androidpublisher_v3 {
 
 
   export class Resource$Edits$Deobfuscationfiles {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -2055,7 +2066,7 @@ export namespace androidpublisher_v3 {
         pathParams: [
           'apkVersionCode', 'deobfuscationFileType', 'editId', 'packageName'
         ],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$DeobfuscationFilesUploadResponse>(
@@ -2111,7 +2122,10 @@ export namespace androidpublisher_v3 {
 
 
   export class Resource$Edits$Details {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -2171,7 +2185,7 @@ export namespace androidpublisher_v3 {
         params,
         requiredParams: ['packageName', 'editId'],
         pathParams: ['editId', 'packageName'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AppDetails>(parameters, callback);
@@ -2243,7 +2257,7 @@ export namespace androidpublisher_v3 {
         params,
         requiredParams: ['packageName', 'editId'],
         pathParams: ['editId', 'packageName'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AppDetails>(parameters, callback);
@@ -2314,7 +2328,7 @@ export namespace androidpublisher_v3 {
         params,
         requiredParams: ['packageName', 'editId'],
         pathParams: ['editId', 'packageName'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AppDetails>(parameters, callback);
@@ -2388,7 +2402,10 @@ export namespace androidpublisher_v3 {
 
 
   export class Resource$Edits$Expansionfiles {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -2451,7 +2468,7 @@ export namespace androidpublisher_v3 {
             ['packageName', 'editId', 'apkVersionCode', 'expansionFileType'],
         pathParams:
             ['apkVersionCode', 'editId', 'expansionFileType', 'packageName'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ExpansionFile>(parameters, callback);
@@ -2528,7 +2545,7 @@ export namespace androidpublisher_v3 {
             ['packageName', 'editId', 'apkVersionCode', 'expansionFileType'],
         pathParams:
             ['apkVersionCode', 'editId', 'expansionFileType', 'packageName'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ExpansionFile>(parameters, callback);
@@ -2604,7 +2621,7 @@ export namespace androidpublisher_v3 {
             ['packageName', 'editId', 'apkVersionCode', 'expansionFileType'],
         pathParams:
             ['apkVersionCode', 'editId', 'expansionFileType', 'packageName'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ExpansionFile>(parameters, callback);
@@ -2690,7 +2707,7 @@ export namespace androidpublisher_v3 {
             ['packageName', 'editId', 'apkVersionCode', 'expansionFileType'],
         pathParams:
             ['apkVersionCode', 'editId', 'expansionFileType', 'packageName'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ExpansionFilesUploadResponse>(
@@ -2835,7 +2852,10 @@ export namespace androidpublisher_v3 {
 
 
   export class Resource$Edits$Images {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -2901,7 +2921,7 @@ export namespace androidpublisher_v3 {
             ['packageName', 'editId', 'language', 'imageType', 'imageId'],
         pathParams:
             ['editId', 'imageId', 'imageType', 'language', 'packageName'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -2975,7 +2995,7 @@ export namespace androidpublisher_v3 {
         params,
         requiredParams: ['packageName', 'editId', 'language', 'imageType'],
         pathParams: ['editId', 'imageType', 'language', 'packageName'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ImagesDeleteAllResponse>(parameters, callback);
@@ -3046,7 +3066,7 @@ export namespace androidpublisher_v3 {
         params,
         requiredParams: ['packageName', 'editId', 'language', 'imageType'],
         pathParams: ['editId', 'imageType', 'language', 'packageName'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ImagesListResponse>(parameters, callback);
@@ -3127,7 +3147,7 @@ export namespace androidpublisher_v3 {
                 .replace(/([^:]\/)\/+/g, '$1'),
         requiredParams: ['packageName', 'editId', 'language', 'imageType'],
         pathParams: ['editId', 'imageType', 'language', 'packageName'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ImagesUploadResponse>(parameters, callback);
@@ -3269,7 +3289,10 @@ export namespace androidpublisher_v3 {
 
 
   export class Resource$Edits$Listings {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -3331,7 +3354,7 @@ export namespace androidpublisher_v3 {
         params,
         requiredParams: ['packageName', 'editId', 'language'],
         pathParams: ['editId', 'language', 'packageName'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -3399,7 +3422,7 @@ export namespace androidpublisher_v3 {
         params,
         requiredParams: ['packageName', 'editId'],
         pathParams: ['editId', 'packageName'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -3465,7 +3488,7 @@ export namespace androidpublisher_v3 {
         params,
         requiredParams: ['packageName', 'editId', 'language'],
         pathParams: ['editId', 'language', 'packageName'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Listing>(parameters, callback);
@@ -3535,7 +3558,7 @@ export namespace androidpublisher_v3 {
         params,
         requiredParams: ['packageName', 'editId'],
         pathParams: ['editId', 'packageName'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListingsListResponse>(parameters, callback);
@@ -3607,7 +3630,7 @@ export namespace androidpublisher_v3 {
         params,
         requiredParams: ['packageName', 'editId', 'language'],
         pathParams: ['editId', 'language', 'packageName'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Listing>(parameters, callback);
@@ -3678,7 +3701,7 @@ export namespace androidpublisher_v3 {
         params,
         requiredParams: ['packageName', 'editId', 'language'],
         pathParams: ['editId', 'language', 'packageName'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Listing>(parameters, callback);
@@ -3823,7 +3846,10 @@ export namespace androidpublisher_v3 {
 
 
   export class Resource$Edits$Testers {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -3881,7 +3907,7 @@ export namespace androidpublisher_v3 {
         params,
         requiredParams: ['packageName', 'editId', 'track'],
         pathParams: ['editId', 'packageName', 'track'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Testers>(parameters, callback);
@@ -3951,7 +3977,7 @@ export namespace androidpublisher_v3 {
         params,
         requiredParams: ['packageName', 'editId', 'track'],
         pathParams: ['editId', 'packageName', 'track'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Testers>(parameters, callback);
@@ -4021,7 +4047,7 @@ export namespace androidpublisher_v3 {
         params,
         requiredParams: ['packageName', 'editId', 'track'],
         pathParams: ['editId', 'packageName', 'track'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Testers>(parameters, callback);
@@ -4110,7 +4136,10 @@ export namespace androidpublisher_v3 {
 
 
   export class Resource$Edits$Tracks {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -4169,7 +4198,7 @@ export namespace androidpublisher_v3 {
         params,
         requiredParams: ['packageName', 'editId', 'track'],
         pathParams: ['editId', 'packageName', 'track'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Track>(parameters, callback);
@@ -4238,7 +4267,7 @@ export namespace androidpublisher_v3 {
         params,
         requiredParams: ['packageName', 'editId'],
         pathParams: ['editId', 'packageName'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TracksListResponse>(parameters, callback);
@@ -4311,7 +4340,7 @@ export namespace androidpublisher_v3 {
         params,
         requiredParams: ['packageName', 'editId', 'track'],
         pathParams: ['editId', 'packageName', 'track'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Track>(parameters, callback);
@@ -4384,7 +4413,7 @@ export namespace androidpublisher_v3 {
         params,
         requiredParams: ['packageName', 'editId', 'track'],
         pathParams: ['editId', 'packageName', 'track'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Track>(parameters, callback);
@@ -4487,7 +4516,10 @@ export namespace androidpublisher_v3 {
 
 
   export class Resource$Inappproducts {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -4548,7 +4580,7 @@ export namespace androidpublisher_v3 {
         params,
         requiredParams: ['packageName', 'sku'],
         pathParams: ['packageName', 'sku'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -4614,7 +4646,7 @@ export namespace androidpublisher_v3 {
         params,
         requiredParams: ['packageName', 'sku'],
         pathParams: ['packageName', 'sku'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$InAppProduct>(parameters, callback);
@@ -4685,7 +4717,7 @@ export namespace androidpublisher_v3 {
         params,
         requiredParams: ['packageName'],
         pathParams: ['packageName'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$InAppProduct>(parameters, callback);
@@ -4759,7 +4791,7 @@ export namespace androidpublisher_v3 {
         params,
         requiredParams: ['packageName'],
         pathParams: ['packageName'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$InappproductsListResponse>(
@@ -4833,7 +4865,7 @@ export namespace androidpublisher_v3 {
         params,
         requiredParams: ['packageName', 'sku'],
         pathParams: ['packageName', 'sku'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$InAppProduct>(parameters, callback);
@@ -4905,7 +4937,7 @@ export namespace androidpublisher_v3 {
         params,
         requiredParams: ['packageName', 'sku'],
         pathParams: ['packageName', 'sku'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$InAppProduct>(parameters, callback);
@@ -5055,7 +5087,10 @@ export namespace androidpublisher_v3 {
 
 
   export class Resource$Orders {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -5115,7 +5150,7 @@ export namespace androidpublisher_v3 {
         params,
         requiredParams: ['packageName', 'orderId'],
         pathParams: ['orderId', 'packageName'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -5152,19 +5187,25 @@ export namespace androidpublisher_v3 {
 
 
   export class Resource$Purchases {
+    context: APIRequestContext;
     products: Resource$Purchases$Products;
     subscriptions: Resource$Purchases$Subscriptions;
     voidedpurchases: Resource$Purchases$Voidedpurchases;
-    constructor() {
-      this.products = new Resource$Purchases$Products();
-      this.subscriptions = new Resource$Purchases$Subscriptions();
-      this.voidedpurchases = new Resource$Purchases$Voidedpurchases();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.products = new Resource$Purchases$Products(this.context);
+      this.subscriptions = new Resource$Purchases$Subscriptions(this.context);
+      this.voidedpurchases =
+          new Resource$Purchases$Voidedpurchases(this.context);
     }
   }
 
 
   export class Resource$Purchases$Products {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -5224,7 +5265,7 @@ export namespace androidpublisher_v3 {
         params,
         requiredParams: ['packageName', 'productId', 'token'],
         pathParams: ['packageName', 'productId', 'token'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ProductPurchase>(parameters, callback);
@@ -5259,7 +5300,10 @@ export namespace androidpublisher_v3 {
 
 
   export class Resource$Purchases$Subscriptions {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -5322,7 +5366,7 @@ export namespace androidpublisher_v3 {
         params,
         requiredParams: ['packageName', 'subscriptionId', 'token'],
         pathParams: ['packageName', 'subscriptionId', 'token'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -5404,7 +5448,7 @@ export namespace androidpublisher_v3 {
         params,
         requiredParams: ['packageName', 'subscriptionId', 'token'],
         pathParams: ['packageName', 'subscriptionId', 'token'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$SubscriptionPurchasesDeferResponse>(
@@ -5475,7 +5519,7 @@ export namespace androidpublisher_v3 {
         params,
         requiredParams: ['packageName', 'subscriptionId', 'token'],
         pathParams: ['packageName', 'subscriptionId', 'token'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$SubscriptionPurchase>(parameters, callback);
@@ -5545,7 +5589,7 @@ export namespace androidpublisher_v3 {
         params,
         requiredParams: ['packageName', 'subscriptionId', 'token'],
         pathParams: ['packageName', 'subscriptionId', 'token'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -5616,7 +5660,7 @@ export namespace androidpublisher_v3 {
         params,
         requiredParams: ['packageName', 'subscriptionId', 'token'],
         pathParams: ['packageName', 'subscriptionId', 'token'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -5744,7 +5788,10 @@ export namespace androidpublisher_v3 {
 
 
   export class Resource$Purchases$Voidedpurchases {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -5816,7 +5863,7 @@ export namespace androidpublisher_v3 {
         params,
         requiredParams: ['packageName'],
         pathParams: ['packageName'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$VoidedPurchasesListResponse>(
@@ -5874,7 +5921,10 @@ export namespace androidpublisher_v3 {
 
 
   export class Resource$Reviews {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -5932,7 +5982,7 @@ export namespace androidpublisher_v3 {
         params,
         requiredParams: ['packageName', 'reviewId'],
         pathParams: ['packageName', 'reviewId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Review>(parameters, callback);
@@ -6003,7 +6053,7 @@ export namespace androidpublisher_v3 {
         params,
         requiredParams: ['packageName'],
         pathParams: ['packageName'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ReviewsListResponse>(parameters, callback);
@@ -6073,7 +6123,7 @@ export namespace androidpublisher_v3 {
         params,
         requiredParams: ['packageName', 'reviewId'],
         pathParams: ['packageName', 'reviewId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ReviewsReplyResponse>(parameters, callback);

--- a/src/apis/appengine/v1.ts
+++ b/src/apis/appengine/v1.ts
@@ -29,8 +29,6 @@ export namespace appengine_v1 {
     version: 'v1';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * V1 error format.
@@ -98,12 +96,13 @@ export namespace appengine_v1 {
    * @param {object=} options Options for Appengine
    */
   export class Appengine {
+    context: APIRequestContext;
     apps: Resource$Apps;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.apps = new Resource$Apps();
+      this.apps = new Resource$Apps(this.context);
     }
   }
 
@@ -1962,6 +1961,7 @@ export namespace appengine_v1 {
 
 
   export class Resource$Apps {
+    context: APIRequestContext;
     authorizedCertificates: Resource$Apps$Authorizedcertificates;
     authorizedDomains: Resource$Apps$Authorizeddomains;
     domainMappings: Resource$Apps$Domainmappings;
@@ -1969,14 +1969,17 @@ export namespace appengine_v1 {
     locations: Resource$Apps$Locations;
     operations: Resource$Apps$Operations;
     services: Resource$Apps$Services;
-    constructor() {
-      this.authorizedCertificates = new Resource$Apps$Authorizedcertificates();
-      this.authorizedDomains = new Resource$Apps$Authorizeddomains();
-      this.domainMappings = new Resource$Apps$Domainmappings();
-      this.firewall = new Resource$Apps$Firewall();
-      this.locations = new Resource$Apps$Locations();
-      this.operations = new Resource$Apps$Operations();
-      this.services = new Resource$Apps$Services();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.authorizedCertificates =
+          new Resource$Apps$Authorizedcertificates(this.context);
+      this.authorizedDomains =
+          new Resource$Apps$Authorizeddomains(this.context);
+      this.domainMappings = new Resource$Apps$Domainmappings(this.context);
+      this.firewall = new Resource$Apps$Firewall(this.context);
+      this.locations = new Resource$Apps$Locations(this.context);
+      this.operations = new Resource$Apps$Operations(this.context);
+      this.services = new Resource$Apps$Services(this.context);
     }
 
 
@@ -2040,7 +2043,7 @@ export namespace appengine_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -2102,7 +2105,7 @@ export namespace appengine_v1 {
         params,
         requiredParams: ['appsId'],
         pathParams: ['appsId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Application>(parameters, callback);
@@ -2172,7 +2175,7 @@ export namespace appengine_v1 {
         params,
         requiredParams: ['appsId'],
         pathParams: ['appsId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -2242,7 +2245,7 @@ export namespace appengine_v1 {
         params,
         requiredParams: ['appsId'],
         pathParams: ['appsId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -2315,7 +2318,10 @@ export namespace appengine_v1 {
   }
 
   export class Resource$Apps$Authorizedcertificates {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -2377,7 +2383,7 @@ export namespace appengine_v1 {
         params,
         requiredParams: ['appsId'],
         pathParams: ['appsId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AuthorizedCertificate>(parameters, callback);
@@ -2446,7 +2452,7 @@ export namespace appengine_v1 {
         params,
         requiredParams: ['appsId', 'authorizedCertificatesId'],
         pathParams: ['appsId', 'authorizedCertificatesId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -2514,7 +2520,7 @@ export namespace appengine_v1 {
         params,
         requiredParams: ['appsId', 'authorizedCertificatesId'],
         pathParams: ['appsId', 'authorizedCertificatesId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AuthorizedCertificate>(parameters, callback);
@@ -2593,7 +2599,7 @@ export namespace appengine_v1 {
         params,
         requiredParams: ['appsId'],
         pathParams: ['appsId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListAuthorizedCertificatesResponse>(
@@ -2672,7 +2678,7 @@ export namespace appengine_v1 {
         params,
         requiredParams: ['appsId', 'authorizedCertificatesId'],
         pathParams: ['appsId', 'authorizedCertificatesId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AuthorizedCertificate>(parameters, callback);
@@ -2793,7 +2799,10 @@ export namespace appengine_v1 {
 
 
   export class Resource$Apps$Authorizeddomains {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -2860,7 +2869,7 @@ export namespace appengine_v1 {
         params,
         requiredParams: ['appsId'],
         pathParams: ['appsId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListAuthorizedDomainsResponse>(
@@ -2896,7 +2905,10 @@ export namespace appengine_v1 {
 
 
   export class Resource$Apps$Domainmappings {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -2961,7 +2973,7 @@ export namespace appengine_v1 {
         params,
         requiredParams: ['appsId'],
         pathParams: ['appsId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -3032,7 +3044,7 @@ export namespace appengine_v1 {
         params,
         requiredParams: ['appsId', 'domainMappingsId'],
         pathParams: ['appsId', 'domainMappingsId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -3097,7 +3109,7 @@ export namespace appengine_v1 {
         params,
         requiredParams: ['appsId', 'domainMappingsId'],
         pathParams: ['appsId', 'domainMappingsId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$DomainMapping>(parameters, callback);
@@ -3171,7 +3183,7 @@ export namespace appengine_v1 {
         params,
         requiredParams: ['appsId'],
         pathParams: ['appsId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListDomainMappingsResponse>(
@@ -3246,7 +3258,7 @@ export namespace appengine_v1 {
         params,
         requiredParams: ['appsId', 'domainMappingsId'],
         pathParams: ['appsId', 'domainMappingsId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -3363,15 +3375,20 @@ export namespace appengine_v1 {
 
 
   export class Resource$Apps$Firewall {
+    context: APIRequestContext;
     ingressRules: Resource$Apps$Firewall$Ingressrules;
-    constructor() {
-      this.ingressRules = new Resource$Apps$Firewall$Ingressrules();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.ingressRules = new Resource$Apps$Firewall$Ingressrules(this.context);
     }
   }
 
 
   export class Resource$Apps$Firewall$Ingressrules {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -3445,7 +3462,7 @@ export namespace appengine_v1 {
         params,
         requiredParams: ['appsId'],
         pathParams: ['appsId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$BatchUpdateIngressRulesResponse>(
@@ -3515,7 +3532,7 @@ export namespace appengine_v1 {
         params,
         requiredParams: ['appsId'],
         pathParams: ['appsId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$FirewallRule>(parameters, callback);
@@ -3583,7 +3600,7 @@ export namespace appengine_v1 {
         params,
         requiredParams: ['appsId', 'ingressRulesId'],
         pathParams: ['appsId', 'ingressRulesId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -3648,7 +3665,7 @@ export namespace appengine_v1 {
         params,
         requiredParams: ['appsId', 'ingressRulesId'],
         pathParams: ['appsId', 'ingressRulesId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$FirewallRule>(parameters, callback);
@@ -3720,7 +3737,7 @@ export namespace appengine_v1 {
         params,
         requiredParams: ['appsId'],
         pathParams: ['appsId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListIngressRulesResponse>(parameters, callback);
@@ -3791,7 +3808,7 @@ export namespace appengine_v1 {
         params,
         requiredParams: ['appsId', 'ingressRulesId'],
         pathParams: ['appsId', 'ingressRulesId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$FirewallRule>(parameters, callback);
@@ -3928,7 +3945,10 @@ export namespace appengine_v1 {
 
 
   export class Resource$Apps$Locations {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -3984,7 +4004,7 @@ export namespace appengine_v1 {
         params,
         requiredParams: ['appsId', 'locationsId'],
         pathParams: ['appsId', 'locationsId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Location>(parameters, callback);
@@ -4054,7 +4074,7 @@ export namespace appengine_v1 {
         params,
         requiredParams: ['appsId'],
         pathParams: ['appsId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListLocationsResponse>(parameters, callback);
@@ -4108,7 +4128,10 @@ export namespace appengine_v1 {
 
 
   export class Resource$Apps$Operations {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -4167,7 +4190,7 @@ export namespace appengine_v1 {
         params,
         requiredParams: ['appsId', 'operationsId'],
         pathParams: ['appsId', 'operationsId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -4246,7 +4269,7 @@ export namespace appengine_v1 {
         params,
         requiredParams: ['appsId'],
         pathParams: ['appsId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListOperationsResponse>(parameters, callback);
@@ -4299,9 +4322,11 @@ export namespace appengine_v1 {
 
 
   export class Resource$Apps$Services {
+    context: APIRequestContext;
     versions: Resource$Apps$Services$Versions;
-    constructor() {
-      this.versions = new Resource$Apps$Services$Versions();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.versions = new Resource$Apps$Services$Versions(this.context);
     }
 
 
@@ -4363,7 +4388,7 @@ export namespace appengine_v1 {
         params,
         requiredParams: ['appsId', 'servicesId'],
         pathParams: ['appsId', 'servicesId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -4426,7 +4451,7 @@ export namespace appengine_v1 {
         params,
         requiredParams: ['appsId', 'servicesId'],
         pathParams: ['appsId', 'servicesId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Service>(parameters, callback);
@@ -4495,7 +4520,7 @@ export namespace appengine_v1 {
         params,
         requiredParams: ['appsId'],
         pathParams: ['appsId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListServicesResponse>(parameters, callback);
@@ -4566,7 +4591,7 @@ export namespace appengine_v1 {
         params,
         requiredParams: ['appsId', 'servicesId'],
         pathParams: ['appsId', 'servicesId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -4675,9 +4700,12 @@ export namespace appengine_v1 {
   }
 
   export class Resource$Apps$Services$Versions {
+    context: APIRequestContext;
     instances: Resource$Apps$Services$Versions$Instances;
-    constructor() {
-      this.instances = new Resource$Apps$Services$Versions$Instances();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.instances =
+          new Resource$Apps$Services$Versions$Instances(this.context);
     }
 
 
@@ -4741,7 +4769,7 @@ export namespace appengine_v1 {
         params,
         requiredParams: ['appsId', 'servicesId'],
         pathParams: ['appsId', 'servicesId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -4812,7 +4840,7 @@ export namespace appengine_v1 {
         params,
         requiredParams: ['appsId', 'servicesId', 'versionsId'],
         pathParams: ['appsId', 'servicesId', 'versionsId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -4881,7 +4909,7 @@ export namespace appengine_v1 {
         params,
         requiredParams: ['appsId', 'servicesId', 'versionsId'],
         pathParams: ['appsId', 'servicesId', 'versionsId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Version>(parameters, callback);
@@ -4954,7 +4982,7 @@ export namespace appengine_v1 {
         params,
         requiredParams: ['appsId', 'servicesId'],
         pathParams: ['appsId', 'servicesId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListVersionsResponse>(parameters, callback);
@@ -5056,7 +5084,7 @@ export namespace appengine_v1 {
         params,
         requiredParams: ['appsId', 'servicesId', 'versionsId'],
         pathParams: ['appsId', 'servicesId', 'versionsId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -5195,7 +5223,10 @@ export namespace appengine_v1 {
   }
 
   export class Resource$Apps$Services$Versions$Instances {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -5267,7 +5298,7 @@ export namespace appengine_v1 {
         params,
         requiredParams: ['appsId', 'servicesId', 'versionsId', 'instancesId'],
         pathParams: ['appsId', 'instancesId', 'servicesId', 'versionsId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -5340,7 +5371,7 @@ export namespace appengine_v1 {
         params,
         requiredParams: ['appsId', 'servicesId', 'versionsId', 'instancesId'],
         pathParams: ['appsId', 'instancesId', 'servicesId', 'versionsId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -5407,7 +5438,7 @@ export namespace appengine_v1 {
         params,
         requiredParams: ['appsId', 'servicesId', 'versionsId', 'instancesId'],
         pathParams: ['appsId', 'instancesId', 'servicesId', 'versionsId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Instance>(parameters, callback);
@@ -5484,7 +5515,7 @@ export namespace appengine_v1 {
         params,
         requiredParams: ['appsId', 'servicesId', 'versionsId'],
         pathParams: ['appsId', 'servicesId', 'versionsId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListInstancesResponse>(parameters, callback);

--- a/src/apis/appengine/v1alpha.ts
+++ b/src/apis/appengine/v1alpha.ts
@@ -29,8 +29,6 @@ export namespace appengine_v1alpha {
     version: 'v1alpha';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * V1 error format.
@@ -98,12 +96,13 @@ export namespace appengine_v1alpha {
    * @param {object=} options Options for Appengine
    */
   export class Appengine {
+    context: APIRequestContext;
     apps: Resource$Apps;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.apps = new Resource$Apps();
+      this.apps = new Resource$Apps(this.context);
     }
   }
 
@@ -646,23 +645,30 @@ export namespace appengine_v1alpha {
 
 
   export class Resource$Apps {
+    context: APIRequestContext;
     authorizedCertificates: Resource$Apps$Authorizedcertificates;
     authorizedDomains: Resource$Apps$Authorizeddomains;
     domainMappings: Resource$Apps$Domainmappings;
     locations: Resource$Apps$Locations;
     operations: Resource$Apps$Operations;
-    constructor() {
-      this.authorizedCertificates = new Resource$Apps$Authorizedcertificates();
-      this.authorizedDomains = new Resource$Apps$Authorizeddomains();
-      this.domainMappings = new Resource$Apps$Domainmappings();
-      this.locations = new Resource$Apps$Locations();
-      this.operations = new Resource$Apps$Operations();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.authorizedCertificates =
+          new Resource$Apps$Authorizedcertificates(this.context);
+      this.authorizedDomains =
+          new Resource$Apps$Authorizeddomains(this.context);
+      this.domainMappings = new Resource$Apps$Domainmappings(this.context);
+      this.locations = new Resource$Apps$Locations(this.context);
+      this.operations = new Resource$Apps$Operations(this.context);
     }
   }
 
 
   export class Resource$Apps$Authorizedcertificates {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -724,7 +730,7 @@ export namespace appengine_v1alpha {
         params,
         requiredParams: ['appsId'],
         pathParams: ['appsId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AuthorizedCertificate>(parameters, callback);
@@ -793,7 +799,7 @@ export namespace appengine_v1alpha {
         params,
         requiredParams: ['appsId', 'authorizedCertificatesId'],
         pathParams: ['appsId', 'authorizedCertificatesId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -861,7 +867,7 @@ export namespace appengine_v1alpha {
         params,
         requiredParams: ['appsId', 'authorizedCertificatesId'],
         pathParams: ['appsId', 'authorizedCertificatesId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AuthorizedCertificate>(parameters, callback);
@@ -940,7 +946,7 @@ export namespace appengine_v1alpha {
         params,
         requiredParams: ['appsId'],
         pathParams: ['appsId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListAuthorizedCertificatesResponse>(
@@ -1019,7 +1025,7 @@ export namespace appengine_v1alpha {
         params,
         requiredParams: ['appsId', 'authorizedCertificatesId'],
         pathParams: ['appsId', 'authorizedCertificatesId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AuthorizedCertificate>(parameters, callback);
@@ -1140,7 +1146,10 @@ export namespace appengine_v1alpha {
 
 
   export class Resource$Apps$Authorizeddomains {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1207,7 +1216,7 @@ export namespace appengine_v1alpha {
         params,
         requiredParams: ['appsId'],
         pathParams: ['appsId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListAuthorizedDomainsResponse>(
@@ -1243,7 +1252,10 @@ export namespace appengine_v1alpha {
 
 
   export class Resource$Apps$Domainmappings {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1309,7 +1321,7 @@ export namespace appengine_v1alpha {
         params,
         requiredParams: ['appsId'],
         pathParams: ['appsId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -1380,7 +1392,7 @@ export namespace appengine_v1alpha {
         params,
         requiredParams: ['appsId', 'domainMappingsId'],
         pathParams: ['appsId', 'domainMappingsId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -1445,7 +1457,7 @@ export namespace appengine_v1alpha {
         params,
         requiredParams: ['appsId', 'domainMappingsId'],
         pathParams: ['appsId', 'domainMappingsId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$DomainMapping>(parameters, callback);
@@ -1519,7 +1531,7 @@ export namespace appengine_v1alpha {
         params,
         requiredParams: ['appsId'],
         pathParams: ['appsId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListDomainMappingsResponse>(
@@ -1595,7 +1607,7 @@ export namespace appengine_v1alpha {
         params,
         requiredParams: ['appsId', 'domainMappingsId'],
         pathParams: ['appsId', 'domainMappingsId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -1728,7 +1740,10 @@ export namespace appengine_v1alpha {
 
 
   export class Resource$Apps$Locations {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1784,7 +1799,7 @@ export namespace appengine_v1alpha {
         params,
         requiredParams: ['appsId', 'locationsId'],
         pathParams: ['appsId', 'locationsId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Location>(parameters, callback);
@@ -1854,7 +1869,7 @@ export namespace appengine_v1alpha {
         params,
         requiredParams: ['appsId'],
         pathParams: ['appsId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListLocationsResponse>(parameters, callback);
@@ -1908,7 +1923,10 @@ export namespace appengine_v1alpha {
 
 
   export class Resource$Apps$Operations {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1968,7 +1986,7 @@ export namespace appengine_v1alpha {
         params,
         requiredParams: ['appsId', 'operationsId'],
         pathParams: ['appsId', 'operationsId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -2047,7 +2065,7 @@ export namespace appengine_v1alpha {
         params,
         requiredParams: ['appsId'],
         pathParams: ['appsId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListOperationsResponse>(parameters, callback);

--- a/src/apis/appengine/v1beta.ts
+++ b/src/apis/appengine/v1beta.ts
@@ -29,8 +29,6 @@ export namespace appengine_v1beta {
     version: 'v1beta';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * V1 error format.
@@ -98,12 +96,13 @@ export namespace appengine_v1beta {
    * @param {object=} options Options for Appengine
    */
   export class Appengine {
+    context: APIRequestContext;
     apps: Resource$Apps;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.apps = new Resource$Apps();
+      this.apps = new Resource$Apps(this.context);
     }
   }
 
@@ -2031,6 +2030,7 @@ export namespace appengine_v1beta {
 
 
   export class Resource$Apps {
+    context: APIRequestContext;
     authorizedCertificates: Resource$Apps$Authorizedcertificates;
     authorizedDomains: Resource$Apps$Authorizeddomains;
     domainMappings: Resource$Apps$Domainmappings;
@@ -2038,14 +2038,17 @@ export namespace appengine_v1beta {
     locations: Resource$Apps$Locations;
     operations: Resource$Apps$Operations;
     services: Resource$Apps$Services;
-    constructor() {
-      this.authorizedCertificates = new Resource$Apps$Authorizedcertificates();
-      this.authorizedDomains = new Resource$Apps$Authorizeddomains();
-      this.domainMappings = new Resource$Apps$Domainmappings();
-      this.firewall = new Resource$Apps$Firewall();
-      this.locations = new Resource$Apps$Locations();
-      this.operations = new Resource$Apps$Operations();
-      this.services = new Resource$Apps$Services();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.authorizedCertificates =
+          new Resource$Apps$Authorizedcertificates(this.context);
+      this.authorizedDomains =
+          new Resource$Apps$Authorizeddomains(this.context);
+      this.domainMappings = new Resource$Apps$Domainmappings(this.context);
+      this.firewall = new Resource$Apps$Firewall(this.context);
+      this.locations = new Resource$Apps$Locations(this.context);
+      this.operations = new Resource$Apps$Operations(this.context);
+      this.services = new Resource$Apps$Services(this.context);
     }
 
 
@@ -2109,7 +2112,7 @@ export namespace appengine_v1beta {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -2171,7 +2174,7 @@ export namespace appengine_v1beta {
         params,
         requiredParams: ['appsId'],
         pathParams: ['appsId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Application>(parameters, callback);
@@ -2241,7 +2244,7 @@ export namespace appengine_v1beta {
         params,
         requiredParams: ['appsId'],
         pathParams: ['appsId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -2311,7 +2314,7 @@ export namespace appengine_v1beta {
         params,
         requiredParams: ['appsId'],
         pathParams: ['appsId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -2384,7 +2387,10 @@ export namespace appengine_v1beta {
   }
 
   export class Resource$Apps$Authorizedcertificates {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -2446,7 +2452,7 @@ export namespace appengine_v1beta {
         params,
         requiredParams: ['appsId'],
         pathParams: ['appsId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AuthorizedCertificate>(parameters, callback);
@@ -2515,7 +2521,7 @@ export namespace appengine_v1beta {
         params,
         requiredParams: ['appsId', 'authorizedCertificatesId'],
         pathParams: ['appsId', 'authorizedCertificatesId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -2583,7 +2589,7 @@ export namespace appengine_v1beta {
         params,
         requiredParams: ['appsId', 'authorizedCertificatesId'],
         pathParams: ['appsId', 'authorizedCertificatesId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AuthorizedCertificate>(parameters, callback);
@@ -2662,7 +2668,7 @@ export namespace appengine_v1beta {
         params,
         requiredParams: ['appsId'],
         pathParams: ['appsId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListAuthorizedCertificatesResponse>(
@@ -2741,7 +2747,7 @@ export namespace appengine_v1beta {
         params,
         requiredParams: ['appsId', 'authorizedCertificatesId'],
         pathParams: ['appsId', 'authorizedCertificatesId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AuthorizedCertificate>(parameters, callback);
@@ -2862,7 +2868,10 @@ export namespace appengine_v1beta {
 
 
   export class Resource$Apps$Authorizeddomains {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -2929,7 +2938,7 @@ export namespace appengine_v1beta {
         params,
         requiredParams: ['appsId'],
         pathParams: ['appsId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListAuthorizedDomainsResponse>(
@@ -2965,7 +2974,10 @@ export namespace appengine_v1beta {
 
 
   export class Resource$Apps$Domainmappings {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -3030,7 +3042,7 @@ export namespace appengine_v1beta {
         params,
         requiredParams: ['appsId'],
         pathParams: ['appsId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -3101,7 +3113,7 @@ export namespace appengine_v1beta {
         params,
         requiredParams: ['appsId', 'domainMappingsId'],
         pathParams: ['appsId', 'domainMappingsId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -3166,7 +3178,7 @@ export namespace appengine_v1beta {
         params,
         requiredParams: ['appsId', 'domainMappingsId'],
         pathParams: ['appsId', 'domainMappingsId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$DomainMapping>(parameters, callback);
@@ -3240,7 +3252,7 @@ export namespace appengine_v1beta {
         params,
         requiredParams: ['appsId'],
         pathParams: ['appsId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListDomainMappingsResponse>(
@@ -3315,7 +3327,7 @@ export namespace appengine_v1beta {
         params,
         requiredParams: ['appsId', 'domainMappingsId'],
         pathParams: ['appsId', 'domainMappingsId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -3432,15 +3444,20 @@ export namespace appengine_v1beta {
 
 
   export class Resource$Apps$Firewall {
+    context: APIRequestContext;
     ingressRules: Resource$Apps$Firewall$Ingressrules;
-    constructor() {
-      this.ingressRules = new Resource$Apps$Firewall$Ingressrules();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.ingressRules = new Resource$Apps$Firewall$Ingressrules(this.context);
     }
   }
 
 
   export class Resource$Apps$Firewall$Ingressrules {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -3514,7 +3531,7 @@ export namespace appengine_v1beta {
         params,
         requiredParams: ['appsId'],
         pathParams: ['appsId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$BatchUpdateIngressRulesResponse>(
@@ -3584,7 +3601,7 @@ export namespace appengine_v1beta {
         params,
         requiredParams: ['appsId'],
         pathParams: ['appsId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$FirewallRule>(parameters, callback);
@@ -3653,7 +3670,7 @@ export namespace appengine_v1beta {
         params,
         requiredParams: ['appsId', 'ingressRulesId'],
         pathParams: ['appsId', 'ingressRulesId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -3719,7 +3736,7 @@ export namespace appengine_v1beta {
         params,
         requiredParams: ['appsId', 'ingressRulesId'],
         pathParams: ['appsId', 'ingressRulesId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$FirewallRule>(parameters, callback);
@@ -3791,7 +3808,7 @@ export namespace appengine_v1beta {
         params,
         requiredParams: ['appsId'],
         pathParams: ['appsId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListIngressRulesResponse>(parameters, callback);
@@ -3863,7 +3880,7 @@ export namespace appengine_v1beta {
         params,
         requiredParams: ['appsId', 'ingressRulesId'],
         pathParams: ['appsId', 'ingressRulesId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$FirewallRule>(parameters, callback);
@@ -4000,7 +4017,10 @@ export namespace appengine_v1beta {
 
 
   export class Resource$Apps$Locations {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -4056,7 +4076,7 @@ export namespace appengine_v1beta {
         params,
         requiredParams: ['appsId', 'locationsId'],
         pathParams: ['appsId', 'locationsId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Location>(parameters, callback);
@@ -4126,7 +4146,7 @@ export namespace appengine_v1beta {
         params,
         requiredParams: ['appsId'],
         pathParams: ['appsId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListLocationsResponse>(parameters, callback);
@@ -4180,7 +4200,10 @@ export namespace appengine_v1beta {
 
 
   export class Resource$Apps$Operations {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -4239,7 +4262,7 @@ export namespace appengine_v1beta {
         params,
         requiredParams: ['appsId', 'operationsId'],
         pathParams: ['appsId', 'operationsId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -4318,7 +4341,7 @@ export namespace appengine_v1beta {
         params,
         requiredParams: ['appsId'],
         pathParams: ['appsId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListOperationsResponse>(parameters, callback);
@@ -4371,9 +4394,11 @@ export namespace appengine_v1beta {
 
 
   export class Resource$Apps$Services {
+    context: APIRequestContext;
     versions: Resource$Apps$Services$Versions;
-    constructor() {
-      this.versions = new Resource$Apps$Services$Versions();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.versions = new Resource$Apps$Services$Versions(this.context);
     }
 
 
@@ -4435,7 +4460,7 @@ export namespace appengine_v1beta {
         params,
         requiredParams: ['appsId', 'servicesId'],
         pathParams: ['appsId', 'servicesId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -4498,7 +4523,7 @@ export namespace appengine_v1beta {
         params,
         requiredParams: ['appsId', 'servicesId'],
         pathParams: ['appsId', 'servicesId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Service>(parameters, callback);
@@ -4567,7 +4592,7 @@ export namespace appengine_v1beta {
         params,
         requiredParams: ['appsId'],
         pathParams: ['appsId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListServicesResponse>(parameters, callback);
@@ -4638,7 +4663,7 @@ export namespace appengine_v1beta {
         params,
         requiredParams: ['appsId', 'servicesId'],
         pathParams: ['appsId', 'servicesId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -4747,9 +4772,12 @@ export namespace appengine_v1beta {
   }
 
   export class Resource$Apps$Services$Versions {
+    context: APIRequestContext;
     instances: Resource$Apps$Services$Versions$Instances;
-    constructor() {
-      this.instances = new Resource$Apps$Services$Versions$Instances();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.instances =
+          new Resource$Apps$Services$Versions$Instances(this.context);
     }
 
 
@@ -4813,7 +4841,7 @@ export namespace appengine_v1beta {
         params,
         requiredParams: ['appsId', 'servicesId'],
         pathParams: ['appsId', 'servicesId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -4884,7 +4912,7 @@ export namespace appengine_v1beta {
         params,
         requiredParams: ['appsId', 'servicesId', 'versionsId'],
         pathParams: ['appsId', 'servicesId', 'versionsId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -4953,7 +4981,7 @@ export namespace appengine_v1beta {
         params,
         requiredParams: ['appsId', 'servicesId', 'versionsId'],
         pathParams: ['appsId', 'servicesId', 'versionsId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Version>(parameters, callback);
@@ -5026,7 +5054,7 @@ export namespace appengine_v1beta {
         params,
         requiredParams: ['appsId', 'servicesId'],
         pathParams: ['appsId', 'servicesId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListVersionsResponse>(parameters, callback);
@@ -5128,7 +5156,7 @@ export namespace appengine_v1beta {
         params,
         requiredParams: ['appsId', 'servicesId', 'versionsId'],
         pathParams: ['appsId', 'servicesId', 'versionsId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -5267,7 +5295,10 @@ export namespace appengine_v1beta {
   }
 
   export class Resource$Apps$Services$Versions$Instances {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -5339,7 +5370,7 @@ export namespace appengine_v1beta {
         params,
         requiredParams: ['appsId', 'servicesId', 'versionsId', 'instancesId'],
         pathParams: ['appsId', 'instancesId', 'servicesId', 'versionsId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -5412,7 +5443,7 @@ export namespace appengine_v1beta {
         params,
         requiredParams: ['appsId', 'servicesId', 'versionsId', 'instancesId'],
         pathParams: ['appsId', 'instancesId', 'servicesId', 'versionsId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -5479,7 +5510,7 @@ export namespace appengine_v1beta {
         params,
         requiredParams: ['appsId', 'servicesId', 'versionsId', 'instancesId'],
         pathParams: ['appsId', 'instancesId', 'servicesId', 'versionsId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Instance>(parameters, callback);
@@ -5556,7 +5587,7 @@ export namespace appengine_v1beta {
         params,
         requiredParams: ['appsId', 'servicesId', 'versionsId'],
         pathParams: ['appsId', 'servicesId', 'versionsId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListInstancesResponse>(parameters, callback);

--- a/src/apis/appsactivity/v1.ts
+++ b/src/apis/appsactivity/v1.ts
@@ -29,8 +29,6 @@ export namespace appsactivity_v1 {
     version: 'v1';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * Data format for the response.
@@ -81,12 +79,13 @@ export namespace appsactivity_v1 {
    * @param {object=} options Options for Appsactivity
    */
   export class Appsactivity {
+    context: APIRequestContext;
     activities: Resource$Activities;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.activities = new Resource$Activities();
+      this.activities = new Resource$Activities(this.context);
     }
   }
 
@@ -317,7 +316,10 @@ export namespace appsactivity_v1 {
 
 
   export class Resource$Activities {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -387,7 +389,7 @@ export namespace appsactivity_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListActivitiesResponse>(parameters, callback);

--- a/src/apis/appstate/v1.ts
+++ b/src/apis/appstate/v1.ts
@@ -29,8 +29,6 @@ export namespace appstate_v1 {
     version: 'v1';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * Data format for the response.
@@ -81,12 +79,13 @@ export namespace appstate_v1 {
    * @param {object=} options Options for Appstate
    */
   export class Appstate {
+    context: APIRequestContext;
     states: Resource$States;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.states = new Resource$States();
+      this.states = new Resource$States(this.context);
     }
   }
 
@@ -165,7 +164,10 @@ export namespace appstate_v1 {
 
 
   export class Resource$States {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -226,7 +228,7 @@ export namespace appstate_v1 {
         params,
         requiredParams: ['stateKey'],
         pathParams: ['stateKey'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$WriteResult>(parameters, callback);
@@ -293,7 +295,7 @@ export namespace appstate_v1 {
         params,
         requiredParams: ['stateKey'],
         pathParams: ['stateKey'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -356,7 +358,7 @@ export namespace appstate_v1 {
         params,
         requiredParams: ['stateKey'],
         pathParams: ['stateKey'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GetResponse>(parameters, callback);
@@ -421,7 +423,7 @@ export namespace appstate_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListResponse>(parameters, callback);
@@ -490,7 +492,7 @@ export namespace appstate_v1 {
         params,
         requiredParams: ['stateKey'],
         pathParams: ['stateKey'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$WriteResult>(parameters, callback);

--- a/src/apis/bigquery/v2.ts
+++ b/src/apis/bigquery/v2.ts
@@ -29,8 +29,6 @@ export namespace bigquery_v2 {
     version: 'v2';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * Data format for the response.
@@ -81,6 +79,7 @@ export namespace bigquery_v2 {
    * @param {object=} options Options for Bigquery
    */
   export class Bigquery {
+    context: APIRequestContext;
     datasets: Resource$Datasets;
     jobs: Resource$Jobs;
     projects: Resource$Projects;
@@ -88,13 +87,13 @@ export namespace bigquery_v2 {
     tables: Resource$Tables;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.datasets = new Resource$Datasets();
-      this.jobs = new Resource$Jobs();
-      this.projects = new Resource$Projects();
-      this.tabledata = new Resource$Tabledata();
-      this.tables = new Resource$Tables();
+      this.datasets = new Resource$Datasets(this.context);
+      this.jobs = new Resource$Jobs(this.context);
+      this.projects = new Resource$Projects(this.context);
+      this.tabledata = new Resource$Tabledata(this.context);
+      this.tables = new Resource$Tables(this.context);
     }
   }
 
@@ -2365,7 +2364,10 @@ export namespace bigquery_v2 {
 
 
   export class Resource$Datasets {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -2480,7 +2482,7 @@ export namespace bigquery_v2 {
         params,
         requiredParams: ['projectId', 'datasetId'],
         pathParams: ['datasetId', 'projectId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -2599,7 +2601,7 @@ export namespace bigquery_v2 {
         params,
         requiredParams: ['projectId', 'datasetId'],
         pathParams: ['datasetId', 'projectId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Dataset>(parameters, callback);
@@ -2721,7 +2723,7 @@ export namespace bigquery_v2 {
         params,
         requiredParams: ['projectId'],
         pathParams: ['projectId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Dataset>(parameters, callback);
@@ -2857,7 +2859,7 @@ export namespace bigquery_v2 {
         params,
         requiredParams: ['projectId'],
         pathParams: ['projectId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$DatasetList>(parameters, callback);
@@ -2989,7 +2991,7 @@ export namespace bigquery_v2 {
         params,
         requiredParams: ['projectId', 'datasetId'],
         pathParams: ['datasetId', 'projectId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Dataset>(parameters, callback);
@@ -3120,7 +3122,7 @@ export namespace bigquery_v2 {
         params,
         requiredParams: ['projectId', 'datasetId'],
         pathParams: ['datasetId', 'projectId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Dataset>(parameters, callback);
@@ -3256,7 +3258,10 @@ export namespace bigquery_v2 {
 
 
   export class Resource$Jobs {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -3376,7 +3381,7 @@ export namespace bigquery_v2 {
         params,
         requiredParams: ['projectId', 'jobId'],
         pathParams: ['jobId', 'projectId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$JobCancelResponse>(parameters, callback);
@@ -3497,7 +3502,7 @@ export namespace bigquery_v2 {
         params,
         requiredParams: ['projectId', 'jobId'],
         pathParams: ['jobId', 'projectId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Job>(parameters, callback);
@@ -3642,7 +3647,7 @@ export namespace bigquery_v2 {
         params,
         requiredParams: ['projectId', 'jobId'],
         pathParams: ['jobId', 'projectId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GetQueryResultsResponse>(parameters, callback);
@@ -3776,7 +3781,7 @@ export namespace bigquery_v2 {
                       .replace(/([^:]\/)\/+/g, '$1'),
         requiredParams: ['projectId'],
         pathParams: ['projectId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Job>(parameters, callback);
@@ -3917,7 +3922,7 @@ export namespace bigquery_v2 {
         params,
         requiredParams: ['projectId'],
         pathParams: ['projectId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$JobList>(parameters, callback);
@@ -4041,7 +4046,7 @@ export namespace bigquery_v2 {
         params,
         requiredParams: ['projectId'],
         pathParams: ['projectId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$QueryResponse>(parameters, callback);
@@ -4226,7 +4231,10 @@ export namespace bigquery_v2 {
 
 
   export class Resource$Projects {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -4344,7 +4352,7 @@ export namespace bigquery_v2 {
         params,
         requiredParams: ['projectId'],
         pathParams: ['projectId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GetServiceAccountResponse>(
@@ -4474,7 +4482,7 @@ export namespace bigquery_v2 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ProjectList>(parameters, callback);
@@ -4515,7 +4523,10 @@ export namespace bigquery_v2 {
 
 
   export class Resource$Tabledata {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -4649,7 +4660,7 @@ export namespace bigquery_v2 {
         params,
         requiredParams: ['projectId', 'datasetId', 'tableId'],
         pathParams: ['datasetId', 'projectId', 'tableId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TableDataInsertAllResponse>(
@@ -4796,7 +4807,7 @@ export namespace bigquery_v2 {
         params,
         requiredParams: ['projectId', 'datasetId', 'tableId'],
         pathParams: ['datasetId', 'projectId', 'tableId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TableDataList>(parameters, callback);
@@ -4870,7 +4881,10 @@ export namespace bigquery_v2 {
 
 
   export class Resource$Tables {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -4987,7 +5001,7 @@ export namespace bigquery_v2 {
         params,
         requiredParams: ['projectId', 'datasetId', 'tableId'],
         pathParams: ['datasetId', 'projectId', 'tableId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -5114,7 +5128,7 @@ export namespace bigquery_v2 {
         params,
         requiredParams: ['projectId', 'datasetId', 'tableId'],
         pathParams: ['datasetId', 'projectId', 'tableId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Table>(parameters, callback);
@@ -5242,7 +5256,7 @@ export namespace bigquery_v2 {
         params,
         requiredParams: ['projectId', 'datasetId'],
         pathParams: ['datasetId', 'projectId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Table>(parameters, callback);
@@ -5382,7 +5396,7 @@ export namespace bigquery_v2 {
         params,
         requiredParams: ['projectId', 'datasetId'],
         pathParams: ['datasetId', 'projectId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TableList>(parameters, callback);
@@ -5519,7 +5533,7 @@ export namespace bigquery_v2 {
         params,
         requiredParams: ['projectId', 'datasetId', 'tableId'],
         pathParams: ['datasetId', 'projectId', 'tableId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Table>(parameters, callback);
@@ -5655,7 +5669,7 @@ export namespace bigquery_v2 {
         params,
         requiredParams: ['projectId', 'datasetId', 'tableId'],
         pathParams: ['datasetId', 'projectId', 'tableId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Table>(parameters, callback);

--- a/src/apis/bigquerydatatransfer/v1.ts
+++ b/src/apis/bigquerydatatransfer/v1.ts
@@ -29,8 +29,6 @@ export namespace bigquerydatatransfer_v1 {
     version: 'v1';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * V1 error format.
@@ -99,12 +97,13 @@ export namespace bigquerydatatransfer_v1 {
    * @param {object=} options Options for Bigquerydatatransfer
    */
   export class Bigquerydatatransfer {
+    context: APIRequestContext;
     projects: Resource$Projects;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.projects = new Resource$Projects();
+      this.projects = new Resource$Projects(this.context);
     }
   }
 
@@ -712,19 +711,25 @@ export namespace bigquerydatatransfer_v1 {
 
 
   export class Resource$Projects {
+    context: APIRequestContext;
     dataSources: Resource$Projects$Datasources;
     locations: Resource$Projects$Locations;
     transferConfigs: Resource$Projects$Transferconfigs;
-    constructor() {
-      this.dataSources = new Resource$Projects$Datasources();
-      this.locations = new Resource$Projects$Locations();
-      this.transferConfigs = new Resource$Projects$Transferconfigs();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.dataSources = new Resource$Projects$Datasources(this.context);
+      this.locations = new Resource$Projects$Locations(this.context);
+      this.transferConfigs =
+          new Resource$Projects$Transferconfigs(this.context);
     }
   }
 
 
   export class Resource$Projects$Datasources {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -792,7 +797,7 @@ export namespace bigquerydatatransfer_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$CheckValidCredsResponse>(parameters, callback);
@@ -856,7 +861,7 @@ export namespace bigquerydatatransfer_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$DataSource>(parameters, callback);
@@ -928,7 +933,7 @@ export namespace bigquerydatatransfer_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListDataSourcesResponse>(parameters, callback);
@@ -996,11 +1001,15 @@ export namespace bigquerydatatransfer_v1 {
 
 
   export class Resource$Projects$Locations {
+    context: APIRequestContext;
     dataSources: Resource$Projects$Locations$Datasources;
     transferConfigs: Resource$Projects$Locations$Transferconfigs;
-    constructor() {
-      this.dataSources = new Resource$Projects$Locations$Datasources();
-      this.transferConfigs = new Resource$Projects$Locations$Transferconfigs();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.dataSources =
+          new Resource$Projects$Locations$Datasources(this.context);
+      this.transferConfigs =
+          new Resource$Projects$Locations$Transferconfigs(this.context);
     }
 
 
@@ -1056,7 +1065,7 @@ export namespace bigquerydatatransfer_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Location>(parameters, callback);
@@ -1128,7 +1137,7 @@ export namespace bigquerydatatransfer_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListLocationsResponse>(parameters, callback);
@@ -1176,7 +1185,10 @@ export namespace bigquerydatatransfer_v1 {
   }
 
   export class Resource$Projects$Locations$Datasources {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1247,7 +1259,7 @@ export namespace bigquerydatatransfer_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$CheckValidCredsResponse>(parameters, callback);
@@ -1311,7 +1323,7 @@ export namespace bigquerydatatransfer_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$DataSource>(parameters, callback);
@@ -1383,7 +1395,7 @@ export namespace bigquerydatatransfer_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListDataSourcesResponse>(parameters, callback);
@@ -1451,9 +1463,12 @@ export namespace bigquerydatatransfer_v1 {
 
 
   export class Resource$Projects$Locations$Transferconfigs {
+    context: APIRequestContext;
     runs: Resource$Projects$Locations$Transferconfigs$Runs;
-    constructor() {
-      this.runs = new Resource$Projects$Locations$Transferconfigs$Runs();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.runs =
+          new Resource$Projects$Locations$Transferconfigs$Runs(this.context);
     }
 
 
@@ -1520,7 +1535,7 @@ export namespace bigquerydatatransfer_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TransferConfig>(parameters, callback);
@@ -1589,7 +1604,7 @@ export namespace bigquerydatatransfer_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -1653,7 +1668,7 @@ export namespace bigquerydatatransfer_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TransferConfig>(parameters, callback);
@@ -1730,7 +1745,7 @@ export namespace bigquerydatatransfer_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListTransferConfigsResponse>(
@@ -1804,7 +1819,7 @@ export namespace bigquerydatatransfer_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TransferConfig>(parameters, callback);
@@ -1886,7 +1901,7 @@ export namespace bigquerydatatransfer_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ScheduleTransferRunsResponse>(
@@ -1973,7 +1988,7 @@ export namespace bigquerydatatransfer_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$StartManualTransferRunsResponse>(
@@ -2178,10 +2193,13 @@ export namespace bigquerydatatransfer_v1 {
   }
 
   export class Resource$Projects$Locations$Transferconfigs$Runs {
+    context: APIRequestContext;
     transferLogs: Resource$Projects$Locations$Transferconfigs$Runs$Transferlogs;
-    constructor() {
+    constructor(context: APIRequestContext) {
+      this.context = context;
       this.transferLogs =
-          new Resource$Projects$Locations$Transferconfigs$Runs$Transferlogs();
+          new Resource$Projects$Locations$Transferconfigs$Runs$Transferlogs(
+              this.context);
     }
 
 
@@ -2244,7 +2262,7 @@ export namespace bigquerydatatransfer_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -2309,7 +2327,7 @@ export namespace bigquerydatatransfer_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TransferRun>(parameters, callback);
@@ -2385,7 +2403,7 @@ export namespace bigquerydatatransfer_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListTransferRunsResponse>(parameters, callback);
@@ -2456,7 +2474,10 @@ export namespace bigquerydatatransfer_v1 {
   }
 
   export class Resource$Projects$Locations$Transferconfigs$Runs$Transferlogs {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -2528,7 +2549,7 @@ export namespace bigquerydatatransfer_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListTransferLogsResponse>(parameters, callback);
@@ -2571,9 +2592,11 @@ export namespace bigquerydatatransfer_v1 {
 
 
   export class Resource$Projects$Transferconfigs {
+    context: APIRequestContext;
     runs: Resource$Projects$Transferconfigs$Runs;
-    constructor() {
-      this.runs = new Resource$Projects$Transferconfigs$Runs();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.runs = new Resource$Projects$Transferconfigs$Runs(this.context);
     }
 
 
@@ -2638,7 +2661,7 @@ export namespace bigquerydatatransfer_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TransferConfig>(parameters, callback);
@@ -2705,7 +2728,7 @@ export namespace bigquerydatatransfer_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -2768,7 +2791,7 @@ export namespace bigquerydatatransfer_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TransferConfig>(parameters, callback);
@@ -2844,7 +2867,7 @@ export namespace bigquerydatatransfer_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListTransferConfigsResponse>(
@@ -2917,7 +2940,7 @@ export namespace bigquerydatatransfer_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TransferConfig>(parameters, callback);
@@ -2996,7 +3019,7 @@ export namespace bigquerydatatransfer_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ScheduleTransferRunsResponse>(
@@ -3078,7 +3101,7 @@ export namespace bigquerydatatransfer_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$StartManualTransferRunsResponse>(
@@ -3283,10 +3306,12 @@ export namespace bigquerydatatransfer_v1 {
   }
 
   export class Resource$Projects$Transferconfigs$Runs {
+    context: APIRequestContext;
     transferLogs: Resource$Projects$Transferconfigs$Runs$Transferlogs;
-    constructor() {
+    constructor(context: APIRequestContext) {
+      this.context = context;
       this.transferLogs =
-          new Resource$Projects$Transferconfigs$Runs$Transferlogs();
+          new Resource$Projects$Transferconfigs$Runs$Transferlogs(this.context);
     }
 
 
@@ -3346,7 +3371,7 @@ export namespace bigquerydatatransfer_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -3409,7 +3434,7 @@ export namespace bigquerydatatransfer_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TransferRun>(parameters, callback);
@@ -3483,7 +3508,7 @@ export namespace bigquerydatatransfer_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListTransferRunsResponse>(parameters, callback);
@@ -3554,7 +3579,10 @@ export namespace bigquerydatatransfer_v1 {
   }
 
   export class Resource$Projects$Transferconfigs$Runs$Transferlogs {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -3624,7 +3652,7 @@ export namespace bigquerydatatransfer_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListTransferLogsResponse>(parameters, callback);

--- a/src/apis/bigtableadmin/v1.ts
+++ b/src/apis/bigtableadmin/v1.ts
@@ -29,8 +29,6 @@ export namespace bigtableadmin_v1 {
     version: 'v1';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * V1 error format.
@@ -98,12 +96,13 @@ export namespace bigtableadmin_v1 {
    * @param {object=} options Options for Bigtableadmin
    */
   export class Bigtableadmin {
+    context: APIRequestContext;
     projects: Resource$Projects;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.projects = new Resource$Projects();
+      this.projects = new Resource$Projects(this.context);
     }
   }
 
@@ -384,15 +383,20 @@ export namespace bigtableadmin_v1 {
 
 
   export class Resource$Projects {
+    context: APIRequestContext;
     locations: Resource$Projects$Locations;
-    constructor() {
-      this.locations = new Resource$Projects$Locations();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.locations = new Resource$Projects$Locations(this.context);
     }
   }
 
 
   export class Resource$Projects$Locations {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -447,7 +451,7 @@ export namespace bigtableadmin_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Location>(parameters, callback);
@@ -519,7 +523,7 @@ export namespace bigtableadmin_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListLocationsResponse>(parameters, callback);

--- a/src/apis/bigtableadmin/v2.ts
+++ b/src/apis/bigtableadmin/v2.ts
@@ -29,8 +29,6 @@ export namespace bigtableadmin_v2 {
     version: 'v2';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * V1 error format.
@@ -98,14 +96,15 @@ export namespace bigtableadmin_v2 {
    * @param {object=} options Options for Bigtableadmin
    */
   export class Bigtableadmin {
+    context: APIRequestContext;
     operations: Resource$Operations;
     projects: Resource$Projects;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.operations = new Resource$Operations();
-      this.projects = new Resource$Projects();
+      this.operations = new Resource$Operations(this.context);
+      this.projects = new Resource$Projects(this.context);
     }
   }
 
@@ -1023,9 +1022,11 @@ export namespace bigtableadmin_v2 {
 
 
   export class Resource$Operations {
+    context: APIRequestContext;
     projects: Resource$Operations$Projects;
-    constructor() {
-      this.projects = new Resource$Operations$Projects();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.projects = new Resource$Operations$Projects(this.context);
     }
 
 
@@ -1093,7 +1094,7 @@ export namespace bigtableadmin_v2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -1161,7 +1162,7 @@ export namespace bigtableadmin_v2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -1225,7 +1226,7 @@ export namespace bigtableadmin_v2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -1272,15 +1273,21 @@ export namespace bigtableadmin_v2 {
   }
 
   export class Resource$Operations$Projects {
+    context: APIRequestContext;
     operations: Resource$Operations$Projects$Operations;
-    constructor() {
-      this.operations = new Resource$Operations$Projects$Operations();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.operations =
+          new Resource$Operations$Projects$Operations(this.context);
     }
   }
 
 
   export class Resource$Operations$Projects$Operations {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1353,7 +1360,7 @@ export namespace bigtableadmin_v2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListOperationsResponse>(parameters, callback);
@@ -1391,21 +1398,26 @@ export namespace bigtableadmin_v2 {
 
 
   export class Resource$Projects {
+    context: APIRequestContext;
     instances: Resource$Projects$Instances;
-    constructor() {
-      this.instances = new Resource$Projects$Instances();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.instances = new Resource$Projects$Instances(this.context);
     }
   }
 
 
   export class Resource$Projects$Instances {
+    context: APIRequestContext;
     appProfiles: Resource$Projects$Instances$Appprofiles;
     clusters: Resource$Projects$Instances$Clusters;
     tables: Resource$Projects$Instances$Tables;
-    constructor() {
-      this.appProfiles = new Resource$Projects$Instances$Appprofiles();
-      this.clusters = new Resource$Projects$Instances$Clusters();
-      this.tables = new Resource$Projects$Instances$Tables();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.appProfiles =
+          new Resource$Projects$Instances$Appprofiles(this.context);
+      this.clusters = new Resource$Projects$Instances$Clusters(this.context);
+      this.tables = new Resource$Projects$Instances$Tables(this.context);
     }
 
 
@@ -1468,7 +1480,7 @@ export namespace bigtableadmin_v2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -1534,7 +1546,7 @@ export namespace bigtableadmin_v2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -1596,7 +1608,7 @@ export namespace bigtableadmin_v2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Instance>(parameters, callback);
@@ -1665,7 +1677,7 @@ export namespace bigtableadmin_v2 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -1735,7 +1747,7 @@ export namespace bigtableadmin_v2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListInstancesResponse>(parameters, callback);
@@ -1808,7 +1820,7 @@ export namespace bigtableadmin_v2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -1877,7 +1889,7 @@ export namespace bigtableadmin_v2 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -1954,7 +1966,7 @@ export namespace bigtableadmin_v2 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TestIamPermissionsResponse>(
@@ -2024,7 +2036,7 @@ export namespace bigtableadmin_v2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Instance>(parameters, callback);
@@ -2192,7 +2204,10 @@ export namespace bigtableadmin_v2 {
   }
 
   export class Resource$Projects$Instances$Appprofiles {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -2257,7 +2272,7 @@ export namespace bigtableadmin_v2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AppProfile>(parameters, callback);
@@ -2325,7 +2340,7 @@ export namespace bigtableadmin_v2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -2388,7 +2403,7 @@ export namespace bigtableadmin_v2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AppProfile>(parameters, callback);
@@ -2459,7 +2474,7 @@ export namespace bigtableadmin_v2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListAppProfilesResponse>(parameters, callback);
@@ -2529,7 +2544,7 @@ export namespace bigtableadmin_v2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -2651,7 +2666,10 @@ export namespace bigtableadmin_v2 {
 
 
   export class Resource$Projects$Instances$Clusters {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -2714,7 +2732,7 @@ export namespace bigtableadmin_v2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -2780,7 +2798,7 @@ export namespace bigtableadmin_v2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -2842,7 +2860,7 @@ export namespace bigtableadmin_v2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Cluster>(parameters, callback);
@@ -2912,7 +2930,7 @@ export namespace bigtableadmin_v2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListClustersResponse>(parameters, callback);
@@ -2980,7 +2998,7 @@ export namespace bigtableadmin_v2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -3081,7 +3099,10 @@ export namespace bigtableadmin_v2 {
 
 
   export class Resource$Projects$Instances$Tables {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -3150,7 +3171,7 @@ export namespace bigtableadmin_v2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$CheckConsistencyResponse>(parameters, callback);
@@ -3220,7 +3241,7 @@ export namespace bigtableadmin_v2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Table>(parameters, callback);
@@ -3286,7 +3307,7 @@ export namespace bigtableadmin_v2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -3357,7 +3378,7 @@ export namespace bigtableadmin_v2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -3444,7 +3465,7 @@ export namespace bigtableadmin_v2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GenerateConsistencyTokenResponse>(
@@ -3509,7 +3530,7 @@ export namespace bigtableadmin_v2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Table>(parameters, callback);
@@ -3580,7 +3601,7 @@ export namespace bigtableadmin_v2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListTablesResponse>(parameters, callback);
@@ -3653,7 +3674,7 @@ export namespace bigtableadmin_v2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Table>(parameters, callback);

--- a/src/apis/binaryauthorization/v1beta1.ts
+++ b/src/apis/binaryauthorization/v1beta1.ts
@@ -29,8 +29,6 @@ export namespace binaryauthorization_v1beta1 {
     version: 'v1beta1';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * V1 error format.
@@ -99,12 +97,13 @@ export namespace binaryauthorization_v1beta1 {
    * @param {object=} options Options for Binaryauthorization
    */
   export class Binaryauthorization {
+    context: APIRequestContext;
     projects: Resource$Projects;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.projects = new Resource$Projects();
+      this.projects = new Resource$Projects(this.context);
     }
   }
 
@@ -469,11 +468,13 @@ export namespace binaryauthorization_v1beta1 {
 
 
   export class Resource$Projects {
+    context: APIRequestContext;
     attestors: Resource$Projects$Attestors;
     policy: Resource$Projects$Policy;
-    constructor() {
-      this.attestors = new Resource$Projects$Attestors();
-      this.policy = new Resource$Projects$Policy();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.attestors = new Resource$Projects$Attestors(this.context);
+      this.policy = new Resource$Projects$Policy(this.context);
     }
 
 
@@ -534,7 +535,7 @@ export namespace binaryauthorization_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -605,7 +606,7 @@ export namespace binaryauthorization_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -648,7 +649,10 @@ export namespace binaryauthorization_v1beta1 {
   }
 
   export class Resource$Projects$Attestors {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -712,7 +716,7 @@ export namespace binaryauthorization_v1beta1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Attestor>(parameters, callback);
@@ -779,7 +783,7 @@ export namespace binaryauthorization_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -841,7 +845,7 @@ export namespace binaryauthorization_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Attestor>(parameters, callback);
@@ -910,7 +914,7 @@ export namespace binaryauthorization_v1beta1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$IamPolicy>(parameters, callback);
@@ -982,7 +986,7 @@ export namespace binaryauthorization_v1beta1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListAttestorsResponse>(parameters, callback);
@@ -1052,7 +1056,7 @@ export namespace binaryauthorization_v1beta1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$IamPolicy>(parameters, callback);
@@ -1132,7 +1136,7 @@ export namespace binaryauthorization_v1beta1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TestIamPermissionsResponse>(
@@ -1201,7 +1205,7 @@ export namespace binaryauthorization_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Attestor>(parameters, callback);
@@ -1352,7 +1356,10 @@ export namespace binaryauthorization_v1beta1 {
 
 
   export class Resource$Projects$Policy {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1414,7 +1421,7 @@ export namespace binaryauthorization_v1beta1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$IamPolicy>(parameters, callback);
@@ -1484,7 +1491,7 @@ export namespace binaryauthorization_v1beta1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$IamPolicy>(parameters, callback);
@@ -1563,7 +1570,7 @@ export namespace binaryauthorization_v1beta1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TestIamPermissionsResponse>(

--- a/src/apis/blogger/v2.ts
+++ b/src/apis/blogger/v2.ts
@@ -29,8 +29,6 @@ export namespace blogger_v2 {
     version: 'v2';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * Data format for the response.
@@ -81,6 +79,7 @@ export namespace blogger_v2 {
    * @param {object=} options Options for Blogger
    */
   export class Blogger {
+    context: APIRequestContext;
     blogs: Resource$Blogs;
     comments: Resource$Comments;
     pages: Resource$Pages;
@@ -88,13 +87,13 @@ export namespace blogger_v2 {
     users: Resource$Users;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.blogs = new Resource$Blogs();
-      this.comments = new Resource$Comments();
-      this.pages = new Resource$Pages();
-      this.posts = new Resource$Posts();
-      this.users = new Resource$Users();
+      this.blogs = new Resource$Blogs(this.context);
+      this.comments = new Resource$Comments(this.context);
+      this.pages = new Resource$Pages(this.context);
+      this.posts = new Resource$Posts(this.context);
+      this.users = new Resource$Users(this.context);
     }
   }
 
@@ -391,7 +390,10 @@ export namespace blogger_v2 {
 
 
   export class Resource$Blogs {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -445,7 +447,7 @@ export namespace blogger_v2 {
         params,
         requiredParams: ['blogId'],
         pathParams: ['blogId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Blog>(parameters, callback);
@@ -469,7 +471,10 @@ export namespace blogger_v2 {
 
 
   export class Resource$Comments {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -527,7 +532,7 @@ export namespace blogger_v2 {
         params,
         requiredParams: ['blogId', 'postId', 'commentId'],
         pathParams: ['blogId', 'commentId', 'postId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Comment>(parameters, callback);
@@ -598,7 +603,7 @@ export namespace blogger_v2 {
         params,
         requiredParams: ['blogId', 'postId'],
         pathParams: ['blogId', 'postId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$CommentList>(parameters, callback);
@@ -661,7 +666,10 @@ export namespace blogger_v2 {
 
 
   export class Resource$Pages {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -716,7 +724,7 @@ export namespace blogger_v2 {
         params,
         requiredParams: ['blogId', 'pageId'],
         pathParams: ['blogId', 'pageId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Page>(parameters, callback);
@@ -781,7 +789,7 @@ export namespace blogger_v2 {
         params,
         requiredParams: ['blogId'],
         pathParams: ['blogId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$PageList>(parameters, callback);
@@ -824,7 +832,10 @@ export namespace blogger_v2 {
 
 
   export class Resource$Posts {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -879,7 +890,7 @@ export namespace blogger_v2 {
         params,
         requiredParams: ['blogId', 'postId'],
         pathParams: ['blogId', 'postId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Post>(parameters, callback);
@@ -947,7 +958,7 @@ export namespace blogger_v2 {
         params,
         requiredParams: ['blogId'],
         pathParams: ['blogId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$PostList>(parameters, callback);
@@ -1002,9 +1013,11 @@ export namespace blogger_v2 {
 
 
   export class Resource$Users {
+    context: APIRequestContext;
     blogs: Resource$Users$Blogs;
-    constructor() {
-      this.blogs = new Resource$Users$Blogs();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.blogs = new Resource$Users$Blogs(this.context);
     }
 
 
@@ -1059,7 +1072,7 @@ export namespace blogger_v2 {
         params,
         requiredParams: ['userId'],
         pathParams: ['userId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$User>(parameters, callback);
@@ -1082,7 +1095,10 @@ export namespace blogger_v2 {
   }
 
   export class Resource$Users$Blogs {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1139,7 +1155,7 @@ export namespace blogger_v2 {
         params,
         requiredParams: ['userId'],
         pathParams: ['userId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$BlogList>(parameters, callback);

--- a/src/apis/blogger/v3.ts
+++ b/src/apis/blogger/v3.ts
@@ -29,8 +29,6 @@ export namespace blogger_v3 {
     version: 'v3';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * Data format for the response.
@@ -81,6 +79,7 @@ export namespace blogger_v3 {
    * @param {object=} options Options for Blogger
    */
   export class Blogger {
+    context: APIRequestContext;
     blogs: Resource$Blogs;
     blogUserInfos: Resource$Bloguserinfos;
     comments: Resource$Comments;
@@ -91,16 +90,16 @@ export namespace blogger_v3 {
     users: Resource$Users;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.blogs = new Resource$Blogs();
-      this.blogUserInfos = new Resource$Bloguserinfos();
-      this.comments = new Resource$Comments();
-      this.pages = new Resource$Pages();
-      this.pageViews = new Resource$Pageviews();
-      this.posts = new Resource$Posts();
-      this.postUserInfos = new Resource$Postuserinfos();
-      this.users = new Resource$Users();
+      this.blogs = new Resource$Blogs(this.context);
+      this.blogUserInfos = new Resource$Bloguserinfos(this.context);
+      this.comments = new Resource$Comments(this.context);
+      this.pages = new Resource$Pages(this.context);
+      this.pageViews = new Resource$Pageviews(this.context);
+      this.posts = new Resource$Posts(this.context);
+      this.postUserInfos = new Resource$Postuserinfos(this.context);
+      this.users = new Resource$Users(this.context);
     }
   }
 
@@ -567,7 +566,10 @@ export namespace blogger_v3 {
 
 
   export class Resource$Blogs {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -623,7 +625,7 @@ export namespace blogger_v3 {
         params,
         requiredParams: ['blogId'],
         pathParams: ['blogId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Blog>(parameters, callback);
@@ -688,7 +690,7 @@ export namespace blogger_v3 {
         params,
         requiredParams: ['url'],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Blog>(parameters, callback);
@@ -757,7 +759,7 @@ export namespace blogger_v3 {
         params,
         requiredParams: ['userId'],
         pathParams: ['userId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$BlogList>(parameters, callback);
@@ -839,7 +841,10 @@ export namespace blogger_v3 {
 
 
   export class Resource$Bloguserinfos {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -897,7 +902,7 @@ export namespace blogger_v3 {
         params,
         requiredParams: ['userId', 'blogId'],
         pathParams: ['blogId', 'userId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$BlogUserInfo>(parameters, callback);
@@ -931,7 +936,10 @@ export namespace blogger_v3 {
 
 
   export class Resource$Comments {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -992,7 +1000,7 @@ export namespace blogger_v3 {
         params,
         requiredParams: ['blogId', 'postId', 'commentId'],
         pathParams: ['blogId', 'commentId', 'postId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Comment>(parameters, callback);
@@ -1059,7 +1067,7 @@ export namespace blogger_v3 {
         params,
         requiredParams: ['blogId', 'postId', 'commentId'],
         pathParams: ['blogId', 'commentId', 'postId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -1125,7 +1133,7 @@ export namespace blogger_v3 {
         params,
         requiredParams: ['blogId', 'postId', 'commentId'],
         pathParams: ['blogId', 'commentId', 'postId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Comment>(parameters, callback);
@@ -1199,7 +1207,7 @@ export namespace blogger_v3 {
         params,
         requiredParams: ['blogId', 'postId'],
         pathParams: ['blogId', 'postId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$CommentList>(parameters, callback);
@@ -1273,7 +1281,7 @@ export namespace blogger_v3 {
         params,
         requiredParams: ['blogId'],
         pathParams: ['blogId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$CommentList>(parameters, callback);
@@ -1343,7 +1351,7 @@ export namespace blogger_v3 {
         params,
         requiredParams: ['blogId', 'postId', 'commentId'],
         pathParams: ['blogId', 'commentId', 'postId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Comment>(parameters, callback);
@@ -1413,7 +1421,7 @@ export namespace blogger_v3 {
         params,
         requiredParams: ['blogId', 'postId', 'commentId'],
         pathParams: ['blogId', 'commentId', 'postId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Comment>(parameters, callback);
@@ -1610,7 +1618,10 @@ export namespace blogger_v3 {
 
 
   export class Resource$Pages {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1667,7 +1678,7 @@ export namespace blogger_v3 {
         params,
         requiredParams: ['blogId', 'pageId'],
         pathParams: ['blogId', 'pageId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -1730,7 +1741,7 @@ export namespace blogger_v3 {
         params,
         requiredParams: ['blogId', 'pageId'],
         pathParams: ['blogId', 'pageId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Page>(parameters, callback);
@@ -1796,7 +1807,7 @@ export namespace blogger_v3 {
         params,
         requiredParams: ['blogId'],
         pathParams: ['blogId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Page>(parameters, callback);
@@ -1866,7 +1877,7 @@ export namespace blogger_v3 {
         params,
         requiredParams: ['blogId'],
         pathParams: ['blogId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$PageList>(parameters, callback);
@@ -1934,7 +1945,7 @@ export namespace blogger_v3 {
         params,
         requiredParams: ['blogId', 'pageId'],
         pathParams: ['blogId', 'pageId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Page>(parameters, callback);
@@ -2000,7 +2011,7 @@ export namespace blogger_v3 {
         params,
         requiredParams: ['blogId', 'pageId'],
         pathParams: ['blogId', 'pageId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Page>(parameters, callback);
@@ -2066,7 +2077,7 @@ export namespace blogger_v3 {
         params,
         requiredParams: ['blogId', 'pageId'],
         pathParams: ['blogId', 'pageId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Page>(parameters, callback);
@@ -2134,7 +2145,7 @@ export namespace blogger_v3 {
         params,
         requiredParams: ['blogId', 'pageId'],
         pathParams: ['blogId', 'pageId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Page>(parameters, callback);
@@ -2323,7 +2334,10 @@ export namespace blogger_v3 {
 
 
   export class Resource$Pageviews {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -2379,7 +2393,7 @@ export namespace blogger_v3 {
         params,
         requiredParams: ['blogId'],
         pathParams: ['blogId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Pageviews>(parameters, callback);
@@ -2407,7 +2421,10 @@ export namespace blogger_v3 {
 
 
   export class Resource$Posts {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -2464,7 +2481,7 @@ export namespace blogger_v3 {
         params,
         requiredParams: ['blogId', 'postId'],
         pathParams: ['blogId', 'postId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -2530,7 +2547,7 @@ export namespace blogger_v3 {
         params,
         requiredParams: ['blogId', 'postId'],
         pathParams: ['blogId', 'postId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Post>(parameters, callback);
@@ -2598,7 +2615,7 @@ export namespace blogger_v3 {
         params,
         requiredParams: ['blogId', 'path'],
         pathParams: ['blogId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Post>(parameters, callback);
@@ -2666,7 +2683,7 @@ export namespace blogger_v3 {
         params,
         requiredParams: ['blogId'],
         pathParams: ['blogId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Post>(parameters, callback);
@@ -2740,7 +2757,7 @@ export namespace blogger_v3 {
         params,
         requiredParams: ['blogId'],
         pathParams: ['blogId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$PostList>(parameters, callback);
@@ -2811,7 +2828,7 @@ export namespace blogger_v3 {
         params,
         requiredParams: ['blogId', 'postId'],
         pathParams: ['blogId', 'postId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Post>(parameters, callback);
@@ -2879,7 +2896,7 @@ export namespace blogger_v3 {
         params,
         requiredParams: ['blogId', 'postId'],
         pathParams: ['blogId', 'postId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Post>(parameters, callback);
@@ -2945,7 +2962,7 @@ export namespace blogger_v3 {
         params,
         requiredParams: ['blogId', 'postId'],
         pathParams: ['blogId', 'postId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Post>(parameters, callback);
@@ -3012,7 +3029,7 @@ export namespace blogger_v3 {
         params,
         requiredParams: ['blogId', 'q'],
         pathParams: ['blogId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$PostList>(parameters, callback);
@@ -3083,7 +3100,7 @@ export namespace blogger_v3 {
         params,
         requiredParams: ['blogId', 'postId'],
         pathParams: ['blogId', 'postId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Post>(parameters, callback);
@@ -3403,7 +3420,10 @@ export namespace blogger_v3 {
 
 
   export class Resource$Postuserinfos {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -3465,7 +3485,7 @@ export namespace blogger_v3 {
         params,
         requiredParams: ['userId', 'blogId', 'postId'],
         pathParams: ['blogId', 'postId', 'userId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$PostUserInfo>(parameters, callback);
@@ -3543,7 +3563,7 @@ export namespace blogger_v3 {
         params,
         requiredParams: ['userId', 'blogId'],
         pathParams: ['blogId', 'userId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$PostUserInfosList>(parameters, callback);
@@ -3635,7 +3655,10 @@ export namespace blogger_v3 {
 
 
   export class Resource$Users {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -3689,7 +3712,7 @@ export namespace blogger_v3 {
         params,
         requiredParams: ['userId'],
         pathParams: ['userId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$User>(parameters, callback);

--- a/src/apis/books/v1.ts
+++ b/src/apis/books/v1.ts
@@ -29,8 +29,6 @@ export namespace books_v1 {
     version: 'v1';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * Data format for the response.
@@ -81,6 +79,7 @@ export namespace books_v1 {
    * @param {object=} options Options for Books
    */
   export class Books {
+    context: APIRequestContext;
     bookshelves: Resource$Bookshelves;
     cloudloading: Resource$Cloudloading;
     dictionary: Resource$Dictionary;
@@ -96,21 +95,21 @@ export namespace books_v1 {
     volumes: Resource$Volumes;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.bookshelves = new Resource$Bookshelves();
-      this.cloudloading = new Resource$Cloudloading();
-      this.dictionary = new Resource$Dictionary();
-      this.familysharing = new Resource$Familysharing();
-      this.layers = new Resource$Layers();
-      this.myconfig = new Resource$Myconfig();
-      this.mylibrary = new Resource$Mylibrary();
-      this.notification = new Resource$Notification();
-      this.onboarding = new Resource$Onboarding();
-      this.personalizedstream = new Resource$Personalizedstream();
-      this.promooffer = new Resource$Promooffer();
-      this.series = new Resource$Series();
-      this.volumes = new Resource$Volumes();
+      this.bookshelves = new Resource$Bookshelves(this.context);
+      this.cloudloading = new Resource$Cloudloading(this.context);
+      this.dictionary = new Resource$Dictionary(this.context);
+      this.familysharing = new Resource$Familysharing(this.context);
+      this.layers = new Resource$Layers(this.context);
+      this.myconfig = new Resource$Myconfig(this.context);
+      this.mylibrary = new Resource$Mylibrary(this.context);
+      this.notification = new Resource$Notification(this.context);
+      this.onboarding = new Resource$Onboarding(this.context);
+      this.personalizedstream = new Resource$Personalizedstream(this.context);
+      this.promooffer = new Resource$Promooffer(this.context);
+      this.series = new Resource$Series(this.context);
+      this.volumes = new Resource$Volumes(this.context);
     }
   }
 
@@ -1149,9 +1148,11 @@ export namespace books_v1 {
 
 
   export class Resource$Bookshelves {
+    context: APIRequestContext;
     volumes: Resource$Bookshelves$Volumes;
-    constructor() {
-      this.volumes = new Resource$Bookshelves$Volumes();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.volumes = new Resource$Bookshelves$Volumes(this.context);
     }
 
 
@@ -1209,7 +1210,7 @@ export namespace books_v1 {
         params,
         requiredParams: ['userId', 'shelf'],
         pathParams: ['shelf', 'userId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Bookshelf>(parameters, callback);
@@ -1275,7 +1276,7 @@ export namespace books_v1 {
         params,
         requiredParams: ['userId'],
         pathParams: ['userId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Bookshelves>(parameters, callback);
@@ -1321,7 +1322,10 @@ export namespace books_v1 {
   }
 
   export class Resource$Bookshelves$Volumes {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1386,7 +1390,7 @@ export namespace books_v1 {
         params,
         requiredParams: ['userId', 'shelf'],
         pathParams: ['shelf', 'userId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Volumes>(parameters, callback);
@@ -1432,7 +1436,10 @@ export namespace books_v1 {
 
 
   export class Resource$Cloudloading {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1496,7 +1503,7 @@ export namespace books_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$BooksCloudloadingResource>(
@@ -1562,7 +1569,7 @@ export namespace books_v1 {
         params,
         requiredParams: ['volumeId'],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -1631,7 +1638,7 @@ export namespace books_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$BooksCloudloadingResource>(
@@ -1695,7 +1702,10 @@ export namespace books_v1 {
 
 
   export class Resource$Dictionary {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1754,7 +1764,7 @@ export namespace books_v1 {
         params,
         requiredParams: ['cpksver'],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Metadata>(parameters, callback);
@@ -1779,7 +1789,10 @@ export namespace books_v1 {
 
 
   export class Resource$Familysharing {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1839,7 +1852,7 @@ export namespace books_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$FamilyInfo>(parameters, callback);
@@ -1907,7 +1920,7 @@ export namespace books_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -1975,7 +1988,7 @@ export namespace books_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -2040,11 +2053,14 @@ export namespace books_v1 {
 
 
   export class Resource$Layers {
+    context: APIRequestContext;
     annotationData: Resource$Layers$Annotationdata;
     volumeAnnotations: Resource$Layers$Volumeannotations;
-    constructor() {
-      this.annotationData = new Resource$Layers$Annotationdata();
-      this.volumeAnnotations = new Resource$Layers$Volumeannotations();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.annotationData = new Resource$Layers$Annotationdata(this.context);
+      this.volumeAnnotations =
+          new Resource$Layers$Volumeannotations(this.context);
     }
 
 
@@ -2104,7 +2120,7 @@ export namespace books_v1 {
         params,
         requiredParams: ['volumeId', 'summaryId'],
         pathParams: ['summaryId', 'volumeId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Layersummary>(parameters, callback);
@@ -2173,7 +2189,7 @@ export namespace books_v1 {
         params,
         requiredParams: ['volumeId'],
         pathParams: ['volumeId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Layersummaries>(parameters, callback);
@@ -2235,7 +2251,10 @@ export namespace books_v1 {
   }
 
   export class Resource$Layers$Annotationdata {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -2303,7 +2322,7 @@ export namespace books_v1 {
         requiredParams:
             ['volumeId', 'layerId', 'annotationDataId', 'contentVersion'],
         pathParams: ['annotationDataId', 'layerId', 'volumeId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Annotationdata>(parameters, callback);
@@ -2383,7 +2402,7 @@ export namespace books_v1 {
         params,
         requiredParams: ['volumeId', 'layerId', 'contentVersion'],
         pathParams: ['layerId', 'volumeId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Annotationsdata>(parameters, callback);
@@ -2513,7 +2532,10 @@ export namespace books_v1 {
 
 
   export class Resource$Layers$Volumeannotations {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -2575,7 +2597,7 @@ export namespace books_v1 {
         params,
         requiredParams: ['volumeId', 'layerId', 'annotationId'],
         pathParams: ['annotationId', 'layerId', 'volumeId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Volumeannotation>(parameters, callback);
@@ -2656,7 +2678,7 @@ export namespace books_v1 {
         params,
         requiredParams: ['volumeId', 'layerId', 'contentVersion'],
         pathParams: ['layerId', 'volumeId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Volumeannotations>(parameters, callback);
@@ -2771,7 +2793,10 @@ export namespace books_v1 {
 
 
   export class Resource$Myconfig {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -2830,7 +2855,7 @@ export namespace books_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Usersettings>(parameters, callback);
@@ -2901,7 +2926,7 @@ export namespace books_v1 {
         params,
         requiredParams: ['volumeIds', 'cpksver'],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$DownloadAccesses>(parameters, callback);
@@ -2973,7 +2998,7 @@ export namespace books_v1 {
         params,
         requiredParams: ['source', 'volumeId', 'nonce', 'cpksver'],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$RequestAccess>(parameters, callback);
@@ -3047,7 +3072,7 @@ export namespace books_v1 {
         params,
         requiredParams: ['source', 'nonce', 'cpksver'],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Volumes>(parameters, callback);
@@ -3117,7 +3142,7 @@ export namespace books_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Usersettings>(parameters, callback);
@@ -3247,19 +3272,25 @@ export namespace books_v1 {
 
 
   export class Resource$Mylibrary {
+    context: APIRequestContext;
     annotations: Resource$Mylibrary$Annotations;
     bookshelves: Resource$Mylibrary$Bookshelves;
     readingpositions: Resource$Mylibrary$Readingpositions;
-    constructor() {
-      this.annotations = new Resource$Mylibrary$Annotations();
-      this.bookshelves = new Resource$Mylibrary$Bookshelves();
-      this.readingpositions = new Resource$Mylibrary$Readingpositions();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.annotations = new Resource$Mylibrary$Annotations(this.context);
+      this.bookshelves = new Resource$Mylibrary$Bookshelves(this.context);
+      this.readingpositions =
+          new Resource$Mylibrary$Readingpositions(this.context);
     }
   }
 
 
   export class Resource$Mylibrary$Annotations {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -3318,7 +3349,7 @@ export namespace books_v1 {
         params,
         requiredParams: ['annotationId'],
         pathParams: ['annotationId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -3389,7 +3420,7 @@ export namespace books_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Annotation>(parameters, callback);
@@ -3465,7 +3496,7 @@ export namespace books_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Annotations>(parameters, callback);
@@ -3533,7 +3564,7 @@ export namespace books_v1 {
         params,
         requiredParams: ['layerIds', 'volumeId'],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AnnotationsSummary>(parameters, callback);
@@ -3602,7 +3633,7 @@ export namespace books_v1 {
         params,
         requiredParams: ['annotationId'],
         pathParams: ['annotationId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Annotation>(parameters, callback);
@@ -3749,9 +3780,11 @@ export namespace books_v1 {
 
 
   export class Resource$Mylibrary$Bookshelves {
+    context: APIRequestContext;
     volumes: Resource$Mylibrary$Bookshelves$Volumes;
-    constructor() {
-      this.volumes = new Resource$Mylibrary$Bookshelves$Volumes();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.volumes = new Resource$Mylibrary$Bookshelves$Volumes(this.context);
     }
 
 
@@ -3814,7 +3847,7 @@ export namespace books_v1 {
         params,
         requiredParams: ['shelf', 'volumeId'],
         pathParams: ['shelf'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -3881,7 +3914,7 @@ export namespace books_v1 {
         params,
         requiredParams: ['shelf'],
         pathParams: ['shelf'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -3946,7 +3979,7 @@ export namespace books_v1 {
         params,
         requiredParams: ['shelf'],
         pathParams: ['shelf'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Bookshelf>(parameters, callback);
@@ -4014,7 +4047,7 @@ export namespace books_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Bookshelves>(parameters, callback);
@@ -4083,7 +4116,7 @@ export namespace books_v1 {
         params,
         requiredParams: ['shelf', 'volumeId', 'volumePosition'],
         pathParams: ['shelf'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -4152,7 +4185,7 @@ export namespace books_v1 {
         params,
         requiredParams: ['shelf', 'volumeId'],
         pathParams: ['shelf'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -4281,7 +4314,10 @@ export namespace books_v1 {
   }
 
   export class Resource$Mylibrary$Bookshelves$Volumes {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -4347,7 +4383,7 @@ export namespace books_v1 {
         params,
         requiredParams: ['shelf'],
         pathParams: ['shelf'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Volumes>(parameters, callback);
@@ -4401,7 +4437,10 @@ export namespace books_v1 {
 
 
   export class Resource$Mylibrary$Readingpositions {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -4459,7 +4498,7 @@ export namespace books_v1 {
         params,
         requiredParams: ['volumeId'],
         pathParams: ['volumeId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ReadingPosition>(parameters, callback);
@@ -4533,7 +4572,7 @@ export namespace books_v1 {
         params,
         requiredParams: ['volumeId', 'timestamp', 'position'],
         pathParams: ['volumeId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -4603,7 +4642,10 @@ export namespace books_v1 {
 
 
   export class Resource$Notification {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -4660,7 +4702,7 @@ export namespace books_v1 {
         params,
         requiredParams: ['notification_id'],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Notification>(parameters, callback);
@@ -4693,7 +4735,10 @@ export namespace books_v1 {
 
 
   export class Resource$Onboarding {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -4752,7 +4797,7 @@ export namespace books_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Category>(parameters, callback);
@@ -4822,7 +4867,7 @@ export namespace books_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Volume2>(parameters, callback);
@@ -4878,7 +4923,10 @@ export namespace books_v1 {
 
 
   export class Resource$Personalizedstream {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -4936,7 +4984,7 @@ export namespace books_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Discoveryclusters>(parameters, callback);
@@ -4971,7 +5019,10 @@ export namespace books_v1 {
 
 
   export class Resource$Promooffer {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -5034,7 +5085,7 @@ export namespace books_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -5104,7 +5155,7 @@ export namespace books_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -5170,7 +5221,7 @@ export namespace books_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Offers>(parameters, callback);
@@ -5290,9 +5341,11 @@ export namespace books_v1 {
 
 
   export class Resource$Series {
+    context: APIRequestContext;
     membership: Resource$Series$Membership;
-    constructor() {
-      this.membership = new Resource$Series$Membership();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.membership = new Resource$Series$Membership(this.context);
     }
 
 
@@ -5347,7 +5400,7 @@ export namespace books_v1 {
         params,
         requiredParams: ['series_id'],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Series>(parameters, callback);
@@ -5370,7 +5423,10 @@ export namespace books_v1 {
   }
 
   export class Resource$Series$Membership {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -5428,7 +5484,7 @@ export namespace books_v1 {
         params,
         requiredParams: ['series_id'],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Seriesmembership>(parameters, callback);
@@ -5462,15 +5518,17 @@ export namespace books_v1 {
 
 
   export class Resource$Volumes {
+    context: APIRequestContext;
     associated: Resource$Volumes$Associated;
     mybooks: Resource$Volumes$Mybooks;
     recommended: Resource$Volumes$Recommended;
     useruploaded: Resource$Volumes$Useruploaded;
-    constructor() {
-      this.associated = new Resource$Volumes$Associated();
-      this.mybooks = new Resource$Volumes$Mybooks();
-      this.recommended = new Resource$Volumes$Recommended();
-      this.useruploaded = new Resource$Volumes$Useruploaded();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.associated = new Resource$Volumes$Associated(this.context);
+      this.mybooks = new Resource$Volumes$Mybooks(this.context);
+      this.recommended = new Resource$Volumes$Recommended(this.context);
+      this.useruploaded = new Resource$Volumes$Useruploaded(this.context);
     }
 
 
@@ -5531,7 +5589,7 @@ export namespace books_v1 {
         params,
         requiredParams: ['volumeId'],
         pathParams: ['volumeId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Volume>(parameters, callback);
@@ -5608,7 +5666,7 @@ export namespace books_v1 {
         params,
         requiredParams: ['q'],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Volumes>(parameters, callback);
@@ -5719,7 +5777,10 @@ export namespace books_v1 {
   }
 
   export class Resource$Volumes$Associated {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -5782,7 +5843,7 @@ export namespace books_v1 {
         params,
         requiredParams: ['volumeId'],
         pathParams: ['volumeId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Volumes>(parameters, callback);
@@ -5825,7 +5886,10 @@ export namespace books_v1 {
 
 
   export class Resource$Volumes$Mybooks {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -5890,7 +5954,7 @@ export namespace books_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Volumes>(parameters, callback);
@@ -5941,7 +6005,10 @@ export namespace books_v1 {
 
 
   export class Resource$Volumes$Recommended {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -6002,7 +6069,7 @@ export namespace books_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Volumes>(parameters, callback);
@@ -6081,7 +6148,7 @@ export namespace books_v1 {
         params,
         requiredParams: ['rating', 'volumeId'],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$BooksVolumesRecommendedRateResponse>(
@@ -6143,7 +6210,10 @@ export namespace books_v1 {
 
 
   export class Resource$Volumes$Useruploaded {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -6207,7 +6277,7 @@ export namespace books_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Volumes>(parameters, callback);

--- a/src/apis/calendar/v3.ts
+++ b/src/apis/calendar/v3.ts
@@ -29,8 +29,6 @@ export namespace calendar_v3 {
     version: 'v3';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * Data format for the response.
@@ -81,6 +79,7 @@ export namespace calendar_v3 {
    * @param {object=} options Options for Calendar
    */
   export class Calendar {
+    context: APIRequestContext;
     acl: Resource$Acl;
     calendarList: Resource$Calendarlist;
     calendars: Resource$Calendars;
@@ -91,16 +90,16 @@ export namespace calendar_v3 {
     settings: Resource$Settings;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.acl = new Resource$Acl();
-      this.calendarList = new Resource$Calendarlist();
-      this.calendars = new Resource$Calendars();
-      this.channels = new Resource$Channels();
-      this.colors = new Resource$Colors();
-      this.events = new Resource$Events();
-      this.freebusy = new Resource$Freebusy();
-      this.settings = new Resource$Settings();
+      this.acl = new Resource$Acl(this.context);
+      this.calendarList = new Resource$Calendarlist(this.context);
+      this.calendars = new Resource$Calendars(this.context);
+      this.channels = new Resource$Channels(this.context);
+      this.colors = new Resource$Colors(this.context);
+      this.events = new Resource$Events(this.context);
+      this.freebusy = new Resource$Freebusy(this.context);
+      this.settings = new Resource$Settings(this.context);
     }
   }
 
@@ -1232,7 +1231,10 @@ export namespace calendar_v3 {
 
 
   export class Resource$Acl {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1290,7 +1292,7 @@ export namespace calendar_v3 {
         params,
         requiredParams: ['calendarId', 'ruleId'],
         pathParams: ['calendarId', 'ruleId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -1353,7 +1355,7 @@ export namespace calendar_v3 {
         params,
         requiredParams: ['calendarId', 'ruleId'],
         pathParams: ['calendarId', 'ruleId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AclRule>(parameters, callback);
@@ -1419,7 +1421,7 @@ export namespace calendar_v3 {
         params,
         requiredParams: ['calendarId'],
         pathParams: ['calendarId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AclRule>(parameters, callback);
@@ -1487,7 +1489,7 @@ export namespace calendar_v3 {
         params,
         requiredParams: ['calendarId'],
         pathParams: ['calendarId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Acl>(parameters, callback);
@@ -1556,7 +1558,7 @@ export namespace calendar_v3 {
         params,
         requiredParams: ['calendarId', 'ruleId'],
         pathParams: ['calendarId', 'ruleId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AclRule>(parameters, callback);
@@ -1624,7 +1626,7 @@ export namespace calendar_v3 {
         params,
         requiredParams: ['calendarId', 'ruleId'],
         pathParams: ['calendarId', 'ruleId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AclRule>(parameters, callback);
@@ -1693,7 +1695,7 @@ export namespace calendar_v3 {
         params,
         requiredParams: ['calendarId'],
         pathParams: ['calendarId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Channel>(parameters, callback);
@@ -1906,7 +1908,10 @@ export namespace calendar_v3 {
 
 
   export class Resource$Calendarlist {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1964,7 +1969,7 @@ export namespace calendar_v3 {
         params,
         requiredParams: ['calendarId'],
         pathParams: ['calendarId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -2026,7 +2031,7 @@ export namespace calendar_v3 {
         params,
         requiredParams: ['calendarId'],
         pathParams: ['calendarId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$CalendarListEntry>(parameters, callback);
@@ -2094,7 +2099,7 @@ export namespace calendar_v3 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$CalendarListEntry>(parameters, callback);
@@ -2165,7 +2170,7 @@ export namespace calendar_v3 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$CalendarList>(parameters, callback);
@@ -2234,7 +2239,7 @@ export namespace calendar_v3 {
         params,
         requiredParams: ['calendarId'],
         pathParams: ['calendarId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$CalendarListEntry>(parameters, callback);
@@ -2303,7 +2308,7 @@ export namespace calendar_v3 {
         params,
         requiredParams: ['calendarId'],
         pathParams: ['calendarId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$CalendarListEntry>(parameters, callback);
@@ -2374,7 +2379,7 @@ export namespace calendar_v3 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Channel>(parameters, callback);
@@ -2587,7 +2592,10 @@ export namespace calendar_v3 {
 
 
   export class Resource$Calendars {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -2644,7 +2652,7 @@ export namespace calendar_v3 {
         params,
         requiredParams: ['calendarId'],
         pathParams: ['calendarId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -2708,7 +2716,7 @@ export namespace calendar_v3 {
         params,
         requiredParams: ['calendarId'],
         pathParams: ['calendarId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -2769,7 +2777,7 @@ export namespace calendar_v3 {
         params,
         requiredParams: ['calendarId'],
         pathParams: ['calendarId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Calendar>(parameters, callback);
@@ -2833,7 +2841,7 @@ export namespace calendar_v3 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Calendar>(parameters, callback);
@@ -2899,7 +2907,7 @@ export namespace calendar_v3 {
         params,
         requiredParams: ['calendarId'],
         pathParams: ['calendarId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Calendar>(parameters, callback);
@@ -2964,7 +2972,7 @@ export namespace calendar_v3 {
         params,
         requiredParams: ['calendarId'],
         pathParams: ['calendarId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Calendar>(parameters, callback);
@@ -3064,7 +3072,10 @@ export namespace calendar_v3 {
 
 
   export class Resource$Channels {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -3120,7 +3131,7 @@ export namespace calendar_v3 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -3145,7 +3156,10 @@ export namespace calendar_v3 {
 
 
   export class Resource$Colors {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -3198,7 +3212,7 @@ export namespace calendar_v3 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Colors>(parameters, callback);
@@ -3217,7 +3231,10 @@ export namespace calendar_v3 {
 
 
   export class Resource$Events {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -3277,7 +3294,7 @@ export namespace calendar_v3 {
         params,
         requiredParams: ['calendarId', 'eventId'],
         pathParams: ['calendarId', 'eventId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -3343,7 +3360,7 @@ export namespace calendar_v3 {
         params,
         requiredParams: ['calendarId', 'eventId'],
         pathParams: ['calendarId', 'eventId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Event>(parameters, callback);
@@ -3386,7 +3403,7 @@ import(paramsOrCallback?: Params$Resource$Events$Import|BodyResponseCallback<Sch
     options = {};
                                                                                                                                                                                                                                                         }
 
-                                                                                                                                                                                                                                                        const rootUrl = options.rootUrl || 'https://www.googleapis.com/'; const parameters = {options: Object.assign({url: (rootUrl + '/calendar/v3/calendars/{calendarId}/events/import').replace(/([^:]\/)\/+/g, '$1'), method: 'POST'}, options), params, requiredParams: ['calendarId'], pathParams: ['calendarId'], context}; if(callback) {
+                                                                                                                                                                                                                                                        const rootUrl = options.rootUrl || 'https://www.googleapis.com/'; const parameters = {options: Object.assign({url: (rootUrl + '/calendar/v3/calendars/{calendarId}/events/import').replace(/([^:]\/)\/+/g, '$1'), method: 'POST'}, options), params, requiredParams: ['calendarId'], pathParams: ['calendarId'], context: this.context}; if(callback) {
     createAPIRequest<Schema$Event>(parameters, callback);
                                                                                                                                                                                                                                                         } else {
     return createAPIRequest<Schema$Event>(parameters);
@@ -3452,7 +3469,7 @@ import(paramsOrCallback?: Params$Resource$Events$Import|BodyResponseCallback<Sch
         params,
         requiredParams: ['calendarId'],
         pathParams: ['calendarId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Event>(parameters, callback);
@@ -3529,7 +3546,7 @@ import(paramsOrCallback?: Params$Resource$Events$Import|BodyResponseCallback<Sch
         params,
         requiredParams: ['calendarId', 'eventId'],
         pathParams: ['calendarId', 'eventId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Events>(parameters, callback);
@@ -3610,7 +3627,7 @@ import(paramsOrCallback?: Params$Resource$Events$Import|BodyResponseCallback<Sch
         params,
         requiredParams: ['calendarId'],
         pathParams: ['calendarId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Events>(parameters, callback);
@@ -3680,7 +3697,7 @@ import(paramsOrCallback?: Params$Resource$Events$Import|BodyResponseCallback<Sch
         params,
         requiredParams: ['calendarId', 'eventId', 'destination'],
         pathParams: ['calendarId', 'eventId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Event>(parameters, callback);
@@ -3753,7 +3770,7 @@ import(paramsOrCallback?: Params$Resource$Events$Import|BodyResponseCallback<Sch
         params,
         requiredParams: ['calendarId', 'eventId'],
         pathParams: ['calendarId', 'eventId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Event>(parameters, callback);
@@ -3821,7 +3838,7 @@ import(paramsOrCallback?: Params$Resource$Events$Import|BodyResponseCallback<Sch
         params,
         requiredParams: ['calendarId', 'text'],
         pathParams: ['calendarId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Event>(parameters, callback);
@@ -3894,7 +3911,7 @@ import(paramsOrCallback?: Params$Resource$Events$Import|BodyResponseCallback<Sch
         params,
         requiredParams: ['calendarId', 'eventId'],
         pathParams: ['calendarId', 'eventId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Event>(parameters, callback);
@@ -3977,7 +3994,7 @@ import(paramsOrCallback?: Params$Resource$Events$Import|BodyResponseCallback<Sch
         params,
         requiredParams: ['calendarId'],
         pathParams: ['calendarId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Channel>(parameters, callback);
@@ -4659,7 +4676,10 @@ import(paramsOrCallback?: Params$Resource$Events$Import|BodyResponseCallback<Sch
 
 
   export class Resource$Freebusy {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -4717,7 +4737,7 @@ import(paramsOrCallback?: Params$Resource$Events$Import|BodyResponseCallback<Sch
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$FreeBusyResponse>(parameters, callback);
@@ -4742,7 +4762,10 @@ import(paramsOrCallback?: Params$Resource$Events$Import|BodyResponseCallback<Sch
 
 
   export class Resource$Settings {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -4796,7 +4819,7 @@ import(paramsOrCallback?: Params$Resource$Events$Import|BodyResponseCallback<Sch
         params,
         requiredParams: ['setting'],
         pathParams: ['setting'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Setting>(parameters, callback);
@@ -4862,7 +4885,7 @@ import(paramsOrCallback?: Params$Resource$Events$Import|BodyResponseCallback<Sch
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Settings>(parameters, callback);
@@ -4929,7 +4952,7 @@ import(paramsOrCallback?: Params$Resource$Events$Import|BodyResponseCallback<Sch
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Channel>(parameters, callback);

--- a/src/apis/chat/v1.ts
+++ b/src/apis/chat/v1.ts
@@ -29,8 +29,6 @@ export namespace chat_v1 {
     version: 'v1';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * V1 error format.
@@ -98,12 +96,13 @@ export namespace chat_v1 {
    * @param {object=} options Options for Chat
    */
   export class Chat {
+    context: APIRequestContext;
     spaces: Resource$Spaces;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.spaces = new Resource$Spaces();
+      this.spaces = new Resource$Spaces(this.context);
     }
   }
 
@@ -641,11 +640,13 @@ export namespace chat_v1 {
 
 
   export class Resource$Spaces {
+    context: APIRequestContext;
     members: Resource$Spaces$Members;
     messages: Resource$Spaces$Messages;
-    constructor() {
-      this.members = new Resource$Spaces$Members();
-      this.messages = new Resource$Spaces$Messages();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.members = new Resource$Spaces$Members(this.context);
+      this.messages = new Resource$Spaces$Messages(this.context);
     }
 
 
@@ -699,7 +700,7 @@ export namespace chat_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Space>(parameters, callback);
@@ -764,7 +765,7 @@ export namespace chat_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListSpacesResponse>(parameters, callback);
@@ -804,7 +805,10 @@ export namespace chat_v1 {
   }
 
   export class Resource$Spaces$Members {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -859,7 +863,7 @@ export namespace chat_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Membership>(parameters, callback);
@@ -928,7 +932,7 @@ export namespace chat_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListMembershipsResponse>(parameters, callback);
@@ -977,7 +981,10 @@ export namespace chat_v1 {
 
 
   export class Resource$Spaces$Messages {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1038,7 +1045,7 @@ export namespace chat_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Message>(parameters, callback);
@@ -1103,7 +1110,7 @@ export namespace chat_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -1164,7 +1171,7 @@ export namespace chat_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Message>(parameters, callback);
@@ -1231,7 +1238,7 @@ export namespace chat_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Message>(parameters, callback);

--- a/src/apis/civicinfo/v2.ts
+++ b/src/apis/civicinfo/v2.ts
@@ -29,8 +29,6 @@ export namespace civicinfo_v2 {
     version: 'v2';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * Data format for the response.
@@ -82,16 +80,17 @@ export namespace civicinfo_v2 {
    * @param {object=} options Options for Civicinfo
    */
   export class Civicinfo {
+    context: APIRequestContext;
     divisions: Resource$Divisions;
     elections: Resource$Elections;
     representatives: Resource$Representatives;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.divisions = new Resource$Divisions();
-      this.elections = new Resource$Elections();
-      this.representatives = new Resource$Representatives();
+      this.divisions = new Resource$Divisions(this.context);
+      this.elections = new Resource$Elections(this.context);
+      this.representatives = new Resource$Representatives(this.context);
     }
   }
 
@@ -986,7 +985,10 @@ export namespace civicinfo_v2 {
 
 
   export class Resource$Divisions {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1046,7 +1048,7 @@ export namespace civicinfo_v2 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$DivisionSearchResponse>(parameters, callback);
@@ -1079,7 +1081,10 @@ export namespace civicinfo_v2 {
 
 
   export class Resource$Elections {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1141,7 +1146,7 @@ export namespace civicinfo_v2 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ElectionsQueryResponse>(parameters, callback);
@@ -1214,7 +1219,7 @@ export namespace civicinfo_v2 {
         params,
         requiredParams: ['address'],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$VoterInfoResponse>(parameters, callback);
@@ -1275,7 +1280,10 @@ export namespace civicinfo_v2 {
 
 
   export class Resource$Representatives {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1348,7 +1356,7 @@ export namespace civicinfo_v2 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$RepresentativeInfoResponse>(
@@ -1425,7 +1433,7 @@ export namespace civicinfo_v2 {
         params,
         requiredParams: ['ocdId'],
         pathParams: ['ocdId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$RepresentativeInfoData>(parameters, callback);

--- a/src/apis/classroom/v1.ts
+++ b/src/apis/classroom/v1.ts
@@ -29,8 +29,6 @@ export namespace classroom_v1 {
     version: 'v1';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * V1 error format.
@@ -98,18 +96,19 @@ export namespace classroom_v1 {
    * @param {object=} options Options for Classroom
    */
   export class Classroom {
+    context: APIRequestContext;
     courses: Resource$Courses;
     invitations: Resource$Invitations;
     registrations: Resource$Registrations;
     userProfiles: Resource$Userprofiles;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.courses = new Resource$Courses();
-      this.invitations = new Resource$Invitations();
-      this.registrations = new Resource$Registrations();
-      this.userProfiles = new Resource$Userprofiles();
+      this.courses = new Resource$Courses(this.context);
+      this.invitations = new Resource$Invitations(this.context);
+      this.registrations = new Resource$Registrations(this.context);
+      this.userProfiles = new Resource$Userprofiles(this.context);
     }
   }
 
@@ -1347,17 +1346,19 @@ export namespace classroom_v1 {
 
 
   export class Resource$Courses {
+    context: APIRequestContext;
     aliases: Resource$Courses$Aliases;
     announcements: Resource$Courses$Announcements;
     courseWork: Resource$Courses$Coursework;
     students: Resource$Courses$Students;
     teachers: Resource$Courses$Teachers;
-    constructor() {
-      this.aliases = new Resource$Courses$Aliases();
-      this.announcements = new Resource$Courses$Announcements();
-      this.courseWork = new Resource$Courses$Coursework();
-      this.students = new Resource$Courses$Students();
-      this.teachers = new Resource$Courses$Teachers();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.aliases = new Resource$Courses$Aliases(this.context);
+      this.announcements = new Resource$Courses$Announcements(this.context);
+      this.courseWork = new Resource$Courses$Coursework(this.context);
+      this.students = new Resource$Courses$Students(this.context);
+      this.teachers = new Resource$Courses$Teachers(this.context);
     }
 
 
@@ -1421,7 +1422,7 @@ export namespace classroom_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Course>(parameters, callback);
@@ -1487,7 +1488,7 @@ export namespace classroom_v1 {
         params,
         requiredParams: ['id'],
         pathParams: ['id'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -1550,7 +1551,7 @@ export namespace classroom_v1 {
         params,
         requiredParams: ['id'],
         pathParams: ['id'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Course>(parameters, callback);
@@ -1623,7 +1624,7 @@ export namespace classroom_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListCoursesResponse>(parameters, callback);
@@ -1694,7 +1695,7 @@ export namespace classroom_v1 {
         params,
         requiredParams: ['id'],
         pathParams: ['id'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Course>(parameters, callback);
@@ -1762,7 +1763,7 @@ export namespace classroom_v1 {
         params,
         requiredParams: ['id'],
         pathParams: ['id'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Course>(parameters, callback);
@@ -1893,7 +1894,10 @@ export namespace classroom_v1 {
   }
 
   export class Resource$Courses$Aliases {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1960,7 +1964,7 @@ export namespace classroom_v1 {
         params,
         requiredParams: ['courseId'],
         pathParams: ['courseId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$CourseAlias>(parameters, callback);
@@ -2032,7 +2036,7 @@ export namespace classroom_v1 {
         params,
         requiredParams: ['courseId', 'alias'],
         pathParams: ['alias', 'courseId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -2106,7 +2110,7 @@ export namespace classroom_v1 {
         params,
         requiredParams: ['courseId'],
         pathParams: ['courseId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListCourseAliasesResponse>(
@@ -2180,7 +2184,10 @@ export namespace classroom_v1 {
 
 
   export class Resource$Courses$Announcements {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -2247,7 +2254,7 @@ export namespace classroom_v1 {
         params,
         requiredParams: ['courseId'],
         pathParams: ['courseId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Announcement>(parameters, callback);
@@ -2322,7 +2329,7 @@ export namespace classroom_v1 {
         params,
         requiredParams: ['courseId', 'id'],
         pathParams: ['courseId', 'id'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -2390,7 +2397,7 @@ export namespace classroom_v1 {
         params,
         requiredParams: ['courseId', 'id'],
         pathParams: ['courseId', 'id'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Announcement>(parameters, callback);
@@ -2470,7 +2477,7 @@ export namespace classroom_v1 {
         params,
         requiredParams: ['courseId'],
         pathParams: ['courseId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListAnnouncementsResponse>(
@@ -2548,7 +2555,7 @@ export namespace classroom_v1 {
         params,
         requiredParams: ['courseId', 'id'],
         pathParams: ['courseId', 'id'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Announcement>(parameters, callback);
@@ -2624,7 +2631,7 @@ export namespace classroom_v1 {
         params,
         requiredParams: ['courseId', 'id'],
         pathParams: ['courseId', 'id'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Announcement>(parameters, callback);
@@ -2783,10 +2790,12 @@ export namespace classroom_v1 {
 
 
   export class Resource$Courses$Coursework {
+    context: APIRequestContext;
     studentSubmissions: Resource$Courses$Coursework$Studentsubmissions;
-    constructor() {
+    constructor(context: APIRequestContext) {
+      this.context = context;
       this.studentSubmissions =
-          new Resource$Courses$Coursework$Studentsubmissions();
+          new Resource$Courses$Coursework$Studentsubmissions(this.context);
     }
 
 
@@ -2859,7 +2868,7 @@ export namespace classroom_v1 {
         params,
         requiredParams: ['courseId'],
         pathParams: ['courseId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$CourseWork>(parameters, callback);
@@ -2934,7 +2943,7 @@ export namespace classroom_v1 {
         params,
         requiredParams: ['courseId', 'id'],
         pathParams: ['courseId', 'id'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -3002,7 +3011,7 @@ export namespace classroom_v1 {
         params,
         requiredParams: ['courseId', 'id'],
         pathParams: ['courseId', 'id'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$CourseWork>(parameters, callback);
@@ -3080,7 +3089,7 @@ export namespace classroom_v1 {
         params,
         requiredParams: ['courseId'],
         pathParams: ['courseId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListCourseWorkResponse>(parameters, callback);
@@ -3156,7 +3165,7 @@ export namespace classroom_v1 {
         params,
         requiredParams: ['courseId', 'id'],
         pathParams: ['courseId', 'id'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$CourseWork>(parameters, callback);
@@ -3238,7 +3247,7 @@ export namespace classroom_v1 {
         params,
         requiredParams: ['courseId', 'id'],
         pathParams: ['courseId', 'id'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$CourseWork>(parameters, callback);
@@ -3398,7 +3407,10 @@ export namespace classroom_v1 {
   }
 
   export class Resource$Courses$Coursework$Studentsubmissions {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -3464,7 +3476,7 @@ export namespace classroom_v1 {
         params,
         requiredParams: ['courseId', 'courseWorkId', 'id'],
         pathParams: ['courseId', 'courseWorkId', 'id'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$StudentSubmission>(parameters, callback);
@@ -3555,7 +3567,7 @@ export namespace classroom_v1 {
         params,
         requiredParams: ['courseId', 'courseWorkId'],
         pathParams: ['courseId', 'courseWorkId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListStudentSubmissionsResponse>(
@@ -3646,7 +3658,7 @@ export namespace classroom_v1 {
         params,
         requiredParams: ['courseId', 'courseWorkId', 'id'],
         pathParams: ['courseId', 'courseWorkId', 'id'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$StudentSubmission>(parameters, callback);
@@ -3732,7 +3744,7 @@ export namespace classroom_v1 {
         params,
         requiredParams: ['courseId', 'courseWorkId', 'id'],
         pathParams: ['courseId', 'courseWorkId', 'id'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$StudentSubmission>(parameters, callback);
@@ -3818,7 +3830,7 @@ export namespace classroom_v1 {
         params,
         requiredParams: ['courseId', 'courseWorkId', 'id'],
         pathParams: ['courseId', 'courseWorkId', 'id'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -3904,7 +3916,7 @@ export namespace classroom_v1 {
         params,
         requiredParams: ['courseId', 'courseWorkId', 'id'],
         pathParams: ['courseId', 'courseWorkId', 'id'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -3988,7 +4000,7 @@ export namespace classroom_v1 {
         params,
         requiredParams: ['courseId', 'courseWorkId', 'id'],
         pathParams: ['courseId', 'courseWorkId', 'id'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -4209,7 +4221,10 @@ export namespace classroom_v1 {
 
 
   export class Resource$Courses$Students {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -4278,7 +4293,7 @@ export namespace classroom_v1 {
         params,
         requiredParams: ['courseId'],
         pathParams: ['courseId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Student>(parameters, callback);
@@ -4349,7 +4364,7 @@ export namespace classroom_v1 {
         params,
         requiredParams: ['courseId', 'userId'],
         pathParams: ['courseId', 'userId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -4416,7 +4431,7 @@ export namespace classroom_v1 {
         params,
         requiredParams: ['courseId', 'userId'],
         pathParams: ['courseId', 'userId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Student>(parameters, callback);
@@ -4489,7 +4504,7 @@ export namespace classroom_v1 {
         params,
         requiredParams: ['courseId'],
         pathParams: ['courseId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListStudentsResponse>(parameters, callback);
@@ -4589,7 +4604,10 @@ export namespace classroom_v1 {
 
 
   export class Resource$Courses$Teachers {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -4657,7 +4675,7 @@ export namespace classroom_v1 {
         params,
         requiredParams: ['courseId'],
         pathParams: ['courseId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Teacher>(parameters, callback);
@@ -4729,7 +4747,7 @@ export namespace classroom_v1 {
         params,
         requiredParams: ['courseId', 'userId'],
         pathParams: ['courseId', 'userId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -4796,7 +4814,7 @@ export namespace classroom_v1 {
         params,
         requiredParams: ['courseId', 'userId'],
         pathParams: ['courseId', 'userId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Teacher>(parameters, callback);
@@ -4869,7 +4887,7 @@ export namespace classroom_v1 {
         params,
         requiredParams: ['courseId'],
         pathParams: ['courseId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListTeachersResponse>(parameters, callback);
@@ -4963,7 +4981,10 @@ export namespace classroom_v1 {
 
 
   export class Resource$Invitations {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -5030,7 +5051,7 @@ export namespace classroom_v1 {
         params,
         requiredParams: ['id'],
         pathParams: ['id'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -5104,7 +5125,7 @@ export namespace classroom_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Invitation>(parameters, callback);
@@ -5173,7 +5194,7 @@ export namespace classroom_v1 {
         params,
         requiredParams: ['id'],
         pathParams: ['id'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -5238,7 +5259,7 @@ export namespace classroom_v1 {
         params,
         requiredParams: ['id'],
         pathParams: ['id'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Invitation>(parameters, callback);
@@ -5310,7 +5331,7 @@ export namespace classroom_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListInvitationsResponse>(parameters, callback);
@@ -5401,7 +5422,10 @@ export namespace classroom_v1 {
 
 
   export class Resource$Registrations {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -5481,7 +5505,7 @@ export namespace classroom_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Registration>(parameters, callback);
@@ -5548,7 +5572,7 @@ export namespace classroom_v1 {
         params,
         requiredParams: ['registrationId'],
         pathParams: ['registrationId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -5586,12 +5610,14 @@ export namespace classroom_v1 {
 
 
   export class Resource$Userprofiles {
+    context: APIRequestContext;
     guardianInvitations: Resource$Userprofiles$Guardianinvitations;
     guardians: Resource$Userprofiles$Guardians;
-    constructor() {
+    constructor(context: APIRequestContext) {
+      this.context = context;
       this.guardianInvitations =
-          new Resource$Userprofiles$Guardianinvitations();
-      this.guardians = new Resource$Userprofiles$Guardians();
+          new Resource$Userprofiles$Guardianinvitations(this.context);
+      this.guardians = new Resource$Userprofiles$Guardians(this.context);
     }
 
 
@@ -5650,7 +5676,7 @@ export namespace classroom_v1 {
         params,
         requiredParams: ['userId'],
         pathParams: ['userId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$UserProfile>(parameters, callback);
@@ -5675,7 +5701,10 @@ export namespace classroom_v1 {
   }
 
   export class Resource$Userprofiles$Guardianinvitations {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -5761,7 +5790,7 @@ export namespace classroom_v1 {
         params,
         requiredParams: ['studentId'],
         pathParams: ['studentId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GuardianInvitation>(parameters, callback);
@@ -5837,7 +5866,7 @@ export namespace classroom_v1 {
         params,
         requiredParams: ['studentId', 'invitationId'],
         pathParams: ['invitationId', 'studentId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GuardianInvitation>(parameters, callback);
@@ -5929,7 +5958,7 @@ export namespace classroom_v1 {
         params,
         requiredParams: ['studentId'],
         pathParams: ['studentId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListGuardianInvitationsResponse>(
@@ -6017,7 +6046,7 @@ export namespace classroom_v1 {
         params,
         requiredParams: ['studentId', 'invitationId'],
         pathParams: ['invitationId', 'studentId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GuardianInvitation>(parameters, callback);
@@ -6132,7 +6161,10 @@ export namespace classroom_v1 {
 
 
   export class Resource$Userprofiles$Guardians {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -6204,7 +6236,7 @@ export namespace classroom_v1 {
         params,
         requiredParams: ['studentId', 'guardianId'],
         pathParams: ['guardianId', 'studentId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -6278,7 +6310,7 @@ export namespace classroom_v1 {
         params,
         requiredParams: ['studentId', 'guardianId'],
         pathParams: ['guardianId', 'studentId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Guardian>(parameters, callback);
@@ -6364,7 +6396,7 @@ export namespace classroom_v1 {
         params,
         requiredParams: ['studentId'],
         pathParams: ['studentId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListGuardiansResponse>(parameters, callback);

--- a/src/apis/cloudasset/v1.ts
+++ b/src/apis/cloudasset/v1.ts
@@ -29,8 +29,6 @@ export namespace cloudasset_v1 {
     version: 'v1';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * V1 error format.
@@ -98,14 +96,15 @@ export namespace cloudasset_v1 {
    * @param {object=} options Options for Cloudasset
    */
   export class Cloudasset {
+    context: APIRequestContext;
     operations: Resource$Operations;
     v1: Resource$V1;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.operations = new Resource$Operations();
-      this.v1 = new Resource$V1();
+      this.operations = new Resource$Operations(this.context);
+      this.v1 = new Resource$V1(this.context);
     }
   }
 
@@ -534,7 +533,10 @@ export namespace cloudasset_v1 {
 
 
   export class Resource$Operations {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -590,7 +592,7 @@ export namespace cloudasset_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -614,7 +616,10 @@ export namespace cloudasset_v1 {
 
 
   export class Resource$V1 {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -689,7 +694,7 @@ export namespace cloudasset_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$BatchGetAssetsHistoryResponse>(
@@ -761,7 +766,7 @@ export namespace cloudasset_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);

--- a/src/apis/cloudasset/v1beta1.ts
+++ b/src/apis/cloudasset/v1beta1.ts
@@ -29,8 +29,6 @@ export namespace cloudasset_v1beta1 {
     version: 'v1beta1';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * V1 error format.
@@ -98,16 +96,17 @@ export namespace cloudasset_v1beta1 {
    * @param {object=} options Options for Cloudasset
    */
   export class Cloudasset {
+    context: APIRequestContext;
     folders: Resource$Folders;
     organizations: Resource$Organizations;
     projects: Resource$Projects;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.folders = new Resource$Folders();
-      this.organizations = new Resource$Organizations();
-      this.projects = new Resource$Projects();
+      this.folders = new Resource$Folders(this.context);
+      this.organizations = new Resource$Organizations(this.context);
+      this.projects = new Resource$Projects(this.context);
     }
   }
 
@@ -536,9 +535,11 @@ export namespace cloudasset_v1beta1 {
 
 
   export class Resource$Folders {
+    context: APIRequestContext;
     operations: Resource$Folders$Operations;
-    constructor() {
-      this.operations = new Resource$Folders$Operations();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.operations = new Resource$Folders$Operations(this.context);
     }
 
 
@@ -603,7 +604,7 @@ export namespace cloudasset_v1beta1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -635,7 +636,10 @@ export namespace cloudasset_v1beta1 {
   }
 
   export class Resource$Folders$Operations {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -692,7 +696,7 @@ export namespace cloudasset_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -718,9 +722,11 @@ export namespace cloudasset_v1beta1 {
 
 
   export class Resource$Organizations {
+    context: APIRequestContext;
     operations: Resource$Organizations$Operations;
-    constructor() {
-      this.operations = new Resource$Organizations$Operations();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.operations = new Resource$Organizations$Operations(this.context);
     }
 
 
@@ -796,7 +802,7 @@ export namespace cloudasset_v1beta1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$BatchGetAssetsHistoryResponse>(
@@ -869,7 +875,7 @@ export namespace cloudasset_v1beta1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -938,7 +944,10 @@ export namespace cloudasset_v1beta1 {
   }
 
   export class Resource$Organizations$Operations {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -995,7 +1004,7 @@ export namespace cloudasset_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -1021,9 +1030,11 @@ export namespace cloudasset_v1beta1 {
 
 
   export class Resource$Projects {
+    context: APIRequestContext;
     operations: Resource$Projects$Operations;
-    constructor() {
-      this.operations = new Resource$Projects$Operations();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.operations = new Resource$Projects$Operations(this.context);
     }
 
 
@@ -1099,7 +1110,7 @@ export namespace cloudasset_v1beta1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$BatchGetAssetsHistoryResponse>(
@@ -1172,7 +1183,7 @@ export namespace cloudasset_v1beta1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -1241,7 +1252,10 @@ export namespace cloudasset_v1beta1 {
   }
 
   export class Resource$Projects$Operations {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1298,7 +1312,7 @@ export namespace cloudasset_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);

--- a/src/apis/cloudbilling/v1.ts
+++ b/src/apis/cloudbilling/v1.ts
@@ -29,8 +29,6 @@ export namespace cloudbilling_v1 {
     version: 'v1';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * V1 error format.
@@ -99,16 +97,17 @@ export namespace cloudbilling_v1 {
    * @param {object=} options Options for Cloudbilling
    */
   export class Cloudbilling {
+    context: APIRequestContext;
     billingAccounts: Resource$Billingaccounts;
     projects: Resource$Projects;
     services: Resource$Services;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.billingAccounts = new Resource$Billingaccounts();
-      this.projects = new Resource$Projects();
-      this.services = new Resource$Services();
+      this.billingAccounts = new Resource$Billingaccounts(this.context);
+      this.projects = new Resource$Projects(this.context);
+      this.services = new Resource$Services(this.context);
     }
   }
 
@@ -675,9 +674,11 @@ export namespace cloudbilling_v1 {
 
 
   export class Resource$Billingaccounts {
+    context: APIRequestContext;
     projects: Resource$Billingaccounts$Projects;
-    constructor() {
-      this.projects = new Resource$Billingaccounts$Projects();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.projects = new Resource$Billingaccounts$Projects(this.context);
     }
 
 
@@ -745,7 +746,7 @@ export namespace cloudbilling_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$BillingAccount>(parameters, callback);
@@ -864,7 +865,7 @@ export namespace cloudbilling_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$BillingAccount>(parameters, callback);
@@ -933,7 +934,7 @@ export namespace cloudbilling_v1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -1072,7 +1073,7 @@ export namespace cloudbilling_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListBillingAccountsResponse>(
@@ -1146,7 +1147,7 @@ export namespace cloudbilling_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$BillingAccount>(parameters, callback);
@@ -1216,7 +1217,7 @@ export namespace cloudbilling_v1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -1293,7 +1294,7 @@ export namespace cloudbilling_v1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TestIamPermissionsResponse>(
@@ -1431,7 +1432,10 @@ export namespace cloudbilling_v1 {
   }
 
   export class Resource$Billingaccounts$Projects {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1571,7 +1575,7 @@ export namespace cloudbilling_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListProjectBillingInfoResponse>(
@@ -1612,7 +1616,10 @@ export namespace cloudbilling_v1 {
 
 
   export class Resource$Projects {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1730,7 +1737,7 @@ export namespace cloudbilling_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ProjectBillingInfo>(parameters, callback);
@@ -1883,7 +1890,7 @@ export namespace cloudbilling_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ProjectBillingInfo>(parameters, callback);
@@ -1927,9 +1934,11 @@ export namespace cloudbilling_v1 {
 
 
   export class Resource$Services {
+    context: APIRequestContext;
     skus: Resource$Services$Skus;
-    constructor() {
-      this.skus = new Resource$Services$Skus();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.skus = new Resource$Services$Skus(this.context);
     }
 
 
@@ -2052,7 +2061,7 @@ export namespace cloudbilling_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListServicesResponse>(parameters, callback);
@@ -2081,7 +2090,10 @@ export namespace cloudbilling_v1 {
   }
 
   export class Resource$Services$Skus {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -2212,7 +2224,7 @@ export namespace cloudbilling_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListSkusResponse>(parameters, callback);

--- a/src/apis/cloudbuild/v1.ts
+++ b/src/apis/cloudbuild/v1.ts
@@ -29,8 +29,6 @@ export namespace cloudbuild_v1 {
     version: 'v1';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * V1 error format.
@@ -98,14 +96,15 @@ export namespace cloudbuild_v1 {
    * @param {object=} options Options for Cloudbuild
    */
   export class Cloudbuild {
+    context: APIRequestContext;
     operations: Resource$Operations;
     projects: Resource$Projects;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.operations = new Resource$Operations();
-      this.projects = new Resource$Projects();
+      this.operations = new Resource$Operations(this.context);
+      this.projects = new Resource$Projects(this.context);
     }
   }
 
@@ -979,7 +978,10 @@ export namespace cloudbuild_v1 {
 
 
   export class Resource$Operations {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1046,7 +1048,7 @@ export namespace cloudbuild_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -1109,7 +1111,7 @@ export namespace cloudbuild_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -1185,7 +1187,7 @@ export namespace cloudbuild_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListOperationsResponse>(parameters, callback);
@@ -1249,17 +1251,22 @@ export namespace cloudbuild_v1 {
 
 
   export class Resource$Projects {
+    context: APIRequestContext;
     builds: Resource$Projects$Builds;
     triggers: Resource$Projects$Triggers;
-    constructor() {
-      this.builds = new Resource$Projects$Builds();
-      this.triggers = new Resource$Projects$Triggers();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.builds = new Resource$Projects$Builds(this.context);
+      this.triggers = new Resource$Projects$Triggers(this.context);
     }
   }
 
 
   export class Resource$Projects$Builds {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1320,7 +1327,7 @@ export namespace cloudbuild_v1 {
         params,
         requiredParams: ['projectId', 'id'],
         pathParams: ['id', 'projectId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Build>(parameters, callback);
@@ -1391,7 +1398,7 @@ export namespace cloudbuild_v1 {
         params,
         requiredParams: ['projectId'],
         pathParams: ['projectId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -1456,7 +1463,7 @@ export namespace cloudbuild_v1 {
         params,
         requiredParams: ['projectId', 'id'],
         pathParams: ['id', 'projectId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Build>(parameters, callback);
@@ -1528,7 +1535,7 @@ export namespace cloudbuild_v1 {
         params,
         requiredParams: ['projectId'],
         pathParams: ['projectId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListBuildsResponse>(parameters, callback);
@@ -1613,7 +1620,7 @@ export namespace cloudbuild_v1 {
         params,
         requiredParams: ['projectId', 'id'],
         pathParams: ['id', 'projectId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -1725,7 +1732,10 @@ export namespace cloudbuild_v1 {
 
 
   export class Resource$Projects$Triggers {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1786,7 +1796,7 @@ export namespace cloudbuild_v1 {
         params,
         requiredParams: ['projectId'],
         pathParams: ['projectId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$BuildTrigger>(parameters, callback);
@@ -1854,7 +1864,7 @@ export namespace cloudbuild_v1 {
         params,
         requiredParams: ['projectId', 'triggerId'],
         pathParams: ['projectId', 'triggerId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -1919,7 +1929,7 @@ export namespace cloudbuild_v1 {
         params,
         requiredParams: ['projectId', 'triggerId'],
         pathParams: ['projectId', 'triggerId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$BuildTrigger>(parameters, callback);
@@ -1991,7 +2001,7 @@ export namespace cloudbuild_v1 {
         params,
         requiredParams: ['projectId'],
         pathParams: ['projectId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListBuildTriggersResponse>(
@@ -2062,7 +2072,7 @@ export namespace cloudbuild_v1 {
         params,
         requiredParams: ['projectId', 'triggerId'],
         pathParams: ['projectId', 'triggerId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$BuildTrigger>(parameters, callback);
@@ -2128,7 +2138,7 @@ export namespace cloudbuild_v1 {
         params,
         requiredParams: ['projectId', 'triggerId'],
         pathParams: ['projectId', 'triggerId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);

--- a/src/apis/cloudbuild/v1alpha1.ts
+++ b/src/apis/cloudbuild/v1alpha1.ts
@@ -29,8 +29,6 @@ export namespace cloudbuild_v1alpha1 {
     version: 'v1alpha1';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * V1 error format.
@@ -98,12 +96,13 @@ export namespace cloudbuild_v1alpha1 {
    * @param {object=} options Options for Cloudbuild
    */
   export class Cloudbuild {
+    context: APIRequestContext;
     projects: Resource$Projects;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.projects = new Resource$Projects();
+      this.projects = new Resource$Projects(this.context);
     }
   }
 
@@ -827,15 +826,20 @@ export namespace cloudbuild_v1alpha1 {
 
 
   export class Resource$Projects {
+    context: APIRequestContext;
     workerPools: Resource$Projects$Workerpools;
-    constructor() {
-      this.workerPools = new Resource$Projects$Workerpools();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.workerPools = new Resource$Projects$Workerpools(this.context);
     }
   }
 
 
   export class Resource$Projects$Workerpools {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -897,7 +901,7 @@ export namespace cloudbuild_v1alpha1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$WorkerPool>(parameters, callback);
@@ -964,7 +968,7 @@ export namespace cloudbuild_v1alpha1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -1028,7 +1032,7 @@ export namespace cloudbuild_v1alpha1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$WorkerPool>(parameters, callback);
@@ -1096,7 +1100,7 @@ export namespace cloudbuild_v1alpha1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListWorkerPoolsResponse>(parameters, callback);
@@ -1164,7 +1168,7 @@ export namespace cloudbuild_v1alpha1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$WorkerPool>(parameters, callback);

--- a/src/apis/clouddebugger/v2.ts
+++ b/src/apis/clouddebugger/v2.ts
@@ -29,8 +29,6 @@ export namespace clouddebugger_v2 {
     version: 'v2';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * V1 error format.
@@ -99,14 +97,15 @@ export namespace clouddebugger_v2 {
    * @param {object=} options Options for Clouddebugger
    */
   export class Clouddebugger {
+    context: APIRequestContext;
     controller: Resource$Controller;
     debugger: Resource$Debugger;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.controller = new Resource$Controller();
-      this.debugger = new Resource$Debugger();
+      this.controller = new Resource$Controller(this.context);
+      this.debugger = new Resource$Debugger(this.context);
     }
   }
 
@@ -746,17 +745,22 @@ export namespace clouddebugger_v2 {
 
 
   export class Resource$Controller {
+    context: APIRequestContext;
     debuggees: Resource$Controller$Debuggees;
-    constructor() {
-      this.debuggees = new Resource$Controller$Debuggees();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.debuggees = new Resource$Controller$Debuggees(this.context);
     }
   }
 
 
   export class Resource$Controller$Debuggees {
+    context: APIRequestContext;
     breakpoints: Resource$Controller$Debuggees$Breakpoints;
-    constructor() {
-      this.breakpoints = new Resource$Controller$Debuggees$Breakpoints();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.breakpoints =
+          new Resource$Controller$Debuggees$Breakpoints(this.context);
     }
 
 
@@ -880,7 +884,7 @@ export namespace clouddebugger_v2 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$RegisterDebuggeeResponse>(parameters, callback);
@@ -905,7 +909,10 @@ export namespace clouddebugger_v2 {
   }
 
   export class Resource$Controller$Debuggees$Breakpoints {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1035,7 +1042,7 @@ export namespace clouddebugger_v2 {
         params,
         requiredParams: ['debuggeeId'],
         pathParams: ['debuggeeId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListActiveBreakpointsResponse>(
@@ -1181,7 +1188,7 @@ export namespace clouddebugger_v2 {
         params,
         requiredParams: ['debuggeeId', 'id'],
         pathParams: ['debuggeeId', 'id'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$UpdateActiveBreakpointResponse>(
@@ -1245,17 +1252,22 @@ export namespace clouddebugger_v2 {
 
 
   export class Resource$Debugger {
+    context: APIRequestContext;
     debuggees: Resource$Debugger$Debuggees;
-    constructor() {
-      this.debuggees = new Resource$Debugger$Debuggees();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.debuggees = new Resource$Debugger$Debuggees(this.context);
     }
   }
 
 
   export class Resource$Debugger$Debuggees {
+    context: APIRequestContext;
     breakpoints: Resource$Debugger$Debuggees$Breakpoints;
-    constructor() {
-      this.breakpoints = new Resource$Debugger$Debuggees$Breakpoints();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.breakpoints =
+          new Resource$Debugger$Debuggees$Breakpoints(this.context);
     }
 
 
@@ -1368,7 +1380,7 @@ export namespace clouddebugger_v2 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListDebuggeesResponse>(parameters, callback);
@@ -1402,7 +1414,10 @@ export namespace clouddebugger_v2 {
   }
 
   export class Resource$Debugger$Debuggees$Breakpoints {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1518,7 +1533,7 @@ export namespace clouddebugger_v2 {
         params,
         requiredParams: ['debuggeeId', 'breakpointId'],
         pathParams: ['breakpointId', 'debuggeeId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -1641,7 +1656,7 @@ export namespace clouddebugger_v2 {
         params,
         requiredParams: ['debuggeeId', 'breakpointId'],
         pathParams: ['breakpointId', 'debuggeeId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GetBreakpointResponse>(parameters, callback);
@@ -1767,7 +1782,7 @@ export namespace clouddebugger_v2 {
         params,
         requiredParams: ['debuggeeId'],
         pathParams: ['debuggeeId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListBreakpointsResponse>(parameters, callback);
@@ -1890,7 +1905,7 @@ export namespace clouddebugger_v2 {
         params,
         requiredParams: ['debuggeeId'],
         pathParams: ['debuggeeId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$SetBreakpointResponse>(parameters, callback);

--- a/src/apis/clouderrorreporting/v1beta1.ts
+++ b/src/apis/clouderrorreporting/v1beta1.ts
@@ -29,8 +29,6 @@ export namespace clouderrorreporting_v1beta1 {
     version: 'v1beta1';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * V1 error format.
@@ -100,12 +98,13 @@ export namespace clouderrorreporting_v1beta1 {
    * @param {object=} options Options for Clouderrorreporting
    */
   export class Clouderrorreporting {
+    context: APIRequestContext;
     projects: Resource$Projects;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.projects = new Resource$Projects();
+      this.projects = new Resource$Projects(this.context);
     }
   }
 
@@ -471,13 +470,15 @@ export namespace clouderrorreporting_v1beta1 {
 
 
   export class Resource$Projects {
+    context: APIRequestContext;
     events: Resource$Projects$Events;
     groups: Resource$Projects$Groups;
     groupStats: Resource$Projects$Groupstats;
-    constructor() {
-      this.events = new Resource$Projects$Events();
-      this.groups = new Resource$Projects$Groups();
-      this.groupStats = new Resource$Projects$Groupstats();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.events = new Resource$Projects$Events(this.context);
+      this.groups = new Resource$Projects$Groups(this.context);
+      this.groupStats = new Resource$Projects$Groupstats(this.context);
     }
 
 
@@ -541,7 +542,7 @@ export namespace clouderrorreporting_v1beta1 {
         params,
         requiredParams: ['projectName'],
         pathParams: ['projectName'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$DeleteEventsResponse>(parameters, callback);
@@ -568,7 +569,10 @@ export namespace clouderrorreporting_v1beta1 {
   }
 
   export class Resource$Projects$Events {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -636,7 +640,7 @@ export namespace clouderrorreporting_v1beta1 {
         params,
         requiredParams: ['projectName'],
         pathParams: ['projectName'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListEventsResponse>(parameters, callback);
@@ -713,7 +717,7 @@ export namespace clouderrorreporting_v1beta1 {
         params,
         requiredParams: ['projectName'],
         pathParams: ['projectName'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ReportErrorEventResponse>(parameters, callback);
@@ -792,7 +796,10 @@ export namespace clouderrorreporting_v1beta1 {
 
 
   export class Resource$Projects$Groups {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -849,7 +856,7 @@ export namespace clouderrorreporting_v1beta1 {
         params,
         requiredParams: ['groupName'],
         pathParams: ['groupName'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ErrorGroup>(parameters, callback);
@@ -918,7 +925,7 @@ export namespace clouderrorreporting_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ErrorGroup>(parameters, callback);
@@ -967,7 +974,10 @@ export namespace clouderrorreporting_v1beta1 {
 
 
   export class Resource$Projects$Groupstats {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1040,7 +1050,7 @@ export namespace clouderrorreporting_v1beta1 {
         params,
         requiredParams: ['projectName'],
         pathParams: ['projectName'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListGroupStatsResponse>(parameters, callback);

--- a/src/apis/cloudfunctions/v1.ts
+++ b/src/apis/cloudfunctions/v1.ts
@@ -29,8 +29,6 @@ export namespace cloudfunctions_v1 {
     version: 'v1';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * V1 error format.
@@ -98,14 +96,15 @@ export namespace cloudfunctions_v1 {
    * @param {object=} options Options for Cloudfunctions
    */
   export class Cloudfunctions {
+    context: APIRequestContext;
     operations: Resource$Operations;
     projects: Resource$Projects;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.operations = new Resource$Operations();
-      this.projects = new Resource$Projects();
+      this.operations = new Resource$Operations(this.context);
+      this.projects = new Resource$Projects(this.context);
     }
   }
 
@@ -813,7 +812,10 @@ export namespace cloudfunctions_v1 {
 
 
   export class Resource$Operations {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -870,7 +872,7 @@ export namespace cloudfunctions_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -947,7 +949,7 @@ export namespace cloudfunctions_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListOperationsResponse>(parameters, callback);
@@ -998,17 +1000,21 @@ export namespace cloudfunctions_v1 {
 
 
   export class Resource$Projects {
+    context: APIRequestContext;
     locations: Resource$Projects$Locations;
-    constructor() {
-      this.locations = new Resource$Projects$Locations();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.locations = new Resource$Projects$Locations(this.context);
     }
   }
 
 
   export class Resource$Projects$Locations {
+    context: APIRequestContext;
     functions: Resource$Projects$Locations$Functions;
-    constructor() {
-      this.functions = new Resource$Projects$Locations$Functions();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.functions = new Resource$Projects$Locations$Functions(this.context);
     }
 
 
@@ -1074,7 +1080,7 @@ export namespace cloudfunctions_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListLocationsResponse>(parameters, callback);
@@ -1110,7 +1116,10 @@ export namespace cloudfunctions_v1 {
   }
 
   export class Resource$Projects$Locations$Functions {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1175,7 +1184,7 @@ export namespace cloudfunctions_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$CallFunctionResponse>(parameters, callback);
@@ -1246,7 +1255,7 @@ export namespace cloudfunctions_v1 {
         params,
         requiredParams: ['location'],
         pathParams: ['location'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -1315,7 +1324,7 @@ export namespace cloudfunctions_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -1398,7 +1407,7 @@ export namespace cloudfunctions_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GenerateDownloadUrlResponse>(
@@ -1488,7 +1497,7 @@ export namespace cloudfunctions_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GenerateUploadUrlResponse>(
@@ -1552,7 +1561,7 @@ export namespace cloudfunctions_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$CloudFunction>(parameters, callback);
@@ -1622,7 +1631,7 @@ export namespace cloudfunctions_v1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -1693,7 +1702,7 @@ export namespace cloudfunctions_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListFunctionsResponse>(parameters, callback);
@@ -1762,7 +1771,7 @@ export namespace cloudfunctions_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -1833,7 +1842,7 @@ export namespace cloudfunctions_v1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -1913,7 +1922,7 @@ export namespace cloudfunctions_v1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TestIamPermissionsResponse>(

--- a/src/apis/cloudfunctions/v1beta2.ts
+++ b/src/apis/cloudfunctions/v1beta2.ts
@@ -29,8 +29,6 @@ export namespace cloudfunctions_v1beta2 {
     version: 'v1beta2';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * V1 error format.
@@ -98,14 +96,15 @@ export namespace cloudfunctions_v1beta2 {
    * @param {object=} options Options for Cloudfunctions
    */
   export class Cloudfunctions {
+    context: APIRequestContext;
     operations: Resource$Operations;
     projects: Resource$Projects;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.operations = new Resource$Operations();
-      this.projects = new Resource$Projects();
+      this.operations = new Resource$Operations(this.context);
+      this.projects = new Resource$Projects(this.context);
     }
   }
 
@@ -627,7 +626,10 @@ export namespace cloudfunctions_v1beta2 {
 
 
   export class Resource$Operations {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -684,7 +686,7 @@ export namespace cloudfunctions_v1beta2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -762,7 +764,7 @@ export namespace cloudfunctions_v1beta2 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListOperationsResponse>(parameters, callback);
@@ -813,17 +815,21 @@ export namespace cloudfunctions_v1beta2 {
 
 
   export class Resource$Projects {
+    context: APIRequestContext;
     locations: Resource$Projects$Locations;
-    constructor() {
-      this.locations = new Resource$Projects$Locations();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.locations = new Resource$Projects$Locations(this.context);
     }
   }
 
 
   export class Resource$Projects$Locations {
+    context: APIRequestContext;
     functions: Resource$Projects$Locations$Functions;
-    constructor() {
-      this.functions = new Resource$Projects$Locations$Functions();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.functions = new Resource$Projects$Locations$Functions(this.context);
     }
 
 
@@ -889,7 +895,7 @@ export namespace cloudfunctions_v1beta2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListLocationsResponse>(parameters, callback);
@@ -925,7 +931,10 @@ export namespace cloudfunctions_v1beta2 {
   }
 
   export class Resource$Projects$Locations$Functions {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -991,7 +1000,7 @@ export namespace cloudfunctions_v1beta2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$CallFunctionResponse>(parameters, callback);
@@ -1062,7 +1071,7 @@ export namespace cloudfunctions_v1beta2 {
         params,
         requiredParams: ['location'],
         pathParams: ['location'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -1131,7 +1140,7 @@ export namespace cloudfunctions_v1beta2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -1214,7 +1223,7 @@ export namespace cloudfunctions_v1beta2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GenerateDownloadUrlResponse>(
@@ -1304,7 +1313,7 @@ export namespace cloudfunctions_v1beta2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GenerateUploadUrlResponse>(
@@ -1368,7 +1377,7 @@ export namespace cloudfunctions_v1beta2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$CloudFunction>(parameters, callback);
@@ -1439,7 +1448,7 @@ export namespace cloudfunctions_v1beta2 {
         params,
         requiredParams: ['location'],
         pathParams: ['location'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListFunctionsResponse>(parameters, callback);
@@ -1507,7 +1516,7 @@ export namespace cloudfunctions_v1beta2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);

--- a/src/apis/cloudidentity/v1.ts
+++ b/src/apis/cloudidentity/v1.ts
@@ -29,8 +29,6 @@ export namespace cloudidentity_v1 {
     version: 'v1';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * V1 error format.
@@ -98,12 +96,13 @@ export namespace cloudidentity_v1 {
    * @param {object=} options Options for Cloudidentity
    */
   export class Cloudidentity {
+    context: APIRequestContext;
     groups: Resource$Groups;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.groups = new Resource$Groups();
+      this.groups = new Resource$Groups(this.context);
     }
   }
 
@@ -367,9 +366,11 @@ export namespace cloudidentity_v1 {
 
 
   export class Resource$Groups {
+    context: APIRequestContext;
     memberships: Resource$Groups$Memberships;
-    constructor() {
-      this.memberships = new Resource$Groups$Memberships();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.memberships = new Resource$Groups$Memberships(this.context);
     }
 
 
@@ -428,7 +429,7 @@ export namespace cloudidentity_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -493,7 +494,7 @@ export namespace cloudidentity_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -554,7 +555,7 @@ export namespace cloudidentity_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Group>(parameters, callback);
@@ -622,7 +623,7 @@ export namespace cloudidentity_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListGroupsResponse>(parameters, callback);
@@ -693,7 +694,7 @@ export namespace cloudidentity_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$LookupGroupNameResponse>(parameters, callback);
@@ -760,7 +761,7 @@ export namespace cloudidentity_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -830,7 +831,7 @@ export namespace cloudidentity_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$SearchGroupsResponse>(parameters, callback);
@@ -975,7 +976,10 @@ export namespace cloudidentity_v1 {
   }
 
   export class Resource$Groups$Memberships {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1037,7 +1041,7 @@ export namespace cloudidentity_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -1104,7 +1108,7 @@ export namespace cloudidentity_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -1167,7 +1171,7 @@ export namespace cloudidentity_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Membership>(parameters, callback);
@@ -1239,7 +1243,7 @@ export namespace cloudidentity_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListMembershipsResponse>(parameters, callback);
@@ -1316,7 +1320,7 @@ export namespace cloudidentity_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$LookupMembershipNameResponse>(

--- a/src/apis/cloudidentity/v1beta1.ts
+++ b/src/apis/cloudidentity/v1beta1.ts
@@ -29,8 +29,6 @@ export namespace cloudidentity_v1beta1 {
     version: 'v1beta1';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * V1 error format.
@@ -98,12 +96,13 @@ export namespace cloudidentity_v1beta1 {
    * @param {object=} options Options for Cloudidentity
    */
   export class Cloudidentity {
+    context: APIRequestContext;
     groups: Resource$Groups;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.groups = new Resource$Groups();
+      this.groups = new Resource$Groups(this.context);
     }
   }
 
@@ -357,9 +356,11 @@ export namespace cloudidentity_v1beta1 {
 
 
   export class Resource$Groups {
+    context: APIRequestContext;
     memberships: Resource$Groups$Memberships;
-    constructor() {
-      this.memberships = new Resource$Groups$Memberships();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.memberships = new Resource$Groups$Memberships(this.context);
     }
 
 
@@ -418,7 +419,7 @@ export namespace cloudidentity_v1beta1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -483,7 +484,7 @@ export namespace cloudidentity_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -544,7 +545,7 @@ export namespace cloudidentity_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Group>(parameters, callback);
@@ -615,7 +616,7 @@ export namespace cloudidentity_v1beta1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$LookupGroupNameResponse>(parameters, callback);
@@ -682,7 +683,7 @@ export namespace cloudidentity_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -752,7 +753,7 @@ export namespace cloudidentity_v1beta1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$SearchGroupsResponse>(parameters, callback);
@@ -875,7 +876,10 @@ export namespace cloudidentity_v1beta1 {
   }
 
   export class Resource$Groups$Memberships {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -937,7 +941,7 @@ export namespace cloudidentity_v1beta1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -1004,7 +1008,7 @@ export namespace cloudidentity_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -1067,7 +1071,7 @@ export namespace cloudidentity_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Membership>(parameters, callback);
@@ -1139,7 +1143,7 @@ export namespace cloudidentity_v1beta1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListMembershipsResponse>(parameters, callback);
@@ -1216,7 +1220,7 @@ export namespace cloudidentity_v1beta1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$LookupMembershipNameResponse>(

--- a/src/apis/cloudiot/v1.ts
+++ b/src/apis/cloudiot/v1.ts
@@ -29,8 +29,6 @@ export namespace cloudiot_v1 {
     version: 'v1';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * V1 error format.
@@ -99,12 +97,13 @@ export namespace cloudiot_v1 {
    * @param {object=} options Options for Cloudiot
    */
   export class Cloudiot {
+    context: APIRequestContext;
     projects: Resource$Projects;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.projects = new Resource$Projects();
+      this.projects = new Resource$Projects(this.context);
     }
   }
 
@@ -829,27 +828,36 @@ export namespace cloudiot_v1 {
 
 
   export class Resource$Projects {
+    context: APIRequestContext;
     locations: Resource$Projects$Locations;
-    constructor() {
-      this.locations = new Resource$Projects$Locations();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.locations = new Resource$Projects$Locations(this.context);
     }
   }
 
 
   export class Resource$Projects$Locations {
+    context: APIRequestContext;
     registries: Resource$Projects$Locations$Registries;
-    constructor() {
-      this.registries = new Resource$Projects$Locations$Registries();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.registries =
+          new Resource$Projects$Locations$Registries(this.context);
     }
   }
 
 
   export class Resource$Projects$Locations$Registries {
+    context: APIRequestContext;
     devices: Resource$Projects$Locations$Registries$Devices;
     groups: Resource$Projects$Locations$Registries$Groups;
-    constructor() {
-      this.devices = new Resource$Projects$Locations$Registries$Devices();
-      this.groups = new Resource$Projects$Locations$Registries$Groups();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.devices =
+          new Resource$Projects$Locations$Registries$Devices(this.context);
+      this.groups =
+          new Resource$Projects$Locations$Registries$Groups(this.context);
     }
 
 
@@ -922,7 +930,7 @@ export namespace cloudiot_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$BindDeviceToGatewayResponse>(
@@ -991,7 +999,7 @@ export namespace cloudiot_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$DeviceRegistry>(parameters, callback);
@@ -1056,7 +1064,7 @@ export namespace cloudiot_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -1118,7 +1126,7 @@ export namespace cloudiot_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$DeviceRegistry>(parameters, callback);
@@ -1188,7 +1196,7 @@ export namespace cloudiot_v1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -1262,7 +1270,7 @@ export namespace cloudiot_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListDeviceRegistriesResponse>(
@@ -1332,7 +1340,7 @@ export namespace cloudiot_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$DeviceRegistry>(parameters, callback);
@@ -1402,7 +1410,7 @@ export namespace cloudiot_v1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -1483,7 +1491,7 @@ export namespace cloudiot_v1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TestIamPermissionsResponse>(
@@ -1564,7 +1572,7 @@ export namespace cloudiot_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$UnbindDeviceFromGatewayResponse>(
@@ -1764,13 +1772,17 @@ export namespace cloudiot_v1 {
   }
 
   export class Resource$Projects$Locations$Registries$Devices {
+    context: APIRequestContext;
     configVersions:
         Resource$Projects$Locations$Registries$Devices$Configversions;
     states: Resource$Projects$Locations$Registries$Devices$States;
-    constructor() {
+    constructor(context: APIRequestContext) {
+      this.context = context;
       this.configVersions =
-          new Resource$Projects$Locations$Registries$Devices$Configversions();
-      this.states = new Resource$Projects$Locations$Registries$Devices$States();
+          new Resource$Projects$Locations$Registries$Devices$Configversions(
+              this.context);
+      this.states = new Resource$Projects$Locations$Registries$Devices$States(
+          this.context);
     }
 
 
@@ -1833,7 +1845,7 @@ export namespace cloudiot_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Device>(parameters, callback);
@@ -1900,7 +1912,7 @@ export namespace cloudiot_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -1964,7 +1976,7 @@ export namespace cloudiot_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Device>(parameters, callback);
@@ -2041,7 +2053,7 @@ export namespace cloudiot_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListDevicesResponse>(parameters, callback);
@@ -2118,7 +2130,7 @@ export namespace cloudiot_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$DeviceConfig>(parameters, callback);
@@ -2187,7 +2199,7 @@ export namespace cloudiot_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Device>(parameters, callback);
@@ -2278,7 +2290,7 @@ export namespace cloudiot_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$SendCommandToDeviceResponse>(
@@ -2475,7 +2487,10 @@ export namespace cloudiot_v1 {
   }
 
   export class Resource$Projects$Locations$Registries$Devices$Configversions {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -2551,7 +2566,7 @@ export namespace cloudiot_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListDeviceConfigVersionsResponse>(
@@ -2587,7 +2602,10 @@ export namespace cloudiot_v1 {
 
 
   export class Resource$Projects$Locations$Registries$Devices$States {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -2656,7 +2674,7 @@ export namespace cloudiot_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListDeviceStatesResponse>(parameters, callback);
@@ -2691,10 +2709,12 @@ export namespace cloudiot_v1 {
 
 
   export class Resource$Projects$Locations$Registries$Groups {
+    context: APIRequestContext;
     devices: Resource$Projects$Locations$Registries$Groups$Devices;
-    constructor() {
-      this.devices =
-          new Resource$Projects$Locations$Registries$Groups$Devices();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.devices = new Resource$Projects$Locations$Registries$Groups$Devices(
+          this.context);
     }
 
 
@@ -2767,7 +2787,7 @@ export namespace cloudiot_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$BindDeviceToGatewayResponse>(
@@ -2841,7 +2861,7 @@ export namespace cloudiot_v1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -2914,7 +2934,7 @@ export namespace cloudiot_v1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -2995,7 +3015,7 @@ export namespace cloudiot_v1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TestIamPermissionsResponse>(
@@ -3077,7 +3097,7 @@ export namespace cloudiot_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$UnbindDeviceFromGatewayResponse>(
@@ -3181,14 +3201,18 @@ export namespace cloudiot_v1 {
   }
 
   export class Resource$Projects$Locations$Registries$Groups$Devices {
+    context: APIRequestContext;
     configVersions:
         Resource$Projects$Locations$Registries$Groups$Devices$Configversions;
     states: Resource$Projects$Locations$Registries$Groups$Devices$States;
-    constructor() {
+    constructor(context: APIRequestContext) {
+      this.context = context;
       this.configVersions =
-          new Resource$Projects$Locations$Registries$Groups$Devices$Configversions();
+          new Resource$Projects$Locations$Registries$Groups$Devices$Configversions(
+              this.context);
       this.states =
-          new Resource$Projects$Locations$Registries$Groups$Devices$States();
+          new Resource$Projects$Locations$Registries$Groups$Devices$States(
+              this.context);
     }
 
 
@@ -3249,7 +3273,7 @@ export namespace cloudiot_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Device>(parameters, callback);
@@ -3329,7 +3353,7 @@ export namespace cloudiot_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListDevicesResponse>(parameters, callback);
@@ -3406,7 +3430,7 @@ export namespace cloudiot_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$DeviceConfig>(parameters, callback);
@@ -3478,7 +3502,7 @@ export namespace cloudiot_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Device>(parameters, callback);
@@ -3570,7 +3594,7 @@ export namespace cloudiot_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$SendCommandToDeviceResponse>(
@@ -3734,7 +3758,10 @@ export namespace cloudiot_v1 {
 
   export class
       Resource$Projects$Locations$Registries$Groups$Devices$Configversions {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -3811,7 +3838,7 @@ export namespace cloudiot_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListDeviceConfigVersionsResponse>(
@@ -3847,7 +3874,10 @@ export namespace cloudiot_v1 {
 
 
   export class Resource$Projects$Locations$Registries$Groups$Devices$States {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -3916,7 +3946,7 @@ export namespace cloudiot_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListDeviceStatesResponse>(parameters, callback);

--- a/src/apis/cloudkms/v1.ts
+++ b/src/apis/cloudkms/v1.ts
@@ -29,8 +29,6 @@ export namespace cloudkms_v1 {
     version: 'v1';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * V1 error format.
@@ -99,12 +97,13 @@ export namespace cloudkms_v1 {
    * @param {object=} options Options for Cloudkms
    */
   export class Cloudkms {
+    context: APIRequestContext;
     projects: Resource$Projects;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.projects = new Resource$Projects();
+      this.projects = new Resource$Projects(this.context);
     }
   }
 
@@ -731,17 +730,21 @@ export namespace cloudkms_v1 {
 
 
   export class Resource$Projects {
+    context: APIRequestContext;
     locations: Resource$Projects$Locations;
-    constructor() {
-      this.locations = new Resource$Projects$Locations();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.locations = new Resource$Projects$Locations(this.context);
     }
   }
 
 
   export class Resource$Projects$Locations {
+    context: APIRequestContext;
     keyRings: Resource$Projects$Locations$Keyrings;
-    constructor() {
-      this.keyRings = new Resource$Projects$Locations$Keyrings();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.keyRings = new Resource$Projects$Locations$Keyrings(this.context);
     }
 
 
@@ -796,7 +799,7 @@ export namespace cloudkms_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Location>(parameters, callback);
@@ -867,7 +870,7 @@ export namespace cloudkms_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListLocationsResponse>(parameters, callback);
@@ -915,11 +918,15 @@ export namespace cloudkms_v1 {
   }
 
   export class Resource$Projects$Locations$Keyrings {
+    context: APIRequestContext;
     cryptoKeys: Resource$Projects$Locations$Keyrings$Cryptokeys;
     importJobs: Resource$Projects$Locations$Keyrings$Importjobs;
-    constructor() {
-      this.cryptoKeys = new Resource$Projects$Locations$Keyrings$Cryptokeys();
-      this.importJobs = new Resource$Projects$Locations$Keyrings$Importjobs();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.cryptoKeys =
+          new Resource$Projects$Locations$Keyrings$Cryptokeys(this.context);
+      this.importJobs =
+          new Resource$Projects$Locations$Keyrings$Importjobs(this.context);
     }
 
 
@@ -981,7 +988,7 @@ export namespace cloudkms_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$KeyRing>(parameters, callback);
@@ -1042,7 +1049,7 @@ export namespace cloudkms_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$KeyRing>(parameters, callback);
@@ -1110,7 +1117,7 @@ export namespace cloudkms_v1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -1180,7 +1187,7 @@ export namespace cloudkms_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListKeyRingsResponse>(parameters, callback);
@@ -1249,7 +1256,7 @@ export namespace cloudkms_v1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -1329,7 +1336,7 @@ export namespace cloudkms_v1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TestIamPermissionsResponse>(
@@ -1451,11 +1458,14 @@ export namespace cloudkms_v1 {
   }
 
   export class Resource$Projects$Locations$Keyrings$Cryptokeys {
+    context: APIRequestContext;
     cryptoKeyVersions:
         Resource$Projects$Locations$Keyrings$Cryptokeys$Cryptokeyversions;
-    constructor() {
+    constructor(context: APIRequestContext) {
+      this.context = context;
       this.cryptoKeyVersions =
-          new Resource$Projects$Locations$Keyrings$Cryptokeys$Cryptokeyversions();
+          new Resource$Projects$Locations$Keyrings$Cryptokeys$Cryptokeyversions(
+              this.context);
     }
 
 
@@ -1521,7 +1531,7 @@ export namespace cloudkms_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$CryptoKey>(parameters, callback);
@@ -1592,7 +1602,7 @@ export namespace cloudkms_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$DecryptResponse>(parameters, callback);
@@ -1663,7 +1673,7 @@ export namespace cloudkms_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$EncryptResponse>(parameters, callback);
@@ -1728,7 +1738,7 @@ export namespace cloudkms_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$CryptoKey>(parameters, callback);
@@ -1800,7 +1810,7 @@ export namespace cloudkms_v1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -1873,7 +1883,7 @@ export namespace cloudkms_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListCryptoKeysResponse>(parameters, callback);
@@ -1943,7 +1953,7 @@ export namespace cloudkms_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$CryptoKey>(parameters, callback);
@@ -2016,7 +2026,7 @@ export namespace cloudkms_v1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -2099,7 +2109,7 @@ export namespace cloudkms_v1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TestIamPermissionsResponse>(
@@ -2176,7 +2186,7 @@ export namespace cloudkms_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$CryptoKey>(parameters, callback);
@@ -2377,7 +2387,10 @@ export namespace cloudkms_v1 {
 
   export class
       Resource$Projects$Locations$Keyrings$Cryptokeys$Cryptokeyversions {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -2449,7 +2462,7 @@ export namespace cloudkms_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AsymmetricDecryptResponse>(
@@ -2528,7 +2541,7 @@ export namespace cloudkms_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AsymmetricSignResponse>(parameters, callback);
@@ -2603,7 +2616,7 @@ export namespace cloudkms_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$CryptoKeyVersion>(parameters, callback);
@@ -2682,7 +2695,7 @@ export namespace cloudkms_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$CryptoKeyVersion>(parameters, callback);
@@ -2750,7 +2763,7 @@ export namespace cloudkms_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$CryptoKeyVersion>(parameters, callback);
@@ -2824,7 +2837,7 @@ export namespace cloudkms_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$PublicKey>(parameters, callback);
@@ -2905,7 +2918,7 @@ export namespace cloudkms_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListCryptoKeyVersionsResponse>(
@@ -2983,7 +2996,7 @@ export namespace cloudkms_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$CryptoKeyVersion>(parameters, callback);
@@ -3059,7 +3072,7 @@ export namespace cloudkms_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$CryptoKeyVersion>(parameters, callback);
@@ -3236,7 +3249,10 @@ export namespace cloudkms_v1 {
 
 
   export class Resource$Projects$Locations$Keyrings$Importjobs {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -3301,7 +3317,7 @@ export namespace cloudkms_v1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -3374,7 +3390,7 @@ export namespace cloudkms_v1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -3457,7 +3473,7 @@ export namespace cloudkms_v1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TestIamPermissionsResponse>(

--- a/src/apis/cloudprivatecatalog/v1beta1.ts
+++ b/src/apis/cloudprivatecatalog/v1beta1.ts
@@ -29,8 +29,6 @@ export namespace cloudprivatecatalog_v1beta1 {
     version: 'v1beta1';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * V1 error format.
@@ -99,16 +97,17 @@ export namespace cloudprivatecatalog_v1beta1 {
    * @param {object=} options Options for Cloudprivatecatalog
    */
   export class Cloudprivatecatalog {
+    context: APIRequestContext;
     folders: Resource$Folders;
     organizations: Resource$Organizations;
     projects: Resource$Projects;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.folders = new Resource$Folders();
-      this.organizations = new Resource$Organizations();
-      this.projects = new Resource$Projects();
+      this.folders = new Resource$Folders(this.context);
+      this.organizations = new Resource$Organizations(this.context);
+      this.projects = new Resource$Projects(this.context);
     }
   }
 
@@ -280,19 +279,24 @@ export namespace cloudprivatecatalog_v1beta1 {
 
 
   export class Resource$Folders {
+    context: APIRequestContext;
     catalogs: Resource$Folders$Catalogs;
     products: Resource$Folders$Products;
     versions: Resource$Folders$Versions;
-    constructor() {
-      this.catalogs = new Resource$Folders$Catalogs();
-      this.products = new Resource$Folders$Products();
-      this.versions = new Resource$Folders$Versions();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.catalogs = new Resource$Folders$Catalogs(this.context);
+      this.products = new Resource$Folders$Products(this.context);
+      this.versions = new Resource$Folders$Versions(this.context);
     }
   }
 
 
   export class Resource$Folders$Catalogs {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -369,7 +373,7 @@ export namespace cloudprivatecatalog_v1beta1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<
@@ -415,7 +419,10 @@ export namespace cloudprivatecatalog_v1beta1 {
 
 
   export class Resource$Folders$Products {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -492,7 +499,7 @@ export namespace cloudprivatecatalog_v1beta1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<
@@ -539,7 +546,10 @@ export namespace cloudprivatecatalog_v1beta1 {
 
 
   export class Resource$Folders$Versions {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -616,7 +626,7 @@ export namespace cloudprivatecatalog_v1beta1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<
@@ -665,19 +675,24 @@ export namespace cloudprivatecatalog_v1beta1 {
 
 
   export class Resource$Organizations {
+    context: APIRequestContext;
     catalogs: Resource$Organizations$Catalogs;
     products: Resource$Organizations$Products;
     versions: Resource$Organizations$Versions;
-    constructor() {
-      this.catalogs = new Resource$Organizations$Catalogs();
-      this.products = new Resource$Organizations$Products();
-      this.versions = new Resource$Organizations$Versions();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.catalogs = new Resource$Organizations$Catalogs(this.context);
+      this.products = new Resource$Organizations$Products(this.context);
+      this.versions = new Resource$Organizations$Versions(this.context);
     }
   }
 
 
   export class Resource$Organizations$Catalogs {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -754,7 +769,7 @@ export namespace cloudprivatecatalog_v1beta1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<
@@ -800,7 +815,10 @@ export namespace cloudprivatecatalog_v1beta1 {
 
 
   export class Resource$Organizations$Products {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -877,7 +895,7 @@ export namespace cloudprivatecatalog_v1beta1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<
@@ -924,7 +942,10 @@ export namespace cloudprivatecatalog_v1beta1 {
 
 
   export class Resource$Organizations$Versions {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1001,7 +1022,7 @@ export namespace cloudprivatecatalog_v1beta1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<
@@ -1050,19 +1071,24 @@ export namespace cloudprivatecatalog_v1beta1 {
 
 
   export class Resource$Projects {
+    context: APIRequestContext;
     catalogs: Resource$Projects$Catalogs;
     products: Resource$Projects$Products;
     versions: Resource$Projects$Versions;
-    constructor() {
-      this.catalogs = new Resource$Projects$Catalogs();
-      this.products = new Resource$Projects$Products();
-      this.versions = new Resource$Projects$Versions();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.catalogs = new Resource$Projects$Catalogs(this.context);
+      this.products = new Resource$Projects$Products(this.context);
+      this.versions = new Resource$Projects$Versions(this.context);
     }
   }
 
 
   export class Resource$Projects$Catalogs {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1139,7 +1165,7 @@ export namespace cloudprivatecatalog_v1beta1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<
@@ -1185,7 +1211,10 @@ export namespace cloudprivatecatalog_v1beta1 {
 
 
   export class Resource$Projects$Products {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1262,7 +1291,7 @@ export namespace cloudprivatecatalog_v1beta1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<
@@ -1309,7 +1338,10 @@ export namespace cloudprivatecatalog_v1beta1 {
 
 
   export class Resource$Projects$Versions {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1386,7 +1418,7 @@ export namespace cloudprivatecatalog_v1beta1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<

--- a/src/apis/cloudprivatecatalogproducer/v1beta1.ts
+++ b/src/apis/cloudprivatecatalogproducer/v1beta1.ts
@@ -29,8 +29,6 @@ export namespace cloudprivatecatalogproducer_v1beta1 {
     version: 'v1beta1';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * V1 error format.
@@ -100,14 +98,15 @@ export namespace cloudprivatecatalogproducer_v1beta1 {
    * @param {object=} options Options for Cloudprivatecatalogproducer
    */
   export class Cloudprivatecatalogproducer {
+    context: APIRequestContext;
     catalogs: Resource$Catalogs;
     operations: Resource$Operations;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.catalogs = new Resource$Catalogs();
-      this.operations = new Resource$Operations();
+      this.catalogs = new Resource$Catalogs(this.context);
+      this.operations = new Resource$Operations(this.context);
     }
   }
 
@@ -701,11 +700,13 @@ export namespace cloudprivatecatalogproducer_v1beta1 {
 
 
   export class Resource$Catalogs {
+    context: APIRequestContext;
     associations: Resource$Catalogs$Associations;
     products: Resource$Catalogs$Products;
-    constructor() {
-      this.associations = new Resource$Catalogs$Associations();
-      this.products = new Resource$Catalogs$Products();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.associations = new Resource$Catalogs$Associations(this.context);
+      this.products = new Resource$Catalogs$Products(this.context);
     }
 
 
@@ -769,7 +770,7 @@ export namespace cloudprivatecatalogproducer_v1beta1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleLongrunningOperation>(
@@ -844,7 +845,7 @@ export namespace cloudprivatecatalogproducer_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<
@@ -914,7 +915,7 @@ export namespace cloudprivatecatalogproducer_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<
@@ -986,7 +987,7 @@ export namespace cloudprivatecatalogproducer_v1beta1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleIamV1Policy>(parameters, callback);
@@ -1065,7 +1066,7 @@ export namespace cloudprivatecatalogproducer_v1beta1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<
@@ -1141,7 +1142,7 @@ export namespace cloudprivatecatalogproducer_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<
@@ -1214,7 +1215,7 @@ export namespace cloudprivatecatalogproducer_v1beta1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleIamV1Policy>(parameters, callback);
@@ -1293,7 +1294,7 @@ export namespace cloudprivatecatalogproducer_v1beta1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleIamV1TestIamPermissionsResponse>(
@@ -1370,7 +1371,7 @@ export namespace cloudprivatecatalogproducer_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<
@@ -1535,7 +1536,10 @@ export namespace cloudprivatecatalogproducer_v1beta1 {
   }
 
   export class Resource$Catalogs$Associations {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1606,7 +1610,7 @@ export namespace cloudprivatecatalogproducer_v1beta1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<
@@ -1677,7 +1681,7 @@ export namespace cloudprivatecatalogproducer_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleProtobufEmpty>(parameters, callback);
@@ -1749,7 +1753,7 @@ export namespace cloudprivatecatalogproducer_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<
@@ -1835,7 +1839,7 @@ export namespace cloudprivatecatalogproducer_v1beta1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<
@@ -1915,11 +1919,13 @@ export namespace cloudprivatecatalogproducer_v1beta1 {
 
 
   export class Resource$Catalogs$Products {
+    context: APIRequestContext;
     icons: Resource$Catalogs$Products$Icons;
     versions: Resource$Catalogs$Products$Versions;
-    constructor() {
-      this.icons = new Resource$Catalogs$Products$Icons();
-      this.versions = new Resource$Catalogs$Products$Versions();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.icons = new Resource$Catalogs$Products$Icons(this.context);
+      this.versions = new Resource$Catalogs$Products$Versions(this.context);
     }
 
 
@@ -1987,7 +1993,7 @@ export namespace cloudprivatecatalogproducer_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleLongrunningOperation>(
@@ -2064,7 +2070,7 @@ export namespace cloudprivatecatalogproducer_v1beta1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<
@@ -2134,7 +2140,7 @@ export namespace cloudprivatecatalogproducer_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleProtobufEmpty>(parameters, callback);
@@ -2204,7 +2210,7 @@ export namespace cloudprivatecatalogproducer_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<
@@ -2291,7 +2297,7 @@ export namespace cloudprivatecatalogproducer_v1beta1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<
@@ -2371,7 +2377,7 @@ export namespace cloudprivatecatalogproducer_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<
@@ -2497,7 +2503,10 @@ export namespace cloudprivatecatalogproducer_v1beta1 {
   }
 
   export class Resource$Catalogs$Products$Icons {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -2563,7 +2572,7 @@ export namespace cloudprivatecatalogproducer_v1beta1 {
         params,
         requiredParams: ['product'],
         pathParams: ['product'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleProtobufEmpty>(parameters, callback);
@@ -2594,7 +2603,10 @@ export namespace cloudprivatecatalogproducer_v1beta1 {
 
 
   export class Resource$Catalogs$Products$Versions {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -2661,7 +2673,7 @@ export namespace cloudprivatecatalogproducer_v1beta1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleLongrunningOperation>(
@@ -2729,7 +2741,7 @@ export namespace cloudprivatecatalogproducer_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleProtobufEmpty>(parameters, callback);
@@ -2799,7 +2811,7 @@ export namespace cloudprivatecatalogproducer_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<
@@ -2885,7 +2897,7 @@ export namespace cloudprivatecatalogproducer_v1beta1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<
@@ -2965,7 +2977,7 @@ export namespace cloudprivatecatalogproducer_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<
@@ -3070,7 +3082,10 @@ export namespace cloudprivatecatalogproducer_v1beta1 {
 
 
   export class Resource$Operations {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -3139,7 +3154,7 @@ export namespace cloudprivatecatalogproducer_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleProtobufEmpty>(parameters, callback);
@@ -3208,7 +3223,7 @@ export namespace cloudprivatecatalogproducer_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleProtobufEmpty>(parameters, callback);
@@ -3276,7 +3291,7 @@ export namespace cloudprivatecatalogproducer_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleLongrunningOperation>(
@@ -3359,7 +3374,7 @@ export namespace cloudprivatecatalogproducer_v1beta1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleLongrunningListOperationsResponse>(

--- a/src/apis/cloudprofiler/v2.ts
+++ b/src/apis/cloudprofiler/v2.ts
@@ -29,8 +29,6 @@ export namespace cloudprofiler_v2 {
     version: 'v2';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * V1 error format.
@@ -98,12 +96,13 @@ export namespace cloudprofiler_v2 {
    * @param {object=} options Options for Cloudprofiler
    */
   export class Cloudprofiler {
+    context: APIRequestContext;
     projects: Resource$Projects;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.projects = new Resource$Projects();
+      this.projects = new Resource$Projects(this.context);
     }
   }
 
@@ -197,15 +196,20 @@ export namespace cloudprofiler_v2 {
 
 
   export class Resource$Projects {
+    context: APIRequestContext;
     profiles: Resource$Projects$Profiles;
-    constructor() {
-      this.profiles = new Resource$Projects$Profiles();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.profiles = new Resource$Projects$Profiles(this.context);
     }
   }
 
 
   export class Resource$Projects$Profiles {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -275,7 +279,7 @@ export namespace cloudprofiler_v2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Profile>(parameters, callback);
@@ -345,7 +349,7 @@ export namespace cloudprofiler_v2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Profile>(parameters, callback);
@@ -416,7 +420,7 @@ export namespace cloudprofiler_v2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Profile>(parameters, callback);

--- a/src/apis/cloudresourcemanager/v1.ts
+++ b/src/apis/cloudresourcemanager/v1.ts
@@ -29,8 +29,6 @@ export namespace cloudresourcemanager_v1 {
     version: 'v1';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * V1 error format.
@@ -99,6 +97,7 @@ export namespace cloudresourcemanager_v1 {
    * @param {object=} options Options for Cloudresourcemanager
    */
   export class Cloudresourcemanager {
+    context: APIRequestContext;
     folders: Resource$Folders;
     liens: Resource$Liens;
     operations: Resource$Operations;
@@ -106,13 +105,13 @@ export namespace cloudresourcemanager_v1 {
     projects: Resource$Projects;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.folders = new Resource$Folders();
-      this.liens = new Resource$Liens();
-      this.operations = new Resource$Operations();
-      this.organizations = new Resource$Organizations();
-      this.projects = new Resource$Projects();
+      this.folders = new Resource$Folders(this.context);
+      this.liens = new Resource$Liens(this.context);
+      this.operations = new Resource$Operations(this.context);
+      this.organizations = new Resource$Organizations(this.context);
+      this.projects = new Resource$Projects(this.context);
     }
   }
 
@@ -1138,7 +1137,10 @@ export namespace cloudresourcemanager_v1 {
 
 
   export class Resource$Folders {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1253,7 +1255,7 @@ export namespace cloudresourcemanager_v1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -1383,7 +1385,7 @@ export namespace cloudresourcemanager_v1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$OrgPolicy>(parameters, callback);
@@ -1511,7 +1513,7 @@ export namespace cloudresourcemanager_v1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$OrgPolicy>(parameters, callback);
@@ -1664,7 +1666,7 @@ export namespace cloudresourcemanager_v1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListAvailableOrgPolicyConstraintsResponse>(
@@ -1807,7 +1809,7 @@ export namespace cloudresourcemanager_v1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListOrgPoliciesResponse>(parameters, callback);
@@ -1934,7 +1936,7 @@ export namespace cloudresourcemanager_v1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$OrgPolicy>(parameters, callback);
@@ -2049,7 +2051,10 @@ export namespace cloudresourcemanager_v1 {
 
 
   export class Resource$Liens {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -2164,7 +2169,7 @@ export namespace cloudresourcemanager_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Lien>(parameters, callback);
@@ -2281,7 +2286,7 @@ export namespace cloudresourcemanager_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -2345,7 +2350,7 @@ export namespace cloudresourcemanager_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Lien>(parameters, callback);
@@ -2478,7 +2483,7 @@ export namespace cloudresourcemanager_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListLiensResponse>(parameters, callback);
@@ -2547,7 +2552,10 @@ export namespace cloudresourcemanager_v1 {
 
 
   export class Resource$Operations {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -2657,7 +2665,7 @@ export namespace cloudresourcemanager_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -2681,7 +2689,10 @@ export namespace cloudresourcemanager_v1 {
 
 
   export class Resource$Organizations {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -2795,7 +2806,7 @@ export namespace cloudresourcemanager_v1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -2911,7 +2922,7 @@ export namespace cloudresourcemanager_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Organization>(parameters, callback);
@@ -3041,7 +3052,7 @@ export namespace cloudresourcemanager_v1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$OrgPolicy>(parameters, callback);
@@ -3171,7 +3182,7 @@ export namespace cloudresourcemanager_v1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -3300,7 +3311,7 @@ export namespace cloudresourcemanager_v1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$OrgPolicy>(parameters, callback);
@@ -3456,7 +3467,7 @@ export namespace cloudresourcemanager_v1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListAvailableOrgPolicyConstraintsResponse>(
@@ -3602,7 +3613,7 @@ export namespace cloudresourcemanager_v1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListOrgPoliciesResponse>(parameters, callback);
@@ -3746,7 +3757,7 @@ export namespace cloudresourcemanager_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$SearchOrganizationsResponse>(
@@ -3877,7 +3888,7 @@ export namespace cloudresourcemanager_v1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -4005,7 +4016,7 @@ export namespace cloudresourcemanager_v1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$OrgPolicy>(parameters, callback);
@@ -4141,7 +4152,7 @@ export namespace cloudresourcemanager_v1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TestIamPermissionsResponse>(
@@ -4338,7 +4349,10 @@ export namespace cloudresourcemanager_v1 {
 
 
   export class Resource$Projects {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -4453,7 +4467,7 @@ export namespace cloudresourcemanager_v1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -4585,7 +4599,7 @@ export namespace cloudresourcemanager_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -4711,7 +4725,7 @@ export namespace cloudresourcemanager_v1 {
         params,
         requiredParams: ['projectId'],
         pathParams: ['projectId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -4829,7 +4843,7 @@ export namespace cloudresourcemanager_v1 {
         params,
         requiredParams: ['projectId'],
         pathParams: ['projectId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Project>(parameters, callback);
@@ -4957,7 +4971,7 @@ export namespace cloudresourcemanager_v1 {
         params,
         requiredParams: ['projectId'],
         pathParams: ['projectId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GetAncestryResponse>(parameters, callback);
@@ -5087,7 +5101,7 @@ export namespace cloudresourcemanager_v1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$OrgPolicy>(parameters, callback);
@@ -5216,7 +5230,7 @@ export namespace cloudresourcemanager_v1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -5344,7 +5358,7 @@ export namespace cloudresourcemanager_v1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$OrgPolicy>(parameters, callback);
@@ -5480,7 +5494,7 @@ export namespace cloudresourcemanager_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListProjectsResponse>(parameters, callback);
@@ -5633,7 +5647,7 @@ export namespace cloudresourcemanager_v1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListAvailableOrgPolicyConstraintsResponse>(
@@ -5776,7 +5790,7 @@ export namespace cloudresourcemanager_v1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListOrgPoliciesResponse>(parameters, callback);
@@ -5928,7 +5942,7 @@ export namespace cloudresourcemanager_v1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -6055,7 +6069,7 @@ export namespace cloudresourcemanager_v1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$OrgPolicy>(parameters, callback);
@@ -6188,7 +6202,7 @@ export namespace cloudresourcemanager_v1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TestIamPermissionsResponse>(
@@ -6316,7 +6330,7 @@ export namespace cloudresourcemanager_v1 {
         params,
         requiredParams: ['projectId'],
         pathParams: ['projectId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -6444,7 +6458,7 @@ export namespace cloudresourcemanager_v1 {
         params,
         requiredParams: ['projectId'],
         pathParams: ['projectId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Project>(parameters, callback);

--- a/src/apis/cloudresourcemanager/v1beta1.ts
+++ b/src/apis/cloudresourcemanager/v1beta1.ts
@@ -29,8 +29,6 @@ export namespace cloudresourcemanager_v1beta1 {
     version: 'v1beta1';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * V1 error format.
@@ -99,14 +97,15 @@ export namespace cloudresourcemanager_v1beta1 {
    * @param {object=} options Options for Cloudresourcemanager
    */
   export class Cloudresourcemanager {
+    context: APIRequestContext;
     organizations: Resource$Organizations;
     projects: Resource$Projects;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.organizations = new Resource$Organizations();
-      this.projects = new Resource$Projects();
+      this.organizations = new Resource$Organizations(this.context);
+      this.projects = new Resource$Projects(this.context);
     }
   }
 
@@ -580,7 +579,10 @@ export namespace cloudresourcemanager_v1beta1 {
 
 
   export class Resource$Organizations {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -690,7 +692,7 @@ export namespace cloudresourcemanager_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Organization>(parameters, callback);
@@ -817,7 +819,7 @@ export namespace cloudresourcemanager_v1beta1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -955,7 +957,7 @@ export namespace cloudresourcemanager_v1beta1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListOrganizationsResponse>(
@@ -1083,7 +1085,7 @@ export namespace cloudresourcemanager_v1beta1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -1218,7 +1220,7 @@ export namespace cloudresourcemanager_v1beta1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TestIamPermissionsResponse>(
@@ -1348,7 +1350,7 @@ export namespace cloudresourcemanager_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Organization>(parameters, callback);
@@ -1483,7 +1485,10 @@ export namespace cloudresourcemanager_v1beta1 {
 
 
   export class Resource$Projects {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1605,7 +1610,7 @@ export namespace cloudresourcemanager_v1beta1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Project>(parameters, callback);
@@ -1731,7 +1736,7 @@ export namespace cloudresourcemanager_v1beta1 {
         params,
         requiredParams: ['projectId'],
         pathParams: ['projectId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -1849,7 +1854,7 @@ export namespace cloudresourcemanager_v1beta1 {
         params,
         requiredParams: ['projectId'],
         pathParams: ['projectId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Project>(parameters, callback);
@@ -1977,7 +1982,7 @@ export namespace cloudresourcemanager_v1beta1 {
         params,
         requiredParams: ['projectId'],
         pathParams: ['projectId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GetAncestryResponse>(parameters, callback);
@@ -2104,7 +2109,7 @@ export namespace cloudresourcemanager_v1beta1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -2241,7 +2246,7 @@ export namespace cloudresourcemanager_v1beta1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListProjectsResponse>(parameters, callback);
@@ -2389,7 +2394,7 @@ export namespace cloudresourcemanager_v1beta1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -2521,7 +2526,7 @@ export namespace cloudresourcemanager_v1beta1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TestIamPermissionsResponse>(
@@ -2649,7 +2654,7 @@ export namespace cloudresourcemanager_v1beta1 {
         params,
         requiredParams: ['projectId'],
         pathParams: ['projectId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -2777,7 +2782,7 @@ export namespace cloudresourcemanager_v1beta1 {
         params,
         requiredParams: ['projectId'],
         pathParams: ['projectId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Project>(parameters, callback);

--- a/src/apis/cloudresourcemanager/v2.ts
+++ b/src/apis/cloudresourcemanager/v2.ts
@@ -29,8 +29,6 @@ export namespace cloudresourcemanager_v2 {
     version: 'v2';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * V1 error format.
@@ -99,14 +97,15 @@ export namespace cloudresourcemanager_v2 {
    * @param {object=} options Options for Cloudresourcemanager
    */
   export class Cloudresourcemanager {
+    context: APIRequestContext;
     folders: Resource$Folders;
     operations: Resource$Operations;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.folders = new Resource$Folders();
-      this.operations = new Resource$Operations();
+      this.folders = new Resource$Folders(this.context);
+      this.operations = new Resource$Operations(this.context);
     }
   }
 
@@ -579,7 +578,10 @@ export namespace cloudresourcemanager_v2 {
 
 
   export class Resource$Folders {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -655,7 +657,7 @@ export namespace cloudresourcemanager_v2 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -724,7 +726,7 @@ export namespace cloudresourcemanager_v2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Folder>(parameters, callback);
@@ -788,7 +790,7 @@ export namespace cloudresourcemanager_v2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Folder>(parameters, callback);
@@ -860,7 +862,7 @@ export namespace cloudresourcemanager_v2 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -933,7 +935,7 @@ export namespace cloudresourcemanager_v2 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListFoldersResponse>(parameters, callback);
@@ -1011,7 +1013,7 @@ export namespace cloudresourcemanager_v2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -1087,7 +1089,7 @@ export namespace cloudresourcemanager_v2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Folder>(parameters, callback);
@@ -1158,7 +1160,7 @@ export namespace cloudresourcemanager_v2 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$SearchFoldersResponse>(parameters, callback);
@@ -1230,7 +1232,7 @@ export namespace cloudresourcemanager_v2 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -1308,7 +1310,7 @@ export namespace cloudresourcemanager_v2 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TestIamPermissionsResponse>(
@@ -1382,7 +1384,7 @@ export namespace cloudresourcemanager_v2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Folder>(parameters, callback);
@@ -1587,7 +1589,10 @@ export namespace cloudresourcemanager_v2 {
 
 
   export class Resource$Operations {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1644,7 +1649,7 @@ export namespace cloudresourcemanager_v2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);

--- a/src/apis/cloudresourcemanager/v2beta1.ts
+++ b/src/apis/cloudresourcemanager/v2beta1.ts
@@ -29,8 +29,6 @@ export namespace cloudresourcemanager_v2beta1 {
     version: 'v2beta1';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * V1 error format.
@@ -99,14 +97,15 @@ export namespace cloudresourcemanager_v2beta1 {
    * @param {object=} options Options for Cloudresourcemanager
    */
   export class Cloudresourcemanager {
+    context: APIRequestContext;
     folders: Resource$Folders;
     operations: Resource$Operations;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.folders = new Resource$Folders();
-      this.operations = new Resource$Operations();
+      this.folders = new Resource$Folders(this.context);
+      this.operations = new Resource$Operations(this.context);
     }
   }
 
@@ -579,7 +578,10 @@ export namespace cloudresourcemanager_v2beta1 {
 
 
   export class Resource$Folders {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -655,7 +657,7 @@ export namespace cloudresourcemanager_v2beta1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -724,7 +726,7 @@ export namespace cloudresourcemanager_v2beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Folder>(parameters, callback);
@@ -788,7 +790,7 @@ export namespace cloudresourcemanager_v2beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Folder>(parameters, callback);
@@ -860,7 +862,7 @@ export namespace cloudresourcemanager_v2beta1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -933,7 +935,7 @@ export namespace cloudresourcemanager_v2beta1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListFoldersResponse>(parameters, callback);
@@ -1011,7 +1013,7 @@ export namespace cloudresourcemanager_v2beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -1087,7 +1089,7 @@ export namespace cloudresourcemanager_v2beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Folder>(parameters, callback);
@@ -1158,7 +1160,7 @@ export namespace cloudresourcemanager_v2beta1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$SearchFoldersResponse>(parameters, callback);
@@ -1230,7 +1232,7 @@ export namespace cloudresourcemanager_v2beta1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -1308,7 +1310,7 @@ export namespace cloudresourcemanager_v2beta1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TestIamPermissionsResponse>(
@@ -1382,7 +1384,7 @@ export namespace cloudresourcemanager_v2beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Folder>(parameters, callback);
@@ -1587,7 +1589,10 @@ export namespace cloudresourcemanager_v2beta1 {
 
 
   export class Resource$Operations {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1644,7 +1649,7 @@ export namespace cloudresourcemanager_v2beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);

--- a/src/apis/cloudscheduler/v1beta1.ts
+++ b/src/apis/cloudscheduler/v1beta1.ts
@@ -29,8 +29,6 @@ export namespace cloudscheduler_v1beta1 {
     version: 'v1beta1';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * V1 error format.
@@ -98,12 +96,13 @@ export namespace cloudscheduler_v1beta1 {
    * @param {object=} options Options for Cloudscheduler
    */
   export class Cloudscheduler {
+    context: APIRequestContext;
     projects: Resource$Projects;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.projects = new Resource$Projects();
+      this.projects = new Resource$Projects(this.context);
     }
   }
 
@@ -608,17 +607,21 @@ export namespace cloudscheduler_v1beta1 {
 
 
   export class Resource$Projects {
+    context: APIRequestContext;
     locations: Resource$Projects$Locations;
-    constructor() {
-      this.locations = new Resource$Projects$Locations();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.locations = new Resource$Projects$Locations(this.context);
     }
   }
 
 
   export class Resource$Projects$Locations {
+    context: APIRequestContext;
     jobs: Resource$Projects$Locations$Jobs;
-    constructor() {
-      this.jobs = new Resource$Projects$Locations$Jobs();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.jobs = new Resource$Projects$Locations$Jobs(this.context);
     }
 
 
@@ -674,7 +677,7 @@ export namespace cloudscheduler_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Location>(parameters, callback);
@@ -746,7 +749,7 @@ export namespace cloudscheduler_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListLocationsResponse>(parameters, callback);
@@ -794,7 +797,10 @@ export namespace cloudscheduler_v1beta1 {
   }
 
   export class Resource$Projects$Locations$Jobs {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -855,7 +861,7 @@ export namespace cloudscheduler_v1beta1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Job>(parameters, callback);
@@ -921,7 +927,7 @@ export namespace cloudscheduler_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -983,7 +989,7 @@ export namespace cloudscheduler_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Job>(parameters, callback);
@@ -1053,7 +1059,7 @@ export namespace cloudscheduler_v1beta1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListJobsResponse>(parameters, callback);
@@ -1126,7 +1132,7 @@ export namespace cloudscheduler_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Job>(parameters, callback);
@@ -1197,7 +1203,7 @@ export namespace cloudscheduler_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Job>(parameters, callback);
@@ -1268,7 +1274,7 @@ export namespace cloudscheduler_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Job>(parameters, callback);
@@ -1333,7 +1339,7 @@ export namespace cloudscheduler_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Job>(parameters, callback);

--- a/src/apis/cloudsearch/v1.ts
+++ b/src/apis/cloudsearch/v1.ts
@@ -29,8 +29,6 @@ export namespace cloudsearch_v1 {
     version: 'v1';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * V1 error format.
@@ -99,6 +97,7 @@ export namespace cloudsearch_v1 {
    * @param {object=} options Options for Cloudsearch
    */
   export class Cloudsearch {
+    context: APIRequestContext;
     debug: Resource$Debug;
     indexing: Resource$Indexing;
     media: Resource$Media;
@@ -108,15 +107,15 @@ export namespace cloudsearch_v1 {
     stats: Resource$Stats;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.debug = new Resource$Debug();
-      this.indexing = new Resource$Indexing();
-      this.media = new Resource$Media();
-      this.operations = new Resource$Operations();
-      this.query = new Resource$Query();
-      this.settings = new Resource$Settings();
-      this.stats = new Resource$Stats();
+      this.debug = new Resource$Debug(this.context);
+      this.indexing = new Resource$Indexing(this.context);
+      this.media = new Resource$Media(this.context);
+      this.operations = new Resource$Operations(this.context);
+      this.query = new Resource$Query(this.context);
+      this.settings = new Resource$Settings(this.context);
+      this.stats = new Resource$Stats(this.context);
     }
   }
 
@@ -2615,27 +2614,34 @@ export namespace cloudsearch_v1 {
 
 
   export class Resource$Debug {
+    context: APIRequestContext;
     datasources: Resource$Debug$Datasources;
     identitysources: Resource$Debug$Identitysources;
-    constructor() {
-      this.datasources = new Resource$Debug$Datasources();
-      this.identitysources = new Resource$Debug$Identitysources();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.datasources = new Resource$Debug$Datasources(this.context);
+      this.identitysources = new Resource$Debug$Identitysources(this.context);
     }
   }
 
 
   export class Resource$Debug$Datasources {
+    context: APIRequestContext;
     items: Resource$Debug$Datasources$Items;
-    constructor() {
-      this.items = new Resource$Debug$Datasources$Items();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.items = new Resource$Debug$Datasources$Items(this.context);
     }
   }
 
 
   export class Resource$Debug$Datasources$Items {
+    context: APIRequestContext;
     unmappedids: Resource$Debug$Datasources$Items$Unmappedids;
-    constructor() {
-      this.unmappedids = new Resource$Debug$Datasources$Items$Unmappedids();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.unmappedids =
+          new Resource$Debug$Datasources$Items$Unmappedids(this.context);
     }
 
 
@@ -2699,7 +2705,7 @@ export namespace cloudsearch_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$CheckAccessResponse>(parameters, callback);
@@ -2775,7 +2781,7 @@ export namespace cloudsearch_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$SearchItemsByViewUrlResponse>(
@@ -2828,7 +2834,10 @@ export namespace cloudsearch_v1 {
   }
 
   export class Resource$Debug$Datasources$Items$Unmappedids {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -2897,7 +2906,7 @@ export namespace cloudsearch_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListUnmappedIdentitiesResponse>(
@@ -2939,17 +2948,23 @@ export namespace cloudsearch_v1 {
 
 
   export class Resource$Debug$Identitysources {
+    context: APIRequestContext;
     items: Resource$Debug$Identitysources$Items;
     unmappedids: Resource$Debug$Identitysources$Unmappedids;
-    constructor() {
-      this.items = new Resource$Debug$Identitysources$Items();
-      this.unmappedids = new Resource$Debug$Identitysources$Unmappedids();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.items = new Resource$Debug$Identitysources$Items(this.context);
+      this.unmappedids =
+          new Resource$Debug$Identitysources$Unmappedids(this.context);
     }
   }
 
 
   export class Resource$Debug$Identitysources$Items {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -3026,7 +3041,7 @@ export namespace cloudsearch_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListItemNamesForUnmappedIdentityResponse>(
@@ -3075,7 +3090,10 @@ export namespace cloudsearch_v1 {
 
 
   export class Resource$Debug$Identitysources$Unmappedids {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -3145,7 +3163,7 @@ export namespace cloudsearch_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListUnmappedIdentitiesResponse>(
@@ -3191,17 +3209,21 @@ export namespace cloudsearch_v1 {
 
 
   export class Resource$Indexing {
+    context: APIRequestContext;
     datasources: Resource$Indexing$Datasources;
-    constructor() {
-      this.datasources = new Resource$Indexing$Datasources();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.datasources = new Resource$Indexing$Datasources(this.context);
     }
   }
 
 
   export class Resource$Indexing$Datasources {
+    context: APIRequestContext;
     items: Resource$Indexing$Datasources$Items;
-    constructor() {
-      this.items = new Resource$Indexing$Datasources$Items();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.items = new Resource$Indexing$Datasources$Items(this.context);
     }
 
 
@@ -3263,7 +3285,7 @@ export namespace cloudsearch_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -3330,7 +3352,7 @@ export namespace cloudsearch_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Schema>(parameters, callback);
@@ -3398,7 +3420,7 @@ export namespace cloudsearch_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -3463,7 +3485,10 @@ export namespace cloudsearch_v1 {
   }
 
   export class Resource$Indexing$Datasources$Items {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -3527,7 +3552,7 @@ export namespace cloudsearch_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -3598,7 +3623,7 @@ export namespace cloudsearch_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -3662,7 +3687,7 @@ export namespace cloudsearch_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Item>(parameters, callback);
@@ -3732,7 +3757,7 @@ export namespace cloudsearch_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -3804,7 +3829,7 @@ export namespace cloudsearch_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListItemsResponse>(parameters, callback);
@@ -3880,7 +3905,7 @@ export namespace cloudsearch_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$PollItemsResponse>(parameters, callback);
@@ -3947,7 +3972,7 @@ export namespace cloudsearch_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Item>(parameters, callback);
@@ -4017,7 +4042,7 @@ export namespace cloudsearch_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -4087,7 +4112,7 @@ export namespace cloudsearch_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$UploadItemRef>(parameters, callback);
@@ -4307,7 +4332,10 @@ export namespace cloudsearch_v1 {
 
 
   export class Resource$Media {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -4377,7 +4405,7 @@ export namespace cloudsearch_v1 {
                       .replace(/([^:]\/)\/+/g, '$1'),
         requiredParams: ['resourceName'],
         pathParams: ['resourceName'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Media>(parameters, callback);
@@ -4422,7 +4450,10 @@ export namespace cloudsearch_v1 {
 
 
   export class Resource$Operations {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -4478,7 +4509,7 @@ export namespace cloudsearch_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -4502,9 +4533,11 @@ export namespace cloudsearch_v1 {
 
 
   export class Resource$Query {
+    context: APIRequestContext;
     sources: Resource$Query$Sources;
-    constructor() {
-      this.sources = new Resource$Query$Sources();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.sources = new Resource$Query$Sources(this.context);
     }
 
 
@@ -4565,7 +4598,7 @@ export namespace cloudsearch_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$SearchResponse>(parameters, callback);
@@ -4630,7 +4663,7 @@ export namespace cloudsearch_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$SuggestResponse>(parameters, callback);
@@ -4666,7 +4699,10 @@ export namespace cloudsearch_v1 {
   }
 
   export class Resource$Query$Sources {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -4731,7 +4767,7 @@ export namespace cloudsearch_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListQuerySourcesResponse>(parameters, callback);
@@ -4781,17 +4817,23 @@ export namespace cloudsearch_v1 {
 
 
   export class Resource$Settings {
+    context: APIRequestContext;
     datasources: Resource$Settings$Datasources;
     searchapplications: Resource$Settings$Searchapplications;
-    constructor() {
-      this.datasources = new Resource$Settings$Datasources();
-      this.searchapplications = new Resource$Settings$Searchapplications();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.datasources = new Resource$Settings$Datasources(this.context);
+      this.searchapplications =
+          new Resource$Settings$Searchapplications(this.context);
     }
   }
 
 
   export class Resource$Settings$Datasources {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -4851,7 +4893,7 @@ export namespace cloudsearch_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -4919,7 +4961,7 @@ export namespace cloudsearch_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -4983,7 +5025,7 @@ export namespace cloudsearch_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$DataSource>(parameters, callback);
@@ -5053,7 +5095,7 @@ export namespace cloudsearch_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListDataSourceResponse>(parameters, callback);
@@ -5121,7 +5163,7 @@ export namespace cloudsearch_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -5221,7 +5263,10 @@ export namespace cloudsearch_v1 {
 
 
   export class Resource$Settings$Searchapplications {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -5281,7 +5326,7 @@ export namespace cloudsearch_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -5349,7 +5394,7 @@ export namespace cloudsearch_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -5413,7 +5458,7 @@ export namespace cloudsearch_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$SearchApplication>(parameters, callback);
@@ -5487,7 +5532,7 @@ export namespace cloudsearch_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListSearchApplicationsResponse>(
@@ -5558,7 +5603,7 @@ export namespace cloudsearch_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -5626,7 +5671,7 @@ export namespace cloudsearch_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -5747,9 +5792,11 @@ export namespace cloudsearch_v1 {
 
 
   export class Resource$Stats {
+    context: APIRequestContext;
     index: Resource$Stats$Index;
-    constructor() {
-      this.index = new Resource$Stats$Index();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.index = new Resource$Stats$Index(this.context);
     }
 
 
@@ -5819,7 +5866,7 @@ export namespace cloudsearch_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GetCustomerIndexStatsResponse>(
@@ -5864,15 +5911,20 @@ export namespace cloudsearch_v1 {
   }
 
   export class Resource$Stats$Index {
+    context: APIRequestContext;
     datasources: Resource$Stats$Index$Datasources;
-    constructor() {
-      this.datasources = new Resource$Stats$Index$Datasources();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.datasources = new Resource$Stats$Index$Datasources(this.context);
     }
   }
 
 
   export class Resource$Stats$Index$Datasources {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -5940,7 +5992,7 @@ export namespace cloudsearch_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GetDataSourceIndexStatsResponse>(

--- a/src/apis/cloudshell/v1.ts
+++ b/src/apis/cloudshell/v1.ts
@@ -29,8 +29,6 @@ export namespace cloudshell_v1 {
     version: 'v1';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * V1 error format.
@@ -99,12 +97,13 @@ export namespace cloudshell_v1 {
    * @param {object=} options Options for Cloudshell
    */
   export class Cloudshell {
+    context: APIRequestContext;
     operations: Resource$Operations;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.operations = new Resource$Operations();
+      this.operations = new Resource$Operations(this.context);
     }
   }
 
@@ -324,7 +323,10 @@ export namespace cloudshell_v1 {
 
 
   export class Resource$Operations {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -391,7 +393,7 @@ export namespace cloudshell_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -458,7 +460,7 @@ export namespace cloudshell_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -521,7 +523,7 @@ export namespace cloudshell_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -597,7 +599,7 @@ export namespace cloudshell_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListOperationsResponse>(parameters, callback);

--- a/src/apis/cloudshell/v1alpha1.ts
+++ b/src/apis/cloudshell/v1alpha1.ts
@@ -29,8 +29,6 @@ export namespace cloudshell_v1alpha1 {
     version: 'v1alpha1';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * V1 error format.
@@ -99,12 +97,13 @@ export namespace cloudshell_v1alpha1 {
    * @param {object=} options Options for Cloudshell
    */
   export class Cloudshell {
+    context: APIRequestContext;
     users: Resource$Users;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.users = new Resource$Users();
+      this.users = new Resource$Users(this.context);
     }
   }
 
@@ -346,17 +345,22 @@ export namespace cloudshell_v1alpha1 {
 
 
   export class Resource$Users {
+    context: APIRequestContext;
     environments: Resource$Users$Environments;
-    constructor() {
-      this.environments = new Resource$Users$Environments();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.environments = new Resource$Users$Environments(this.context);
     }
   }
 
 
   export class Resource$Users$Environments {
+    context: APIRequestContext;
     publicKeys: Resource$Users$Environments$Publickeys;
-    constructor() {
-      this.publicKeys = new Resource$Users$Environments$Publickeys();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.publicKeys =
+          new Resource$Users$Environments$Publickeys(this.context);
     }
 
 
@@ -420,7 +424,7 @@ export namespace cloudshell_v1alpha1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -484,7 +488,7 @@ export namespace cloudshell_v1alpha1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Environment>(parameters, callback);
@@ -553,7 +557,7 @@ export namespace cloudshell_v1alpha1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Environment>(parameters, callback);
@@ -626,7 +630,7 @@ export namespace cloudshell_v1alpha1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -713,7 +717,10 @@ export namespace cloudshell_v1alpha1 {
   }
 
   export class Resource$Users$Environments$Publickeys {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -777,7 +784,7 @@ export namespace cloudshell_v1alpha1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$PublicKey>(parameters, callback);
@@ -845,7 +852,7 @@ export namespace cloudshell_v1alpha1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);

--- a/src/apis/cloudtasks/v2.ts
+++ b/src/apis/cloudtasks/v2.ts
@@ -29,8 +29,6 @@ export namespace cloudtasks_v2 {
     version: 'v2';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * V1 error format.
@@ -98,12 +96,13 @@ export namespace cloudtasks_v2 {
    * @param {object=} options Options for Cloudtasks
    */
   export class Cloudtasks {
+    context: APIRequestContext;
     projects: Resource$Projects;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.projects = new Resource$Projects();
+      this.projects = new Resource$Projects(this.context);
     }
   }
 
@@ -904,17 +903,21 @@ export namespace cloudtasks_v2 {
 
 
   export class Resource$Projects {
+    context: APIRequestContext;
     locations: Resource$Projects$Locations;
-    constructor() {
-      this.locations = new Resource$Projects$Locations();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.locations = new Resource$Projects$Locations(this.context);
     }
   }
 
 
   export class Resource$Projects$Locations {
+    context: APIRequestContext;
     queues: Resource$Projects$Locations$Queues;
-    constructor() {
-      this.queues = new Resource$Projects$Locations$Queues();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.queues = new Resource$Projects$Locations$Queues(this.context);
     }
 
 
@@ -969,7 +972,7 @@ export namespace cloudtasks_v2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Location>(parameters, callback);
@@ -1040,7 +1043,7 @@ export namespace cloudtasks_v2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListLocationsResponse>(parameters, callback);
@@ -1088,9 +1091,11 @@ export namespace cloudtasks_v2 {
   }
 
   export class Resource$Projects$Locations$Queues {
+    context: APIRequestContext;
     tasks: Resource$Projects$Locations$Queues$Tasks;
-    constructor() {
-      this.tasks = new Resource$Projects$Locations$Queues$Tasks();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.tasks = new Resource$Projects$Locations$Queues$Tasks(this.context);
     }
 
 
@@ -1158,7 +1163,7 @@ export namespace cloudtasks_v2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Queue>(parameters, callback);
@@ -1230,7 +1235,7 @@ export namespace cloudtasks_v2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -1291,7 +1296,7 @@ export namespace cloudtasks_v2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Queue>(parameters, callback);
@@ -1363,7 +1368,7 @@ export namespace cloudtasks_v2 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -1433,7 +1438,7 @@ export namespace cloudtasks_v2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListQueuesResponse>(parameters, callback);
@@ -1508,7 +1513,7 @@ export namespace cloudtasks_v2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Queue>(parameters, callback);
@@ -1578,7 +1583,7 @@ export namespace cloudtasks_v2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Queue>(parameters, callback);
@@ -1648,7 +1653,7 @@ export namespace cloudtasks_v2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Queue>(parameters, callback);
@@ -1721,7 +1726,7 @@ export namespace cloudtasks_v2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Queue>(parameters, callback);
@@ -1794,7 +1799,7 @@ export namespace cloudtasks_v2 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -1874,7 +1879,7 @@ export namespace cloudtasks_v2 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TestIamPermissionsResponse>(
@@ -2112,7 +2117,10 @@ export namespace cloudtasks_v2 {
   }
 
   export class Resource$Projects$Locations$Queues$Tasks {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -2175,7 +2183,7 @@ export namespace cloudtasks_v2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Task>(parameters, callback);
@@ -2243,7 +2251,7 @@ export namespace cloudtasks_v2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -2305,7 +2313,7 @@ export namespace cloudtasks_v2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Task>(parameters, callback);
@@ -2378,7 +2386,7 @@ export namespace cloudtasks_v2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListTasksResponse>(parameters, callback);
@@ -2452,7 +2460,7 @@ export namespace cloudtasks_v2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Task>(parameters, callback);

--- a/src/apis/cloudtasks/v2beta2.ts
+++ b/src/apis/cloudtasks/v2beta2.ts
@@ -29,8 +29,6 @@ export namespace cloudtasks_v2beta2 {
     version: 'v2beta2';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * V1 error format.
@@ -98,12 +96,13 @@ export namespace cloudtasks_v2beta2 {
    * @param {object=} options Options for Cloudtasks
    */
   export class Cloudtasks {
+    context: APIRequestContext;
     projects: Resource$Projects;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.projects = new Resource$Projects();
+      this.projects = new Resource$Projects(this.context);
     }
   }
 
@@ -1091,17 +1090,21 @@ export namespace cloudtasks_v2beta2 {
 
 
   export class Resource$Projects {
+    context: APIRequestContext;
     locations: Resource$Projects$Locations;
-    constructor() {
-      this.locations = new Resource$Projects$Locations();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.locations = new Resource$Projects$Locations(this.context);
     }
   }
 
 
   export class Resource$Projects$Locations {
+    context: APIRequestContext;
     queues: Resource$Projects$Locations$Queues;
-    constructor() {
-      this.queues = new Resource$Projects$Locations$Queues();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.queues = new Resource$Projects$Locations$Queues(this.context);
     }
 
 
@@ -1210,7 +1213,7 @@ export namespace cloudtasks_v2beta2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Location>(parameters, callback);
@@ -1347,7 +1350,7 @@ export namespace cloudtasks_v2beta2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListLocationsResponse>(parameters, callback);
@@ -1395,9 +1398,11 @@ export namespace cloudtasks_v2beta2 {
   }
 
   export class Resource$Projects$Locations$Queues {
+    context: APIRequestContext;
     tasks: Resource$Projects$Locations$Queues$Tasks;
-    constructor() {
-      this.tasks = new Resource$Projects$Locations$Queues$Tasks();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.tasks = new Resource$Projects$Locations$Queues$Tasks(this.context);
     }
 
 
@@ -1526,7 +1531,7 @@ export namespace cloudtasks_v2beta2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Queue>(parameters, callback);
@@ -1651,7 +1656,7 @@ export namespace cloudtasks_v2beta2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -1766,7 +1771,7 @@ export namespace cloudtasks_v2beta2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Queue>(parameters, callback);
@@ -1896,7 +1901,7 @@ export namespace cloudtasks_v2beta2 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -2035,7 +2040,7 @@ export namespace cloudtasks_v2beta2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListQueuesResponse>(parameters, callback);
@@ -2179,7 +2184,7 @@ export namespace cloudtasks_v2beta2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Queue>(parameters, callback);
@@ -2307,7 +2312,7 @@ export namespace cloudtasks_v2beta2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Queue>(parameters, callback);
@@ -2435,7 +2440,7 @@ export namespace cloudtasks_v2beta2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Queue>(parameters, callback);
@@ -2566,7 +2571,7 @@ export namespace cloudtasks_v2beta2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Queue>(parameters, callback);
@@ -2697,7 +2702,7 @@ export namespace cloudtasks_v2beta2 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -2836,7 +2841,7 @@ export namespace cloudtasks_v2beta2 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TestIamPermissionsResponse>(
@@ -3074,7 +3079,10 @@ export namespace cloudtasks_v2beta2 {
   }
 
   export class Resource$Projects$Locations$Queues$Tasks {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -3198,7 +3206,7 @@ export namespace cloudtasks_v2beta2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -3329,7 +3337,7 @@ export namespace cloudtasks_v2beta2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Task>(parameters, callback);
@@ -3459,7 +3467,7 @@ export namespace cloudtasks_v2beta2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Task>(parameters, callback);
@@ -3580,7 +3588,7 @@ export namespace cloudtasks_v2beta2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -3698,7 +3706,7 @@ export namespace cloudtasks_v2beta2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Task>(parameters, callback);
@@ -3775,7 +3783,7 @@ export namespace cloudtasks_v2beta2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$LeaseTasksResponse>(parameters, callback);
@@ -3918,7 +3926,7 @@ export namespace cloudtasks_v2beta2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListTasksResponse>(parameters, callback);
@@ -4049,7 +4057,7 @@ export namespace cloudtasks_v2beta2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Task>(parameters, callback);
@@ -4184,7 +4192,7 @@ export namespace cloudtasks_v2beta2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Task>(parameters, callback);

--- a/src/apis/cloudtasks/v2beta3.ts
+++ b/src/apis/cloudtasks/v2beta3.ts
@@ -29,8 +29,6 @@ export namespace cloudtasks_v2beta3 {
     version: 'v2beta3';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * V1 error format.
@@ -98,12 +96,13 @@ export namespace cloudtasks_v2beta3 {
    * @param {object=} options Options for Cloudtasks
    */
   export class Cloudtasks {
+    context: APIRequestContext;
     projects: Resource$Projects;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.projects = new Resource$Projects();
+      this.projects = new Resource$Projects(this.context);
     }
   }
 
@@ -919,17 +918,21 @@ export namespace cloudtasks_v2beta3 {
 
 
   export class Resource$Projects {
+    context: APIRequestContext;
     locations: Resource$Projects$Locations;
-    constructor() {
-      this.locations = new Resource$Projects$Locations();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.locations = new Resource$Projects$Locations(this.context);
     }
   }
 
 
   export class Resource$Projects$Locations {
+    context: APIRequestContext;
     queues: Resource$Projects$Locations$Queues;
-    constructor() {
-      this.queues = new Resource$Projects$Locations$Queues();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.queues = new Resource$Projects$Locations$Queues(this.context);
     }
 
 
@@ -984,7 +987,7 @@ export namespace cloudtasks_v2beta3 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Location>(parameters, callback);
@@ -1055,7 +1058,7 @@ export namespace cloudtasks_v2beta3 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListLocationsResponse>(parameters, callback);
@@ -1103,9 +1106,11 @@ export namespace cloudtasks_v2beta3 {
   }
 
   export class Resource$Projects$Locations$Queues {
+    context: APIRequestContext;
     tasks: Resource$Projects$Locations$Queues$Tasks;
-    constructor() {
-      this.tasks = new Resource$Projects$Locations$Queues$Tasks();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.tasks = new Resource$Projects$Locations$Queues$Tasks(this.context);
     }
 
 
@@ -1173,7 +1178,7 @@ export namespace cloudtasks_v2beta3 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Queue>(parameters, callback);
@@ -1245,7 +1250,7 @@ export namespace cloudtasks_v2beta3 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -1306,7 +1311,7 @@ export namespace cloudtasks_v2beta3 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Queue>(parameters, callback);
@@ -1378,7 +1383,7 @@ export namespace cloudtasks_v2beta3 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -1448,7 +1453,7 @@ export namespace cloudtasks_v2beta3 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListQueuesResponse>(parameters, callback);
@@ -1523,7 +1528,7 @@ export namespace cloudtasks_v2beta3 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Queue>(parameters, callback);
@@ -1593,7 +1598,7 @@ export namespace cloudtasks_v2beta3 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Queue>(parameters, callback);
@@ -1663,7 +1668,7 @@ export namespace cloudtasks_v2beta3 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Queue>(parameters, callback);
@@ -1736,7 +1741,7 @@ export namespace cloudtasks_v2beta3 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Queue>(parameters, callback);
@@ -1809,7 +1814,7 @@ export namespace cloudtasks_v2beta3 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -1889,7 +1894,7 @@ export namespace cloudtasks_v2beta3 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TestIamPermissionsResponse>(
@@ -2127,7 +2132,10 @@ export namespace cloudtasks_v2beta3 {
   }
 
   export class Resource$Projects$Locations$Queues$Tasks {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -2190,7 +2198,7 @@ export namespace cloudtasks_v2beta3 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Task>(parameters, callback);
@@ -2258,7 +2266,7 @@ export namespace cloudtasks_v2beta3 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -2320,7 +2328,7 @@ export namespace cloudtasks_v2beta3 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Task>(parameters, callback);
@@ -2393,7 +2401,7 @@ export namespace cloudtasks_v2beta3 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListTasksResponse>(parameters, callback);
@@ -2468,7 +2476,7 @@ export namespace cloudtasks_v2beta3 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Task>(parameters, callback);

--- a/src/apis/cloudtrace/v1.ts
+++ b/src/apis/cloudtrace/v1.ts
@@ -29,8 +29,6 @@ export namespace cloudtrace_v1 {
     version: 'v1';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * V1 error format.
@@ -102,12 +100,13 @@ export namespace cloudtrace_v1 {
    * @param {object=} options Options for Cloudtrace
    */
   export class Cloudtrace {
+    context: APIRequestContext;
     projects: Resource$Projects;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.projects = new Resource$Projects();
+      this.projects = new Resource$Projects(this.context);
     }
   }
 
@@ -226,9 +225,11 @@ export namespace cloudtrace_v1 {
 
 
   export class Resource$Projects {
+    context: APIRequestContext;
     traces: Resource$Projects$Traces;
-    constructor() {
-      this.traces = new Resource$Projects$Traces();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.traces = new Resource$Projects$Traces(this.context);
     }
 
 
@@ -349,7 +350,7 @@ export namespace cloudtrace_v1 {
         params,
         requiredParams: ['projectId'],
         pathParams: ['projectId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -378,7 +379,10 @@ export namespace cloudtrace_v1 {
   }
 
   export class Resource$Projects$Traces {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -490,7 +494,7 @@ export namespace cloudtrace_v1 {
         params,
         requiredParams: ['projectId', 'traceId'],
         pathParams: ['projectId', 'traceId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Trace>(parameters, callback);
@@ -631,7 +635,7 @@ export namespace cloudtrace_v1 {
         params,
         requiredParams: ['projectId'],
         pathParams: ['projectId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListTracesResponse>(parameters, callback);

--- a/src/apis/cloudtrace/v2.ts
+++ b/src/apis/cloudtrace/v2.ts
@@ -29,8 +29,6 @@ export namespace cloudtrace_v2 {
     version: 'v2';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * V1 error format.
@@ -102,12 +100,13 @@ export namespace cloudtrace_v2 {
    * @param {object=} options Options for Cloudtrace
    */
   export class Cloudtrace {
+    context: APIRequestContext;
     projects: Resource$Projects;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.projects = new Resource$Projects();
+      this.projects = new Resource$Projects(this.context);
     }
   }
 
@@ -527,17 +526,21 @@ export namespace cloudtrace_v2 {
 
 
   export class Resource$Projects {
+    context: APIRequestContext;
     traces: Resource$Projects$Traces;
-    constructor() {
-      this.traces = new Resource$Projects$Traces();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.traces = new Resource$Projects$Traces(this.context);
     }
   }
 
 
   export class Resource$Projects$Traces {
+    context: APIRequestContext;
     spans: Resource$Projects$Traces$Spans;
-    constructor() {
-      this.spans = new Resource$Projects$Traces$Spans();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.spans = new Resource$Projects$Traces$Spans(this.context);
     }
 
 
@@ -599,7 +602,7 @@ export namespace cloudtrace_v2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -629,7 +632,10 @@ export namespace cloudtrace_v2 {
   }
 
   export class Resource$Projects$Traces$Spans {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -688,7 +694,7 @@ export namespace cloudtrace_v2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Span>(parameters, callback);

--- a/src/apis/composer/v1.ts
+++ b/src/apis/composer/v1.ts
@@ -29,8 +29,6 @@ export namespace composer_v1 {
     version: 'v1';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * V1 error format.
@@ -98,12 +96,13 @@ export namespace composer_v1 {
    * @param {object=} options Options for Composer
    */
   export class Composer {
+    context: APIRequestContext;
     projects: Resource$Projects;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.projects = new Resource$Projects();
+      this.projects = new Resource$Projects(this.context);
     }
   }
 
@@ -531,27 +530,37 @@ export namespace composer_v1 {
 
 
   export class Resource$Projects {
+    context: APIRequestContext;
     locations: Resource$Projects$Locations;
-    constructor() {
-      this.locations = new Resource$Projects$Locations();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.locations = new Resource$Projects$Locations(this.context);
     }
   }
 
 
   export class Resource$Projects$Locations {
+    context: APIRequestContext;
     environments: Resource$Projects$Locations$Environments;
     imageVersions: Resource$Projects$Locations$Imageversions;
     operations: Resource$Projects$Locations$Operations;
-    constructor() {
-      this.environments = new Resource$Projects$Locations$Environments();
-      this.imageVersions = new Resource$Projects$Locations$Imageversions();
-      this.operations = new Resource$Projects$Locations$Operations();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.environments =
+          new Resource$Projects$Locations$Environments(this.context);
+      this.imageVersions =
+          new Resource$Projects$Locations$Imageversions(this.context);
+      this.operations =
+          new Resource$Projects$Locations$Operations(this.context);
     }
   }
 
 
   export class Resource$Projects$Locations$Environments {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -613,7 +622,7 @@ export namespace composer_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -680,7 +689,7 @@ export namespace composer_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -742,7 +751,7 @@ export namespace composer_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Environment>(parameters, callback);
@@ -813,7 +822,7 @@ export namespace composer_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListEnvironmentsResponse>(parameters, callback);
@@ -882,7 +891,7 @@ export namespace composer_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -1055,7 +1064,10 @@ export namespace composer_v1 {
 
 
   export class Resource$Projects$Locations$Imageversions {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1121,7 +1133,7 @@ export namespace composer_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListImageVersionsResponse>(
@@ -1156,7 +1168,10 @@ export namespace composer_v1 {
 
 
   export class Resource$Projects$Locations$Operations {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1217,7 +1232,7 @@ export namespace composer_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -1281,7 +1296,7 @@ export namespace composer_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -1360,7 +1375,7 @@ export namespace composer_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListOperationsResponse>(parameters, callback);

--- a/src/apis/composer/v1beta1.ts
+++ b/src/apis/composer/v1beta1.ts
@@ -29,8 +29,6 @@ export namespace composer_v1beta1 {
     version: 'v1beta1';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * V1 error format.
@@ -98,12 +96,13 @@ export namespace composer_v1beta1 {
    * @param {object=} options Options for Composer
    */
   export class Composer {
+    context: APIRequestContext;
     projects: Resource$Projects;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.projects = new Resource$Projects();
+      this.projects = new Resource$Projects(this.context);
     }
   }
 
@@ -626,27 +625,37 @@ export namespace composer_v1beta1 {
 
 
   export class Resource$Projects {
+    context: APIRequestContext;
     locations: Resource$Projects$Locations;
-    constructor() {
-      this.locations = new Resource$Projects$Locations();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.locations = new Resource$Projects$Locations(this.context);
     }
   }
 
 
   export class Resource$Projects$Locations {
+    context: APIRequestContext;
     environments: Resource$Projects$Locations$Environments;
     imageVersions: Resource$Projects$Locations$Imageversions;
     operations: Resource$Projects$Locations$Operations;
-    constructor() {
-      this.environments = new Resource$Projects$Locations$Environments();
-      this.imageVersions = new Resource$Projects$Locations$Imageversions();
-      this.operations = new Resource$Projects$Locations$Operations();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.environments =
+          new Resource$Projects$Locations$Environments(this.context);
+      this.imageVersions =
+          new Resource$Projects$Locations$Imageversions(this.context);
+      this.operations =
+          new Resource$Projects$Locations$Operations(this.context);
     }
   }
 
 
   export class Resource$Projects$Locations$Environments {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -708,7 +717,7 @@ export namespace composer_v1beta1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -775,7 +784,7 @@ export namespace composer_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -837,7 +846,7 @@ export namespace composer_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Environment>(parameters, callback);
@@ -908,7 +917,7 @@ export namespace composer_v1beta1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListEnvironmentsResponse>(parameters, callback);
@@ -977,7 +986,7 @@ export namespace composer_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -1159,7 +1168,10 @@ export namespace composer_v1beta1 {
 
 
   export class Resource$Projects$Locations$Imageversions {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1225,7 +1237,7 @@ export namespace composer_v1beta1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListImageVersionsResponse>(
@@ -1260,7 +1272,10 @@ export namespace composer_v1beta1 {
 
 
   export class Resource$Projects$Locations$Operations {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1321,7 +1336,7 @@ export namespace composer_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -1385,7 +1400,7 @@ export namespace composer_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -1464,7 +1479,7 @@ export namespace composer_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListOperationsResponse>(parameters, callback);

--- a/src/apis/compute/alpha.ts
+++ b/src/apis/compute/alpha.ts
@@ -29,8 +29,6 @@ export namespace compute_alpha {
     version: 'alpha';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * Data format for the response.
@@ -81,6 +79,7 @@ export namespace compute_alpha {
    * @param {object=} options Options for Compute
    */
   export class Compute {
+    context: APIRequestContext;
     acceleratorTypes: Resource$Acceleratortypes;
     addresses: Resource$Addresses;
     autoscalers: Resource$Autoscalers;
@@ -156,85 +155,96 @@ export namespace compute_alpha {
     zones: Resource$Zones;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.acceleratorTypes = new Resource$Acceleratortypes();
-      this.addresses = new Resource$Addresses();
-      this.autoscalers = new Resource$Autoscalers();
-      this.backendBuckets = new Resource$Backendbuckets();
-      this.backendServices = new Resource$Backendservices();
-      this.disks = new Resource$Disks();
-      this.diskTypes = new Resource$Disktypes();
-      this.externalVpnGateways = new Resource$Externalvpngateways();
-      this.firewalls = new Resource$Firewalls();
-      this.forwardingRules = new Resource$Forwardingrules();
-      this.globalAddresses = new Resource$Globaladdresses();
-      this.globalForwardingRules = new Resource$Globalforwardingrules();
-      this.globalOperations = new Resource$Globaloperations();
+      this.acceleratorTypes = new Resource$Acceleratortypes(this.context);
+      this.addresses = new Resource$Addresses(this.context);
+      this.autoscalers = new Resource$Autoscalers(this.context);
+      this.backendBuckets = new Resource$Backendbuckets(this.context);
+      this.backendServices = new Resource$Backendservices(this.context);
+      this.disks = new Resource$Disks(this.context);
+      this.diskTypes = new Resource$Disktypes(this.context);
+      this.externalVpnGateways = new Resource$Externalvpngateways(this.context);
+      this.firewalls = new Resource$Firewalls(this.context);
+      this.forwardingRules = new Resource$Forwardingrules(this.context);
+      this.globalAddresses = new Resource$Globaladdresses(this.context);
+      this.globalForwardingRules =
+          new Resource$Globalforwardingrules(this.context);
+      this.globalOperations = new Resource$Globaloperations(this.context);
       this.globalOrganizationOperations =
-          new Resource$Globalorganizationoperations();
-      this.healthChecks = new Resource$Healthchecks();
-      this.httpHealthChecks = new Resource$Httphealthchecks();
-      this.httpsHealthChecks = new Resource$Httpshealthchecks();
-      this.images = new Resource$Images();
-      this.instanceGroupManagers = new Resource$Instancegroupmanagers();
-      this.instanceGroups = new Resource$Instancegroups();
-      this.instances = new Resource$Instances();
-      this.instanceTemplates = new Resource$Instancetemplates();
-      this.interconnectAttachments = new Resource$Interconnectattachments();
-      this.interconnectLocations = new Resource$Interconnectlocations();
-      this.interconnects = new Resource$Interconnects();
-      this.licenseCodes = new Resource$Licensecodes();
-      this.licenses = new Resource$Licenses();
-      this.machineImages = new Resource$Machineimages();
-      this.machineTypes = new Resource$Machinetypes();
-      this.networkEndpointGroups = new Resource$Networkendpointgroups();
-      this.networks = new Resource$Networks();
-      this.nodeGroups = new Resource$Nodegroups();
-      this.nodeTemplates = new Resource$Nodetemplates();
-      this.nodeTypes = new Resource$Nodetypes();
+          new Resource$Globalorganizationoperations(this.context);
+      this.healthChecks = new Resource$Healthchecks(this.context);
+      this.httpHealthChecks = new Resource$Httphealthchecks(this.context);
+      this.httpsHealthChecks = new Resource$Httpshealthchecks(this.context);
+      this.images = new Resource$Images(this.context);
+      this.instanceGroupManagers =
+          new Resource$Instancegroupmanagers(this.context);
+      this.instanceGroups = new Resource$Instancegroups(this.context);
+      this.instances = new Resource$Instances(this.context);
+      this.instanceTemplates = new Resource$Instancetemplates(this.context);
+      this.interconnectAttachments =
+          new Resource$Interconnectattachments(this.context);
+      this.interconnectLocations =
+          new Resource$Interconnectlocations(this.context);
+      this.interconnects = new Resource$Interconnects(this.context);
+      this.licenseCodes = new Resource$Licensecodes(this.context);
+      this.licenses = new Resource$Licenses(this.context);
+      this.machineImages = new Resource$Machineimages(this.context);
+      this.machineTypes = new Resource$Machinetypes(this.context);
+      this.networkEndpointGroups =
+          new Resource$Networkendpointgroups(this.context);
+      this.networks = new Resource$Networks(this.context);
+      this.nodeGroups = new Resource$Nodegroups(this.context);
+      this.nodeTemplates = new Resource$Nodetemplates(this.context);
+      this.nodeTypes = new Resource$Nodetypes(this.context);
       this.organizationSecurityPolicies =
-          new Resource$Organizationsecuritypolicies();
-      this.projects = new Resource$Projects();
-      this.regionAutoscalers = new Resource$Regionautoscalers();
-      this.regionBackendServices = new Resource$Regionbackendservices();
-      this.regionCommitments = new Resource$Regioncommitments();
-      this.regionDisks = new Resource$Regiondisks();
-      this.regionDiskTypes = new Resource$Regiondisktypes();
-      this.regionHealthChecks = new Resource$Regionhealthchecks();
-      this.regionHealthCheckServices = new Resource$Regionhealthcheckservices();
+          new Resource$Organizationsecuritypolicies(this.context);
+      this.projects = new Resource$Projects(this.context);
+      this.regionAutoscalers = new Resource$Regionautoscalers(this.context);
+      this.regionBackendServices =
+          new Resource$Regionbackendservices(this.context);
+      this.regionCommitments = new Resource$Regioncommitments(this.context);
+      this.regionDisks = new Resource$Regiondisks(this.context);
+      this.regionDiskTypes = new Resource$Regiondisktypes(this.context);
+      this.regionHealthChecks = new Resource$Regionhealthchecks(this.context);
+      this.regionHealthCheckServices =
+          new Resource$Regionhealthcheckservices(this.context);
       this.regionInstanceGroupManagers =
-          new Resource$Regioninstancegroupmanagers();
-      this.regionInstanceGroups = new Resource$Regioninstancegroups();
+          new Resource$Regioninstancegroupmanagers(this.context);
+      this.regionInstanceGroups =
+          new Resource$Regioninstancegroups(this.context);
       this.regionNotificationEndpoints =
-          new Resource$Regionnotificationendpoints();
-      this.regionOperations = new Resource$Regionoperations();
-      this.regions = new Resource$Regions();
-      this.regionSslCertificates = new Resource$Regionsslcertificates();
-      this.regionTargetHttpProxies = new Resource$Regiontargethttpproxies();
-      this.regionTargetHttpsProxies = new Resource$Regiontargethttpsproxies();
-      this.regionUrlMaps = new Resource$Regionurlmaps();
-      this.reservations = new Resource$Reservations();
-      this.resourcePolicies = new Resource$Resourcepolicies();
-      this.routers = new Resource$Routers();
-      this.routes = new Resource$Routes();
-      this.securityPolicies = new Resource$Securitypolicies();
-      this.snapshots = new Resource$Snapshots();
-      this.sslCertificates = new Resource$Sslcertificates();
-      this.sslPolicies = new Resource$Sslpolicies();
-      this.subnetworks = new Resource$Subnetworks();
-      this.targetHttpProxies = new Resource$Targethttpproxies();
-      this.targetHttpsProxies = new Resource$Targethttpsproxies();
-      this.targetInstances = new Resource$Targetinstances();
-      this.targetPools = new Resource$Targetpools();
-      this.targetSslProxies = new Resource$Targetsslproxies();
-      this.targetTcpProxies = new Resource$Targettcpproxies();
-      this.targetVpnGateways = new Resource$Targetvpngateways();
-      this.urlMaps = new Resource$Urlmaps();
-      this.vpnGateways = new Resource$Vpngateways();
-      this.vpnTunnels = new Resource$Vpntunnels();
-      this.zoneOperations = new Resource$Zoneoperations();
-      this.zones = new Resource$Zones();
+          new Resource$Regionnotificationendpoints(this.context);
+      this.regionOperations = new Resource$Regionoperations(this.context);
+      this.regions = new Resource$Regions(this.context);
+      this.regionSslCertificates =
+          new Resource$Regionsslcertificates(this.context);
+      this.regionTargetHttpProxies =
+          new Resource$Regiontargethttpproxies(this.context);
+      this.regionTargetHttpsProxies =
+          new Resource$Regiontargethttpsproxies(this.context);
+      this.regionUrlMaps = new Resource$Regionurlmaps(this.context);
+      this.reservations = new Resource$Reservations(this.context);
+      this.resourcePolicies = new Resource$Resourcepolicies(this.context);
+      this.routers = new Resource$Routers(this.context);
+      this.routes = new Resource$Routes(this.context);
+      this.securityPolicies = new Resource$Securitypolicies(this.context);
+      this.snapshots = new Resource$Snapshots(this.context);
+      this.sslCertificates = new Resource$Sslcertificates(this.context);
+      this.sslPolicies = new Resource$Sslpolicies(this.context);
+      this.subnetworks = new Resource$Subnetworks(this.context);
+      this.targetHttpProxies = new Resource$Targethttpproxies(this.context);
+      this.targetHttpsProxies = new Resource$Targethttpsproxies(this.context);
+      this.targetInstances = new Resource$Targetinstances(this.context);
+      this.targetPools = new Resource$Targetpools(this.context);
+      this.targetSslProxies = new Resource$Targetsslproxies(this.context);
+      this.targetTcpProxies = new Resource$Targettcpproxies(this.context);
+      this.targetVpnGateways = new Resource$Targetvpngateways(this.context);
+      this.urlMaps = new Resource$Urlmaps(this.context);
+      this.vpnGateways = new Resource$Vpngateways(this.context);
+      this.vpnTunnels = new Resource$Vpntunnels(this.context);
+      this.zoneOperations = new Resource$Zoneoperations(this.context);
+      this.zones = new Resource$Zones(this.context);
     }
   }
 
@@ -16982,7 +16992,10 @@ export namespace compute_alpha {
 
 
   export class Resource$Acceleratortypes {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -17054,7 +17067,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AcceleratorTypeAggregatedList>(
@@ -17123,7 +17136,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'acceleratorType'],
         pathParams: ['acceleratorType', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AcceleratorType>(parameters, callback);
@@ -17198,7 +17211,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone'],
         pathParams: ['project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AcceleratorTypeList>(parameters, callback);
@@ -17345,7 +17358,10 @@ export namespace compute_alpha {
 
 
   export class Resource$Addresses {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -17412,7 +17428,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AddressAggregatedList>(parameters, callback);
@@ -17482,7 +17498,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'address'],
         pathParams: ['address', 'project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -17547,7 +17563,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'address'],
         pathParams: ['address', 'project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Address>(parameters, callback);
@@ -17618,7 +17634,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -17691,7 +17707,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AddressList>(parameters, callback);
@@ -17765,7 +17781,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'resource'],
         pathParams: ['project', 'region', 'resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -17839,7 +17855,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'resource'],
         pathParams: ['project', 'region', 'resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -18112,7 +18128,10 @@ export namespace compute_alpha {
 
 
   export class Resource$Autoscalers {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -18180,7 +18199,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AutoscalerAggregatedList>(parameters, callback);
@@ -18252,7 +18271,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'autoscaler'],
         pathParams: ['autoscaler', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -18319,7 +18338,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'autoscaler'],
         pathParams: ['autoscaler', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Autoscaler>(parameters, callback);
@@ -18392,7 +18411,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone'],
         pathParams: ['project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -18465,7 +18484,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone'],
         pathParams: ['project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AutoscalerList>(parameters, callback);
@@ -18539,7 +18558,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone'],
         pathParams: ['project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -18613,7 +18632,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'resource'],
         pathParams: ['project', 'resource', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -18687,7 +18706,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone'],
         pathParams: ['project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -19000,7 +19019,10 @@ export namespace compute_alpha {
 
 
   export class Resource$Backendbuckets {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -19066,7 +19088,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'backendBucket'],
         pathParams: ['backendBucket', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -19137,7 +19159,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'backendBucket'],
         pathParams: ['backendBucket', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -19210,7 +19232,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'backendBucket', 'keyName'],
         pathParams: ['backendBucket', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -19277,7 +19299,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'backendBucket'],
         pathParams: ['backendBucket', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$BackendBucket>(parameters, callback);
@@ -19347,7 +19369,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -19418,7 +19440,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -19490,7 +19512,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$BackendBucketList>(parameters, callback);
@@ -19564,7 +19586,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'backendBucket'],
         pathParams: ['backendBucket', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -19635,7 +19657,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -19708,7 +19730,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -19781,7 +19803,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'backendBucket'],
         pathParams: ['backendBucket', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -20119,7 +20141,10 @@ export namespace compute_alpha {
 
 
   export class Resource$Backendservices {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -20185,7 +20210,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'backendService'],
         pathParams: ['backendService', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -20265,7 +20290,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$BackendServiceAggregatedList>(
@@ -20338,7 +20363,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'backendService'],
         pathParams: ['backendService', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -20411,7 +20436,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'backendService', 'keyName'],
         pathParams: ['backendService', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -20478,7 +20503,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'backendService'],
         pathParams: ['backendService', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$BackendService>(parameters, callback);
@@ -20552,7 +20577,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'backendService'],
         pathParams: ['backendService', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$BackendServiceGroupHealth>(
@@ -20626,7 +20651,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -20699,7 +20724,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$BackendServiceList>(parameters, callback);
@@ -20775,7 +20800,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'backendService'],
         pathParams: ['backendService', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -20847,7 +20872,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'backendService'],
         pathParams: ['backendService', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -20920,7 +20945,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -20995,7 +21020,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'backendService'],
         pathParams: ['backendService', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -21408,7 +21433,10 @@ export namespace compute_alpha {
 
 
   export class Resource$Disks {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -21476,7 +21504,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'disk'],
         pathParams: ['disk', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -21549,7 +21577,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$DiskAggregatedList>(parameters, callback);
@@ -21623,7 +21651,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'disk'],
         pathParams: ['disk', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -21696,7 +21724,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'disk'],
         pathParams: ['disk', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -21762,7 +21790,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'disk'],
         pathParams: ['disk', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Disk>(parameters, callback);
@@ -21833,7 +21861,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'resource'],
         pathParams: ['project', 'resource', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -21907,7 +21935,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone'],
         pathParams: ['project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -21978,7 +22006,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone'],
         pathParams: ['project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$DiskList>(parameters, callback);
@@ -22052,7 +22080,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'disk'],
         pathParams: ['disk', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -22124,7 +22152,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'disk'],
         pathParams: ['disk', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -22196,7 +22224,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'resource'],
         pathParams: ['project', 'resource', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -22269,7 +22297,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'resource'],
         pathParams: ['project', 'resource', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -22343,7 +22371,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'resource'],
         pathParams: ['project', 'resource', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -22819,7 +22847,10 @@ export namespace compute_alpha {
 
 
   export class Resource$Disktypes {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -22886,7 +22917,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$DiskTypeAggregatedList>(parameters, callback);
@@ -22952,7 +22983,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'diskType'],
         pathParams: ['diskType', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$DiskType>(parameters, callback);
@@ -23023,7 +23054,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone'],
         pathParams: ['project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$DiskTypeList>(parameters, callback);
@@ -23168,7 +23199,10 @@ export namespace compute_alpha {
 
 
   export class Resource$Externalvpngateways {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -23232,7 +23266,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'externalVpnGateway'],
         pathParams: ['externalVpnGateway', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -23299,7 +23333,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'externalVpnGateway'],
         pathParams: ['externalVpnGateway', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ExternalVpnGateway>(parameters, callback);
@@ -23371,7 +23405,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -23446,7 +23480,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ExternalVpnGatewayList>(parameters, callback);
@@ -23518,7 +23552,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -23592,7 +23626,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -23777,7 +23811,10 @@ export namespace compute_alpha {
 
 
   export class Resource$Firewalls {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -23839,7 +23876,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'firewall'],
         pathParams: ['firewall', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -23903,7 +23940,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'firewall'],
         pathParams: ['firewall', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Firewall>(parameters, callback);
@@ -23972,7 +24009,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -24043,7 +24080,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$FirewallList>(parameters, callback);
@@ -24115,7 +24152,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'firewall'],
         pathParams: ['firewall', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -24188,7 +24225,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -24260,7 +24297,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'firewall'],
         pathParams: ['firewall', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -24486,7 +24523,10 @@ export namespace compute_alpha {
 
 
   export class Resource$Forwardingrules {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -24558,7 +24598,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ForwardingRuleAggregatedList>(
@@ -24632,7 +24672,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'forwardingRule'],
         pathParams: ['forwardingRule', 'project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -24699,7 +24739,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'forwardingRule'],
         pathParams: ['forwardingRule', 'project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ForwardingRule>(parameters, callback);
@@ -24772,7 +24812,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -24847,7 +24887,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ForwardingRuleList>(parameters, callback);
@@ -24923,7 +24963,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'forwardingRule'],
         pathParams: ['forwardingRule', 'project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -24997,7 +25037,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'resource'],
         pathParams: ['project', 'region', 'resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -25071,7 +25111,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'forwardingRule'],
         pathParams: ['forwardingRule', 'project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -25145,7 +25185,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'resource'],
         pathParams: ['project', 'region', 'resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -25498,7 +25538,10 @@ export namespace compute_alpha {
 
 
   export class Resource$Globaladdresses {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -25562,7 +25605,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'address'],
         pathParams: ['address', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -25628,7 +25671,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'address'],
         pathParams: ['address', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Address>(parameters, callback);
@@ -25699,7 +25742,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -25771,7 +25814,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AddressList>(parameters, callback);
@@ -25843,7 +25886,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -25916,7 +25959,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -26101,7 +26144,10 @@ export namespace compute_alpha {
 
 
   export class Resource$Globalforwardingrules {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -26165,7 +26211,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'forwardingRule'],
         pathParams: ['forwardingRule', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -26232,7 +26278,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'forwardingRule'],
         pathParams: ['forwardingRule', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ForwardingRule>(parameters, callback);
@@ -26303,7 +26349,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -26376,7 +26422,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ForwardingRuleList>(parameters, callback);
@@ -26451,7 +26497,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'forwardingRule'],
         pathParams: ['forwardingRule', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -26523,7 +26569,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -26596,7 +26642,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'forwardingRule'],
         pathParams: ['forwardingRule', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -26670,7 +26716,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -26923,7 +26969,10 @@ export namespace compute_alpha {
 
 
   export class Resource$Globaloperations {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -26990,7 +27039,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$OperationAggregatedList>(parameters, callback);
@@ -27058,7 +27107,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'operation'],
         pathParams: ['operation', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -27125,7 +27174,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'operation'],
         pathParams: ['operation', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -27198,7 +27247,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$OperationList>(parameters, callback);
@@ -27276,7 +27325,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'operation'],
         pathParams: ['operation', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -27447,7 +27496,10 @@ export namespace compute_alpha {
 
 
   export class Resource$Globalorganizationoperations {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -27508,7 +27560,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['operation'],
         pathParams: ['operation'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -27575,7 +27627,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['operation'],
         pathParams: ['operation'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -27648,7 +27700,7 @@ export namespace compute_alpha {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$OperationList>(parameters, callback);
@@ -27726,7 +27778,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['operation'],
         pathParams: ['operation'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -27842,7 +27894,10 @@ export namespace compute_alpha {
 
 
   export class Resource$Healthchecks {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -27914,7 +27969,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$HealthChecksAggregatedList>(
@@ -27986,7 +28041,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'healthCheck'],
         pathParams: ['healthCheck', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -28052,7 +28107,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'healthCheck'],
         pathParams: ['healthCheck', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$HealthCheck>(parameters, callback);
@@ -28123,7 +28178,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -28195,7 +28250,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$HealthCheckList>(parameters, callback);
@@ -28268,7 +28323,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'healthCheck'],
         pathParams: ['healthCheck', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -28341,7 +28396,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -28414,7 +28469,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'healthCheck'],
         pathParams: ['healthCheck', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -28700,7 +28755,10 @@ export namespace compute_alpha {
 
 
   export class Resource$Httphealthchecks {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -28764,7 +28822,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'httpHealthCheck'],
         pathParams: ['httpHealthCheck', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -28831,7 +28889,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'httpHealthCheck'],
         pathParams: ['httpHealthCheck', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$HttpHealthCheck>(parameters, callback);
@@ -28902,7 +28960,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -28975,7 +29033,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$HttpHealthCheckList>(parameters, callback);
@@ -29049,7 +29107,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'httpHealthCheck'],
         pathParams: ['httpHealthCheck', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -29122,7 +29180,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -29195,7 +29253,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'httpHealthCheck'],
         pathParams: ['httpHealthCheck', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -29427,7 +29485,10 @@ export namespace compute_alpha {
 
 
   export class Resource$Httpshealthchecks {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -29491,7 +29552,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'httpsHealthCheck'],
         pathParams: ['httpsHealthCheck', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -29558,7 +29619,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'httpsHealthCheck'],
         pathParams: ['httpsHealthCheck', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$HttpsHealthCheck>(parameters, callback);
@@ -29630,7 +29691,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -29705,7 +29766,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$HttpsHealthCheckList>(parameters, callback);
@@ -29779,7 +29840,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'httpsHealthCheck'],
         pathParams: ['httpsHealthCheck', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -29852,7 +29913,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -29925,7 +29986,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'httpsHealthCheck'],
         pathParams: ['httpsHealthCheck', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -30157,7 +30218,10 @@ export namespace compute_alpha {
 
 
   export class Resource$Images {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -30218,7 +30282,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'image'],
         pathParams: ['image', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -30290,7 +30354,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'image'],
         pathParams: ['image', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -30354,7 +30418,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'image'],
         pathParams: ['image', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Image>(parameters, callback);
@@ -30424,7 +30488,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'family'],
         pathParams: ['family', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Image>(parameters, callback);
@@ -30494,7 +30558,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -30563,7 +30627,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -30637,7 +30701,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ImageList>(parameters, callback);
@@ -30708,7 +30772,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -30779,7 +30843,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -30852,7 +30916,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -31122,7 +31186,10 @@ export namespace compute_alpha {
 
 
   export class Resource$Instancegroupmanagers {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -31201,7 +31268,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'instanceGroupManager'],
         pathParams: ['instanceGroupManager', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -31285,7 +31352,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$InstanceGroupManagerAggregatedList>(
@@ -31363,7 +31430,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'instanceGroupManager'],
         pathParams: ['instanceGroupManager', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -31442,7 +31509,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'instanceGroupManager'],
         pathParams: ['instanceGroupManager', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -31516,7 +31583,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'instanceGroupManager'],
         pathParams: ['instanceGroupManager', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -31600,7 +31667,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'instanceGroupManager'],
         pathParams: ['instanceGroupManager', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -31676,7 +31743,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'instanceGroupManager'],
         pathParams: ['instanceGroupManager', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -31746,7 +31813,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'instanceGroupManager'],
         pathParams: ['instanceGroupManager', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$InstanceGroupManager>(parameters, callback);
@@ -31825,7 +31892,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone'],
         pathParams: ['project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -31902,7 +31969,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone'],
         pathParams: ['project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$InstanceGroupManagerList>(parameters, callback);
@@ -31993,7 +32060,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'instanceGroupManager'],
         pathParams: ['instanceGroupManager', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<
@@ -32083,7 +32150,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'instanceGroupManager'],
         pathParams: ['instanceGroupManager', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<
@@ -32165,7 +32232,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'instanceGroupManager'],
         pathParams: ['instanceGroupManager', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -32243,7 +32310,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'instanceGroupManager'],
         pathParams: ['instanceGroupManager', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -32326,7 +32393,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'instanceGroupManager'],
         pathParams: ['instanceGroupManager', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -32413,7 +32480,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'instanceGroupManager', 'size'],
         pathParams: ['instanceGroupManager', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -32497,7 +32564,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'instanceGroupManager'],
         pathParams: ['instanceGroupManager', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -32574,7 +32641,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'instanceGroupManager'],
         pathParams: ['instanceGroupManager', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -32651,7 +32718,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'instanceGroupManager'],
         pathParams: ['instanceGroupManager', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -32729,7 +32796,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'instanceGroupManager'],
         pathParams: ['instanceGroupManager', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -32804,7 +32871,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'resource'],
         pathParams: ['project', 'resource', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -32881,7 +32948,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'instanceGroupManager'],
         pathParams: ['instanceGroupManager', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -32959,7 +33026,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'instanceGroupManager'],
         pathParams: ['instanceGroupManager', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -33875,7 +33942,10 @@ export namespace compute_alpha {
 
 
   export class Resource$Instancegroups {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -33943,7 +34013,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'instanceGroup'],
         pathParams: ['instanceGroup', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -34022,7 +34092,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$InstanceGroupAggregatedList>(
@@ -34097,7 +34167,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'instanceGroup'],
         pathParams: ['instanceGroup', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -34165,7 +34235,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'instanceGroup'],
         pathParams: ['instanceGroup', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$InstanceGroup>(parameters, callback);
@@ -34238,7 +34308,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone'],
         pathParams: ['project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -34312,7 +34382,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone'],
         pathParams: ['project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$InstanceGroupList>(parameters, callback);
@@ -34394,7 +34464,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'instanceGroup'],
         pathParams: ['instanceGroup', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$InstanceGroupsListInstances>(
@@ -34472,7 +34542,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'instanceGroup'],
         pathParams: ['instanceGroup', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -34545,7 +34615,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'instanceGroup'],
         pathParams: ['instanceGroup', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -34619,7 +34689,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'resource'],
         pathParams: ['project', 'resource', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -35042,7 +35112,10 @@ export namespace compute_alpha {
 
 
   export class Resource$Instances {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -35109,7 +35182,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'instance', 'networkInterface'],
         pathParams: ['instance', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -35184,7 +35257,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'instance'],
         pathParams: ['instance', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -35259,7 +35332,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$InstanceAggregatedList>(parameters, callback);
@@ -35336,7 +35409,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'instance'],
         pathParams: ['instance', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -35407,7 +35480,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'instance'],
         pathParams: ['instance', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -35482,7 +35555,7 @@ export namespace compute_alpha {
         requiredParams:
             ['project', 'zone', 'instance', 'accessConfig', 'networkInterface'],
         pathParams: ['instance', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -35555,7 +35628,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'instance', 'deviceName'],
         pathParams: ['instance', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -35621,7 +35694,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'instance'],
         pathParams: ['instance', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Instance>(parameters, callback);
@@ -35695,7 +35768,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'instance'],
         pathParams: ['instance', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GuestAttributes>(parameters, callback);
@@ -35766,7 +35839,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'resource'],
         pathParams: ['project', 'resource', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -35841,7 +35914,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'instance'],
         pathParams: ['instance', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$SerialPortOutput>(parameters, callback);
@@ -35916,7 +35989,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'instance'],
         pathParams: ['instance', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ShieldedInstanceIdentity>(parameters, callback);
@@ -35988,7 +36061,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'instance'],
         pathParams: ['instance', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ShieldedVmIdentity>(parameters, callback);
@@ -36060,7 +36133,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone'],
         pathParams: ['project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -36132,7 +36205,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone'],
         pathParams: ['project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$InstanceList>(parameters, callback);
@@ -36211,7 +36284,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'instance'],
         pathParams: ['instance', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$InstanceListReferrers>(parameters, callback);
@@ -36285,7 +36358,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'instance'],
         pathParams: ['instance', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -36357,7 +36430,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'instance'],
         pathParams: ['instance', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -36429,7 +36502,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'instance'],
         pathParams: ['instance', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -36503,7 +36576,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'resource'],
         pathParams: ['project', 'resource', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -36578,7 +36651,7 @@ export namespace compute_alpha {
         requiredParams:
             ['project', 'zone', 'instance', 'autoDelete', 'deviceName'],
         pathParams: ['instance', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -36650,7 +36723,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'resource'],
         pathParams: ['project', 'resource', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -36724,7 +36797,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'instance'],
         pathParams: ['instance', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -36798,7 +36871,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'instance'],
         pathParams: ['instance', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -36872,7 +36945,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'instance'],
         pathParams: ['instance', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -36946,7 +37019,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'instance'],
         pathParams: ['instance', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -37021,7 +37094,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'instance'],
         pathParams: ['instance', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -37094,7 +37167,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'instance'],
         pathParams: ['instance', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -37168,7 +37241,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'instance'],
         pathParams: ['instance', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -37247,7 +37320,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'instance'],
         pathParams: ['instance', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -37324,7 +37397,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'instance'],
         pathParams: ['instance', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -37398,7 +37471,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'instance'],
         pathParams: ['instance', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -37470,7 +37543,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'instance'],
         pathParams: ['instance', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -37541,7 +37614,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'instance'],
         pathParams: ['instance', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -37616,7 +37689,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'instance'],
         pathParams: ['instance', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -37692,7 +37765,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'instance'],
         pathParams: ['instance', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -37770,7 +37843,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'instance'],
         pathParams: ['instance', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -37844,7 +37917,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'resource'],
         pathParams: ['project', 'resource', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -37921,7 +37994,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'instance', 'networkInterface'],
         pathParams: ['instance', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -37996,7 +38069,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'instance'],
         pathParams: ['instance', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -38072,7 +38145,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'instance', 'networkInterface'],
         pathParams: ['instance', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -38149,7 +38222,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'instance'],
         pathParams: ['instance', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -38225,7 +38298,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'instance'],
         pathParams: ['instance', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -39818,7 +39891,10 @@ export namespace compute_alpha {
 
 
   export class Resource$Instancetemplates {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -39884,7 +39960,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'instanceTemplate'],
         pathParams: ['instanceTemplate', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -39951,7 +40027,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'instanceTemplate'],
         pathParams: ['instanceTemplate', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$InstanceTemplate>(parameters, callback);
@@ -40021,7 +40097,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -40096,7 +40172,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -40171,7 +40247,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$InstanceTemplateList>(parameters, callback);
@@ -40242,7 +40318,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -40315,7 +40391,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -40516,7 +40592,10 @@ export namespace compute_alpha {
 
 
   export class Resource$Interconnectattachments {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -40593,7 +40672,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$InterconnectAttachmentAggregatedList>(
@@ -40667,7 +40746,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'interconnectAttachment'],
         pathParams: ['interconnectAttachment', 'project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -40735,7 +40814,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'interconnectAttachment'],
         pathParams: ['interconnectAttachment', 'project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$InterconnectAttachment>(parameters, callback);
@@ -40806,7 +40885,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'resource'],
         pathParams: ['project', 'region', 'resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -40879,7 +40958,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -40959,7 +41038,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$InterconnectAttachmentList>(
@@ -41035,7 +41114,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'interconnectAttachment'],
         pathParams: ['interconnectAttachment', 'project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -41107,7 +41186,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'resource'],
         pathParams: ['project', 'region', 'resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -41181,7 +41260,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'resource'],
         pathParams: ['project', 'region', 'resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -41257,7 +41336,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'resource'],
         pathParams: ['project', 'region', 'resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -41617,7 +41696,10 @@ export namespace compute_alpha {
 
 
   export class Resource$Interconnectlocations {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -41678,7 +41760,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'interconnectLocation'],
         pathParams: ['interconnectLocation', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$InterconnectLocation>(parameters, callback);
@@ -41754,7 +41836,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$InterconnectLocationList>(parameters, callback);
@@ -41828,7 +41910,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -41933,7 +42015,10 @@ export namespace compute_alpha {
 
 
   export class Resource$Interconnects {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -41997,7 +42082,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'interconnect'],
         pathParams: ['interconnect', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -42064,7 +42149,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'interconnect'],
         pathParams: ['interconnect', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Interconnect>(parameters, callback);
@@ -42144,7 +42229,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'interconnect'],
         pathParams: ['interconnect', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$InterconnectsGetDiagnosticsResponse>(
@@ -42216,7 +42301,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -42287,7 +42372,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -42359,7 +42444,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$InterconnectList>(parameters, callback);
@@ -42433,7 +42518,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'interconnect'],
         pathParams: ['interconnect', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -42504,7 +42589,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -42576,7 +42661,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -42649,7 +42734,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -42921,7 +43006,10 @@ export namespace compute_alpha {
 
 
   export class Resource$Licensecodes {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -42980,7 +43068,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'licenseCode'],
         pathParams: ['licenseCode', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$LicenseCode>(parameters, callback);
@@ -43050,7 +43138,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -43121,7 +43209,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -43194,7 +43282,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -43280,7 +43368,10 @@ export namespace compute_alpha {
 
 
   export class Resource$Licenses {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -43342,7 +43433,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'license'],
         pathParams: ['license', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -43406,7 +43497,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'license'],
         pathParams: ['license', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$License>(parameters, callback);
@@ -43476,7 +43567,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -43544,7 +43635,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -43620,7 +43711,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$LicensesListResponse>(parameters, callback);
@@ -43691,7 +43782,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -43764,7 +43855,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -43961,7 +44052,10 @@ export namespace compute_alpha {
 
 
   export class Resource$Machineimages {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -44026,7 +44120,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'machineImage'],
         pathParams: ['machineImage', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -44093,7 +44187,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'machineImage'],
         pathParams: ['machineImage', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$MachineImage>(parameters, callback);
@@ -44163,7 +44257,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -44238,7 +44332,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -44310,7 +44404,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$MachineImageList>(parameters, callback);
@@ -44381,7 +44475,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -44454,7 +44548,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -44659,7 +44753,10 @@ export namespace compute_alpha {
 
 
   export class Resource$Machinetypes {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -44727,7 +44824,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$MachineTypeAggregatedList>(
@@ -44795,7 +44892,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'machineType'],
         pathParams: ['machineType', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$MachineType>(parameters, callback);
@@ -44869,7 +44966,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone'],
         pathParams: ['project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$MachineTypeList>(parameters, callback);
@@ -45015,7 +45112,10 @@ export namespace compute_alpha {
 
 
   export class Resource$Networkendpointgroups {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -45092,7 +45192,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$NetworkEndpointGroupAggregatedList>(
@@ -45171,7 +45271,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'networkEndpointGroup'],
         pathParams: ['networkEndpointGroup', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -45246,7 +45346,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'networkEndpointGroup'],
         pathParams: ['networkEndpointGroup', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -45323,7 +45423,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'networkEndpointGroup'],
         pathParams: ['networkEndpointGroup', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -45392,7 +45492,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'networkEndpointGroup'],
         pathParams: ['networkEndpointGroup', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$NetworkEndpointGroup>(parameters, callback);
@@ -45465,7 +45565,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone'],
         pathParams: ['project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -45542,7 +45642,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone'],
         pathParams: ['project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$NetworkEndpointGroupList>(parameters, callback);
@@ -45628,7 +45728,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'networkEndpointGroup'],
         pathParams: ['networkEndpointGroup', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$NetworkEndpointGroupsListNetworkEndpoints>(
@@ -45705,7 +45805,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'resource'],
         pathParams: ['project', 'resource', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -46099,7 +46199,10 @@ export namespace compute_alpha {
 
 
   export class Resource$Networks {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -46164,7 +46267,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'network'],
         pathParams: ['network', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -46233,7 +46336,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'network'],
         pathParams: ['network', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -46298,7 +46401,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'network'],
         pathParams: ['network', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Network>(parameters, callback);
@@ -46367,7 +46470,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -46437,7 +46540,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$NetworkList>(parameters, callback);
@@ -46513,7 +46616,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'network'],
         pathParams: ['network', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$IpAddressesList>(parameters, callback);
@@ -46592,7 +46695,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'network'],
         pathParams: ['network', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$IpOwnerList>(parameters, callback);
@@ -46675,7 +46778,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'network'],
         pathParams: ['network', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ExchangedPeeringRoutesList>(
@@ -46748,7 +46851,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'network'],
         pathParams: ['network', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -46820,7 +46923,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'network'],
         pathParams: ['network', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -46892,7 +46995,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'network'],
         pathParams: ['network', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -46965,7 +47068,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -47040,7 +47143,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'network'],
         pathParams: ['network', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -47580,7 +47683,10 @@ export namespace compute_alpha {
 
 
   export class Resource$Nodegroups {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -47646,7 +47752,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'nodeGroup'],
         pathParams: ['nodeGroup', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -47721,7 +47827,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$NodeGroupAggregatedList>(parameters, callback);
@@ -47792,7 +47898,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'nodeGroup'],
         pathParams: ['nodeGroup', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -47865,7 +47971,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'nodeGroup'],
         pathParams: ['nodeGroup', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -47933,7 +48039,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'nodeGroup'],
         pathParams: ['nodeGroup', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$NodeGroup>(parameters, callback);
@@ -48004,7 +48110,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'resource'],
         pathParams: ['project', 'resource', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -48076,7 +48182,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'initialNodeCount'],
         pathParams: ['project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -48148,7 +48254,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone'],
         pathParams: ['project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$NodeGroupList>(parameters, callback);
@@ -48223,7 +48329,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'nodeGroup'],
         pathParams: ['nodeGroup', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$NodeGroupsListNodes>(parameters, callback);
@@ -48297,7 +48403,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'nodeGroup'],
         pathParams: ['nodeGroup', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -48369,7 +48475,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'resource'],
         pathParams: ['project', 'resource', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -48442,7 +48548,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'nodeGroup'],
         pathParams: ['nodeGroup', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -48516,7 +48622,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'resource'],
         pathParams: ['project', 'resource', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -49017,7 +49123,10 @@ export namespace compute_alpha {
 
 
   export class Resource$Nodetemplates {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -49089,7 +49198,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$NodeTemplateAggregatedList>(
@@ -49162,7 +49271,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'nodeTemplate'],
         pathParams: ['nodeTemplate', 'project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -49230,7 +49339,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'nodeTemplate'],
         pathParams: ['nodeTemplate', 'project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$NodeTemplate>(parameters, callback);
@@ -49301,7 +49410,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'resource'],
         pathParams: ['project', 'region', 'resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -49374,7 +49483,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -49448,7 +49557,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$NodeTemplateList>(parameters, callback);
@@ -49520,7 +49629,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'resource'],
         pathParams: ['project', 'region', 'resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -49594,7 +49703,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'resource'],
         pathParams: ['project', 'region', 'resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -49878,7 +49987,10 @@ export namespace compute_alpha {
 
 
   export class Resource$Nodetypes {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -49945,7 +50057,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$NodeTypeAggregatedList>(parameters, callback);
@@ -50011,7 +50123,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'nodeType'],
         pathParams: ['nodeType', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$NodeType>(parameters, callback);
@@ -50082,7 +50194,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone'],
         pathParams: ['project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$NodeTypeList>(parameters, callback);
@@ -50227,7 +50339,10 @@ export namespace compute_alpha {
 
 
   export class Resource$Organizationsecuritypolicies {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -50294,7 +50409,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['securityPolicy'],
         pathParams: ['securityPolicy'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -50365,7 +50480,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['securityPolicy'],
         pathParams: ['securityPolicy'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -50437,7 +50552,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['securityPolicy'],
         pathParams: ['securityPolicy'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -50507,7 +50622,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['securityPolicy'],
         pathParams: ['securityPolicy'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -50572,7 +50687,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['securityPolicy'],
         pathParams: ['securityPolicy'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$SecurityPolicy>(parameters, callback);
@@ -50647,7 +50762,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['securityPolicy'],
         pathParams: ['securityPolicy'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$SecurityPolicyAssociation>(
@@ -50718,7 +50833,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['securityPolicy'],
         pathParams: ['securityPolicy'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$SecurityPolicyRule>(parameters, callback);
@@ -50789,7 +50904,7 @@ export namespace compute_alpha {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -50862,7 +50977,7 @@ export namespace compute_alpha {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$SecurityPolicyList>(parameters, callback);
@@ -50944,7 +51059,7 @@ export namespace compute_alpha {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<
@@ -51019,7 +51134,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['securityPolicy'],
         pathParams: ['securityPolicy'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -51090,7 +51205,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['securityPolicy'],
         pathParams: ['securityPolicy'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -51163,7 +51278,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['securityPolicy'],
         pathParams: ['securityPolicy'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -51236,7 +51351,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['securityPolicy'],
         pathParams: ['securityPolicy'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -51308,7 +51423,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['securityPolicy'],
         pathParams: ['securityPolicy'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -51734,7 +51849,10 @@ export namespace compute_alpha {
 
 
   export class Resource$Projects {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -51796,7 +51914,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -51867,7 +51985,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -51935,7 +52053,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -52007,7 +52125,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -52068,7 +52186,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Project>(parameters, callback);
@@ -52135,7 +52253,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Project>(parameters, callback);
@@ -52210,7 +52328,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ProjectsGetXpnResources>(parameters, callback);
@@ -52283,7 +52401,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$XpnHostList>(parameters, callback);
@@ -52352,7 +52470,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -52422,7 +52540,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -52495,7 +52613,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -52568,7 +52686,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -52642,7 +52760,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -52715,7 +52833,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -53156,7 +53274,10 @@ export namespace compute_alpha {
 
 
   export class Resource$Regionautoscalers {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -53221,7 +53342,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'autoscaler'],
         pathParams: ['autoscaler', 'project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -53288,7 +53409,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'autoscaler'],
         pathParams: ['autoscaler', 'project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Autoscaler>(parameters, callback);
@@ -53361,7 +53482,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -53437,7 +53558,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$RegionAutoscalerList>(parameters, callback);
@@ -53512,7 +53633,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -53586,7 +53707,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'resource'],
         pathParams: ['project', 'region', 'resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -53660,7 +53781,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -53920,7 +54041,10 @@ export namespace compute_alpha {
 
 
   export class Resource$Regionbackendservices {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -53985,7 +54109,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'backendService'],
         pathParams: ['backendService', 'project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -54052,7 +54176,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'backendService'],
         pathParams: ['backendService', 'project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$BackendService>(parameters, callback);
@@ -54128,7 +54252,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'backendService'],
         pathParams: ['backendService', 'project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$BackendServiceGroupHealth>(
@@ -54204,7 +54328,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -54279,7 +54403,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$BackendServiceList>(parameters, callback);
@@ -54357,7 +54481,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'backendService'],
         pathParams: ['backendService', 'project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -54432,7 +54556,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'resource'],
         pathParams: ['project', 'region', 'resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -54508,7 +54632,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'backendService'],
         pathParams: ['backendService', 'project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -54793,7 +54917,10 @@ export namespace compute_alpha {
 
 
   export class Resource$Regioncommitments {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -54861,7 +54988,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$CommitmentAggregatedList>(parameters, callback);
@@ -54929,7 +55056,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'commitment'],
         pathParams: ['commitment', 'project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Commitment>(parameters, callback);
@@ -55002,7 +55129,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -55077,7 +55204,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$CommitmentList>(parameters, callback);
@@ -55151,7 +55278,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'resource'],
         pathParams: ['project', 'region', 'resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -55225,7 +55352,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'commitment'],
         pathParams: ['commitment', 'project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -55470,7 +55597,10 @@ export namespace compute_alpha {
 
 
   export class Resource$Regiondisks {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -55538,7 +55668,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'disk'],
         pathParams: ['disk', 'project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -55612,7 +55742,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'disk'],
         pathParams: ['disk', 'project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -55687,7 +55817,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'disk'],
         pathParams: ['disk', 'project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -55752,7 +55882,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'disk'],
         pathParams: ['disk', 'project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Disk>(parameters, callback);
@@ -55823,7 +55953,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'resource'],
         pathParams: ['project', 'region', 'resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -55896,7 +56026,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -55967,7 +56097,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$DiskList>(parameters, callback);
@@ -56041,7 +56171,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'disk'],
         pathParams: ['disk', 'project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -56114,7 +56244,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'disk'],
         pathParams: ['disk', 'project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -56186,7 +56316,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'resource'],
         pathParams: ['project', 'region', 'resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -56259,7 +56389,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'resource'],
         pathParams: ['project', 'region', 'resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -56333,7 +56463,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'resource'],
         pathParams: ['project', 'region', 'resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -56758,7 +56888,10 @@ export namespace compute_alpha {
 
 
   export class Resource$Regiondisktypes {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -56818,7 +56951,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'diskType'],
         pathParams: ['diskType', 'project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$DiskType>(parameters, callback);
@@ -56893,7 +57026,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$RegionDiskTypeList>(parameters, callback);
@@ -56985,7 +57118,10 @@ export namespace compute_alpha {
 
 
   export class Resource$Regionhealthchecks {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -57050,7 +57186,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'healthCheck'],
         pathParams: ['healthCheck', 'project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -57118,7 +57254,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'healthCheck'],
         pathParams: ['healthCheck', 'project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$HealthCheck>(parameters, callback);
@@ -57191,7 +57327,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -57266,7 +57402,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$HealthCheckList>(parameters, callback);
@@ -57341,7 +57477,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'healthCheck'],
         pathParams: ['healthCheck', 'project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -57416,7 +57552,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'resource'],
         pathParams: ['project', 'region', 'resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -57490,7 +57626,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'healthCheck'],
         pathParams: ['healthCheck', 'project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -57750,7 +57886,10 @@ export namespace compute_alpha {
 
 
   export class Resource$Regionhealthcheckservices {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -57815,7 +57954,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'healthCheckService'],
         pathParams: ['healthCheckService', 'project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -57882,7 +58021,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'healthCheckService'],
         pathParams: ['healthCheckService', 'project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$HealthCheckService>(parameters, callback);
@@ -57955,7 +58094,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -58031,7 +58170,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$HealthCheckServicesList>(parameters, callback);
@@ -58107,7 +58246,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'resource'],
         pathParams: ['project', 'region', 'resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -58293,7 +58432,10 @@ export namespace compute_alpha {
 
 
   export class Resource$Regioninstancegroupmanagers {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -58373,7 +58515,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'instanceGroupManager'],
         pathParams: ['instanceGroupManager', 'project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -58451,7 +58593,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'instanceGroupManager'],
         pathParams: ['instanceGroupManager', 'project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -58531,7 +58673,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'instanceGroupManager'],
         pathParams: ['instanceGroupManager', 'project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -58604,7 +58746,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'instanceGroupManager'],
         pathParams: ['instanceGroupManager', 'project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -58690,7 +58832,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'instanceGroupManager'],
         pathParams: ['instanceGroupManager', 'project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -58769,7 +58911,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'instanceGroupManager'],
         pathParams: ['instanceGroupManager', 'project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -58838,7 +58980,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'instanceGroupManager'],
         pathParams: ['instanceGroupManager', 'project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$InstanceGroupManager>(parameters, callback);
@@ -58916,7 +59058,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -58996,7 +59138,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$RegionInstanceGroupManagerList>(
@@ -59088,7 +59230,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'instanceGroupManager'],
         pathParams: ['instanceGroupManager', 'project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<
@@ -59183,7 +59325,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'instanceGroupManager'],
         pathParams: ['instanceGroupManager', 'project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<
@@ -59266,7 +59408,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'instanceGroupManager'],
         pathParams: ['instanceGroupManager', 'project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -59347,7 +59489,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'instanceGroupManager'],
         pathParams: ['instanceGroupManager', 'project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -59431,7 +59573,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'instanceGroupManager'],
         pathParams: ['instanceGroupManager', 'project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -59513,7 +59655,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'instanceGroupManager', 'size'],
         pathParams: ['instanceGroupManager', 'project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -59594,7 +59736,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'instanceGroupManager'],
         pathParams: ['instanceGroupManager', 'project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -59671,7 +59813,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'instanceGroupManager'],
         pathParams: ['instanceGroupManager', 'project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -59747,7 +59889,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'instanceGroupManager'],
         pathParams: ['instanceGroupManager', 'project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -59823,7 +59965,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'resource'],
         pathParams: ['project', 'region', 'resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -59900,7 +60042,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'instanceGroupManager'],
         pathParams: ['instanceGroupManager', 'project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -59981,7 +60123,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'instanceGroupManager'],
         pathParams: ['instanceGroupManager', 'project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -60796,7 +60938,10 @@ export namespace compute_alpha {
 
 
   export class Resource$Regioninstancegroups {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -60856,7 +61001,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'instanceGroup'],
         pathParams: ['instanceGroup', 'project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$InstanceGroup>(parameters, callback);
@@ -60932,7 +61077,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$RegionInstanceGroupList>(parameters, callback);
@@ -61021,7 +61166,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'instanceGroup'],
         pathParams: ['instanceGroup', 'project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$RegionInstanceGroupsListInstances>(
@@ -61096,7 +61241,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'instanceGroup'],
         pathParams: ['instanceGroup', 'project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -61171,7 +61316,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'resource'],
         pathParams: ['project', 'region', 'resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -61396,7 +61541,10 @@ export namespace compute_alpha {
 
 
   export class Resource$Regionnotificationendpoints {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -61461,7 +61609,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'notificationEndpoint'],
         pathParams: ['notificationEndpoint', 'project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -61530,7 +61678,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'notificationEndpoint'],
         pathParams: ['notificationEndpoint', 'project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$NotificationEndpoint>(parameters, callback);
@@ -61603,7 +61751,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -61679,7 +61827,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$NotificationEndpointList>(parameters, callback);
@@ -61755,7 +61903,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'resource'],
         pathParams: ['project', 'region', 'resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -61939,7 +62087,10 @@ export namespace compute_alpha {
 
 
   export class Resource$Regionoperations {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -62001,7 +62152,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'operation'],
         pathParams: ['operation', 'project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -62068,7 +62219,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'operation'],
         pathParams: ['operation', 'project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -62143,7 +62294,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$OperationList>(parameters, callback);
@@ -62223,7 +62374,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'operation'],
         pathParams: ['operation', 'project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -62355,7 +62506,10 @@ export namespace compute_alpha {
 
 
   export class Resource$Regions {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -62412,7 +62566,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Region>(parameters, callback);
@@ -62482,7 +62636,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$RegionList>(parameters, callback);
@@ -62564,7 +62718,10 @@ export namespace compute_alpha {
 
 
   export class Resource$Regionsslcertificates {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -62629,7 +62786,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'sslCertificate'],
         pathParams: ['project', 'region', 'sslCertificate'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -62698,7 +62855,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'sslCertificate'],
         pathParams: ['project', 'region', 'sslCertificate'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$SslCertificate>(parameters, callback);
@@ -62771,7 +62928,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -62846,7 +63003,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$SslCertificateList>(parameters, callback);
@@ -62922,7 +63079,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'resource'],
         pathParams: ['project', 'region', 'resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -63106,7 +63263,10 @@ export namespace compute_alpha {
 
 
   export class Resource$Regiontargethttpproxies {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -63171,7 +63331,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'targetHttpProxy'],
         pathParams: ['project', 'region', 'targetHttpProxy'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -63240,7 +63400,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'targetHttpProxy'],
         pathParams: ['project', 'region', 'targetHttpProxy'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TargetHttpProxy>(parameters, callback);
@@ -63313,7 +63473,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -63388,7 +63548,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TargetHttpProxyList>(parameters, callback);
@@ -63461,7 +63621,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'targetHttpProxy'],
         pathParams: ['project', 'region', 'targetHttpProxy'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -63537,7 +63697,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'resource'],
         pathParams: ['project', 'region', 'resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -63759,7 +63919,10 @@ export namespace compute_alpha {
 
 
   export class Resource$Regiontargethttpsproxies {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -63824,7 +63987,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'targetHttpsProxy'],
         pathParams: ['project', 'region', 'targetHttpsProxy'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -63893,7 +64056,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'targetHttpsProxy'],
         pathParams: ['project', 'region', 'targetHttpsProxy'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TargetHttpsProxy>(parameters, callback);
@@ -63966,7 +64129,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -64042,7 +64205,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TargetHttpsProxyList>(parameters, callback);
@@ -64117,7 +64280,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'targetHttpsProxy'],
         pathParams: ['project', 'region', 'targetHttpsProxy'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -64190,7 +64353,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'targetHttpsProxy'],
         pathParams: ['project', 'region', 'targetHttpsProxy'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -64266,7 +64429,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'resource'],
         pathParams: ['project', 'region', 'resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -64527,7 +64690,10 @@ export namespace compute_alpha {
 
 
   export class Resource$Regionurlmaps {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -64592,7 +64758,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'urlMap'],
         pathParams: ['project', 'region', 'urlMap'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -64659,7 +64825,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'urlMap'],
         pathParams: ['project', 'region', 'urlMap'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$UrlMap>(parameters, callback);
@@ -64732,7 +64898,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -64806,7 +64972,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'urlMap'],
         pathParams: ['project', 'region', 'urlMap'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -64880,7 +65046,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$UrlMapList>(parameters, callback);
@@ -64955,7 +65121,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'urlMap'],
         pathParams: ['project', 'region', 'urlMap'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -65029,7 +65195,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'resource'],
         pathParams: ['project', 'region', 'resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -65103,7 +65269,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'urlMap'],
         pathParams: ['project', 'region', 'urlMap'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -65179,7 +65345,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'urlMap'],
         pathParams: ['project', 'region', 'urlMap'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$UrlMapsValidateResponse>(parameters, callback);
@@ -65462,7 +65628,10 @@ export namespace compute_alpha {
 
 
   export class Resource$Reservations {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -65530,7 +65699,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ReservationAggregatedList>(
@@ -65603,7 +65772,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'reservation'],
         pathParams: ['project', 'reservation', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -65669,7 +65838,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'reservation'],
         pathParams: ['project', 'reservation', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Reservation>(parameters, callback);
@@ -65740,7 +65909,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'resource'],
         pathParams: ['project', 'resource', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -65812,7 +65981,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone'],
         pathParams: ['project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -65886,7 +66055,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone'],
         pathParams: ['project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ReservationList>(parameters, callback);
@@ -65960,7 +66129,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'reservation'],
         pathParams: ['project', 'reservation', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -66032,7 +66201,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'resource'],
         pathParams: ['project', 'resource', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -66106,7 +66275,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'resource'],
         pathParams: ['project', 'resource', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -66427,7 +66596,10 @@ export namespace compute_alpha {
 
 
   export class Resource$Resourcepolicies {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -66499,7 +66671,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ResourcePolicyAggregatedList>(
@@ -66573,7 +66745,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'resourcePolicy'],
         pathParams: ['project', 'region', 'resourcePolicy'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -66640,7 +66812,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'resourcePolicy'],
         pathParams: ['project', 'region', 'resourcePolicy'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ResourcePolicy>(parameters, callback);
@@ -66711,7 +66883,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'resource'],
         pathParams: ['project', 'region', 'resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -66783,7 +66955,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -66858,7 +67030,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ResourcePolicyList>(parameters, callback);
@@ -66930,7 +67102,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'resource'],
         pathParams: ['project', 'region', 'resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -67004,7 +67176,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'resource'],
         pathParams: ['project', 'region', 'resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -67288,7 +67460,10 @@ export namespace compute_alpha {
 
 
   export class Resource$Routers {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -67355,7 +67530,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$RouterAggregatedList>(parameters, callback);
@@ -67425,7 +67600,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'router'],
         pathParams: ['project', 'region', 'router'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -67491,7 +67666,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'router'],
         pathParams: ['project', 'region', 'router'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Router>(parameters, callback);
@@ -67570,7 +67745,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'router'],
         pathParams: ['project', 'region', 'router'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$VmEndpointNatMappingsList>(
@@ -67644,7 +67819,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'router'],
         pathParams: ['project', 'region', 'router'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$RouterStatusResponse>(parameters, callback);
@@ -67715,7 +67890,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -67788,7 +67963,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$RouterList>(parameters, callback);
@@ -67861,7 +68036,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'router'],
         pathParams: ['project', 'region', 'router'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -67934,7 +68109,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'router'],
         pathParams: ['project', 'region', 'router'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$RoutersPreviewResponse>(parameters, callback);
@@ -68008,7 +68183,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'resource'],
         pathParams: ['project', 'region', 'resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -68080,7 +68255,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'router'],
         pathParams: ['project', 'region', 'router'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -68503,7 +68678,10 @@ export namespace compute_alpha {
 
 
   export class Resource$Routes {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -68564,7 +68742,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'route'],
         pathParams: ['project', 'route'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -68628,7 +68806,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'route'],
         pathParams: ['project', 'route'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Route>(parameters, callback);
@@ -68696,7 +68874,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -68766,7 +68944,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$RouteList>(parameters, callback);
@@ -68839,7 +69017,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -68999,7 +69177,10 @@ export namespace compute_alpha {
 
 
   export class Resource$Securitypolicies {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -69064,7 +69245,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'securityPolicy'],
         pathParams: ['project', 'securityPolicy'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -69135,7 +69316,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'securityPolicy'],
         pathParams: ['project', 'securityPolicy'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -69201,7 +69382,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'securityPolicy'],
         pathParams: ['project', 'securityPolicy'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$SecurityPolicy>(parameters, callback);
@@ -69272,7 +69453,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'securityPolicy'],
         pathParams: ['project', 'securityPolicy'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$SecurityPolicyRule>(parameters, callback);
@@ -69344,7 +69525,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -69417,7 +69598,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$SecurityPolicyList>(parameters, callback);
@@ -69509,7 +69690,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<
@@ -69585,7 +69766,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'securityPolicy'],
         pathParams: ['project', 'securityPolicy'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -69658,7 +69839,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'securityPolicy'],
         pathParams: ['project', 'securityPolicy'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -69729,7 +69910,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'securityPolicy'],
         pathParams: ['project', 'securityPolicy'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -69801,7 +69982,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -69874,7 +70055,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -70246,7 +70427,10 @@ export namespace compute_alpha {
 
 
   export class Resource$Snapshots {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -70312,7 +70496,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'snapshot'],
         pathParams: ['project', 'snapshot'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -70377,7 +70561,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'snapshot'],
         pathParams: ['project', 'snapshot'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Snapshot>(parameters, callback);
@@ -70447,7 +70631,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -70518,7 +70702,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$SnapshotList>(parameters, callback);
@@ -70589,7 +70773,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -70661,7 +70845,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -70734,7 +70918,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -70923,7 +71107,10 @@ export namespace compute_alpha {
 
 
   export class Resource$Sslcertificates {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -70996,7 +71183,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$SslCertificateAggregatedList>(
@@ -71069,7 +71256,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'sslCertificate'],
         pathParams: ['project', 'sslCertificate'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -71136,7 +71323,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'sslCertificate'],
         pathParams: ['project', 'sslCertificate'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$SslCertificate>(parameters, callback);
@@ -71207,7 +71394,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -71280,7 +71467,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$SslCertificateList>(parameters, callback);
@@ -71353,7 +71540,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -71572,7 +71759,10 @@ export namespace compute_alpha {
 
 
   export class Resource$Sslpolicies {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -71638,7 +71828,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'sslPolicy'],
         pathParams: ['project', 'sslPolicy'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -71704,7 +71894,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'sslPolicy'],
         pathParams: ['project', 'sslPolicy'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$SslPolicy>(parameters, callback);
@@ -71775,7 +71965,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -71846,7 +72036,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$SslPoliciesList>(parameters, callback);
@@ -71927,7 +72117,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$SslPoliciesListAvailableFeaturesResponse>(
@@ -72001,7 +72191,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'sslPolicy'],
         pathParams: ['project', 'sslPolicy'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -72074,7 +72264,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -72328,7 +72518,10 @@ export namespace compute_alpha {
 
 
   export class Resource$Subnetworks {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -72396,7 +72589,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$SubnetworkAggregatedList>(parameters, callback);
@@ -72468,7 +72661,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'subnetwork'],
         pathParams: ['project', 'region', 'subnetwork'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -72541,7 +72734,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'subnetwork'],
         pathParams: ['project', 'region', 'subnetwork'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -72608,7 +72801,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'subnetwork'],
         pathParams: ['project', 'region', 'subnetwork'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Subnetwork>(parameters, callback);
@@ -72679,7 +72872,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'resource'],
         pathParams: ['project', 'region', 'resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -72752,7 +72945,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -72824,7 +73017,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$SubnetworkList>(parameters, callback);
@@ -72904,7 +73097,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$UsableSubnetworksAggregatedList>(
@@ -72982,7 +73175,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'subnetwork'],
         pathParams: ['project', 'region', 'subnetwork'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -73054,7 +73247,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'resource'],
         pathParams: ['project', 'region', 'resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -73129,7 +73322,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'subnetwork'],
         pathParams: ['project', 'region', 'subnetwork'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -73203,7 +73396,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'resource'],
         pathParams: ['project', 'region', 'resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -73665,7 +73858,10 @@ export namespace compute_alpha {
 
 
   export class Resource$Targethttpproxies {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -73738,7 +73934,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TargetHttpProxyAggregatedList>(
@@ -73811,7 +74007,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'targetHttpProxy'],
         pathParams: ['project', 'targetHttpProxy'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -73878,7 +74074,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'targetHttpProxy'],
         pathParams: ['project', 'targetHttpProxy'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TargetHttpProxy>(parameters, callback);
@@ -73950,7 +74146,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -74024,7 +74220,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TargetHttpProxyList>(parameters, callback);
@@ -74096,7 +74292,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'targetHttpProxy'],
         pathParams: ['project', 'targetHttpProxy'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -74169,7 +74365,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -74422,7 +74618,10 @@ export namespace compute_alpha {
 
 
   export class Resource$Targethttpsproxies {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -74495,7 +74694,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TargetHttpsProxyAggregatedList>(
@@ -74568,7 +74767,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'targetHttpsProxy'],
         pathParams: ['project', 'targetHttpsProxy'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -74635,7 +74834,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'targetHttpsProxy'],
         pathParams: ['project', 'targetHttpsProxy'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TargetHttpsProxy>(parameters, callback);
@@ -74707,7 +74906,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -74782,7 +74981,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TargetHttpsProxyList>(parameters, callback);
@@ -74854,7 +75053,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'targetHttpsProxy'],
         pathParams: ['project', 'targetHttpsProxy'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -74927,7 +75126,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'targetHttpsProxy'],
         pathParams: ['project', 'targetHttpsProxy'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -75002,7 +75201,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'targetHttpsProxy'],
         pathParams: ['project', 'targetHttpsProxy'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -75074,7 +75273,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'targetHttpsProxy'],
         pathParams: ['project', 'targetHttpsProxy'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -75148,7 +75347,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -75506,7 +75705,10 @@ export namespace compute_alpha {
 
 
   export class Resource$Targetinstances {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -75578,7 +75780,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TargetInstanceAggregatedList>(
@@ -75652,7 +75854,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'targetInstance'],
         pathParams: ['project', 'targetInstance', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -75720,7 +75922,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'targetInstance'],
         pathParams: ['project', 'targetInstance', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TargetInstance>(parameters, callback);
@@ -75793,7 +75995,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone'],
         pathParams: ['project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -75868,7 +76070,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone'],
         pathParams: ['project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TargetInstanceList>(parameters, callback);
@@ -75942,7 +76144,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'resource'],
         pathParams: ['project', 'resource', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -76181,7 +76383,10 @@ export namespace compute_alpha {
 
 
   export class Resource$Targetpools {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -76247,7 +76452,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'targetPool'],
         pathParams: ['project', 'region', 'targetPool'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -76320,7 +76525,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'targetPool'],
         pathParams: ['project', 'region', 'targetPool'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -76395,7 +76600,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TargetPoolAggregatedList>(parameters, callback);
@@ -76467,7 +76672,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'targetPool'],
         pathParams: ['project', 'region', 'targetPool'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -76534,7 +76739,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'targetPool'],
         pathParams: ['project', 'region', 'targetPool'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TargetPool>(parameters, callback);
@@ -76610,7 +76815,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'targetPool'],
         pathParams: ['project', 'region', 'targetPool'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TargetPoolInstanceHealth>(parameters, callback);
@@ -76683,7 +76888,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -76756,7 +76961,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TargetPoolList>(parameters, callback);
@@ -76829,7 +77034,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'targetPool'],
         pathParams: ['project', 'region', 'targetPool'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -76902,7 +77107,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'targetPool'],
         pathParams: ['project', 'region', 'targetPool'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -76976,7 +77181,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'targetPool'],
         pathParams: ['project', 'region', 'targetPool'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -77050,7 +77255,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'resource'],
         pathParams: ['project', 'region', 'resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -77506,7 +77711,10 @@ export namespace compute_alpha {
 
 
   export class Resource$Targetsslproxies {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -77570,7 +77778,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'targetSslProxy'],
         pathParams: ['project', 'targetSslProxy'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -77637,7 +77845,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'targetSslProxy'],
         pathParams: ['project', 'targetSslProxy'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TargetSslProxy>(parameters, callback);
@@ -77708,7 +77916,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -77781,7 +77989,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TargetSslProxyList>(parameters, callback);
@@ -77853,7 +78061,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'targetSslProxy'],
         pathParams: ['project', 'targetSslProxy'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -77925,7 +78133,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'targetSslProxy'],
         pathParams: ['project', 'targetSslProxy'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -77997,7 +78205,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'targetSslProxy'],
         pathParams: ['project', 'targetSslProxy'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -78072,7 +78280,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'targetSslProxy'],
         pathParams: ['project', 'targetSslProxy'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -78145,7 +78353,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -78448,7 +78656,10 @@ export namespace compute_alpha {
 
 
   export class Resource$Targettcpproxies {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -78512,7 +78723,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'targetTcpProxy'],
         pathParams: ['project', 'targetTcpProxy'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -78579,7 +78790,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'targetTcpProxy'],
         pathParams: ['project', 'targetTcpProxy'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TargetTcpProxy>(parameters, callback);
@@ -78650,7 +78861,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -78723,7 +78934,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TargetTcpProxyList>(parameters, callback);
@@ -78795,7 +79006,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'targetTcpProxy'],
         pathParams: ['project', 'targetTcpProxy'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -78867,7 +79078,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'targetTcpProxy'],
         pathParams: ['project', 'targetTcpProxy'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -78940,7 +79151,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -79173,7 +79384,10 @@ export namespace compute_alpha {
 
 
   export class Resource$Targetvpngateways {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -79245,7 +79459,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TargetVpnGatewayAggregatedList>(
@@ -79319,7 +79533,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'targetVpnGateway'],
         pathParams: ['project', 'region', 'targetVpnGateway'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -79387,7 +79601,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'targetVpnGateway'],
         pathParams: ['project', 'region', 'targetVpnGateway'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TargetVpnGateway>(parameters, callback);
@@ -79460,7 +79674,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -79536,7 +79750,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TargetVpnGatewayList>(parameters, callback);
@@ -79610,7 +79824,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'resource'],
         pathParams: ['project', 'region', 'resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -79684,7 +79898,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'resource'],
         pathParams: ['project', 'region', 'resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -79961,7 +80175,10 @@ export namespace compute_alpha {
 
 
   export class Resource$Urlmaps {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -80029,7 +80246,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$UrlMapsAggregatedList>(parameters, callback);
@@ -80097,7 +80314,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'urlMap'],
         pathParams: ['project', 'urlMap'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -80161,7 +80378,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'urlMap'],
         pathParams: ['project', 'urlMap'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$UrlMap>(parameters, callback);
@@ -80230,7 +80447,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -80303,7 +80520,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'urlMap'],
         pathParams: ['project', 'urlMap'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -80374,7 +80591,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$UrlMapList>(parameters, callback);
@@ -80445,7 +80662,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'urlMap'],
         pathParams: ['project', 'urlMap'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -80518,7 +80735,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -80588,7 +80805,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'urlMap'],
         pathParams: ['project', 'urlMap'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -80662,7 +80879,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'urlMap'],
         pathParams: ['project', 'urlMap'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$UrlMapsValidateResponse>(parameters, callback);
@@ -80997,7 +81214,10 @@ export namespace compute_alpha {
 
 
   export class Resource$Vpngateways {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -81065,7 +81285,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$VpnGatewayAggregatedList>(parameters, callback);
@@ -81137,7 +81357,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'vpnGateway'],
         pathParams: ['project', 'region', 'vpnGateway'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -81204,7 +81424,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'vpnGateway'],
         pathParams: ['project', 'region', 'vpnGateway'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$VpnGateway>(parameters, callback);
@@ -81281,7 +81501,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'vpnGateway'],
         pathParams: ['project', 'region', 'vpnGateway'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$VpnGatewaysGetStatusResponse>(
@@ -81356,7 +81576,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -81429,7 +81649,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$VpnGatewayList>(parameters, callback);
@@ -81503,7 +81723,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'resource'],
         pathParams: ['project', 'region', 'resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -81577,7 +81797,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'resource'],
         pathParams: ['project', 'region', 'resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -81872,7 +82092,10 @@ export namespace compute_alpha {
 
 
   export class Resource$Vpntunnels {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -81939,7 +82162,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$VpnTunnelAggregatedList>(parameters, callback);
@@ -82010,7 +82233,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'vpnTunnel'],
         pathParams: ['project', 'region', 'vpnTunnel'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -82077,7 +82300,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'vpnTunnel'],
         pathParams: ['project', 'region', 'vpnTunnel'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$VpnTunnel>(parameters, callback);
@@ -82149,7 +82372,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -82222,7 +82445,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$VpnTunnelList>(parameters, callback);
@@ -82296,7 +82519,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'resource'],
         pathParams: ['project', 'region', 'resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -82370,7 +82593,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'region', 'resource'],
         pathParams: ['project', 'region', 'resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -82645,7 +82868,10 @@ export namespace compute_alpha {
 
 
   export class Resource$Zoneoperations {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -82707,7 +82933,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'operation'],
         pathParams: ['operation', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -82774,7 +83000,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'operation'],
         pathParams: ['operation', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -82847,7 +83073,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone'],
         pathParams: ['project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$OperationList>(parameters, callback);
@@ -82925,7 +83151,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone', 'operation'],
         pathParams: ['operation', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -83057,7 +83283,10 @@ export namespace compute_alpha {
 
 
   export class Resource$Zones {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -83113,7 +83342,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project', 'zone'],
         pathParams: ['project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Zone>(parameters, callback);
@@ -83182,7 +83411,7 @@ export namespace compute_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ZoneList>(parameters, callback);

--- a/src/apis/compute/beta.ts
+++ b/src/apis/compute/beta.ts
@@ -29,8 +29,6 @@ export namespace compute_beta {
     version: 'beta';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * Data format for the response.
@@ -81,6 +79,7 @@ export namespace compute_beta {
    * @param {object=} options Options for Compute
    */
   export class Compute {
+    context: APIRequestContext;
     acceleratorTypes: Resource$Acceleratortypes;
     addresses: Resource$Addresses;
     autoscalers: Resource$Autoscalers;
@@ -146,72 +145,79 @@ export namespace compute_beta {
     zones: Resource$Zones;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.acceleratorTypes = new Resource$Acceleratortypes();
-      this.addresses = new Resource$Addresses();
-      this.autoscalers = new Resource$Autoscalers();
-      this.backendBuckets = new Resource$Backendbuckets();
-      this.backendServices = new Resource$Backendservices();
-      this.disks = new Resource$Disks();
-      this.diskTypes = new Resource$Disktypes();
-      this.externalVpnGateways = new Resource$Externalvpngateways();
-      this.firewalls = new Resource$Firewalls();
-      this.forwardingRules = new Resource$Forwardingrules();
-      this.globalAddresses = new Resource$Globaladdresses();
-      this.globalForwardingRules = new Resource$Globalforwardingrules();
-      this.globalOperations = new Resource$Globaloperations();
-      this.healthChecks = new Resource$Healthchecks();
-      this.httpHealthChecks = new Resource$Httphealthchecks();
-      this.httpsHealthChecks = new Resource$Httpshealthchecks();
-      this.images = new Resource$Images();
-      this.instanceGroupManagers = new Resource$Instancegroupmanagers();
-      this.instanceGroups = new Resource$Instancegroups();
-      this.instances = new Resource$Instances();
-      this.instanceTemplates = new Resource$Instancetemplates();
-      this.interconnectAttachments = new Resource$Interconnectattachments();
-      this.interconnectLocations = new Resource$Interconnectlocations();
-      this.interconnects = new Resource$Interconnects();
-      this.licenseCodes = new Resource$Licensecodes();
-      this.licenses = new Resource$Licenses();
-      this.machineTypes = new Resource$Machinetypes();
-      this.networkEndpointGroups = new Resource$Networkendpointgroups();
-      this.networks = new Resource$Networks();
-      this.nodeGroups = new Resource$Nodegroups();
-      this.nodeTemplates = new Resource$Nodetemplates();
-      this.nodeTypes = new Resource$Nodetypes();
-      this.projects = new Resource$Projects();
-      this.regionAutoscalers = new Resource$Regionautoscalers();
-      this.regionBackendServices = new Resource$Regionbackendservices();
-      this.regionCommitments = new Resource$Regioncommitments();
-      this.regionDisks = new Resource$Regiondisks();
-      this.regionDiskTypes = new Resource$Regiondisktypes();
+      this.acceleratorTypes = new Resource$Acceleratortypes(this.context);
+      this.addresses = new Resource$Addresses(this.context);
+      this.autoscalers = new Resource$Autoscalers(this.context);
+      this.backendBuckets = new Resource$Backendbuckets(this.context);
+      this.backendServices = new Resource$Backendservices(this.context);
+      this.disks = new Resource$Disks(this.context);
+      this.diskTypes = new Resource$Disktypes(this.context);
+      this.externalVpnGateways = new Resource$Externalvpngateways(this.context);
+      this.firewalls = new Resource$Firewalls(this.context);
+      this.forwardingRules = new Resource$Forwardingrules(this.context);
+      this.globalAddresses = new Resource$Globaladdresses(this.context);
+      this.globalForwardingRules =
+          new Resource$Globalforwardingrules(this.context);
+      this.globalOperations = new Resource$Globaloperations(this.context);
+      this.healthChecks = new Resource$Healthchecks(this.context);
+      this.httpHealthChecks = new Resource$Httphealthchecks(this.context);
+      this.httpsHealthChecks = new Resource$Httpshealthchecks(this.context);
+      this.images = new Resource$Images(this.context);
+      this.instanceGroupManagers =
+          new Resource$Instancegroupmanagers(this.context);
+      this.instanceGroups = new Resource$Instancegroups(this.context);
+      this.instances = new Resource$Instances(this.context);
+      this.instanceTemplates = new Resource$Instancetemplates(this.context);
+      this.interconnectAttachments =
+          new Resource$Interconnectattachments(this.context);
+      this.interconnectLocations =
+          new Resource$Interconnectlocations(this.context);
+      this.interconnects = new Resource$Interconnects(this.context);
+      this.licenseCodes = new Resource$Licensecodes(this.context);
+      this.licenses = new Resource$Licenses(this.context);
+      this.machineTypes = new Resource$Machinetypes(this.context);
+      this.networkEndpointGroups =
+          new Resource$Networkendpointgroups(this.context);
+      this.networks = new Resource$Networks(this.context);
+      this.nodeGroups = new Resource$Nodegroups(this.context);
+      this.nodeTemplates = new Resource$Nodetemplates(this.context);
+      this.nodeTypes = new Resource$Nodetypes(this.context);
+      this.projects = new Resource$Projects(this.context);
+      this.regionAutoscalers = new Resource$Regionautoscalers(this.context);
+      this.regionBackendServices =
+          new Resource$Regionbackendservices(this.context);
+      this.regionCommitments = new Resource$Regioncommitments(this.context);
+      this.regionDisks = new Resource$Regiondisks(this.context);
+      this.regionDiskTypes = new Resource$Regiondisktypes(this.context);
       this.regionInstanceGroupManagers =
-          new Resource$Regioninstancegroupmanagers();
-      this.regionInstanceGroups = new Resource$Regioninstancegroups();
-      this.regionOperations = new Resource$Regionoperations();
-      this.regions = new Resource$Regions();
-      this.reservations = new Resource$Reservations();
-      this.resourcePolicies = new Resource$Resourcepolicies();
-      this.routers = new Resource$Routers();
-      this.routes = new Resource$Routes();
-      this.securityPolicies = new Resource$Securitypolicies();
-      this.snapshots = new Resource$Snapshots();
-      this.sslCertificates = new Resource$Sslcertificates();
-      this.sslPolicies = new Resource$Sslpolicies();
-      this.subnetworks = new Resource$Subnetworks();
-      this.targetHttpProxies = new Resource$Targethttpproxies();
-      this.targetHttpsProxies = new Resource$Targethttpsproxies();
-      this.targetInstances = new Resource$Targetinstances();
-      this.targetPools = new Resource$Targetpools();
-      this.targetSslProxies = new Resource$Targetsslproxies();
-      this.targetTcpProxies = new Resource$Targettcpproxies();
-      this.targetVpnGateways = new Resource$Targetvpngateways();
-      this.urlMaps = new Resource$Urlmaps();
-      this.vpnGateways = new Resource$Vpngateways();
-      this.vpnTunnels = new Resource$Vpntunnels();
-      this.zoneOperations = new Resource$Zoneoperations();
-      this.zones = new Resource$Zones();
+          new Resource$Regioninstancegroupmanagers(this.context);
+      this.regionInstanceGroups =
+          new Resource$Regioninstancegroups(this.context);
+      this.regionOperations = new Resource$Regionoperations(this.context);
+      this.regions = new Resource$Regions(this.context);
+      this.reservations = new Resource$Reservations(this.context);
+      this.resourcePolicies = new Resource$Resourcepolicies(this.context);
+      this.routers = new Resource$Routers(this.context);
+      this.routes = new Resource$Routes(this.context);
+      this.securityPolicies = new Resource$Securitypolicies(this.context);
+      this.snapshots = new Resource$Snapshots(this.context);
+      this.sslCertificates = new Resource$Sslcertificates(this.context);
+      this.sslPolicies = new Resource$Sslpolicies(this.context);
+      this.subnetworks = new Resource$Subnetworks(this.context);
+      this.targetHttpProxies = new Resource$Targethttpproxies(this.context);
+      this.targetHttpsProxies = new Resource$Targethttpsproxies(this.context);
+      this.targetInstances = new Resource$Targetinstances(this.context);
+      this.targetPools = new Resource$Targetpools(this.context);
+      this.targetSslProxies = new Resource$Targetsslproxies(this.context);
+      this.targetTcpProxies = new Resource$Targettcpproxies(this.context);
+      this.targetVpnGateways = new Resource$Targetvpngateways(this.context);
+      this.urlMaps = new Resource$Urlmaps(this.context);
+      this.vpnGateways = new Resource$Vpngateways(this.context);
+      this.vpnTunnels = new Resource$Vpntunnels(this.context);
+      this.zoneOperations = new Resource$Zoneoperations(this.context);
+      this.zones = new Resource$Zones(this.context);
     }
   }
 
@@ -13282,7 +13288,10 @@ export namespace compute_beta {
 
 
   export class Resource$Acceleratortypes {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -13421,7 +13430,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AcceleratorTypeAggregatedList>(
@@ -13550,7 +13559,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone', 'acceleratorType'],
         pathParams: ['acceleratorType', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AcceleratorType>(parameters, callback);
@@ -13694,7 +13703,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone'],
         pathParams: ['project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AcceleratorTypeList>(parameters, callback);
@@ -13841,7 +13850,10 @@ export namespace compute_beta {
 
 
   export class Resource$Addresses {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -13975,7 +13987,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AddressAggregatedList>(parameters, callback);
@@ -14104,7 +14116,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region', 'address'],
         pathParams: ['address', 'project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -14228,7 +14240,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region', 'address'],
         pathParams: ['address', 'project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Address>(parameters, callback);
@@ -14359,7 +14371,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -14501,7 +14513,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AddressList>(parameters, callback);
@@ -14638,7 +14650,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region', 'resource'],
         pathParams: ['project', 'region', 'resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -14775,7 +14787,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region', 'resource'],
         pathParams: ['project', 'region', 'resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -15048,7 +15060,10 @@ export namespace compute_beta {
 
 
   export class Resource$Autoscalers {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -15183,7 +15198,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AutoscalerAggregatedList>(parameters, callback);
@@ -15314,7 +15329,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone', 'autoscaler'],
         pathParams: ['autoscaler', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -15440,7 +15455,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone', 'autoscaler'],
         pathParams: ['autoscaler', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Autoscaler>(parameters, callback);
@@ -15572,7 +15587,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone'],
         pathParams: ['project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -15713,7 +15728,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone'],
         pathParams: ['project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AutoscalerList>(parameters, callback);
@@ -15848,7 +15863,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone'],
         pathParams: ['project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -15983,7 +15998,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone', 'resource'],
         pathParams: ['project', 'resource', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -16118,7 +16133,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone'],
         pathParams: ['project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -16431,7 +16446,10 @@ export namespace compute_beta {
 
 
   export class Resource$Backendbuckets {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -16497,7 +16515,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'backendBucket'],
         pathParams: ['backendBucket', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -16625,7 +16643,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'backendBucket'],
         pathParams: ['backendBucket', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -16698,7 +16716,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'backendBucket', 'keyName'],
         pathParams: ['backendBucket', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -16822,7 +16840,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'backendBucket'],
         pathParams: ['backendBucket', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$BackendBucket>(parameters, callback);
@@ -16950,7 +16968,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -17088,7 +17106,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$BackendBucketList>(parameters, callback);
@@ -17225,7 +17243,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'backendBucket'],
         pathParams: ['backendBucket', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -17361,7 +17379,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'backendBucket'],
         pathParams: ['backendBucket', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -17641,7 +17659,10 @@ export namespace compute_beta {
 
 
   export class Resource$Backendservices {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -17707,7 +17728,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'backendService'],
         pathParams: ['backendService', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -17854,7 +17875,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$BackendServiceAggregatedList>(
@@ -17984,7 +18005,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'backendService'],
         pathParams: ['backendService', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -18057,7 +18078,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'backendService', 'keyName'],
         pathParams: ['backendService', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -18181,7 +18202,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'backendService'],
         pathParams: ['backendService', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$BackendService>(parameters, callback);
@@ -18315,7 +18336,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'backendService'],
         pathParams: ['backendService', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$BackendServiceGroupHealth>(
@@ -18446,7 +18467,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -18585,7 +18606,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$BackendServiceList>(parameters, callback);
@@ -18724,7 +18745,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'backendService'],
         pathParams: ['backendService', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -18857,7 +18878,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'backendService'],
         pathParams: ['backendService', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -18988,7 +19009,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -19126,7 +19147,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'backendService'],
         pathParams: ['backendService', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -19539,7 +19560,10 @@ export namespace compute_beta {
 
 
   export class Resource$Disks {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -19607,7 +19631,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone', 'disk'],
         pathParams: ['disk', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -19747,7 +19771,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$DiskAggregatedList>(parameters, callback);
@@ -19884,7 +19908,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone', 'disk'],
         pathParams: ['disk', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -20016,7 +20040,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone', 'disk'],
         pathParams: ['disk', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -20141,7 +20165,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone', 'disk'],
         pathParams: ['disk', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Disk>(parameters, callback);
@@ -20212,7 +20236,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone', 'resource'],
         pathParams: ['project', 'resource', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -20346,7 +20370,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone'],
         pathParams: ['project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -20486,7 +20510,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone'],
         pathParams: ['project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$DiskList>(parameters, callback);
@@ -20560,7 +20584,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone', 'disk'],
         pathParams: ['disk', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -20695,7 +20719,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone', 'disk'],
         pathParams: ['disk', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -20767,7 +20791,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone', 'resource'],
         pathParams: ['project', 'resource', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -20903,7 +20927,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone', 'resource'],
         pathParams: ['project', 'resource', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -21040,7 +21064,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone', 'resource'],
         pathParams: ['project', 'resource', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -21516,7 +21540,10 @@ export namespace compute_beta {
 
 
   export class Resource$Disktypes {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -21650,7 +21677,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$DiskTypeAggregatedList>(parameters, callback);
@@ -21775,7 +21802,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone', 'diskType'],
         pathParams: ['diskType', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$DiskType>(parameters, callback);
@@ -21915,7 +21942,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone'],
         pathParams: ['project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$DiskTypeList>(parameters, callback);
@@ -22060,7 +22087,10 @@ export namespace compute_beta {
 
 
   export class Resource$Externalvpngateways {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -22124,7 +22154,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'externalVpnGateway'],
         pathParams: ['externalVpnGateway', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -22191,7 +22221,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'externalVpnGateway'],
         pathParams: ['externalVpnGateway', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ExternalVpnGateway>(parameters, callback);
@@ -22263,7 +22293,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -22338,7 +22368,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ExternalVpnGatewayList>(parameters, callback);
@@ -22410,7 +22440,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -22484,7 +22514,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -22669,7 +22699,10 @@ export namespace compute_beta {
 
 
   export class Resource$Firewalls {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -22787,7 +22820,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'firewall'],
         pathParams: ['firewall', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -22907,7 +22940,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'firewall'],
         pathParams: ['firewall', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Firewall>(parameters, callback);
@@ -23033,7 +23066,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -23170,7 +23203,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$FirewallList>(parameters, callback);
@@ -23304,7 +23337,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'firewall'],
         pathParams: ['firewall', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -23437,7 +23470,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -23571,7 +23604,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'firewall'],
         pathParams: ['firewall', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -23797,7 +23830,10 @@ export namespace compute_beta {
 
 
   export class Resource$Forwardingrules {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -23936,7 +23972,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ForwardingRuleAggregatedList>(
@@ -24070,7 +24106,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region', 'forwardingRule'],
         pathParams: ['forwardingRule', 'project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -24197,7 +24233,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region', 'forwardingRule'],
         pathParams: ['forwardingRule', 'project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ForwardingRule>(parameters, callback);
@@ -24330,7 +24366,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -24474,7 +24510,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ForwardingRuleList>(parameters, callback);
@@ -24550,7 +24586,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region', 'forwardingRule'],
         pathParams: ['forwardingRule', 'project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -24687,7 +24723,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region', 'resource'],
         pathParams: ['project', 'region', 'resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -24825,7 +24861,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region', 'forwardingRule'],
         pathParams: ['forwardingRule', 'project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -24960,7 +24996,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region', 'resource'],
         pathParams: ['project', 'region', 'resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -25313,7 +25349,10 @@ export namespace compute_beta {
 
 
   export class Resource$Globaladdresses {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -25433,7 +25472,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'address'],
         pathParams: ['address', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -25555,7 +25594,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'address'],
         pathParams: ['address', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Address>(parameters, callback);
@@ -25683,7 +25722,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -25821,7 +25860,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AddressList>(parameters, callback);
@@ -25953,7 +25992,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -26084,7 +26123,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -26269,7 +26308,10 @@ export namespace compute_beta {
 
 
   export class Resource$Globalforwardingrules {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -26390,7 +26432,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'forwardingRule'],
         pathParams: ['forwardingRule', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -26514,7 +26556,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'forwardingRule'],
         pathParams: ['forwardingRule', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ForwardingRule>(parameters, callback);
@@ -26642,7 +26684,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -26781,7 +26823,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ForwardingRuleList>(parameters, callback);
@@ -26856,7 +26898,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'forwardingRule'],
         pathParams: ['forwardingRule', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -26986,7 +27028,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -27118,7 +27160,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'forwardingRule'],
         pathParams: ['forwardingRule', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -27250,7 +27292,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -27503,7 +27545,10 @@ export namespace compute_beta {
 
 
   export class Resource$Globaloperations {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -27637,7 +27682,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$OperationAggregatedList>(parameters, callback);
@@ -27758,7 +27803,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'operation'],
         pathParams: ['operation', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -27881,7 +27926,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'operation'],
         pathParams: ['operation', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -28020,7 +28065,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$OperationList>(parameters, callback);
@@ -28175,7 +28220,10 @@ export namespace compute_beta {
 
 
   export class Resource$Healthchecks {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -28295,7 +28343,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'healthCheck'],
         pathParams: ['healthCheck', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -28417,7 +28465,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'healthCheck'],
         pathParams: ['healthCheck', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$HealthCheck>(parameters, callback);
@@ -28545,7 +28593,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -28683,7 +28731,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$HealthCheckList>(parameters, callback);
@@ -28818,7 +28866,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'healthCheck'],
         pathParams: ['healthCheck', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -28949,7 +28997,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -29084,7 +29132,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'healthCheck'],
         pathParams: ['healthCheck', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -29315,7 +29363,10 @@ export namespace compute_beta {
 
 
   export class Resource$Httphealthchecks {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -29436,7 +29487,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'httpHealthCheck'],
         pathParams: ['httpHealthCheck', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -29560,7 +29611,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'httpHealthCheck'],
         pathParams: ['httpHealthCheck', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$HttpHealthCheck>(parameters, callback);
@@ -29688,7 +29739,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -29827,7 +29878,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$HttpHealthCheckList>(parameters, callback);
@@ -29964,7 +30015,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'httpHealthCheck'],
         pathParams: ['httpHealthCheck', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -30095,7 +30146,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -30231,7 +30282,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'httpHealthCheck'],
         pathParams: ['httpHealthCheck', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -30463,7 +30514,10 @@ export namespace compute_beta {
 
 
   export class Resource$Httpshealthchecks {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -30584,7 +30638,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'httpsHealthCheck'],
         pathParams: ['httpsHealthCheck', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -30708,7 +30762,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'httpsHealthCheck'],
         pathParams: ['httpsHealthCheck', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$HttpsHealthCheck>(parameters, callback);
@@ -30836,7 +30890,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -30976,7 +31030,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$HttpsHealthCheckList>(parameters, callback);
@@ -31113,7 +31167,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'httpsHealthCheck'],
         pathParams: ['httpsHealthCheck', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -31244,7 +31298,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -31380,7 +31434,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'httpsHealthCheck'],
         pathParams: ['httpsHealthCheck', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -31612,7 +31666,10 @@ export namespace compute_beta {
 
 
   export class Resource$Images {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -31729,7 +31786,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'image'],
         pathParams: ['image', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -31861,7 +31918,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'image'],
         pathParams: ['image', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -31981,7 +32038,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'image'],
         pathParams: ['image', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Image>(parameters, callback);
@@ -32107,7 +32164,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'family'],
         pathParams: ['family', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Image>(parameters, callback);
@@ -32177,7 +32234,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -32303,7 +32360,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -32443,7 +32500,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ImageList>(parameters, callback);
@@ -32514,7 +32571,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -32645,7 +32702,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -32778,7 +32835,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -33048,7 +33105,10 @@ export namespace compute_beta {
 
 
   export class Resource$Instancegroupmanagers {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -33189,7 +33249,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone', 'instanceGroupManager'],
         pathParams: ['instanceGroupManager', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -33340,7 +33400,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$InstanceGroupManagerAggregatedList>(
@@ -33418,7 +33478,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone', 'instanceGroupManager'],
         pathParams: ['instanceGroupManager', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -33552,7 +33612,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone', 'instanceGroupManager'],
         pathParams: ['instanceGroupManager', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -33698,7 +33758,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone', 'instanceGroupManager'],
         pathParams: ['instanceGroupManager', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -33828,7 +33888,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone', 'instanceGroupManager'],
         pathParams: ['instanceGroupManager', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$InstanceGroupManager>(parameters, callback);
@@ -33967,7 +34027,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone'],
         pathParams: ['project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -34113,7 +34173,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone'],
         pathParams: ['project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$InstanceGroupManagerList>(parameters, callback);
@@ -34280,7 +34340,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone', 'instanceGroupManager'],
         pathParams: ['instanceGroupManager', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<
@@ -34429,7 +34489,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone', 'instanceGroupManager'],
         pathParams: ['instanceGroupManager', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -34574,7 +34634,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone', 'instanceGroupManager'],
         pathParams: ['instanceGroupManager', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -34728,7 +34788,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone', 'instanceGroupManager', 'size'],
         pathParams: ['instanceGroupManager', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -34874,7 +34934,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone', 'instanceGroupManager'],
         pathParams: ['instanceGroupManager', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -35013,7 +35073,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone', 'instanceGroupManager'],
         pathParams: ['instanceGroupManager', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -35152,7 +35212,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone', 'instanceGroupManager'],
         pathParams: ['instanceGroupManager', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -35292,7 +35352,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone', 'instanceGroupManager'],
         pathParams: ['instanceGroupManager', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -35428,7 +35488,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone', 'resource'],
         pathParams: ['project', 'resource', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -35571,7 +35631,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone', 'instanceGroupManager'],
         pathParams: ['instanceGroupManager', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -36281,7 +36341,10 @@ export namespace compute_beta {
 
 
   export class Resource$Instancegroups {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -36413,7 +36476,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone', 'instanceGroup'],
         pathParams: ['instanceGroup', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -36559,7 +36622,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$InstanceGroupAggregatedList>(
@@ -36694,7 +36757,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone', 'instanceGroup'],
         pathParams: ['instanceGroup', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -36822,7 +36885,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone', 'instanceGroup'],
         pathParams: ['instanceGroup', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$InstanceGroup>(parameters, callback);
@@ -36955,7 +37018,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone'],
         pathParams: ['project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -37098,7 +37161,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone'],
         pathParams: ['project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$InstanceGroupList>(parameters, callback);
@@ -37257,7 +37320,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone', 'instanceGroup'],
         pathParams: ['instanceGroup', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$InstanceGroupsListInstances>(
@@ -37397,7 +37460,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone', 'instanceGroup'],
         pathParams: ['instanceGroup', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -37534,7 +37597,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone', 'instanceGroup'],
         pathParams: ['instanceGroup', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -37669,7 +37732,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone', 'resource'],
         pathParams: ['project', 'resource', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -38092,7 +38155,10 @@ export namespace compute_beta {
 
 
   export class Resource$Instances {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -38225,7 +38291,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone', 'instance', 'networkInterface'],
         pathParams: ['instance', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -38367,7 +38433,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$InstanceAggregatedList>(parameters, callback);
@@ -38507,7 +38573,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone', 'instance'],
         pathParams: ['instance', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -38637,7 +38703,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone', 'instance'],
         pathParams: ['instance', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -38777,7 +38843,7 @@ export namespace compute_beta {
         requiredParams:
             ['project', 'zone', 'instance', 'accessConfig', 'networkInterface'],
         pathParams: ['instance', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -38912,7 +38978,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone', 'instance', 'deviceName'],
         pathParams: ['instance', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -39037,7 +39103,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone', 'instance'],
         pathParams: ['instance', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Instance>(parameters, callback);
@@ -39111,7 +39177,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone', 'instance'],
         pathParams: ['instance', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GuestAttributes>(parameters, callback);
@@ -39182,7 +39248,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone', 'resource'],
         pathParams: ['project', 'resource', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -39314,7 +39380,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone', 'instance'],
         pathParams: ['instance', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$SerialPortOutput>(parameters, callback);
@@ -39389,7 +39455,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone', 'instance'],
         pathParams: ['instance', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ShieldedInstanceIdentity>(parameters, callback);
@@ -39461,7 +39527,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone', 'instance'],
         pathParams: ['instance', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ShieldedVmIdentity>(parameters, callback);
@@ -39592,7 +39658,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone'],
         pathParams: ['project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -39733,7 +39799,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone'],
         pathParams: ['project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$InstanceList>(parameters, callback);
@@ -39886,7 +39952,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone', 'instance'],
         pathParams: ['instance', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$InstanceListReferrers>(parameters, callback);
@@ -40017,7 +40083,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone', 'instance'],
         pathParams: ['instance', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -40089,7 +40155,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone', 'instance'],
         pathParams: ['instance', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -40220,7 +40286,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone', 'resource'],
         pathParams: ['project', 'resource', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -40360,7 +40426,7 @@ export namespace compute_beta {
         requiredParams:
             ['project', 'zone', 'instance', 'autoDelete', 'deviceName'],
         pathParams: ['instance', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -40432,7 +40498,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone', 'resource'],
         pathParams: ['project', 'resource', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -40569,7 +40635,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone', 'instance'],
         pathParams: ['instance', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -40704,7 +40770,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone', 'instance'],
         pathParams: ['instance', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -40841,7 +40907,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone', 'instance'],
         pathParams: ['instance', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -40978,7 +41044,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone', 'instance'],
         pathParams: ['instance', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -41116,7 +41182,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone', 'instance'],
         pathParams: ['instance', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -41252,7 +41318,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone', 'instance'],
         pathParams: ['instance', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -41389,7 +41455,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone', 'instance'],
         pathParams: ['instance', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -41468,7 +41534,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone', 'instance'],
         pathParams: ['instance', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -41545,7 +41611,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone', 'instance'],
         pathParams: ['instance', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -41682,7 +41748,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone', 'instance'],
         pathParams: ['instance', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -41754,7 +41820,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone', 'instance'],
         pathParams: ['instance', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -41884,7 +41950,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone', 'instance'],
         pathParams: ['instance', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -42020,7 +42086,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone', 'instance'],
         pathParams: ['instance', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -42154,7 +42220,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone', 'instance'],
         pathParams: ['instance', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -42232,7 +42298,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone', 'instance'],
         pathParams: ['instance', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -42369,7 +42435,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone', 'resource'],
         pathParams: ['project', 'resource', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -42512,7 +42578,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone', 'instance', 'networkInterface'],
         pathParams: ['instance', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -42587,7 +42653,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone', 'instance'],
         pathParams: ['instance', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -42729,7 +42795,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone', 'instance', 'networkInterface'],
         pathParams: ['instance', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -42806,7 +42872,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone', 'instance'],
         pathParams: ['instance', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -42882,7 +42948,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone', 'instance'],
         pathParams: ['instance', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -44385,7 +44451,10 @@ export namespace compute_beta {
 
 
   export class Resource$Instancetemplates {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -44508,7 +44577,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'instanceTemplate'],
         pathParams: ['instanceTemplate', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -44632,7 +44701,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'instanceTemplate'],
         pathParams: ['instanceTemplate', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$InstanceTemplate>(parameters, callback);
@@ -44702,7 +44771,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -44833,7 +44902,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -44973,7 +45042,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$InstanceTemplateList>(parameters, callback);
@@ -45044,7 +45113,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -45175,7 +45244,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -45376,7 +45445,10 @@ export namespace compute_beta {
 
 
   export class Resource$Interconnectattachments {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -45521,7 +45593,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$InterconnectAttachmentAggregatedList>(
@@ -45653,7 +45725,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region', 'interconnectAttachment'],
         pathParams: ['interconnectAttachment', 'project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -45781,7 +45853,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region', 'interconnectAttachment'],
         pathParams: ['interconnectAttachment', 'project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$InterconnectAttachment>(parameters, callback);
@@ -45912,7 +45984,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -46061,7 +46133,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$InterconnectAttachmentList>(
@@ -46137,7 +46209,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region', 'interconnectAttachment'],
         pathParams: ['interconnectAttachment', 'project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -46211,7 +46283,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region', 'resource'],
         pathParams: ['project', 'region', 'resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -46348,7 +46420,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region', 'resource'],
         pathParams: ['project', 'region', 'resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -46663,7 +46735,10 @@ export namespace compute_beta {
 
 
   export class Resource$Interconnectlocations {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -46781,7 +46856,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'interconnectLocation'],
         pathParams: ['interconnectLocation', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$InterconnectLocation>(parameters, callback);
@@ -46923,7 +46998,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$InterconnectLocationList>(parameters, callback);
@@ -47007,7 +47082,10 @@ export namespace compute_beta {
 
 
   export class Resource$Interconnects {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -47127,7 +47205,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'interconnect'],
         pathParams: ['interconnect', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -47250,7 +47328,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'interconnect'],
         pathParams: ['interconnect', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Interconnect>(parameters, callback);
@@ -47330,7 +47408,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'interconnect'],
         pathParams: ['interconnect', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$InterconnectsGetDiagnosticsResponse>(
@@ -47460,7 +47538,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -47598,7 +47676,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$InterconnectList>(parameters, callback);
@@ -47734,7 +47812,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'interconnect'],
         pathParams: ['interconnect', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -47806,7 +47884,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -47937,7 +48015,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -48172,7 +48250,10 @@ export namespace compute_beta {
 
 
   export class Resource$Licensecodes {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -48231,7 +48312,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'licenseCode'],
         pathParams: ['licenseCode', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$LicenseCode>(parameters, callback);
@@ -48259,7 +48340,10 @@ export namespace compute_beta {
 
 
   export class Resource$Licenses {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -48321,7 +48405,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'license'],
         pathParams: ['license', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -48441,7 +48525,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'license'],
         pathParams: ['license', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$License>(parameters, callback);
@@ -48511,7 +48595,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -48579,7 +48663,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -48655,7 +48739,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$LicensesListResponse>(parameters, callback);
@@ -48726,7 +48810,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -48902,7 +48986,10 @@ export namespace compute_beta {
 
 
   export class Resource$Machinetypes {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -49037,7 +49124,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$MachineTypeAggregatedList>(
@@ -49164,7 +49251,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone', 'machineType'],
         pathParams: ['machineType', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$MachineType>(parameters, callback);
@@ -49307,7 +49394,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone'],
         pathParams: ['project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$MachineTypeList>(parameters, callback);
@@ -49453,7 +49540,10 @@ export namespace compute_beta {
 
 
   export class Resource$Networkendpointgroups {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -49530,7 +49620,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$NetworkEndpointGroupAggregatedList>(
@@ -49609,7 +49699,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone', 'networkEndpointGroup'],
         pathParams: ['networkEndpointGroup', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -49684,7 +49774,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone', 'networkEndpointGroup'],
         pathParams: ['networkEndpointGroup', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -49761,7 +49851,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone', 'networkEndpointGroup'],
         pathParams: ['networkEndpointGroup', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -49830,7 +49920,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone', 'networkEndpointGroup'],
         pathParams: ['networkEndpointGroup', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$NetworkEndpointGroup>(parameters, callback);
@@ -49903,7 +49993,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone'],
         pathParams: ['project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -49980,7 +50070,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone'],
         pathParams: ['project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$NetworkEndpointGroupList>(parameters, callback);
@@ -50066,7 +50156,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone', 'networkEndpointGroup'],
         pathParams: ['networkEndpointGroup', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$NetworkEndpointGroupsListNetworkEndpoints>(
@@ -50143,7 +50233,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone', 'resource'],
         pathParams: ['project', 'resource', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -50537,7 +50627,10 @@ export namespace compute_beta {
 
 
   export class Resource$Networks {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -50662,7 +50755,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'network'],
         pathParams: ['network', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -50787,7 +50880,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'network'],
         pathParams: ['network', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -50908,7 +51001,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'network'],
         pathParams: ['network', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Network>(parameters, callback);
@@ -51034,7 +51127,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -51170,7 +51263,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$NetworkList>(parameters, callback);
@@ -51253,7 +51346,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'network'],
         pathParams: ['network', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ExchangedPeeringRoutesList>(
@@ -51388,7 +51481,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'network'],
         pathParams: ['network', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -51520,7 +51613,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'network'],
         pathParams: ['network', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -51648,7 +51741,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'network'],
         pathParams: ['network', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -51781,7 +51874,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -51856,7 +51949,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'network'],
         pathParams: ['network', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -52253,7 +52346,10 @@ export namespace compute_beta {
 
 
   export class Resource$Nodegroups {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -52319,7 +52415,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone', 'nodeGroup'],
         pathParams: ['nodeGroup', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -52394,7 +52490,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$NodeGroupAggregatedList>(parameters, callback);
@@ -52465,7 +52561,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone', 'nodeGroup'],
         pathParams: ['nodeGroup', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -52538,7 +52634,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone', 'nodeGroup'],
         pathParams: ['nodeGroup', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -52606,7 +52702,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone', 'nodeGroup'],
         pathParams: ['nodeGroup', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$NodeGroup>(parameters, callback);
@@ -52677,7 +52773,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone', 'resource'],
         pathParams: ['project', 'resource', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -52749,7 +52845,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone', 'initialNodeCount'],
         pathParams: ['project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -52821,7 +52917,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone'],
         pathParams: ['project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$NodeGroupList>(parameters, callback);
@@ -52896,7 +52992,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone', 'nodeGroup'],
         pathParams: ['nodeGroup', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$NodeGroupsListNodes>(parameters, callback);
@@ -52968,7 +53064,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone', 'resource'],
         pathParams: ['project', 'resource', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -53041,7 +53137,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone', 'nodeGroup'],
         pathParams: ['nodeGroup', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -53115,7 +53211,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone', 'resource'],
         pathParams: ['project', 'resource', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -53578,7 +53674,10 @@ export namespace compute_beta {
 
 
   export class Resource$Nodetemplates {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -53649,7 +53748,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$NodeTemplateAggregatedList>(
@@ -53722,7 +53821,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region', 'nodeTemplate'],
         pathParams: ['nodeTemplate', 'project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -53790,7 +53889,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region', 'nodeTemplate'],
         pathParams: ['nodeTemplate', 'project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$NodeTemplate>(parameters, callback);
@@ -53861,7 +53960,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region', 'resource'],
         pathParams: ['project', 'region', 'resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -53934,7 +54033,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -54008,7 +54107,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$NodeTemplateList>(parameters, callback);
@@ -54080,7 +54179,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region', 'resource'],
         pathParams: ['project', 'region', 'resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -54154,7 +54253,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region', 'resource'],
         pathParams: ['project', 'region', 'resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -54438,7 +54537,10 @@ export namespace compute_beta {
 
 
   export class Resource$Nodetypes {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -54505,7 +54607,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$NodeTypeAggregatedList>(parameters, callback);
@@ -54571,7 +54673,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone', 'nodeType'],
         pathParams: ['nodeType', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$NodeType>(parameters, callback);
@@ -54642,7 +54744,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone'],
         pathParams: ['project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$NodeTypeList>(parameters, callback);
@@ -54787,7 +54889,10 @@ export namespace compute_beta {
 
 
   export class Resource$Projects {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -54901,7 +55006,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -55029,7 +55134,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -55150,7 +55255,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -55279,7 +55384,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -55393,7 +55498,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Project>(parameters, callback);
@@ -55513,7 +55618,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Project>(parameters, callback);
@@ -55654,7 +55759,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ProjectsGetXpnResources>(parameters, callback);
@@ -55797,7 +55902,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$XpnHostList>(parameters, callback);
@@ -55923,7 +56028,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -56050,7 +56155,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -56178,7 +56283,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -56251,7 +56356,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -56379,7 +56484,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -56790,7 +56895,10 @@ export namespace compute_beta {
 
 
   export class Resource$Regionautoscalers {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -56914,7 +57022,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region', 'autoscaler'],
         pathParams: ['autoscaler', 'project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -57040,7 +57148,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region', 'autoscaler'],
         pathParams: ['autoscaler', 'project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Autoscaler>(parameters, callback);
@@ -57173,7 +57281,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -57318,7 +57426,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$RegionAutoscalerList>(parameters, callback);
@@ -57455,7 +57563,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -57590,7 +57698,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region', 'resource'],
         pathParams: ['project', 'region', 'resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -57726,7 +57834,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -57986,7 +58094,10 @@ export namespace compute_beta {
 
 
   export class Resource$Regionbackendservices {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -58111,7 +58222,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region', 'backendService'],
         pathParams: ['backendService', 'project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -58238,7 +58349,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region', 'backendService'],
         pathParams: ['backendService', 'project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$BackendService>(parameters, callback);
@@ -58375,7 +58486,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region', 'backendService'],
         pathParams: ['backendService', 'project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$BackendServiceGroupHealth>(
@@ -58511,7 +58622,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -58655,7 +58766,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$BackendServiceList>(parameters, callback);
@@ -58799,7 +58910,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region', 'backendService'],
         pathParams: ['backendService', 'project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -58935,7 +59046,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region', 'resource'],
         pathParams: ['project', 'region', 'resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -59077,7 +59188,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region', 'backendService'],
         pathParams: ['backendService', 'project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -59362,7 +59473,10 @@ export namespace compute_beta {
 
 
   export class Resource$Regioncommitments {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -59497,7 +59611,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$CommitmentAggregatedList>(parameters, callback);
@@ -59624,7 +59738,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region', 'commitment'],
         pathParams: ['commitment', 'project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Commitment>(parameters, callback);
@@ -59757,7 +59871,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -59901,7 +60015,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$CommitmentList>(parameters, callback);
@@ -59975,7 +60089,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region', 'commitment'],
         pathParams: ['commitment', 'project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -60195,7 +60309,10 @@ export namespace compute_beta {
 
 
   export class Resource$Regiondisks {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -60263,7 +60380,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region', 'disk'],
         pathParams: ['disk', 'project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -60336,7 +60453,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region', 'disk'],
         pathParams: ['disk', 'project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -60411,7 +60528,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region', 'disk'],
         pathParams: ['disk', 'project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -60476,7 +60593,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region', 'disk'],
         pathParams: ['disk', 'project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Disk>(parameters, callback);
@@ -60547,7 +60664,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region', 'resource'],
         pathParams: ['project', 'region', 'resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -60620,7 +60737,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -60691,7 +60808,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$DiskList>(parameters, callback);
@@ -60765,7 +60882,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region', 'disk'],
         pathParams: ['disk', 'project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -60838,7 +60955,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region', 'disk'],
         pathParams: ['disk', 'project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -60910,7 +61027,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region', 'resource'],
         pathParams: ['project', 'region', 'resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -60983,7 +61100,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region', 'resource'],
         pathParams: ['project', 'region', 'resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -61057,7 +61174,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region', 'resource'],
         pathParams: ['project', 'region', 'resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -61478,7 +61595,10 @@ export namespace compute_beta {
 
 
   export class Resource$Regiondisktypes {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -61538,7 +61658,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region', 'diskType'],
         pathParams: ['diskType', 'project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$DiskType>(parameters, callback);
@@ -61613,7 +61733,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$RegionDiskTypeList>(parameters, callback);
@@ -61705,7 +61825,10 @@ export namespace compute_beta {
 
 
   export class Resource$Regioninstancegroupmanagers {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -61847,7 +61970,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region', 'instanceGroupManager'],
         pathParams: ['instanceGroupManager', 'project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -61925,7 +62048,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region', 'instanceGroupManager'],
         pathParams: ['instanceGroupManager', 'project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -62056,7 +62179,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region', 'instanceGroupManager'],
         pathParams: ['instanceGroupManager', 'project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -62204,7 +62327,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region', 'instanceGroupManager'],
         pathParams: ['instanceGroupManager', 'project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -62331,7 +62454,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region', 'instanceGroupManager'],
         pathParams: ['instanceGroupManager', 'project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$InstanceGroupManager>(parameters, callback);
@@ -62467,7 +62590,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -62616,7 +62739,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$RegionInstanceGroupManagerList>(
@@ -62784,7 +62907,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region', 'instanceGroupManager'],
         pathParams: ['instanceGroupManager', 'project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<
@@ -62931,7 +63054,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region', 'instanceGroupManager'],
         pathParams: ['instanceGroupManager', 'project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -63077,7 +63200,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region', 'instanceGroupManager'],
         pathParams: ['instanceGroupManager', 'project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -63220,7 +63343,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region', 'instanceGroupManager', 'size'],
         pathParams: ['instanceGroupManager', 'project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -63363,7 +63486,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region', 'instanceGroupManager'],
         pathParams: ['instanceGroupManager', 'project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -63502,7 +63625,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region', 'instanceGroupManager'],
         pathParams: ['instanceGroupManager', 'project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -63640,7 +63763,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region', 'instanceGroupManager'],
         pathParams: ['instanceGroupManager', 'project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -63777,7 +63900,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region', 'resource'],
         pathParams: ['project', 'region', 'resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -63918,7 +64041,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region', 'instanceGroupManager'],
         pathParams: ['instanceGroupManager', 'project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -64531,7 +64654,10 @@ export namespace compute_beta {
 
 
   export class Resource$Regioninstancegroups {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -64651,7 +64777,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region', 'instanceGroup'],
         pathParams: ['instanceGroup', 'project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$InstanceGroup>(parameters, callback);
@@ -64796,7 +64922,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$RegionInstanceGroupList>(parameters, callback);
@@ -64962,7 +65088,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region', 'instanceGroup'],
         pathParams: ['instanceGroup', 'project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$RegionInstanceGroupsListInstances>(
@@ -65099,7 +65225,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region', 'instanceGroup'],
         pathParams: ['instanceGroup', 'project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -65235,7 +65361,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region', 'resource'],
         pathParams: ['project', 'region', 'resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -65460,7 +65586,10 @@ export namespace compute_beta {
 
 
   export class Resource$Regionoperations {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -65578,7 +65707,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region', 'operation'],
         pathParams: ['operation', 'project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -65704,7 +65833,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region', 'operation'],
         pathParams: ['operation', 'project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -65848,7 +65977,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$OperationList>(parameters, callback);
@@ -65960,7 +66089,10 @@ export namespace compute_beta {
 
 
   export class Resource$Regions {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -66073,7 +66205,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Region>(parameters, callback);
@@ -66209,7 +66341,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$RegionList>(parameters, callback);
@@ -66291,7 +66423,10 @@ export namespace compute_beta {
 
 
   export class Resource$Reservations {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -66359,7 +66494,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ReservationAggregatedList>(
@@ -66432,7 +66567,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone', 'reservation'],
         pathParams: ['project', 'reservation', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -66498,7 +66633,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone', 'reservation'],
         pathParams: ['project', 'reservation', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Reservation>(parameters, callback);
@@ -66569,7 +66704,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone', 'resource'],
         pathParams: ['project', 'resource', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -66641,7 +66776,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone'],
         pathParams: ['project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -66715,7 +66850,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone'],
         pathParams: ['project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ReservationList>(parameters, callback);
@@ -66789,7 +66924,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone', 'reservation'],
         pathParams: ['project', 'reservation', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -66861,7 +66996,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone', 'resource'],
         pathParams: ['project', 'resource', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -66935,7 +67070,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone', 'resource'],
         pathParams: ['project', 'resource', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -67256,7 +67391,10 @@ export namespace compute_beta {
 
 
   export class Resource$Resourcepolicies {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -67328,7 +67466,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ResourcePolicyAggregatedList>(
@@ -67402,7 +67540,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region', 'resourcePolicy'],
         pathParams: ['project', 'region', 'resourcePolicy'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -67469,7 +67607,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region', 'resourcePolicy'],
         pathParams: ['project', 'region', 'resourcePolicy'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ResourcePolicy>(parameters, callback);
@@ -67541,7 +67679,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -67616,7 +67754,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ResourcePolicyList>(parameters, callback);
@@ -67690,7 +67828,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region', 'resource'],
         pathParams: ['project', 'region', 'resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -67929,7 +68067,10 @@ export namespace compute_beta {
 
 
   export class Resource$Routers {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -68063,7 +68204,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$RouterAggregatedList>(parameters, callback);
@@ -68192,7 +68333,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region', 'router'],
         pathParams: ['project', 'region', 'router'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -68317,7 +68458,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region', 'router'],
         pathParams: ['project', 'region', 'router'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Router>(parameters, callback);
@@ -68395,7 +68536,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region', 'router'],
         pathParams: ['project', 'region', 'router'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$VmEndpointNatMappingsList>(
@@ -68528,7 +68669,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region', 'router'],
         pathParams: ['project', 'region', 'router'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$RouterStatusResponse>(parameters, callback);
@@ -68658,7 +68799,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -68799,7 +68940,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$RouterList>(parameters, callback);
@@ -68937,7 +69078,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region', 'router'],
         pathParams: ['project', 'region', 'router'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -69073,7 +69214,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region', 'router'],
         pathParams: ['project', 'region', 'router'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$RoutersPreviewResponse>(parameters, callback);
@@ -69210,7 +69351,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region', 'resource'],
         pathParams: ['project', 'region', 'resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -69347,7 +69488,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region', 'router'],
         pathParams: ['project', 'region', 'router'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -69764,7 +69905,10 @@ export namespace compute_beta {
 
 
   export class Resource$Routes {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -69881,7 +70025,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'route'],
         pathParams: ['project', 'route'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -70001,7 +70145,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'route'],
         pathParams: ['project', 'route'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Route>(parameters, callback);
@@ -70126,7 +70270,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -70262,7 +70406,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$RouteList>(parameters, callback);
@@ -70395,7 +70539,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -70555,7 +70699,10 @@ export namespace compute_beta {
 
 
   export class Resource$Securitypolicies {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -70620,7 +70767,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'securityPolicy'],
         pathParams: ['project', 'securityPolicy'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -70748,7 +70895,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'securityPolicy'],
         pathParams: ['project', 'securityPolicy'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -70871,7 +71018,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'securityPolicy'],
         pathParams: ['project', 'securityPolicy'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$SecurityPolicy>(parameters, callback);
@@ -70942,7 +71089,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'securityPolicy'],
         pathParams: ['project', 'securityPolicy'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$SecurityPolicyRule>(parameters, callback);
@@ -71071,7 +71218,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -71210,7 +71357,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$SecurityPolicyList>(parameters, callback);
@@ -71302,7 +71449,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<
@@ -71441,7 +71588,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'securityPolicy'],
         pathParams: ['project', 'securityPolicy'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -71514,7 +71661,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'securityPolicy'],
         pathParams: ['project', 'securityPolicy'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -71585,7 +71732,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'securityPolicy'],
         pathParams: ['project', 'securityPolicy'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -71657,7 +71804,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -71788,7 +71935,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -72160,7 +72307,10 @@ export namespace compute_beta {
 
 
   export class Resource$Snapshots {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -72282,7 +72432,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'snapshot'],
         pathParams: ['project', 'snapshot'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -72403,7 +72553,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'snapshot'],
         pathParams: ['project', 'snapshot'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Snapshot>(parameters, callback);
@@ -72473,7 +72623,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -72610,7 +72760,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$SnapshotList>(parameters, callback);
@@ -72681,7 +72831,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -72813,7 +72963,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -72946,7 +73096,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -73135,7 +73285,10 @@ export namespace compute_beta {
 
 
   export class Resource$Sslcertificates {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -73256,7 +73409,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'sslCertificate'],
         pathParams: ['project', 'sslCertificate'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -73380,7 +73533,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'sslCertificate'],
         pathParams: ['project', 'sslCertificate'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$SslCertificate>(parameters, callback);
@@ -73508,7 +73661,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -73647,7 +73800,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$SslCertificateList>(parameters, callback);
@@ -73778,7 +73931,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -73942,7 +74095,10 @@ export namespace compute_beta {
 
 
   export class Resource$Sslpolicies {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -74008,7 +74164,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'sslPolicy'],
         pathParams: ['project', 'sslPolicy'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -74074,7 +74230,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'sslPolicy'],
         pathParams: ['project', 'sslPolicy'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$SslPolicy>(parameters, callback);
@@ -74145,7 +74301,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -74216,7 +74372,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$SslPoliciesList>(parameters, callback);
@@ -74297,7 +74453,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$SslPoliciesListAvailableFeaturesResponse>(
@@ -74371,7 +74527,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'sslPolicy'],
         pathParams: ['project', 'sslPolicy'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -74444,7 +74600,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -74698,7 +74854,10 @@ export namespace compute_beta {
 
 
   export class Resource$Subnetworks {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -74833,7 +74992,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$SubnetworkAggregatedList>(parameters, callback);
@@ -74964,7 +75123,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region', 'subnetwork'],
         pathParams: ['project', 'region', 'subnetwork'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -75098,7 +75257,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region', 'subnetwork'],
         pathParams: ['project', 'region', 'subnetwork'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -75224,7 +75383,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region', 'subnetwork'],
         pathParams: ['project', 'region', 'subnetwork'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Subnetwork>(parameters, callback);
@@ -75354,7 +75513,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region', 'resource'],
         pathParams: ['project', 'region', 'resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -75487,7 +75646,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -75628,7 +75787,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$SubnetworkList>(parameters, callback);
@@ -75708,7 +75867,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$UsableSubnetworksAggregatedList>(
@@ -75850,7 +76009,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region', 'subnetwork'],
         pathParams: ['project', 'region', 'subnetwork'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -75985,7 +76144,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region', 'resource'],
         pathParams: ['project', 'region', 'resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -76121,7 +76280,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region', 'subnetwork'],
         pathParams: ['project', 'region', 'subnetwork'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -76256,7 +76415,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region', 'resource'],
         pathParams: ['project', 'region', 'resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -76707,7 +76866,10 @@ export namespace compute_beta {
 
 
   export class Resource$Targethttpproxies {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -76828,7 +76990,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'targetHttpProxy'],
         pathParams: ['project', 'targetHttpProxy'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -76952,7 +77114,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'targetHttpProxy'],
         pathParams: ['project', 'targetHttpProxy'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TargetHttpProxy>(parameters, callback);
@@ -77080,7 +77242,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -77219,7 +77381,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TargetHttpProxyList>(parameters, callback);
@@ -77352,7 +77514,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'targetHttpProxy'],
         pathParams: ['project', 'targetHttpProxy'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -77483,7 +77645,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -77681,7 +77843,10 @@ export namespace compute_beta {
 
 
   export class Resource$Targethttpsproxies {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -77802,7 +77967,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'targetHttpsProxy'],
         pathParams: ['project', 'targetHttpsProxy'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -77926,7 +78091,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'targetHttpsProxy'],
         pathParams: ['project', 'targetHttpsProxy'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TargetHttpsProxy>(parameters, callback);
@@ -78055,7 +78220,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -78196,7 +78361,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TargetHttpsProxyList>(parameters, callback);
@@ -78268,7 +78433,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'targetHttpsProxy'],
         pathParams: ['project', 'targetHttpsProxy'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -78400,7 +78565,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'targetHttpsProxy'],
         pathParams: ['project', 'targetHttpsProxy'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -78475,7 +78640,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'targetHttpsProxy'],
         pathParams: ['project', 'targetHttpsProxy'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -78608,7 +78773,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'targetHttpsProxy'],
         pathParams: ['project', 'targetHttpsProxy'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -78740,7 +78905,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -79043,7 +79208,10 @@ export namespace compute_beta {
 
 
   export class Resource$Targetinstances {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -79182,7 +79350,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TargetInstanceAggregatedList>(
@@ -79316,7 +79484,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone', 'targetInstance'],
         pathParams: ['project', 'targetInstance', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -79444,7 +79612,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone', 'targetInstance'],
         pathParams: ['project', 'targetInstance', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TargetInstance>(parameters, callback);
@@ -79577,7 +79745,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone'],
         pathParams: ['project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -79721,7 +79889,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone'],
         pathParams: ['project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TargetInstanceList>(parameters, callback);
@@ -79856,7 +80024,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone', 'resource'],
         pathParams: ['project', 'resource', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -80095,7 +80263,10 @@ export namespace compute_beta {
 
 
   export class Resource$Targetpools {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -80224,7 +80395,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region', 'targetPool'],
         pathParams: ['project', 'region', 'targetPool'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -80360,7 +80531,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region', 'targetPool'],
         pathParams: ['project', 'region', 'targetPool'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -80502,7 +80673,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TargetPoolAggregatedList>(parameters, callback);
@@ -80633,7 +80804,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region', 'targetPool'],
         pathParams: ['project', 'region', 'targetPool'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -80759,7 +80930,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region', 'targetPool'],
         pathParams: ['project', 'region', 'targetPool'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TargetPool>(parameters, callback);
@@ -80899,7 +81070,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region', 'targetPool'],
         pathParams: ['project', 'region', 'targetPool'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TargetPoolInstanceHealth>(parameters, callback);
@@ -81032,7 +81203,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -81174,7 +81345,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TargetPoolList>(parameters, callback);
@@ -81308,7 +81479,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region', 'targetPool'],
         pathParams: ['project', 'region', 'targetPool'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -81444,7 +81615,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region', 'targetPool'],
         pathParams: ['project', 'region', 'targetPool'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -81581,7 +81752,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region', 'targetPool'],
         pathParams: ['project', 'region', 'targetPool'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -81716,7 +81887,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region', 'resource'],
         pathParams: ['project', 'region', 'resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -82172,7 +82343,10 @@ export namespace compute_beta {
 
 
   export class Resource$Targetsslproxies {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -82293,7 +82467,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'targetSslProxy'],
         pathParams: ['project', 'targetSslProxy'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -82417,7 +82591,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'targetSslProxy'],
         pathParams: ['project', 'targetSslProxy'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TargetSslProxy>(parameters, callback);
@@ -82545,7 +82719,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -82684,7 +82858,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TargetSslProxyList>(parameters, callback);
@@ -82815,7 +82989,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'targetSslProxy'],
         pathParams: ['project', 'targetSslProxy'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -82946,7 +83120,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'targetSslProxy'],
         pathParams: ['project', 'targetSslProxy'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -83077,7 +83251,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'targetSslProxy'],
         pathParams: ['project', 'targetSslProxy'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -83152,7 +83326,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'targetSslProxy'],
         pathParams: ['project', 'targetSslProxy'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -83283,7 +83457,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -83586,7 +83760,10 @@ export namespace compute_beta {
 
 
   export class Resource$Targettcpproxies {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -83707,7 +83884,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'targetTcpProxy'],
         pathParams: ['project', 'targetTcpProxy'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -83831,7 +84008,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'targetTcpProxy'],
         pathParams: ['project', 'targetTcpProxy'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TargetTcpProxy>(parameters, callback);
@@ -83959,7 +84136,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -84098,7 +84275,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TargetTcpProxyList>(parameters, callback);
@@ -84229,7 +84406,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'targetTcpProxy'],
         pathParams: ['project', 'targetTcpProxy'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -84360,7 +84537,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'targetTcpProxy'],
         pathParams: ['project', 'targetTcpProxy'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -84572,7 +84749,10 @@ export namespace compute_beta {
 
 
   export class Resource$Targetvpngateways {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -84711,7 +84891,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TargetVpnGatewayAggregatedList>(
@@ -84845,7 +85025,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region', 'targetVpnGateway'],
         pathParams: ['project', 'region', 'targetVpnGateway'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -84973,7 +85153,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region', 'targetVpnGateway'],
         pathParams: ['project', 'region', 'targetVpnGateway'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TargetVpnGateway>(parameters, callback);
@@ -85106,7 +85286,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -85251,7 +85431,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TargetVpnGatewayList>(parameters, callback);
@@ -85325,7 +85505,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region', 'resource'],
         pathParams: ['project', 'region', 'resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -85460,7 +85640,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region', 'resource'],
         pathParams: ['project', 'region', 'resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -85737,7 +85917,10 @@ export namespace compute_beta {
 
 
   export class Resource$Urlmaps {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -85854,7 +86037,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'urlMap'],
         pathParams: ['project', 'urlMap'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -85974,7 +86157,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'urlMap'],
         pathParams: ['project', 'urlMap'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$UrlMap>(parameters, callback);
@@ -86099,7 +86282,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -86232,7 +86415,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'urlMap'],
         pathParams: ['project', 'urlMap'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -86368,7 +86551,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$UrlMapList>(parameters, callback);
@@ -86501,7 +86684,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'urlMap'],
         pathParams: ['project', 'urlMap'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -86634,7 +86817,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -86766,7 +86949,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'urlMap'],
         pathParams: ['project', 'urlMap'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -86900,7 +87083,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'urlMap'],
         pathParams: ['project', 'urlMap'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$UrlMapsValidateResponse>(parameters, callback);
@@ -87180,7 +87363,10 @@ export namespace compute_beta {
 
 
   export class Resource$Vpngateways {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -87248,7 +87434,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$VpnGatewayAggregatedList>(parameters, callback);
@@ -87320,7 +87506,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region', 'vpnGateway'],
         pathParams: ['project', 'region', 'vpnGateway'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -87387,7 +87573,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region', 'vpnGateway'],
         pathParams: ['project', 'region', 'vpnGateway'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$VpnGateway>(parameters, callback);
@@ -87464,7 +87650,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region', 'vpnGateway'],
         pathParams: ['project', 'region', 'vpnGateway'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$VpnGatewaysGetStatusResponse>(
@@ -87539,7 +87725,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -87612,7 +87798,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$VpnGatewayList>(parameters, callback);
@@ -87686,7 +87872,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region', 'resource'],
         pathParams: ['project', 'region', 'resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -87956,7 +88142,10 @@ export namespace compute_beta {
 
 
   export class Resource$Vpntunnels {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -88090,7 +88279,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$VpnTunnelAggregatedList>(parameters, callback);
@@ -88220,7 +88409,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region', 'vpnTunnel'],
         pathParams: ['project', 'region', 'vpnTunnel'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -88346,7 +88535,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region', 'vpnTunnel'],
         pathParams: ['project', 'region', 'vpnTunnel'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$VpnTunnel>(parameters, callback);
@@ -88478,7 +88667,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -88620,7 +88809,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$VpnTunnelList>(parameters, callback);
@@ -88694,7 +88883,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region', 'resource'],
         pathParams: ['project', 'region', 'resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -88829,7 +89018,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'region', 'resource'],
         pathParams: ['project', 'region', 'resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -89104,7 +89293,10 @@ export namespace compute_beta {
 
 
   export class Resource$Zoneoperations {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -89222,7 +89414,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone', 'operation'],
         pathParams: ['operation', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -89348,7 +89540,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone', 'operation'],
         pathParams: ['operation', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -89490,7 +89682,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone'],
         pathParams: ['project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$OperationList>(parameters, callback);
@@ -89602,7 +89794,10 @@ export namespace compute_beta {
 
 
   export class Resource$Zones {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -89714,7 +89909,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project', 'zone'],
         pathParams: ['project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Zone>(parameters, callback);
@@ -89849,7 +90044,7 @@ export namespace compute_beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ZoneList>(parameters, callback);

--- a/src/apis/compute/v1.ts
+++ b/src/apis/compute/v1.ts
@@ -29,8 +29,6 @@ export namespace compute_v1 {
     version: 'v1';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * Data format for the response.
@@ -81,6 +79,7 @@ export namespace compute_v1 {
    * @param {object=} options Options for Compute
    */
   export class Compute {
+    context: APIRequestContext;
     acceleratorTypes: Resource$Acceleratortypes;
     addresses: Resource$Addresses;
     autoscalers: Resource$Autoscalers;
@@ -141,67 +140,73 @@ export namespace compute_v1 {
     zones: Resource$Zones;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.acceleratorTypes = new Resource$Acceleratortypes();
-      this.addresses = new Resource$Addresses();
-      this.autoscalers = new Resource$Autoscalers();
-      this.backendBuckets = new Resource$Backendbuckets();
-      this.backendServices = new Resource$Backendservices();
-      this.disks = new Resource$Disks();
-      this.diskTypes = new Resource$Disktypes();
-      this.firewalls = new Resource$Firewalls();
-      this.forwardingRules = new Resource$Forwardingrules();
-      this.globalAddresses = new Resource$Globaladdresses();
-      this.globalForwardingRules = new Resource$Globalforwardingrules();
-      this.globalOperations = new Resource$Globaloperations();
-      this.healthChecks = new Resource$Healthchecks();
-      this.httpHealthChecks = new Resource$Httphealthchecks();
-      this.httpsHealthChecks = new Resource$Httpshealthchecks();
-      this.images = new Resource$Images();
-      this.instanceGroupManagers = new Resource$Instancegroupmanagers();
-      this.instanceGroups = new Resource$Instancegroups();
-      this.instances = new Resource$Instances();
-      this.instanceTemplates = new Resource$Instancetemplates();
-      this.interconnectAttachments = new Resource$Interconnectattachments();
-      this.interconnectLocations = new Resource$Interconnectlocations();
-      this.interconnects = new Resource$Interconnects();
-      this.licenseCodes = new Resource$Licensecodes();
-      this.licenses = new Resource$Licenses();
-      this.machineTypes = new Resource$Machinetypes();
-      this.networks = new Resource$Networks();
-      this.nodeGroups = new Resource$Nodegroups();
-      this.nodeTemplates = new Resource$Nodetemplates();
-      this.nodeTypes = new Resource$Nodetypes();
-      this.projects = new Resource$Projects();
-      this.regionAutoscalers = new Resource$Regionautoscalers();
-      this.regionBackendServices = new Resource$Regionbackendservices();
-      this.regionCommitments = new Resource$Regioncommitments();
-      this.regionDisks = new Resource$Regiondisks();
-      this.regionDiskTypes = new Resource$Regiondisktypes();
+      this.acceleratorTypes = new Resource$Acceleratortypes(this.context);
+      this.addresses = new Resource$Addresses(this.context);
+      this.autoscalers = new Resource$Autoscalers(this.context);
+      this.backendBuckets = new Resource$Backendbuckets(this.context);
+      this.backendServices = new Resource$Backendservices(this.context);
+      this.disks = new Resource$Disks(this.context);
+      this.diskTypes = new Resource$Disktypes(this.context);
+      this.firewalls = new Resource$Firewalls(this.context);
+      this.forwardingRules = new Resource$Forwardingrules(this.context);
+      this.globalAddresses = new Resource$Globaladdresses(this.context);
+      this.globalForwardingRules =
+          new Resource$Globalforwardingrules(this.context);
+      this.globalOperations = new Resource$Globaloperations(this.context);
+      this.healthChecks = new Resource$Healthchecks(this.context);
+      this.httpHealthChecks = new Resource$Httphealthchecks(this.context);
+      this.httpsHealthChecks = new Resource$Httpshealthchecks(this.context);
+      this.images = new Resource$Images(this.context);
+      this.instanceGroupManagers =
+          new Resource$Instancegroupmanagers(this.context);
+      this.instanceGroups = new Resource$Instancegroups(this.context);
+      this.instances = new Resource$Instances(this.context);
+      this.instanceTemplates = new Resource$Instancetemplates(this.context);
+      this.interconnectAttachments =
+          new Resource$Interconnectattachments(this.context);
+      this.interconnectLocations =
+          new Resource$Interconnectlocations(this.context);
+      this.interconnects = new Resource$Interconnects(this.context);
+      this.licenseCodes = new Resource$Licensecodes(this.context);
+      this.licenses = new Resource$Licenses(this.context);
+      this.machineTypes = new Resource$Machinetypes(this.context);
+      this.networks = new Resource$Networks(this.context);
+      this.nodeGroups = new Resource$Nodegroups(this.context);
+      this.nodeTemplates = new Resource$Nodetemplates(this.context);
+      this.nodeTypes = new Resource$Nodetypes(this.context);
+      this.projects = new Resource$Projects(this.context);
+      this.regionAutoscalers = new Resource$Regionautoscalers(this.context);
+      this.regionBackendServices =
+          new Resource$Regionbackendservices(this.context);
+      this.regionCommitments = new Resource$Regioncommitments(this.context);
+      this.regionDisks = new Resource$Regiondisks(this.context);
+      this.regionDiskTypes = new Resource$Regiondisktypes(this.context);
       this.regionInstanceGroupManagers =
-          new Resource$Regioninstancegroupmanagers();
-      this.regionInstanceGroups = new Resource$Regioninstancegroups();
-      this.regionOperations = new Resource$Regionoperations();
-      this.regions = new Resource$Regions();
-      this.routers = new Resource$Routers();
-      this.routes = new Resource$Routes();
-      this.securityPolicies = new Resource$Securitypolicies();
-      this.snapshots = new Resource$Snapshots();
-      this.sslCertificates = new Resource$Sslcertificates();
-      this.sslPolicies = new Resource$Sslpolicies();
-      this.subnetworks = new Resource$Subnetworks();
-      this.targetHttpProxies = new Resource$Targethttpproxies();
-      this.targetHttpsProxies = new Resource$Targethttpsproxies();
-      this.targetInstances = new Resource$Targetinstances();
-      this.targetPools = new Resource$Targetpools();
-      this.targetSslProxies = new Resource$Targetsslproxies();
-      this.targetTcpProxies = new Resource$Targettcpproxies();
-      this.targetVpnGateways = new Resource$Targetvpngateways();
-      this.urlMaps = new Resource$Urlmaps();
-      this.vpnTunnels = new Resource$Vpntunnels();
-      this.zoneOperations = new Resource$Zoneoperations();
-      this.zones = new Resource$Zones();
+          new Resource$Regioninstancegroupmanagers(this.context);
+      this.regionInstanceGroups =
+          new Resource$Regioninstancegroups(this.context);
+      this.regionOperations = new Resource$Regionoperations(this.context);
+      this.regions = new Resource$Regions(this.context);
+      this.routers = new Resource$Routers(this.context);
+      this.routes = new Resource$Routes(this.context);
+      this.securityPolicies = new Resource$Securitypolicies(this.context);
+      this.snapshots = new Resource$Snapshots(this.context);
+      this.sslCertificates = new Resource$Sslcertificates(this.context);
+      this.sslPolicies = new Resource$Sslpolicies(this.context);
+      this.subnetworks = new Resource$Subnetworks(this.context);
+      this.targetHttpProxies = new Resource$Targethttpproxies(this.context);
+      this.targetHttpsProxies = new Resource$Targethttpsproxies(this.context);
+      this.targetInstances = new Resource$Targetinstances(this.context);
+      this.targetPools = new Resource$Targetpools(this.context);
+      this.targetSslProxies = new Resource$Targetsslproxies(this.context);
+      this.targetTcpProxies = new Resource$Targettcpproxies(this.context);
+      this.targetVpnGateways = new Resource$Targetvpngateways(this.context);
+      this.urlMaps = new Resource$Urlmaps(this.context);
+      this.vpnTunnels = new Resource$Vpntunnels(this.context);
+      this.zoneOperations = new Resource$Zoneoperations(this.context);
+      this.zones = new Resource$Zones(this.context);
     }
   }
 
@@ -11136,7 +11141,10 @@ export namespace compute_v1 {
 
 
   export class Resource$Acceleratortypes {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -11275,7 +11283,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AcceleratorTypeAggregatedList>(
@@ -11404,7 +11412,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'zone', 'acceleratorType'],
         pathParams: ['acceleratorType', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AcceleratorType>(parameters, callback);
@@ -11548,7 +11556,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'zone'],
         pathParams: ['project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AcceleratorTypeList>(parameters, callback);
@@ -11695,7 +11703,10 @@ export namespace compute_v1 {
 
 
   export class Resource$Addresses {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -11829,7 +11840,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AddressAggregatedList>(parameters, callback);
@@ -11958,7 +11969,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region', 'address'],
         pathParams: ['address', 'project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -12082,7 +12093,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region', 'address'],
         pathParams: ['address', 'project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Address>(parameters, callback);
@@ -12212,7 +12223,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -12353,7 +12364,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AddressList>(parameters, callback);
@@ -12563,7 +12574,10 @@ export namespace compute_v1 {
 
 
   export class Resource$Autoscalers {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -12698,7 +12712,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AutoscalerAggregatedList>(parameters, callback);
@@ -12829,7 +12843,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'zone', 'autoscaler'],
         pathParams: ['autoscaler', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -12955,7 +12969,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'zone', 'autoscaler'],
         pathParams: ['autoscaler', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Autoscaler>(parameters, callback);
@@ -13087,7 +13101,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'zone'],
         pathParams: ['project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -13228,7 +13242,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'zone'],
         pathParams: ['project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AutoscalerList>(parameters, callback);
@@ -13363,7 +13377,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'zone'],
         pathParams: ['project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -13498,7 +13512,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'zone'],
         pathParams: ['project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -13786,7 +13800,10 @@ export namespace compute_v1 {
 
 
   export class Resource$Backendbuckets {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -13852,7 +13869,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'backendBucket'],
         pathParams: ['backendBucket', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -13980,7 +13997,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'backendBucket'],
         pathParams: ['backendBucket', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -14053,7 +14070,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'backendBucket', 'keyName'],
         pathParams: ['backendBucket', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -14177,7 +14194,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'backendBucket'],
         pathParams: ['backendBucket', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$BackendBucket>(parameters, callback);
@@ -14305,7 +14322,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -14443,7 +14460,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$BackendBucketList>(parameters, callback);
@@ -14580,7 +14597,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'backendBucket'],
         pathParams: ['backendBucket', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -14716,7 +14733,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'backendBucket'],
         pathParams: ['backendBucket', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -14996,7 +15013,10 @@ export namespace compute_v1 {
 
 
   export class Resource$Backendservices {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -15062,7 +15082,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'backendService'],
         pathParams: ['backendService', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -15208,7 +15228,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$BackendServiceAggregatedList>(
@@ -15338,7 +15358,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'backendService'],
         pathParams: ['backendService', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -15411,7 +15431,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'backendService', 'keyName'],
         pathParams: ['backendService', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -15535,7 +15555,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'backendService'],
         pathParams: ['backendService', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$BackendService>(parameters, callback);
@@ -15669,7 +15689,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'backendService'],
         pathParams: ['backendService', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$BackendServiceGroupHealth>(
@@ -15800,7 +15820,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -15939,7 +15959,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$BackendServiceList>(parameters, callback);
@@ -16078,7 +16098,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'backendService'],
         pathParams: ['backendService', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -16150,7 +16170,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'backendService'],
         pathParams: ['backendService', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -16288,7 +16308,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'backendService'],
         pathParams: ['backendService', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -16680,7 +16700,10 @@ export namespace compute_v1 {
 
 
   export class Resource$Disks {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -16812,7 +16835,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$DiskAggregatedList>(parameters, callback);
@@ -16949,7 +16972,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'zone', 'disk'],
         pathParams: ['disk', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -17080,7 +17103,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'zone', 'disk'],
         pathParams: ['disk', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -17204,7 +17227,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'zone', 'disk'],
         pathParams: ['disk', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Disk>(parameters, callback);
@@ -17275,7 +17298,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'zone', 'resource'],
         pathParams: ['project', 'resource', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -17409,7 +17432,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'zone'],
         pathParams: ['project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -17549,7 +17572,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'zone'],
         pathParams: ['project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$DiskList>(parameters, callback);
@@ -17684,7 +17707,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'zone', 'disk'],
         pathParams: ['disk', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -17756,7 +17779,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'zone', 'resource'],
         pathParams: ['project', 'resource', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -17892,7 +17915,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'zone', 'resource'],
         pathParams: ['project', 'resource', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -17966,7 +17989,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'zone', 'resource'],
         pathParams: ['project', 'resource', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -18366,7 +18389,10 @@ export namespace compute_v1 {
 
 
   export class Resource$Disktypes {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -18500,7 +18526,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$DiskTypeAggregatedList>(parameters, callback);
@@ -18625,7 +18651,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'zone', 'diskType'],
         pathParams: ['diskType', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$DiskType>(parameters, callback);
@@ -18765,7 +18791,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'zone'],
         pathParams: ['project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$DiskTypeList>(parameters, callback);
@@ -18910,7 +18936,10 @@ export namespace compute_v1 {
 
 
   export class Resource$Firewalls {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -19028,7 +19057,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'firewall'],
         pathParams: ['firewall', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -19148,7 +19177,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'firewall'],
         pathParams: ['firewall', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Firewall>(parameters, callback);
@@ -19273,7 +19302,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -19409,7 +19438,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$FirewallList>(parameters, callback);
@@ -19543,7 +19572,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'firewall'],
         pathParams: ['firewall', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -19677,7 +19706,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'firewall'],
         pathParams: ['firewall', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -19882,7 +19911,10 @@ export namespace compute_v1 {
 
 
   export class Resource$Forwardingrules {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -20020,7 +20052,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ForwardingRuleAggregatedList>(
@@ -20154,7 +20186,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region', 'forwardingRule'],
         pathParams: ['forwardingRule', 'project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -20281,7 +20313,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region', 'forwardingRule'],
         pathParams: ['forwardingRule', 'project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ForwardingRule>(parameters, callback);
@@ -20414,7 +20446,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -20558,7 +20590,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ForwardingRuleList>(parameters, callback);
@@ -20696,7 +20728,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region', 'forwardingRule'],
         pathParams: ['forwardingRule', 'project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -20948,7 +20980,10 @@ export namespace compute_v1 {
 
 
   export class Resource$Globaladdresses {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -21067,7 +21102,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'address'],
         pathParams: ['address', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -21188,7 +21223,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'address'],
         pathParams: ['address', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Address>(parameters, callback);
@@ -21315,7 +21350,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -21452,7 +21487,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AddressList>(parameters, callback);
@@ -21595,7 +21630,10 @@ export namespace compute_v1 {
 
 
   export class Resource$Globalforwardingrules {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -21716,7 +21754,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'forwardingRule'],
         pathParams: ['forwardingRule', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -21840,7 +21878,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'forwardingRule'],
         pathParams: ['forwardingRule', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ForwardingRule>(parameters, callback);
@@ -21968,7 +22006,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -22107,7 +22145,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ForwardingRuleList>(parameters, callback);
@@ -22239,7 +22277,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'forwardingRule'],
         pathParams: ['forwardingRule', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -22416,7 +22454,10 @@ export namespace compute_v1 {
 
 
   export class Resource$Globaloperations {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -22550,7 +22591,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$OperationAggregatedList>(parameters, callback);
@@ -22671,7 +22712,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'operation'],
         pathParams: ['operation', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -22794,7 +22835,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'operation'],
         pathParams: ['operation', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -22933,7 +22974,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$OperationList>(parameters, callback);
@@ -23088,7 +23129,10 @@ export namespace compute_v1 {
 
 
   export class Resource$Healthchecks {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -23208,7 +23252,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'healthCheck'],
         pathParams: ['healthCheck', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -23330,7 +23374,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'healthCheck'],
         pathParams: ['healthCheck', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$HealthCheck>(parameters, callback);
@@ -23458,7 +23502,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -23596,7 +23640,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$HealthCheckList>(parameters, callback);
@@ -23731,7 +23775,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'healthCheck'],
         pathParams: ['healthCheck', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -23866,7 +23910,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'healthCheck'],
         pathParams: ['healthCheck', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -24076,7 +24120,10 @@ export namespace compute_v1 {
 
 
   export class Resource$Httphealthchecks {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -24197,7 +24244,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'httpHealthCheck'],
         pathParams: ['httpHealthCheck', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -24321,7 +24368,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'httpHealthCheck'],
         pathParams: ['httpHealthCheck', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$HttpHealthCheck>(parameters, callback);
@@ -24449,7 +24496,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -24588,7 +24635,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$HttpHealthCheckList>(parameters, callback);
@@ -24725,7 +24772,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'httpHealthCheck'],
         pathParams: ['httpHealthCheck', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -24861,7 +24908,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'httpHealthCheck'],
         pathParams: ['httpHealthCheck', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -25072,7 +25119,10 @@ export namespace compute_v1 {
 
 
   export class Resource$Httpshealthchecks {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -25193,7 +25243,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'httpsHealthCheck'],
         pathParams: ['httpsHealthCheck', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -25317,7 +25367,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'httpsHealthCheck'],
         pathParams: ['httpsHealthCheck', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$HttpsHealthCheck>(parameters, callback);
@@ -25445,7 +25495,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -25585,7 +25635,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$HttpsHealthCheckList>(parameters, callback);
@@ -25722,7 +25772,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'httpsHealthCheck'],
         pathParams: ['httpsHealthCheck', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -25858,7 +25908,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'httpsHealthCheck'],
         pathParams: ['httpsHealthCheck', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -26069,7 +26119,10 @@ export namespace compute_v1 {
 
 
   export class Resource$Images {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -26186,7 +26239,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'image'],
         pathParams: ['image', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -26318,7 +26371,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'image'],
         pathParams: ['image', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -26438,7 +26491,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'image'],
         pathParams: ['image', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Image>(parameters, callback);
@@ -26564,7 +26617,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'family'],
         pathParams: ['family', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Image>(parameters, callback);
@@ -26634,7 +26687,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -26760,7 +26813,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -26900,7 +26953,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ImageList>(parameters, callback);
@@ -26971,7 +27024,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -27102,7 +27155,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -27175,7 +27228,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -27445,7 +27498,10 @@ export namespace compute_v1 {
 
 
   export class Resource$Instancegroupmanagers {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -27586,7 +27642,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'zone', 'instanceGroupManager'],
         pathParams: ['instanceGroupManager', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -27737,7 +27793,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$InstanceGroupManagerAggregatedList>(
@@ -27873,7 +27929,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'zone', 'instanceGroupManager'],
         pathParams: ['instanceGroupManager', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -28019,7 +28075,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'zone', 'instanceGroupManager'],
         pathParams: ['instanceGroupManager', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -28149,7 +28205,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'zone', 'instanceGroupManager'],
         pathParams: ['instanceGroupManager', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$InstanceGroupManager>(parameters, callback);
@@ -28288,7 +28344,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'zone'],
         pathParams: ['project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -28434,7 +28490,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'zone'],
         pathParams: ['project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$InstanceGroupManagerList>(parameters, callback);
@@ -28583,7 +28639,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'zone', 'instanceGroupManager'],
         pathParams: ['instanceGroupManager', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<
@@ -28666,7 +28722,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'zone', 'instanceGroupManager'],
         pathParams: ['instanceGroupManager', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -28811,7 +28867,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'zone', 'instanceGroupManager'],
         pathParams: ['instanceGroupManager', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -28965,7 +29021,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'zone', 'instanceGroupManager', 'size'],
         pathParams: ['instanceGroupManager', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -29104,7 +29160,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'zone', 'instanceGroupManager'],
         pathParams: ['instanceGroupManager', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -29244,7 +29300,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'zone', 'instanceGroupManager'],
         pathParams: ['instanceGroupManager', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -29789,7 +29845,10 @@ export namespace compute_v1 {
 
 
   export class Resource$Instancegroups {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -29921,7 +29980,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'zone', 'instanceGroup'],
         pathParams: ['instanceGroup', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -30066,7 +30125,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$InstanceGroupAggregatedList>(
@@ -30201,7 +30260,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'zone', 'instanceGroup'],
         pathParams: ['instanceGroup', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -30329,7 +30388,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'zone', 'instanceGroup'],
         pathParams: ['instanceGroup', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$InstanceGroup>(parameters, callback);
@@ -30462,7 +30521,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'zone'],
         pathParams: ['project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -30605,7 +30664,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'zone'],
         pathParams: ['project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$InstanceGroupList>(parameters, callback);
@@ -30764,7 +30823,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'zone', 'instanceGroup'],
         pathParams: ['instanceGroup', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$InstanceGroupsListInstances>(
@@ -30904,7 +30963,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'zone', 'instanceGroup'],
         pathParams: ['instanceGroup', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -31041,7 +31100,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'zone', 'instanceGroup'],
         pathParams: ['instanceGroup', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -31439,7 +31498,10 @@ export namespace compute_v1 {
 
 
   export class Resource$Instances {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -31572,7 +31634,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'zone', 'instance', 'networkInterface'],
         pathParams: ['instance', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -31714,7 +31776,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$InstanceAggregatedList>(parameters, callback);
@@ -31854,7 +31916,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'zone', 'instance'],
         pathParams: ['instance', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -31984,7 +32046,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'zone', 'instance'],
         pathParams: ['instance', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -32124,7 +32186,7 @@ export namespace compute_v1 {
         requiredParams:
             ['project', 'zone', 'instance', 'accessConfig', 'networkInterface'],
         pathParams: ['instance', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -32259,7 +32321,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'zone', 'instance', 'deviceName'],
         pathParams: ['instance', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -32384,7 +32446,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'zone', 'instance'],
         pathParams: ['instance', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Instance>(parameters, callback);
@@ -32455,7 +32517,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'zone', 'resource'],
         pathParams: ['project', 'resource', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -32587,7 +32649,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'zone', 'instance'],
         pathParams: ['instance', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$SerialPortOutput>(parameters, callback);
@@ -32662,7 +32724,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'zone', 'instance'],
         pathParams: ['instance', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ShieldedInstanceIdentity>(parameters, callback);
@@ -32793,7 +32855,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'zone'],
         pathParams: ['project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -32934,7 +32996,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'zone'],
         pathParams: ['project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$InstanceList>(parameters, callback);
@@ -33013,7 +33075,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'zone', 'instance'],
         pathParams: ['instance', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$InstanceListReferrers>(parameters, callback);
@@ -33144,7 +33206,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'zone', 'instance'],
         pathParams: ['instance', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -33275,7 +33337,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'zone', 'resource'],
         pathParams: ['project', 'resource', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -33415,7 +33477,7 @@ export namespace compute_v1 {
         requiredParams:
             ['project', 'zone', 'instance', 'autoDelete', 'deviceName'],
         pathParams: ['instance', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -33487,7 +33549,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'zone', 'resource'],
         pathParams: ['project', 'resource', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -33624,7 +33686,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'zone', 'instance'],
         pathParams: ['instance', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -33759,7 +33821,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'zone', 'instance'],
         pathParams: ['instance', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -33896,7 +33958,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'zone', 'instance'],
         pathParams: ['instance', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -34033,7 +34095,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'zone', 'instance'],
         pathParams: ['instance', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -34171,7 +34233,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'zone', 'instance'],
         pathParams: ['instance', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -34307,7 +34369,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'zone', 'instance'],
         pathParams: ['instance', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -34444,7 +34506,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'zone', 'instance'],
         pathParams: ['instance', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -34523,7 +34585,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'zone', 'instance'],
         pathParams: ['instance', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -34660,7 +34722,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'zone', 'instance'],
         pathParams: ['instance', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -34732,7 +34794,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'zone', 'instance'],
         pathParams: ['instance', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -34862,7 +34924,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'zone', 'instance'],
         pathParams: ['instance', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -34998,7 +35060,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'zone', 'instance'],
         pathParams: ['instance', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -35132,7 +35194,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'zone', 'instance'],
         pathParams: ['instance', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -35206,7 +35268,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'zone', 'resource'],
         pathParams: ['project', 'resource', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -35283,7 +35345,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'zone', 'instance', 'networkInterface'],
         pathParams: ['instance', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -35359,7 +35421,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'zone', 'instance', 'networkInterface'],
         pathParams: ['instance', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -35436,7 +35498,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'zone', 'instance'],
         pathParams: ['instance', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -36702,7 +36764,10 @@ export namespace compute_v1 {
 
 
   export class Resource$Instancetemplates {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -36825,7 +36890,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'instanceTemplate'],
         pathParams: ['instanceTemplate', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -36949,7 +37014,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'instanceTemplate'],
         pathParams: ['instanceTemplate', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$InstanceTemplate>(parameters, callback);
@@ -37019,7 +37084,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -37150,7 +37215,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -37290,7 +37355,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$InstanceTemplateList>(parameters, callback);
@@ -37361,7 +37426,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -37434,7 +37499,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -37635,7 +37700,10 @@ export namespace compute_v1 {
 
 
   export class Resource$Interconnectattachments {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -37780,7 +37848,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$InterconnectAttachmentAggregatedList>(
@@ -37912,7 +37980,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region', 'interconnectAttachment'],
         pathParams: ['interconnectAttachment', 'project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -38040,7 +38108,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region', 'interconnectAttachment'],
         pathParams: ['interconnectAttachment', 'project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$InterconnectAttachment>(parameters, callback);
@@ -38171,7 +38239,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -38320,7 +38388,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$InterconnectAttachmentList>(
@@ -38396,7 +38464,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region', 'interconnectAttachment'],
         pathParams: ['interconnectAttachment', 'project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -38648,7 +38716,10 @@ export namespace compute_v1 {
 
 
   export class Resource$Interconnectlocations {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -38766,7 +38837,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'interconnectLocation'],
         pathParams: ['interconnectLocation', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$InterconnectLocation>(parameters, callback);
@@ -38908,7 +38979,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$InterconnectLocationList>(parameters, callback);
@@ -38992,7 +39063,10 @@ export namespace compute_v1 {
 
 
   export class Resource$Interconnects {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -39112,7 +39186,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'interconnect'],
         pathParams: ['interconnect', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -39235,7 +39309,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'interconnect'],
         pathParams: ['interconnect', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Interconnect>(parameters, callback);
@@ -39315,7 +39389,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'interconnect'],
         pathParams: ['interconnect', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$InterconnectsGetDiagnosticsResponse>(
@@ -39445,7 +39519,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -39583,7 +39657,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$InterconnectList>(parameters, callback);
@@ -39719,7 +39793,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'interconnect'],
         pathParams: ['interconnect', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -39912,7 +39986,10 @@ export namespace compute_v1 {
 
 
   export class Resource$Licensecodes {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -39971,7 +40048,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'licenseCode'],
         pathParams: ['licenseCode', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$LicenseCode>(parameters, callback);
@@ -40044,7 +40121,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -40093,7 +40170,10 @@ export namespace compute_v1 {
 
 
   export class Resource$Licenses {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -40154,7 +40234,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'license'],
         pathParams: ['license', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -40273,7 +40353,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'license'],
         pathParams: ['license', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$License>(parameters, callback);
@@ -40343,7 +40423,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -40410,7 +40490,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -40485,7 +40565,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$LicensesListResponse>(parameters, callback);
@@ -40556,7 +40636,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -40629,7 +40709,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -40826,7 +40906,10 @@ export namespace compute_v1 {
 
 
   export class Resource$Machinetypes {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -40961,7 +41044,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$MachineTypeAggregatedList>(
@@ -41088,7 +41171,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'zone', 'machineType'],
         pathParams: ['machineType', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$MachineType>(parameters, callback);
@@ -41230,7 +41313,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'zone'],
         pathParams: ['project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$MachineTypeList>(parameters, callback);
@@ -41376,7 +41459,10 @@ export namespace compute_v1 {
 
 
   export class Resource$Networks {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -41501,7 +41587,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'network'],
         pathParams: ['network', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -41625,7 +41711,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'network'],
         pathParams: ['network', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -41745,7 +41831,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'network'],
         pathParams: ['network', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Network>(parameters, callback);
@@ -41870,7 +41956,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -42005,7 +42091,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$NetworkList>(parameters, callback);
@@ -42138,7 +42224,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'network'],
         pathParams: ['network', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -42270,7 +42356,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'network'],
         pathParams: ['network', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -42398,7 +42484,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'network'],
         pathParams: ['network', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -42667,7 +42753,10 @@ export namespace compute_v1 {
 
 
   export class Resource$Nodegroups {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -42733,7 +42822,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'zone', 'nodeGroup'],
         pathParams: ['nodeGroup', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -42808,7 +42897,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$NodeGroupAggregatedList>(parameters, callback);
@@ -42879,7 +42968,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'zone', 'nodeGroup'],
         pathParams: ['nodeGroup', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -42952,7 +43041,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'zone', 'nodeGroup'],
         pathParams: ['nodeGroup', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -43020,7 +43109,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'zone', 'nodeGroup'],
         pathParams: ['nodeGroup', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$NodeGroup>(parameters, callback);
@@ -43091,7 +43180,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'zone', 'resource'],
         pathParams: ['project', 'resource', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -43163,7 +43252,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'zone', 'initialNodeCount'],
         pathParams: ['project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -43235,7 +43324,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'zone'],
         pathParams: ['project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$NodeGroupList>(parameters, callback);
@@ -43310,7 +43399,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'zone', 'nodeGroup'],
         pathParams: ['nodeGroup', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$NodeGroupsListNodes>(parameters, callback);
@@ -43382,7 +43471,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'zone', 'resource'],
         pathParams: ['project', 'resource', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -43455,7 +43544,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'zone', 'nodeGroup'],
         pathParams: ['nodeGroup', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -43529,7 +43618,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'zone', 'resource'],
         pathParams: ['project', 'resource', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -43992,7 +44081,10 @@ export namespace compute_v1 {
 
 
   export class Resource$Nodetemplates {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -44063,7 +44155,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$NodeTemplateAggregatedList>(
@@ -44136,7 +44228,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region', 'nodeTemplate'],
         pathParams: ['nodeTemplate', 'project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -44204,7 +44296,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region', 'nodeTemplate'],
         pathParams: ['nodeTemplate', 'project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$NodeTemplate>(parameters, callback);
@@ -44275,7 +44367,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region', 'resource'],
         pathParams: ['project', 'region', 'resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -44348,7 +44440,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -44422,7 +44514,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$NodeTemplateList>(parameters, callback);
@@ -44494,7 +44586,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region', 'resource'],
         pathParams: ['project', 'region', 'resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -44568,7 +44660,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region', 'resource'],
         pathParams: ['project', 'region', 'resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -44852,7 +44944,10 @@ export namespace compute_v1 {
 
 
   export class Resource$Nodetypes {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -44919,7 +45014,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$NodeTypeAggregatedList>(parameters, callback);
@@ -44985,7 +45080,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'zone', 'nodeType'],
         pathParams: ['nodeType', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$NodeType>(parameters, callback);
@@ -45056,7 +45151,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'zone'],
         pathParams: ['project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$NodeTypeList>(parameters, callback);
@@ -45201,7 +45296,10 @@ export namespace compute_v1 {
 
 
   export class Resource$Projects {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -45315,7 +45413,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -45443,7 +45541,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -45564,7 +45662,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -45693,7 +45791,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -45807,7 +45905,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Project>(parameters, callback);
@@ -45927,7 +46025,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Project>(parameters, callback);
@@ -46067,7 +46165,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ProjectsGetXpnResources>(parameters, callback);
@@ -46210,7 +46308,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$XpnHostList>(parameters, callback);
@@ -46336,7 +46434,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -46463,7 +46561,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -46590,7 +46688,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -46663,7 +46761,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -46791,7 +46889,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -47202,7 +47300,10 @@ export namespace compute_v1 {
 
 
   export class Resource$Regionautoscalers {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -47326,7 +47427,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region', 'autoscaler'],
         pathParams: ['autoscaler', 'project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -47452,7 +47553,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region', 'autoscaler'],
         pathParams: ['autoscaler', 'project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Autoscaler>(parameters, callback);
@@ -47585,7 +47686,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -47730,7 +47831,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$RegionAutoscalerList>(parameters, callback);
@@ -47867,7 +47968,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -48003,7 +48104,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -48238,7 +48339,10 @@ export namespace compute_v1 {
 
 
   export class Resource$Regionbackendservices {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -48363,7 +48467,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region', 'backendService'],
         pathParams: ['backendService', 'project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -48490,7 +48594,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region', 'backendService'],
         pathParams: ['backendService', 'project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$BackendService>(parameters, callback);
@@ -48627,7 +48731,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region', 'backendService'],
         pathParams: ['backendService', 'project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$BackendServiceGroupHealth>(
@@ -48763,7 +48867,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -48907,7 +49011,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$BackendServiceList>(parameters, callback);
@@ -49051,7 +49155,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region', 'backendService'],
         pathParams: ['backendService', 'project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -49193,7 +49297,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region', 'backendService'],
         pathParams: ['backendService', 'project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -49453,7 +49557,10 @@ export namespace compute_v1 {
 
 
   export class Resource$Regioncommitments {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -49588,7 +49695,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$CommitmentAggregatedList>(parameters, callback);
@@ -49715,7 +49822,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region', 'commitment'],
         pathParams: ['commitment', 'project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Commitment>(parameters, callback);
@@ -49848,7 +49955,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -49992,7 +50099,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$CommitmentList>(parameters, callback);
@@ -50173,7 +50280,10 @@ export namespace compute_v1 {
 
 
   export class Resource$Regiondisks {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -50239,7 +50349,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region', 'disk'],
         pathParams: ['disk', 'project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -50314,7 +50424,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region', 'disk'],
         pathParams: ['disk', 'project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -50379,7 +50489,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region', 'disk'],
         pathParams: ['disk', 'project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Disk>(parameters, callback);
@@ -50452,7 +50562,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -50523,7 +50633,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$DiskList>(parameters, callback);
@@ -50596,7 +50706,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region', 'disk'],
         pathParams: ['disk', 'project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -50669,7 +50779,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region', 'resource'],
         pathParams: ['project', 'region', 'resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -50743,7 +50853,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region', 'resource'],
         pathParams: ['project', 'region', 'resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -51043,7 +51153,10 @@ export namespace compute_v1 {
 
 
   export class Resource$Regiondisktypes {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -51103,7 +51216,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region', 'diskType'],
         pathParams: ['diskType', 'project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$DiskType>(parameters, callback);
@@ -51177,7 +51290,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$RegionDiskTypeList>(parameters, callback);
@@ -51269,7 +51382,10 @@ export namespace compute_v1 {
 
 
   export class Resource$Regioninstancegroupmanagers {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -51411,7 +51527,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region', 'instanceGroupManager'],
         pathParams: ['instanceGroupManager', 'project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -51542,7 +51658,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region', 'instanceGroupManager'],
         pathParams: ['instanceGroupManager', 'project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -51690,7 +51806,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region', 'instanceGroupManager'],
         pathParams: ['instanceGroupManager', 'project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -51817,7 +51933,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region', 'instanceGroupManager'],
         pathParams: ['instanceGroupManager', 'project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$InstanceGroupManager>(parameters, callback);
@@ -51953,7 +52069,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -52102,7 +52218,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$RegionInstanceGroupManagerList>(
@@ -52252,7 +52368,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region', 'instanceGroupManager'],
         pathParams: ['instanceGroupManager', 'project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<
@@ -52335,7 +52451,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region', 'instanceGroupManager'],
         pathParams: ['instanceGroupManager', 'project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -52481,7 +52597,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region', 'instanceGroupManager'],
         pathParams: ['instanceGroupManager', 'project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -52624,7 +52740,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region', 'instanceGroupManager', 'size'],
         pathParams: ['instanceGroupManager', 'project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -52763,7 +52879,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region', 'instanceGroupManager'],
         pathParams: ['instanceGroupManager', 'project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -52901,7 +53017,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region', 'instanceGroupManager'],
         pathParams: ['instanceGroupManager', 'project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -53388,7 +53504,10 @@ export namespace compute_v1 {
 
 
   export class Resource$Regioninstancegroups {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -53508,7 +53627,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region', 'instanceGroup'],
         pathParams: ['instanceGroup', 'project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$InstanceGroup>(parameters, callback);
@@ -53653,7 +53772,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$RegionInstanceGroupList>(parameters, callback);
@@ -53819,7 +53938,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region', 'instanceGroup'],
         pathParams: ['instanceGroup', 'project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$RegionInstanceGroupsListInstances>(
@@ -53956,7 +54075,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region', 'instanceGroup'],
         pathParams: ['instanceGroup', 'project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -54156,7 +54275,10 @@ export namespace compute_v1 {
 
 
   export class Resource$Regionoperations {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -54274,7 +54396,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region', 'operation'],
         pathParams: ['operation', 'project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -54400,7 +54522,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region', 'operation'],
         pathParams: ['operation', 'project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -54544,7 +54666,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$OperationList>(parameters, callback);
@@ -54656,7 +54778,10 @@ export namespace compute_v1 {
 
 
   export class Resource$Regions {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -54768,7 +54893,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Region>(parameters, callback);
@@ -54904,7 +55029,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$RegionList>(parameters, callback);
@@ -54986,7 +55111,10 @@ export namespace compute_v1 {
 
 
   export class Resource$Routers {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -55120,7 +55248,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$RouterAggregatedList>(parameters, callback);
@@ -55249,7 +55377,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region', 'router'],
         pathParams: ['project', 'region', 'router'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -55374,7 +55502,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region', 'router'],
         pathParams: ['project', 'region', 'router'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Router>(parameters, callback);
@@ -55452,7 +55580,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region', 'router'],
         pathParams: ['project', 'region', 'router'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$VmEndpointNatMappingsList>(
@@ -55585,7 +55713,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region', 'router'],
         pathParams: ['project', 'region', 'router'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$RouterStatusResponse>(parameters, callback);
@@ -55715,7 +55843,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -55856,7 +55984,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$RouterList>(parameters, callback);
@@ -55994,7 +56122,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region', 'router'],
         pathParams: ['project', 'region', 'router'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -56130,7 +56258,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region', 'router'],
         pathParams: ['project', 'region', 'router'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$RoutersPreviewResponse>(parameters, callback);
@@ -56267,7 +56395,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region', 'router'],
         pathParams: ['project', 'region', 'router'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -56659,7 +56787,10 @@ export namespace compute_v1 {
 
 
   export class Resource$Routes {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -56776,7 +56907,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'route'],
         pathParams: ['project', 'route'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -56896,7 +57027,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'route'],
         pathParams: ['project', 'route'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Route>(parameters, callback);
@@ -57021,7 +57152,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -57157,7 +57288,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$RouteList>(parameters, callback);
@@ -57296,7 +57427,10 @@ export namespace compute_v1 {
 
 
   export class Resource$Securitypolicies {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -57360,7 +57494,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'securityPolicy'],
         pathParams: ['project', 'securityPolicy'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -57431,7 +57565,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'securityPolicy'],
         pathParams: ['project', 'securityPolicy'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -57497,7 +57631,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'securityPolicy'],
         pathParams: ['project', 'securityPolicy'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$SecurityPolicy>(parameters, callback);
@@ -57568,7 +57702,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'securityPolicy'],
         pathParams: ['project', 'securityPolicy'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$SecurityPolicyRule>(parameters, callback);
@@ -57639,7 +57773,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -57712,7 +57846,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$SecurityPolicyList>(parameters, callback);
@@ -57784,7 +57918,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'securityPolicy'],
         pathParams: ['project', 'securityPolicy'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -57856,7 +57990,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'securityPolicy'],
         pathParams: ['project', 'securityPolicy'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -57927,7 +58061,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'securityPolicy'],
         pathParams: ['project', 'securityPolicy'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -58190,7 +58324,10 @@ export namespace compute_v1 {
 
 
   export class Resource$Snapshots {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -58312,7 +58449,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'snapshot'],
         pathParams: ['project', 'snapshot'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -58433,7 +58570,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'snapshot'],
         pathParams: ['project', 'snapshot'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Snapshot>(parameters, callback);
@@ -58503,7 +58640,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -58639,7 +58776,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$SnapshotList>(parameters, callback);
@@ -58710,7 +58847,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -58842,7 +58979,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -58915,7 +59052,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -59104,7 +59241,10 @@ export namespace compute_v1 {
 
 
   export class Resource$Sslcertificates {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -59225,7 +59365,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'sslCertificate'],
         pathParams: ['project', 'sslCertificate'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -59349,7 +59489,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'sslCertificate'],
         pathParams: ['project', 'sslCertificate'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$SslCertificate>(parameters, callback);
@@ -59477,7 +59617,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -59616,7 +59756,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$SslCertificateList>(parameters, callback);
@@ -59759,7 +59899,10 @@ export namespace compute_v1 {
 
 
   export class Resource$Sslpolicies {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -59825,7 +59968,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'sslPolicy'],
         pathParams: ['project', 'sslPolicy'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -59891,7 +60034,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'sslPolicy'],
         pathParams: ['project', 'sslPolicy'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$SslPolicy>(parameters, callback);
@@ -59962,7 +60105,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -60033,7 +60176,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$SslPoliciesList>(parameters, callback);
@@ -60114,7 +60257,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$SslPoliciesListAvailableFeaturesResponse>(
@@ -60188,7 +60331,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'sslPolicy'],
         pathParams: ['project', 'sslPolicy'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -60421,7 +60564,10 @@ export namespace compute_v1 {
 
 
   export class Resource$Subnetworks {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -60556,7 +60702,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$SubnetworkAggregatedList>(parameters, callback);
@@ -60687,7 +60833,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region', 'subnetwork'],
         pathParams: ['project', 'region', 'subnetwork'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -60821,7 +60967,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region', 'subnetwork'],
         pathParams: ['project', 'region', 'subnetwork'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -60947,7 +61093,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region', 'subnetwork'],
         pathParams: ['project', 'region', 'subnetwork'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Subnetwork>(parameters, callback);
@@ -61018,7 +61164,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region', 'resource'],
         pathParams: ['project', 'region', 'resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -61151,7 +61297,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -61292,7 +61438,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$SubnetworkList>(parameters, callback);
@@ -61372,7 +61518,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$UsableSubnetworksAggregatedList>(
@@ -61449,7 +61595,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region', 'subnetwork'],
         pathParams: ['project', 'region', 'subnetwork'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -61521,7 +61667,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region', 'resource'],
         pathParams: ['project', 'region', 'resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -61657,7 +61803,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region', 'subnetwork'],
         pathParams: ['project', 'region', 'subnetwork'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -61731,7 +61877,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region', 'resource'],
         pathParams: ['project', 'region', 'resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -62182,7 +62328,10 @@ export namespace compute_v1 {
 
 
   export class Resource$Targethttpproxies {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -62303,7 +62452,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'targetHttpProxy'],
         pathParams: ['project', 'targetHttpProxy'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -62427,7 +62576,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'targetHttpProxy'],
         pathParams: ['project', 'targetHttpProxy'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TargetHttpProxy>(parameters, callback);
@@ -62555,7 +62704,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -62694,7 +62843,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TargetHttpProxyList>(parameters, callback);
@@ -62827,7 +62976,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'targetHttpProxy'],
         pathParams: ['project', 'targetHttpProxy'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -63004,7 +63153,10 @@ export namespace compute_v1 {
 
 
   export class Resource$Targethttpsproxies {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -63125,7 +63277,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'targetHttpsProxy'],
         pathParams: ['project', 'targetHttpsProxy'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -63249,7 +63401,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'targetHttpsProxy'],
         pathParams: ['project', 'targetHttpsProxy'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TargetHttpsProxy>(parameters, callback);
@@ -63377,7 +63529,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -63517,7 +63669,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TargetHttpsProxyList>(parameters, callback);
@@ -63589,7 +63741,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'targetHttpsProxy'],
         pathParams: ['project', 'targetHttpsProxy'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -63721,7 +63873,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'targetHttpsProxy'],
         pathParams: ['project', 'targetHttpsProxy'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -63796,7 +63948,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'targetHttpsProxy'],
         pathParams: ['project', 'targetHttpsProxy'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -63929,7 +64081,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'targetHttpsProxy'],
         pathParams: ['project', 'targetHttpsProxy'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -64211,7 +64363,10 @@ export namespace compute_v1 {
 
 
   export class Resource$Targetinstances {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -64349,7 +64504,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TargetInstanceAggregatedList>(
@@ -64483,7 +64638,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'zone', 'targetInstance'],
         pathParams: ['project', 'targetInstance', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -64611,7 +64766,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'zone', 'targetInstance'],
         pathParams: ['project', 'targetInstance', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TargetInstance>(parameters, callback);
@@ -64744,7 +64899,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'zone'],
         pathParams: ['project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -64888,7 +65043,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'zone'],
         pathParams: ['project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TargetInstanceList>(parameters, callback);
@@ -65102,7 +65257,10 @@ export namespace compute_v1 {
 
 
   export class Resource$Targetpools {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -65231,7 +65389,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region', 'targetPool'],
         pathParams: ['project', 'region', 'targetPool'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -65367,7 +65525,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region', 'targetPool'],
         pathParams: ['project', 'region', 'targetPool'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -65509,7 +65667,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TargetPoolAggregatedList>(parameters, callback);
@@ -65640,7 +65798,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region', 'targetPool'],
         pathParams: ['project', 'region', 'targetPool'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -65766,7 +65924,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region', 'targetPool'],
         pathParams: ['project', 'region', 'targetPool'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TargetPool>(parameters, callback);
@@ -65906,7 +66064,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region', 'targetPool'],
         pathParams: ['project', 'region', 'targetPool'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TargetPoolInstanceHealth>(parameters, callback);
@@ -66039,7 +66197,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -66181,7 +66339,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TargetPoolList>(parameters, callback);
@@ -66315,7 +66473,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region', 'targetPool'],
         pathParams: ['project', 'region', 'targetPool'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -66451,7 +66609,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region', 'targetPool'],
         pathParams: ['project', 'region', 'targetPool'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -66588,7 +66746,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region', 'targetPool'],
         pathParams: ['project', 'region', 'targetPool'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -67019,7 +67177,10 @@ export namespace compute_v1 {
 
 
   export class Resource$Targetsslproxies {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -67140,7 +67301,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'targetSslProxy'],
         pathParams: ['project', 'targetSslProxy'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -67264,7 +67425,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'targetSslProxy'],
         pathParams: ['project', 'targetSslProxy'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TargetSslProxy>(parameters, callback);
@@ -67392,7 +67553,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -67531,7 +67692,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TargetSslProxyList>(parameters, callback);
@@ -67662,7 +67823,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'targetSslProxy'],
         pathParams: ['project', 'targetSslProxy'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -67793,7 +67954,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'targetSslProxy'],
         pathParams: ['project', 'targetSslProxy'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -67924,7 +68085,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'targetSslProxy'],
         pathParams: ['project', 'targetSslProxy'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -67999,7 +68160,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'targetSslProxy'],
         pathParams: ['project', 'targetSslProxy'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -68281,7 +68442,10 @@ export namespace compute_v1 {
 
 
   export class Resource$Targettcpproxies {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -68402,7 +68566,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'targetTcpProxy'],
         pathParams: ['project', 'targetTcpProxy'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -68526,7 +68690,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'targetTcpProxy'],
         pathParams: ['project', 'targetTcpProxy'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TargetTcpProxy>(parameters, callback);
@@ -68654,7 +68818,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -68793,7 +68957,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TargetTcpProxyList>(parameters, callback);
@@ -68924,7 +69088,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'targetTcpProxy'],
         pathParams: ['project', 'targetTcpProxy'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -69055,7 +69219,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'targetTcpProxy'],
         pathParams: ['project', 'targetTcpProxy'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -69267,7 +69431,10 @@ export namespace compute_v1 {
 
 
   export class Resource$Targetvpngateways {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -69406,7 +69573,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TargetVpnGatewayAggregatedList>(
@@ -69540,7 +69707,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region', 'targetVpnGateway'],
         pathParams: ['project', 'region', 'targetVpnGateway'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -69668,7 +69835,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region', 'targetVpnGateway'],
         pathParams: ['project', 'region', 'targetVpnGateway'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TargetVpnGateway>(parameters, callback);
@@ -69801,7 +69968,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -69946,7 +70113,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TargetVpnGatewayList>(parameters, callback);
@@ -70160,7 +70327,10 @@ export namespace compute_v1 {
 
 
   export class Resource$Urlmaps {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -70277,7 +70447,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'urlMap'],
         pathParams: ['project', 'urlMap'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -70397,7 +70567,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'urlMap'],
         pathParams: ['project', 'urlMap'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$UrlMap>(parameters, callback);
@@ -70522,7 +70692,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -70655,7 +70825,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'urlMap'],
         pathParams: ['project', 'urlMap'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -70791,7 +70961,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$UrlMapList>(parameters, callback);
@@ -70924,7 +71094,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'urlMap'],
         pathParams: ['project', 'urlMap'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -71056,7 +71226,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'urlMap'],
         pathParams: ['project', 'urlMap'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -71190,7 +71360,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'urlMap'],
         pathParams: ['project', 'urlMap'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$UrlMapsValidateResponse>(parameters, callback);
@@ -71449,7 +71619,10 @@ export namespace compute_v1 {
 
 
   export class Resource$Vpntunnels {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -71583,7 +71756,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$VpnTunnelAggregatedList>(parameters, callback);
@@ -71713,7 +71886,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region', 'vpnTunnel'],
         pathParams: ['project', 'region', 'vpnTunnel'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -71839,7 +72012,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region', 'vpnTunnel'],
         pathParams: ['project', 'region', 'vpnTunnel'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$VpnTunnel>(parameters, callback);
@@ -71971,7 +72144,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -72113,7 +72286,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'region'],
         pathParams: ['project', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$VpnTunnelList>(parameters, callback);
@@ -72325,7 +72498,10 @@ export namespace compute_v1 {
 
 
   export class Resource$Zoneoperations {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -72443,7 +72619,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'zone', 'operation'],
         pathParams: ['operation', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -72569,7 +72745,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'zone', 'operation'],
         pathParams: ['operation', 'project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -72711,7 +72887,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'zone'],
         pathParams: ['project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$OperationList>(parameters, callback);
@@ -72823,7 +72999,10 @@ export namespace compute_v1 {
 
 
   export class Resource$Zones {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -72935,7 +73114,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project', 'zone'],
         pathParams: ['project', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Zone>(parameters, callback);
@@ -73070,7 +73249,7 @@ export namespace compute_v1 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ZoneList>(parameters, callback);

--- a/src/apis/container/v1.ts
+++ b/src/apis/container/v1.ts
@@ -29,8 +29,6 @@ export namespace container_v1 {
     version: 'v1';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * V1 error format.
@@ -99,12 +97,13 @@ export namespace container_v1 {
    * @param {object=} options Options for Container
    */
   export class Container {
+    context: APIRequestContext;
     projects: Resource$Projects;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.projects = new Resource$Projects();
+      this.projects = new Resource$Projects(this.context);
     }
   }
 
@@ -268,10 +267,6 @@ export namespace container_v1 {
      * clusters are automatically deleted thirty days after creation.
      */
     enableKubernetesAlpha?: boolean;
-    /**
-     * Enable the ability to use Cloud TPUs in this cluster.
-     */
-    enableTpu?: boolean;
     /**
      * [Output only] The IP address of this cluster&#39;s master endpoint. The
      * endpoint can be accessed from the internet at
@@ -450,12 +445,6 @@ export namespace container_v1 {
      * connected.
      */
     subnetwork?: string;
-    /**
-     * [Output only] The IP address range of the Cloud TPUs in this cluster, in
-     * [CIDR](http://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing)
-     * notation (e.g. `1.2.3.4/29`).
-     */
-    tpuIpv4CidrBlock?: string;
     /**
      * [Output only] The name of the Google Compute Engine
      * [zone](/compute/docs/zones#available) in which the cluster resides. This
@@ -799,18 +788,6 @@ export namespace container_v1 {
      * subnetwork.
      */
     subnetworkName?: string;
-    /**
-     * The IP address range of the Cloud TPUs in this cluster. If unspecified, a
-     * range will be automatically chosen with the default size.  This field is
-     * only applicable when `use_ip_aliases` is true.  If unspecified, the range
-     * will use the default size.  Set to /netmask (e.g. `/14`) to have a range
-     * chosen with a specific netmask.  Set to a
-     * [CIDR](http://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing)
-     * notation (e.g. `10.96.0.0/14`) from the RFC-1918 private networks (e.g.
-     * `10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`) to pick a specific range
-     * to use.
-     */
-    tpuIpv4CidrBlock?: string;
     /**
      * Whether alias IPs will be used for pod IPs in the cluster.
      */
@@ -2027,21 +2004,26 @@ export namespace container_v1 {
 
 
   export class Resource$Projects {
+    context: APIRequestContext;
     locations: Resource$Projects$Locations;
     zones: Resource$Projects$Zones;
-    constructor() {
-      this.locations = new Resource$Projects$Locations();
-      this.zones = new Resource$Projects$Zones();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.locations = new Resource$Projects$Locations(this.context);
+      this.zones = new Resource$Projects$Zones(this.context);
     }
   }
 
 
   export class Resource$Projects$Locations {
+    context: APIRequestContext;
     clusters: Resource$Projects$Locations$Clusters;
     operations: Resource$Projects$Locations$Operations;
-    constructor() {
-      this.clusters = new Resource$Projects$Locations$Clusters();
-      this.operations = new Resource$Projects$Locations$Operations();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.clusters = new Resource$Projects$Locations$Clusters(this.context);
+      this.operations =
+          new Resource$Projects$Locations$Operations(this.context);
     }
 
 
@@ -2104,7 +2086,7 @@ export namespace container_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ServerConfig>(parameters, callback);
@@ -2141,11 +2123,15 @@ export namespace container_v1 {
   }
 
   export class Resource$Projects$Locations$Clusters {
+    context: APIRequestContext;
     nodePools: Resource$Projects$Locations$Clusters$Nodepools;
     wellKnown: Resource$Projects$Locations$Clusters$WellKnown;
-    constructor() {
-      this.nodePools = new Resource$Projects$Locations$Clusters$Nodepools();
-      this.wellKnown = new Resource$Projects$Locations$Clusters$WellKnown();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.nodePools =
+          new Resource$Projects$Locations$Clusters$Nodepools(this.context);
+      this.wellKnown =
+          new Resource$Projects$Locations$Clusters$WellKnown(this.context);
     }
 
 
@@ -2209,7 +2195,7 @@ export namespace container_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -2285,7 +2271,7 @@ export namespace container_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -2358,7 +2344,7 @@ export namespace container_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -2422,7 +2408,7 @@ export namespace container_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Cluster>(parameters, callback);
@@ -2493,7 +2479,7 @@ export namespace container_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GetJSONWebKeysResponse>(parameters, callback);
@@ -2564,7 +2550,7 @@ export namespace container_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListClustersResponse>(parameters, callback);
@@ -2633,7 +2619,7 @@ export namespace container_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -2703,7 +2689,7 @@ export namespace container_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -2772,7 +2758,7 @@ export namespace container_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -2841,7 +2827,7 @@ export namespace container_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -2915,7 +2901,7 @@ export namespace container_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -2987,7 +2973,7 @@ export namespace container_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -3057,7 +3043,7 @@ export namespace container_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -3127,7 +3113,7 @@ export namespace container_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -3197,7 +3183,7 @@ export namespace container_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -3267,7 +3253,7 @@ export namespace container_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -3334,7 +3320,7 @@ export namespace container_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -3403,7 +3389,7 @@ export namespace container_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -3768,7 +3754,10 @@ export namespace container_v1 {
   }
 
   export class Resource$Projects$Locations$Clusters$Nodepools {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -3831,7 +3820,7 @@ export namespace container_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -3903,7 +3892,7 @@ export namespace container_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -3970,7 +3959,7 @@ export namespace container_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$NodePool>(parameters, callback);
@@ -4043,7 +4032,7 @@ export namespace container_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListNodePoolsResponse>(parameters, callback);
@@ -4114,7 +4103,7 @@ export namespace container_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -4187,7 +4176,7 @@ export namespace container_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -4260,7 +4249,7 @@ export namespace container_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -4330,7 +4319,7 @@ export namespace container_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -4399,7 +4388,7 @@ export namespace container_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -4627,7 +4616,10 @@ export namespace container_v1 {
 
 
   export class Resource$Projects$Locations$Clusters$WellKnown {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -4698,7 +4690,7 @@ export namespace container_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GetOpenIDConfigResponse>(parameters, callback);
@@ -4725,7 +4717,10 @@ export namespace container_v1 {
 
 
   export class Resource$Projects$Locations$Operations {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -4785,7 +4780,7 @@ export namespace container_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -4850,7 +4845,7 @@ export namespace container_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -4920,7 +4915,7 @@ export namespace container_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListOperationsResponse>(parameters, callback);
@@ -5009,11 +5004,13 @@ export namespace container_v1 {
 
 
   export class Resource$Projects$Zones {
+    context: APIRequestContext;
     clusters: Resource$Projects$Zones$Clusters;
     operations: Resource$Projects$Zones$Operations;
-    constructor() {
-      this.clusters = new Resource$Projects$Zones$Clusters();
-      this.operations = new Resource$Projects$Zones$Operations();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.clusters = new Resource$Projects$Zones$Clusters(this.context);
+      this.operations = new Resource$Projects$Zones$Operations(this.context);
     }
 
 
@@ -5134,7 +5131,7 @@ export namespace container_v1 {
         params,
         requiredParams: ['projectId', 'zone'],
         pathParams: ['projectId', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ServerConfig>(parameters, callback);
@@ -5171,9 +5168,12 @@ export namespace container_v1 {
   }
 
   export class Resource$Projects$Zones$Clusters {
+    context: APIRequestContext;
     nodePools: Resource$Projects$Zones$Clusters$Nodepools;
-    constructor() {
-      this.nodePools = new Resource$Projects$Zones$Clusters$Nodepools();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.nodePools =
+          new Resource$Projects$Zones$Clusters$Nodepools(this.context);
     }
 
 
@@ -5303,7 +5303,7 @@ export namespace container_v1 {
         params,
         requiredParams: ['projectId', 'zone', 'clusterId'],
         pathParams: ['clusterId', 'projectId', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -5442,7 +5442,7 @@ export namespace container_v1 {
         params,
         requiredParams: ['projectId', 'zone', 'clusterId'],
         pathParams: ['clusterId', 'projectId', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -5580,7 +5580,7 @@ export namespace container_v1 {
         params,
         requiredParams: ['projectId', 'zone'],
         pathParams: ['projectId', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -5716,7 +5716,7 @@ export namespace container_v1 {
         params,
         requiredParams: ['projectId', 'zone', 'clusterId'],
         pathParams: ['clusterId', 'projectId', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -5843,7 +5843,7 @@ export namespace container_v1 {
         params,
         requiredParams: ['projectId', 'zone', 'clusterId'],
         pathParams: ['clusterId', 'projectId', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Cluster>(parameters, callback);
@@ -5979,7 +5979,7 @@ export namespace container_v1 {
         params,
         requiredParams: ['projectId', 'zone', 'clusterId'],
         pathParams: ['clusterId', 'projectId', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -6107,7 +6107,7 @@ export namespace container_v1 {
         params,
         requiredParams: ['projectId', 'zone'],
         pathParams: ['projectId', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListClustersResponse>(parameters, callback);
@@ -6243,7 +6243,7 @@ export namespace container_v1 {
         params,
         requiredParams: ['projectId', 'zone', 'clusterId'],
         pathParams: ['clusterId', 'projectId', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -6379,7 +6379,7 @@ export namespace container_v1 {
         params,
         requiredParams: ['projectId', 'zone', 'clusterId'],
         pathParams: ['clusterId', 'projectId', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -6515,7 +6515,7 @@ export namespace container_v1 {
         params,
         requiredParams: ['projectId', 'zone', 'clusterId'],
         pathParams: ['clusterId', 'projectId', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -6651,7 +6651,7 @@ export namespace container_v1 {
         params,
         requiredParams: ['projectId', 'zone', 'clusterId'],
         pathParams: ['clusterId', 'projectId', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -6789,7 +6789,7 @@ export namespace container_v1 {
         params,
         requiredParams: ['projectId', 'zone', 'clusterId'],
         pathParams: ['clusterId', 'projectId', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -6928,7 +6928,7 @@ export namespace container_v1 {
         params,
         requiredParams: ['projectId', 'zone', 'clusterId'],
         pathParams: ['clusterId', 'projectId', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -7067,7 +7067,7 @@ export namespace container_v1 {
         params,
         requiredParams: ['projectId', 'zone', 'clusterId'],
         pathParams: ['clusterId', 'projectId', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -7205,7 +7205,7 @@ export namespace container_v1 {
         params,
         requiredParams: ['projectId', 'zone', 'clusterId'],
         pathParams: ['clusterId', 'projectId', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -7343,7 +7343,7 @@ export namespace container_v1 {
         params,
         requiredParams: ['projectId', 'zone', 'clusterId'],
         pathParams: ['clusterId', 'projectId', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -7481,7 +7481,7 @@ export namespace container_v1 {
         params,
         requiredParams: ['projectId', 'zone', 'clusterId'],
         pathParams: ['clusterId', 'projectId', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -7992,7 +7992,10 @@ export namespace container_v1 {
   }
 
   export class Resource$Projects$Zones$Clusters$Nodepools {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -8127,7 +8130,7 @@ export namespace container_v1 {
         params,
         requiredParams: ['projectId', 'zone', 'clusterId', 'nodePoolId'],
         pathParams: ['clusterId', 'nodePoolId', 'projectId', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -8265,7 +8268,7 @@ export namespace container_v1 {
         params,
         requiredParams: ['projectId', 'zone', 'clusterId'],
         pathParams: ['clusterId', 'projectId', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -8403,7 +8406,7 @@ export namespace container_v1 {
         params,
         requiredParams: ['projectId', 'zone', 'clusterId', 'nodePoolId'],
         pathParams: ['clusterId', 'nodePoolId', 'projectId', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -8536,7 +8539,7 @@ export namespace container_v1 {
         params,
         requiredParams: ['projectId', 'zone', 'clusterId', 'nodePoolId'],
         pathParams: ['clusterId', 'nodePoolId', 'projectId', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$NodePool>(parameters, callback);
@@ -8671,7 +8674,7 @@ export namespace container_v1 {
         params,
         requiredParams: ['projectId', 'zone', 'clusterId'],
         pathParams: ['clusterId', 'projectId', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListNodePoolsResponse>(parameters, callback);
@@ -8814,7 +8817,7 @@ export namespace container_v1 {
         params,
         requiredParams: ['projectId', 'zone', 'clusterId', 'nodePoolId'],
         pathParams: ['clusterId', 'nodePoolId', 'projectId', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -8957,7 +8960,7 @@ export namespace container_v1 {
         params,
         requiredParams: ['projectId', 'zone', 'clusterId', 'nodePoolId'],
         pathParams: ['clusterId', 'nodePoolId', 'projectId', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -9099,7 +9102,7 @@ export namespace container_v1 {
         params,
         requiredParams: ['projectId', 'zone', 'clusterId', 'nodePoolId'],
         pathParams: ['clusterId', 'nodePoolId', 'projectId', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -9240,7 +9243,7 @@ export namespace container_v1 {
         params,
         requiredParams: ['projectId', 'zone', 'clusterId', 'nodePoolId'],
         pathParams: ['clusterId', 'nodePoolId', 'projectId', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -9561,7 +9564,10 @@ export namespace container_v1 {
 
 
   export class Resource$Projects$Zones$Operations {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -9687,7 +9693,7 @@ export namespace container_v1 {
         params,
         requiredParams: ['projectId', 'zone', 'operationId'],
         pathParams: ['operationId', 'projectId', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -9815,7 +9821,7 @@ export namespace container_v1 {
         params,
         requiredParams: ['projectId', 'zone', 'operationId'],
         pathParams: ['operationId', 'projectId', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -9943,7 +9949,7 @@ export namespace container_v1 {
         params,
         requiredParams: ['projectId', 'zone'],
         pathParams: ['projectId', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListOperationsResponse>(parameters, callback);

--- a/src/apis/container/v1beta1.ts
+++ b/src/apis/container/v1beta1.ts
@@ -29,8 +29,6 @@ export namespace container_v1beta1 {
     version: 'v1beta1';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * V1 error format.
@@ -99,12 +97,13 @@ export namespace container_v1beta1 {
    * @param {object=} options Options for Container
    */
   export class Container {
+    context: APIRequestContext;
     projects: Resource$Projects;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.projects = new Resource$Projects();
+      this.projects = new Resource$Projects(this.context);
     }
   }
 
@@ -159,6 +158,21 @@ export namespace container_v1beta1 {
      * enabled for the nodes.
      */
     networkPolicyConfig?: Schema$NetworkPolicyConfig;
+  }
+  /**
+   * Configuration for returning group information from authenticators.
+   */
+  export interface Schema$AuthenticatorGroupsConfig {
+    /**
+     * Whether this cluster should return group membership lookups during
+     * authentication using a group of security groups.
+     */
+    enabled?: boolean;
+    /**
+     * The name of the security group-of-groups to be used. Only relevant if
+     * enabled = true.
+     */
+    securityGroup?: string;
   }
   /**
    * AutoUpgradeOptions defines the set of options for the user to control how
@@ -262,6 +276,10 @@ export namespace container_v1beta1 {
      * Configurations for the various addons available to run in the cluster.
      */
     addonsConfig?: Schema$AddonsConfig;
+    /**
+     * Configuration controlling RBAC group membership information.
+     */
+    authenticatorGroupsConfig?: Schema$AuthenticatorGroupsConfig;
     /**
      * Cluster-level autoscaling configuration.
      */
@@ -591,6 +609,10 @@ export namespace container_v1beta1 {
      */
     desiredImageType?: string;
     /**
+     * The desired config of Intra-node visibility.
+     */
+    desiredIntraNodeVisibilityConfig?: Schema$IntraNodeVisibilityConfig;
+    /**
      * The desired list of Google Compute Engine
      * [zones](/compute/docs/zones#available) in which the cluster&#39;s nodes
      * should be located. Changing the locations a cluster is in will result in
@@ -867,6 +889,16 @@ export namespace container_v1beta1 {
      * balancers.
      */
     disabled?: boolean;
+  }
+  /**
+   * IntraNodeVisibilityConfig contains the desired config of the intra-node
+   * visibility on this cluster.
+   */
+  export interface Schema$IntraNodeVisibilityConfig {
+    /**
+     * Enables intra node visibility for this cluster.
+     */
+    enabled?: boolean;
   }
   /**
    * Configuration for controlling how IPs are allocated in the cluster.
@@ -1256,6 +1288,11 @@ export namespace container_v1beta1 {
    * NetworkConfig reports the relative names of network &amp; subnetwork.
    */
   export interface Schema$NetworkConfig {
+    /**
+     * Whether Intra-node visibility is enabled for this cluster. This makes
+     * same node pod to pod traffic visible for VPC network.
+     */
+    enableIntraNodeVisibility?: boolean;
     /**
      * Output only. The relative name of the Google Compute Engine
      * network(/compute/docs/networks-and-firewalls#networks) to which the
@@ -2435,28 +2472,35 @@ export namespace container_v1beta1 {
 
 
   export class Resource$Projects {
+    context: APIRequestContext;
     aggregated: Resource$Projects$Aggregated;
     locations: Resource$Projects$Locations;
     zones: Resource$Projects$Zones;
-    constructor() {
-      this.aggregated = new Resource$Projects$Aggregated();
-      this.locations = new Resource$Projects$Locations();
-      this.zones = new Resource$Projects$Zones();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.aggregated = new Resource$Projects$Aggregated(this.context);
+      this.locations = new Resource$Projects$Locations(this.context);
+      this.zones = new Resource$Projects$Zones(this.context);
     }
   }
 
 
   export class Resource$Projects$Aggregated {
+    context: APIRequestContext;
     usableSubnetworks: Resource$Projects$Aggregated$Usablesubnetworks;
-    constructor() {
+    constructor(context: APIRequestContext) {
+      this.context = context;
       this.usableSubnetworks =
-          new Resource$Projects$Aggregated$Usablesubnetworks();
+          new Resource$Projects$Aggregated$Usablesubnetworks(this.context);
     }
   }
 
 
   export class Resource$Projects$Aggregated$Usablesubnetworks {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -2527,7 +2571,7 @@ export namespace container_v1beta1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListUsableSubnetworksResponse>(
@@ -2575,11 +2619,14 @@ export namespace container_v1beta1 {
 
 
   export class Resource$Projects$Locations {
+    context: APIRequestContext;
     clusters: Resource$Projects$Locations$Clusters;
     operations: Resource$Projects$Locations$Operations;
-    constructor() {
-      this.clusters = new Resource$Projects$Locations$Clusters();
-      this.operations = new Resource$Projects$Locations$Operations();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.clusters = new Resource$Projects$Locations$Clusters(this.context);
+      this.operations =
+          new Resource$Projects$Locations$Operations(this.context);
     }
 
 
@@ -2642,7 +2689,7 @@ export namespace container_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ServerConfig>(parameters, callback);
@@ -2710,7 +2757,7 @@ export namespace container_v1beta1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListLocationsResponse>(parameters, callback);
@@ -2760,11 +2807,15 @@ export namespace container_v1beta1 {
   }
 
   export class Resource$Projects$Locations$Clusters {
+    context: APIRequestContext;
     nodePools: Resource$Projects$Locations$Clusters$Nodepools;
     wellKnown: Resource$Projects$Locations$Clusters$WellKnown;
-    constructor() {
-      this.nodePools = new Resource$Projects$Locations$Clusters$Nodepools();
-      this.wellKnown = new Resource$Projects$Locations$Clusters$WellKnown();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.nodePools =
+          new Resource$Projects$Locations$Clusters$Nodepools(this.context);
+      this.wellKnown =
+          new Resource$Projects$Locations$Clusters$WellKnown(this.context);
     }
 
 
@@ -2828,7 +2879,7 @@ export namespace container_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -2904,7 +2955,7 @@ export namespace container_v1beta1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -2977,7 +3028,7 @@ export namespace container_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -3041,7 +3092,7 @@ export namespace container_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Cluster>(parameters, callback);
@@ -3112,7 +3163,7 @@ export namespace container_v1beta1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GetJSONWebKeysResponse>(parameters, callback);
@@ -3183,7 +3234,7 @@ export namespace container_v1beta1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListClustersResponse>(parameters, callback);
@@ -3252,7 +3303,7 @@ export namespace container_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -3322,7 +3373,7 @@ export namespace container_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -3391,7 +3442,7 @@ export namespace container_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -3460,7 +3511,7 @@ export namespace container_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -3534,7 +3585,7 @@ export namespace container_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -3607,7 +3658,7 @@ export namespace container_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -3677,7 +3728,7 @@ export namespace container_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -3747,7 +3798,7 @@ export namespace container_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -3817,7 +3868,7 @@ export namespace container_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -3887,7 +3938,7 @@ export namespace container_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -3954,7 +4005,7 @@ export namespace container_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -4023,7 +4074,7 @@ export namespace container_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -4388,7 +4439,10 @@ export namespace container_v1beta1 {
   }
 
   export class Resource$Projects$Locations$Clusters$Nodepools {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -4451,7 +4505,7 @@ export namespace container_v1beta1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -4523,7 +4577,7 @@ export namespace container_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -4590,7 +4644,7 @@ export namespace container_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$NodePool>(parameters, callback);
@@ -4663,7 +4717,7 @@ export namespace container_v1beta1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListNodePoolsResponse>(parameters, callback);
@@ -4734,7 +4788,7 @@ export namespace container_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -4807,7 +4861,7 @@ export namespace container_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -4880,7 +4934,7 @@ export namespace container_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -4950,7 +5004,7 @@ export namespace container_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -5019,7 +5073,7 @@ export namespace container_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -5247,7 +5301,10 @@ export namespace container_v1beta1 {
 
 
   export class Resource$Projects$Locations$Clusters$WellKnown {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -5319,7 +5376,7 @@ export namespace container_v1beta1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GetOpenIDConfigResponse>(parameters, callback);
@@ -5346,7 +5403,10 @@ export namespace container_v1beta1 {
 
 
   export class Resource$Projects$Locations$Operations {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -5406,7 +5466,7 @@ export namespace container_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -5471,7 +5531,7 @@ export namespace container_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -5541,7 +5601,7 @@ export namespace container_v1beta1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListOperationsResponse>(parameters, callback);
@@ -5630,11 +5690,13 @@ export namespace container_v1beta1 {
 
 
   export class Resource$Projects$Zones {
+    context: APIRequestContext;
     clusters: Resource$Projects$Zones$Clusters;
     operations: Resource$Projects$Zones$Operations;
-    constructor() {
-      this.clusters = new Resource$Projects$Zones$Clusters();
-      this.operations = new Resource$Projects$Zones$Operations();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.clusters = new Resource$Projects$Zones$Clusters(this.context);
+      this.operations = new Resource$Projects$Zones$Operations(this.context);
     }
 
 
@@ -5698,7 +5760,7 @@ export namespace container_v1beta1 {
         params,
         requiredParams: ['projectId', 'zone'],
         pathParams: ['projectId', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ServerConfig>(parameters, callback);
@@ -5735,9 +5797,12 @@ export namespace container_v1beta1 {
   }
 
   export class Resource$Projects$Zones$Clusters {
+    context: APIRequestContext;
     nodePools: Resource$Projects$Zones$Clusters$Nodepools;
-    constructor() {
-      this.nodePools = new Resource$Projects$Zones$Clusters$Nodepools();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.nodePools =
+          new Resource$Projects$Zones$Clusters$Nodepools(this.context);
     }
 
 
@@ -5803,7 +5868,7 @@ export namespace container_v1beta1 {
         params,
         requiredParams: ['projectId', 'zone', 'clusterId'],
         pathParams: ['clusterId', 'projectId', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -5877,7 +5942,7 @@ export namespace container_v1beta1 {
         params,
         requiredParams: ['projectId', 'zone', 'clusterId'],
         pathParams: ['clusterId', 'projectId', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -5955,7 +6020,7 @@ export namespace container_v1beta1 {
         params,
         requiredParams: ['projectId', 'zone'],
         pathParams: ['projectId', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -6031,7 +6096,7 @@ export namespace container_v1beta1 {
         params,
         requiredParams: ['projectId', 'zone', 'clusterId'],
         pathParams: ['clusterId', 'projectId', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -6098,7 +6163,7 @@ export namespace container_v1beta1 {
         params,
         requiredParams: ['projectId', 'zone', 'clusterId'],
         pathParams: ['clusterId', 'projectId', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Cluster>(parameters, callback);
@@ -6170,7 +6235,7 @@ export namespace container_v1beta1 {
         params,
         requiredParams: ['projectId', 'zone', 'clusterId'],
         pathParams: ['clusterId', 'projectId', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -6242,7 +6307,7 @@ export namespace container_v1beta1 {
         params,
         requiredParams: ['projectId', 'zone'],
         pathParams: ['projectId', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListClustersResponse>(parameters, callback);
@@ -6314,7 +6379,7 @@ export namespace container_v1beta1 {
         params,
         requiredParams: ['projectId', 'zone', 'clusterId'],
         pathParams: ['clusterId', 'projectId', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -6386,7 +6451,7 @@ export namespace container_v1beta1 {
         params,
         requiredParams: ['projectId', 'zone', 'clusterId'],
         pathParams: ['clusterId', 'projectId', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -6458,7 +6523,7 @@ export namespace container_v1beta1 {
         params,
         requiredParams: ['projectId', 'zone', 'clusterId'],
         pathParams: ['clusterId', 'projectId', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -6530,7 +6595,7 @@ export namespace container_v1beta1 {
         params,
         requiredParams: ['projectId', 'zone', 'clusterId'],
         pathParams: ['clusterId', 'projectId', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -6603,7 +6668,7 @@ export namespace container_v1beta1 {
         params,
         requiredParams: ['projectId', 'zone', 'clusterId'],
         pathParams: ['clusterId', 'projectId', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -6678,7 +6743,7 @@ export namespace container_v1beta1 {
         params,
         requiredParams: ['projectId', 'zone', 'clusterId'],
         pathParams: ['clusterId', 'projectId', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -6754,7 +6819,7 @@ export namespace container_v1beta1 {
         params,
         requiredParams: ['projectId', 'zone', 'clusterId'],
         pathParams: ['clusterId', 'projectId', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -6827,7 +6892,7 @@ export namespace container_v1beta1 {
         params,
         requiredParams: ['projectId', 'zone', 'clusterId'],
         pathParams: ['clusterId', 'projectId', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -6900,7 +6965,7 @@ export namespace container_v1beta1 {
         params,
         requiredParams: ['projectId', 'zone', 'clusterId'],
         pathParams: ['clusterId', 'projectId', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -6972,7 +7037,7 @@ export namespace container_v1beta1 {
         params,
         requiredParams: ['projectId', 'zone', 'clusterId'],
         pathParams: ['clusterId', 'projectId', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -7483,7 +7548,10 @@ export namespace container_v1beta1 {
   }
 
   export class Resource$Projects$Zones$Clusters$Nodepools {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -7551,7 +7619,7 @@ export namespace container_v1beta1 {
         params,
         requiredParams: ['projectId', 'zone', 'clusterId', 'nodePoolId'],
         pathParams: ['clusterId', 'nodePoolId', 'projectId', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -7624,7 +7692,7 @@ export namespace container_v1beta1 {
         params,
         requiredParams: ['projectId', 'zone', 'clusterId'],
         pathParams: ['clusterId', 'projectId', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -7698,7 +7766,7 @@ export namespace container_v1beta1 {
         params,
         requiredParams: ['projectId', 'zone', 'clusterId', 'nodePoolId'],
         pathParams: ['clusterId', 'nodePoolId', 'projectId', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -7767,7 +7835,7 @@ export namespace container_v1beta1 {
         params,
         requiredParams: ['projectId', 'zone', 'clusterId', 'nodePoolId'],
         pathParams: ['clusterId', 'nodePoolId', 'projectId', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$NodePool>(parameters, callback);
@@ -7841,7 +7909,7 @@ export namespace container_v1beta1 {
         params,
         requiredParams: ['projectId', 'zone', 'clusterId'],
         pathParams: ['clusterId', 'projectId', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListNodePoolsResponse>(parameters, callback);
@@ -7917,7 +7985,7 @@ export namespace container_v1beta1 {
         params,
         requiredParams: ['projectId', 'zone', 'clusterId', 'nodePoolId'],
         pathParams: ['clusterId', 'nodePoolId', 'projectId', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -7993,7 +8061,7 @@ export namespace container_v1beta1 {
         params,
         requiredParams: ['projectId', 'zone', 'clusterId', 'nodePoolId'],
         pathParams: ['clusterId', 'nodePoolId', 'projectId', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -8068,7 +8136,7 @@ export namespace container_v1beta1 {
         params,
         requiredParams: ['projectId', 'zone', 'clusterId', 'nodePoolId'],
         pathParams: ['clusterId', 'nodePoolId', 'projectId', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -8142,7 +8210,7 @@ export namespace container_v1beta1 {
         params,
         requiredParams: ['projectId', 'zone', 'clusterId', 'nodePoolId'],
         pathParams: ['clusterId', 'nodePoolId', 'projectId', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -8463,7 +8531,10 @@ export namespace container_v1beta1 {
 
 
   export class Resource$Projects$Zones$Operations {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -8527,7 +8598,7 @@ export namespace container_v1beta1 {
         params,
         requiredParams: ['projectId', 'zone', 'operationId'],
         pathParams: ['operationId', 'projectId', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -8595,7 +8666,7 @@ export namespace container_v1beta1 {
         params,
         requiredParams: ['projectId', 'zone', 'operationId'],
         pathParams: ['operationId', 'projectId', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -8666,7 +8737,7 @@ export namespace container_v1beta1 {
         params,
         requiredParams: ['projectId', 'zone'],
         pathParams: ['projectId', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListOperationsResponse>(parameters, callback);

--- a/src/apis/containeranalysis/v1alpha1.ts
+++ b/src/apis/containeranalysis/v1alpha1.ts
@@ -29,8 +29,6 @@ export namespace containeranalysis_v1alpha1 {
     version: 'v1alpha1';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * V1 error format.
@@ -99,14 +97,15 @@ export namespace containeranalysis_v1alpha1 {
    * @param {object=} options Options for Containeranalysis
    */
   export class Containeranalysis {
+    context: APIRequestContext;
     projects: Resource$Projects;
     providers: Resource$Providers;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.projects = new Resource$Projects();
-      this.providers = new Resource$Providers();
+      this.projects = new Resource$Projects(this.context);
+      this.providers = new Resource$Providers(this.context);
     }
   }
 
@@ -1651,23 +1650,27 @@ export namespace containeranalysis_v1alpha1 {
 
 
   export class Resource$Projects {
+    context: APIRequestContext;
     notes: Resource$Projects$Notes;
     occurrences: Resource$Projects$Occurrences;
     operations: Resource$Projects$Operations;
     scanConfigs: Resource$Projects$Scanconfigs;
-    constructor() {
-      this.notes = new Resource$Projects$Notes();
-      this.occurrences = new Resource$Projects$Occurrences();
-      this.operations = new Resource$Projects$Operations();
-      this.scanConfigs = new Resource$Projects$Scanconfigs();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.notes = new Resource$Projects$Notes(this.context);
+      this.occurrences = new Resource$Projects$Occurrences(this.context);
+      this.operations = new Resource$Projects$Operations(this.context);
+      this.scanConfigs = new Resource$Projects$Scanconfigs(this.context);
     }
   }
 
 
   export class Resource$Projects$Notes {
+    context: APIRequestContext;
     occurrences: Resource$Projects$Notes$Occurrences;
-    constructor() {
-      this.occurrences = new Resource$Projects$Notes$Occurrences();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.occurrences = new Resource$Projects$Notes$Occurrences(this.context);
     }
 
 
@@ -1731,7 +1734,7 @@ export namespace containeranalysis_v1alpha1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Note>(parameters, callback);
@@ -1798,7 +1801,7 @@ export namespace containeranalysis_v1alpha1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -1861,7 +1864,7 @@ export namespace containeranalysis_v1alpha1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Note>(parameters, callback);
@@ -1939,7 +1942,7 @@ export namespace containeranalysis_v1alpha1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -2010,7 +2013,7 @@ export namespace containeranalysis_v1alpha1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListNotesResponse>(parameters, callback);
@@ -2079,7 +2082,7 @@ export namespace containeranalysis_v1alpha1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Note>(parameters, callback);
@@ -2158,7 +2161,7 @@ export namespace containeranalysis_v1alpha1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -2241,7 +2244,7 @@ export namespace containeranalysis_v1alpha1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TestIamPermissionsResponse>(
@@ -2411,7 +2414,10 @@ export namespace containeranalysis_v1alpha1 {
   }
 
   export class Resource$Projects$Notes$Occurrences {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -2482,7 +2488,7 @@ export namespace containeranalysis_v1alpha1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListNoteOccurrencesResponse>(
@@ -2522,7 +2528,10 @@ export namespace containeranalysis_v1alpha1 {
 
 
   export class Resource$Projects$Occurrences {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -2586,7 +2595,7 @@ export namespace containeranalysis_v1alpha1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Occurrence>(parameters, callback);
@@ -2654,7 +2663,7 @@ export namespace containeranalysis_v1alpha1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -2718,7 +2727,7 @@ export namespace containeranalysis_v1alpha1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Occurrence>(parameters, callback);
@@ -2796,7 +2805,7 @@ export namespace containeranalysis_v1alpha1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -2863,7 +2872,7 @@ export namespace containeranalysis_v1alpha1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Note>(parameters, callback);
@@ -2945,7 +2954,7 @@ export namespace containeranalysis_v1alpha1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GetVulnzOccurrencesSummaryResponse>(
@@ -3022,7 +3031,7 @@ export namespace containeranalysis_v1alpha1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListOccurrencesResponse>(parameters, callback);
@@ -3092,7 +3101,7 @@ export namespace containeranalysis_v1alpha1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Occurrence>(parameters, callback);
@@ -3171,7 +3180,7 @@ export namespace containeranalysis_v1alpha1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -3255,7 +3264,7 @@ export namespace containeranalysis_v1alpha1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TestIamPermissionsResponse>(
@@ -3455,7 +3464,10 @@ export namespace containeranalysis_v1alpha1 {
 
 
   export class Resource$Projects$Operations {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -3517,7 +3529,7 @@ export namespace containeranalysis_v1alpha1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -3588,7 +3600,7 @@ export namespace containeranalysis_v1alpha1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -3636,7 +3648,10 @@ export namespace containeranalysis_v1alpha1 {
 
 
   export class Resource$Projects$Scanconfigs {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -3693,7 +3708,7 @@ export namespace containeranalysis_v1alpha1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ScanConfig>(parameters, callback);
@@ -3765,7 +3780,7 @@ export namespace containeranalysis_v1alpha1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListScanConfigsResponse>(parameters, callback);
@@ -3835,7 +3850,7 @@ export namespace containeranalysis_v1alpha1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ScanConfig>(parameters, callback);
@@ -3908,17 +3923,21 @@ export namespace containeranalysis_v1alpha1 {
 
 
   export class Resource$Providers {
+    context: APIRequestContext;
     notes: Resource$Providers$Notes;
-    constructor() {
-      this.notes = new Resource$Providers$Notes();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.notes = new Resource$Providers$Notes(this.context);
     }
   }
 
 
   export class Resource$Providers$Notes {
+    context: APIRequestContext;
     occurrences: Resource$Providers$Notes$Occurrences;
-    constructor() {
-      this.occurrences = new Resource$Providers$Notes$Occurrences();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.occurrences = new Resource$Providers$Notes$Occurrences(this.context);
     }
 
 
@@ -3982,7 +4001,7 @@ export namespace containeranalysis_v1alpha1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Note>(parameters, callback);
@@ -4049,7 +4068,7 @@ export namespace containeranalysis_v1alpha1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -4112,7 +4131,7 @@ export namespace containeranalysis_v1alpha1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Note>(parameters, callback);
@@ -4190,7 +4209,7 @@ export namespace containeranalysis_v1alpha1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -4262,7 +4281,7 @@ export namespace containeranalysis_v1alpha1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListNotesResponse>(parameters, callback);
@@ -4331,7 +4350,7 @@ export namespace containeranalysis_v1alpha1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Note>(parameters, callback);
@@ -4410,7 +4429,7 @@ export namespace containeranalysis_v1alpha1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -4493,7 +4512,7 @@ export namespace containeranalysis_v1alpha1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TestIamPermissionsResponse>(
@@ -4663,7 +4682,10 @@ export namespace containeranalysis_v1alpha1 {
   }
 
   export class Resource$Providers$Notes$Occurrences {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -4734,7 +4756,7 @@ export namespace containeranalysis_v1alpha1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListNoteOccurrencesResponse>(

--- a/src/apis/containeranalysis/v1beta1.ts
+++ b/src/apis/containeranalysis/v1beta1.ts
@@ -29,8 +29,6 @@ export namespace containeranalysis_v1beta1 {
     version: 'v1beta1';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * V1 error format.
@@ -99,12 +97,13 @@ export namespace containeranalysis_v1beta1 {
    * @param {object=} options Options for Containeranalysis
    */
   export class Containeranalysis {
+    context: APIRequestContext;
     projects: Resource$Projects;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.projects = new Resource$Projects();
+      this.projects = new Resource$Projects(this.context);
     }
   }
 
@@ -1743,21 +1742,25 @@ export namespace containeranalysis_v1beta1 {
 
 
   export class Resource$Projects {
+    context: APIRequestContext;
     notes: Resource$Projects$Notes;
     occurrences: Resource$Projects$Occurrences;
     scanConfigs: Resource$Projects$Scanconfigs;
-    constructor() {
-      this.notes = new Resource$Projects$Notes();
-      this.occurrences = new Resource$Projects$Occurrences();
-      this.scanConfigs = new Resource$Projects$Scanconfigs();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.notes = new Resource$Projects$Notes(this.context);
+      this.occurrences = new Resource$Projects$Occurrences(this.context);
+      this.scanConfigs = new Resource$Projects$Scanconfigs(this.context);
     }
   }
 
 
   export class Resource$Projects$Notes {
+    context: APIRequestContext;
     occurrences: Resource$Projects$Notes$Occurrences;
-    constructor() {
-      this.occurrences = new Resource$Projects$Notes$Occurrences();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.occurrences = new Resource$Projects$Notes$Occurrences(this.context);
     }
 
 
@@ -1823,7 +1826,7 @@ export namespace containeranalysis_v1beta1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$BatchCreateNotesResponse>(parameters, callback);
@@ -1892,7 +1895,7 @@ export namespace containeranalysis_v1beta1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Note>(parameters, callback);
@@ -1958,7 +1961,7 @@ export namespace containeranalysis_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -2020,7 +2023,7 @@ export namespace containeranalysis_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Note>(parameters, callback);
@@ -2093,7 +2096,7 @@ export namespace containeranalysis_v1beta1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -2163,7 +2166,7 @@ export namespace containeranalysis_v1beta1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListNotesResponse>(parameters, callback);
@@ -2231,7 +2234,7 @@ export namespace containeranalysis_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Note>(parameters, callback);
@@ -2304,7 +2307,7 @@ export namespace containeranalysis_v1beta1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -2383,7 +2386,7 @@ export namespace containeranalysis_v1beta1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TestIamPermissionsResponse>(
@@ -2564,7 +2567,10 @@ export namespace containeranalysis_v1beta1 {
   }
 
   export class Resource$Projects$Notes$Occurrences {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -2635,7 +2641,7 @@ export namespace containeranalysis_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListNoteOccurrencesResponse>(
@@ -2675,7 +2681,10 @@ export namespace containeranalysis_v1beta1 {
 
 
   export class Resource$Projects$Occurrences {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -2743,7 +2752,7 @@ export namespace containeranalysis_v1beta1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$BatchCreateOccurrencesResponse>(
@@ -2814,7 +2823,7 @@ export namespace containeranalysis_v1beta1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Occurrence>(parameters, callback);
@@ -2882,7 +2891,7 @@ export namespace containeranalysis_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -2945,7 +2954,7 @@ export namespace containeranalysis_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Occurrence>(parameters, callback);
@@ -3018,7 +3027,7 @@ export namespace containeranalysis_v1beta1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -3087,7 +3096,7 @@ export namespace containeranalysis_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Note>(parameters, callback);
@@ -3166,7 +3175,7 @@ export namespace containeranalysis_v1beta1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$VulnerabilityOccurrencesSummary>(
@@ -3240,7 +3249,7 @@ export namespace containeranalysis_v1beta1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListOccurrencesResponse>(parameters, callback);
@@ -3309,7 +3318,7 @@ export namespace containeranalysis_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Occurrence>(parameters, callback);
@@ -3382,7 +3391,7 @@ export namespace containeranalysis_v1beta1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -3462,7 +3471,7 @@ export namespace containeranalysis_v1beta1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TestIamPermissionsResponse>(
@@ -3670,7 +3679,10 @@ export namespace containeranalysis_v1beta1 {
 
 
   export class Resource$Projects$Scanconfigs {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -3726,7 +3738,7 @@ export namespace containeranalysis_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ScanConfig>(parameters, callback);
@@ -3798,7 +3810,7 @@ export namespace containeranalysis_v1beta1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListScanConfigsResponse>(parameters, callback);
@@ -3866,7 +3878,7 @@ export namespace containeranalysis_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ScanConfig>(parameters, callback);

--- a/src/apis/content/v2.1.ts
+++ b/src/apis/content/v2.1.ts
@@ -29,8 +29,6 @@ export namespace content_v2_1 {
     version: 'v2_1';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * Data format for the response.
@@ -82,6 +80,7 @@ export namespace content_v2_1 {
    * @param {object=} options Options for Content
    */
   export class Content {
+    context: APIRequestContext;
     accounts: Resource$Accounts;
     accountstatuses: Resource$Accountstatuses;
     accounttax: Resource$Accounttax;
@@ -99,23 +98,23 @@ export namespace content_v2_1 {
     shippingsettings: Resource$Shippingsettings;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.accounts = new Resource$Accounts();
-      this.accountstatuses = new Resource$Accountstatuses();
-      this.accounttax = new Resource$Accounttax();
-      this.datafeeds = new Resource$Datafeeds();
-      this.datafeedstatuses = new Resource$Datafeedstatuses();
-      this.liasettings = new Resource$Liasettings();
-      this.orderinvoices = new Resource$Orderinvoices();
-      this.orderreports = new Resource$Orderreports();
-      this.orderreturns = new Resource$Orderreturns();
-      this.orders = new Resource$Orders();
-      this.pos = new Resource$Pos();
-      this.products = new Resource$Products();
-      this.productstatuses = new Resource$Productstatuses();
-      this.regionalinventory = new Resource$Regionalinventory();
-      this.shippingsettings = new Resource$Shippingsettings();
+      this.accounts = new Resource$Accounts(this.context);
+      this.accountstatuses = new Resource$Accountstatuses(this.context);
+      this.accounttax = new Resource$Accounttax(this.context);
+      this.datafeeds = new Resource$Datafeeds(this.context);
+      this.datafeedstatuses = new Resource$Datafeedstatuses(this.context);
+      this.liasettings = new Resource$Liasettings(this.context);
+      this.orderinvoices = new Resource$Orderinvoices(this.context);
+      this.orderreports = new Resource$Orderreports(this.context);
+      this.orderreturns = new Resource$Orderreturns(this.context);
+      this.orders = new Resource$Orders(this.context);
+      this.pos = new Resource$Pos(this.context);
+      this.products = new Resource$Products(this.context);
+      this.productstatuses = new Resource$Productstatuses(this.context);
+      this.regionalinventory = new Resource$Regionalinventory(this.context);
+      this.shippingsettings = new Resource$Shippingsettings(this.context);
     }
   }
 
@@ -4767,7 +4766,10 @@ export namespace content_v2_1 {
 
 
   export class Resource$Accounts {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -4828,7 +4830,7 @@ export namespace content_v2_1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AccountsAuthInfoResponse>(parameters, callback);
@@ -4905,7 +4907,7 @@ export namespace content_v2_1 {
         params,
         requiredParams: ['merchantId', 'accountId'],
         pathParams: ['accountId', 'merchantId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AccountsClaimWebsiteResponse>(
@@ -4980,7 +4982,7 @@ export namespace content_v2_1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AccountsCustomBatchResponse>(
@@ -5046,7 +5048,7 @@ export namespace content_v2_1 {
         params,
         requiredParams: ['merchantId', 'accountId'],
         pathParams: ['accountId', 'merchantId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -5108,7 +5110,7 @@ export namespace content_v2_1 {
         params,
         requiredParams: ['merchantId', 'accountId'],
         pathParams: ['accountId', 'merchantId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Account>(parameters, callback);
@@ -5173,7 +5175,7 @@ export namespace content_v2_1 {
         params,
         requiredParams: ['merchantId'],
         pathParams: ['merchantId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Account>(parameters, callback);
@@ -5243,7 +5245,7 @@ export namespace content_v2_1 {
         params,
         requiredParams: ['merchantId', 'accountId'],
         pathParams: ['accountId', 'merchantId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AccountsLinkResponse>(parameters, callback);
@@ -5311,7 +5313,7 @@ export namespace content_v2_1 {
         params,
         requiredParams: ['merchantId'],
         pathParams: ['merchantId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AccountsListResponse>(parameters, callback);
@@ -5377,7 +5379,7 @@ export namespace content_v2_1 {
         params,
         requiredParams: ['merchantId', 'accountId'],
         pathParams: ['accountId', 'merchantId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Account>(parameters, callback);
@@ -5551,7 +5553,10 @@ export namespace content_v2_1 {
 
 
   export class Resource$Accountstatuses {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -5622,7 +5627,7 @@ export namespace content_v2_1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AccountstatusesCustomBatchResponse>(
@@ -5691,7 +5696,7 @@ export namespace content_v2_1 {
         params,
         requiredParams: ['merchantId', 'accountId'],
         pathParams: ['accountId', 'merchantId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AccountStatus>(parameters, callback);
@@ -5766,7 +5771,7 @@ export namespace content_v2_1 {
         params,
         requiredParams: ['merchantId'],
         pathParams: ['merchantId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AccountstatusesListResponse>(
@@ -5842,7 +5847,10 @@ export namespace content_v2_1 {
 
 
   export class Resource$Accounttax {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -5909,7 +5917,7 @@ export namespace content_v2_1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AccounttaxCustomBatchResponse>(
@@ -5975,7 +5983,7 @@ export namespace content_v2_1 {
         params,
         requiredParams: ['merchantId', 'accountId'],
         pathParams: ['accountId', 'merchantId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AccountTax>(parameters, callback);
@@ -6044,7 +6052,7 @@ export namespace content_v2_1 {
         params,
         requiredParams: ['merchantId'],
         pathParams: ['merchantId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AccounttaxListResponse>(parameters, callback);
@@ -6113,7 +6121,7 @@ export namespace content_v2_1 {
         params,
         requiredParams: ['merchantId', 'accountId'],
         pathParams: ['accountId', 'merchantId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AccountTax>(parameters, callback);
@@ -6199,7 +6207,10 @@ export namespace content_v2_1 {
 
 
   export class Resource$Datafeeds {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -6266,7 +6277,7 @@ export namespace content_v2_1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$DatafeedsCustomBatchResponse>(
@@ -6333,7 +6344,7 @@ export namespace content_v2_1 {
         params,
         requiredParams: ['merchantId', 'datafeedId'],
         pathParams: ['datafeedId', 'merchantId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -6405,7 +6416,7 @@ export namespace content_v2_1 {
         params,
         requiredParams: ['merchantId', 'datafeedId'],
         pathParams: ['datafeedId', 'merchantId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$DatafeedsFetchNowResponse>(
@@ -6470,7 +6481,7 @@ export namespace content_v2_1 {
         params,
         requiredParams: ['merchantId', 'datafeedId'],
         pathParams: ['datafeedId', 'merchantId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Datafeed>(parameters, callback);
@@ -6536,7 +6547,7 @@ export namespace content_v2_1 {
         params,
         requiredParams: ['merchantId'],
         pathParams: ['merchantId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Datafeed>(parameters, callback);
@@ -6605,7 +6616,7 @@ export namespace content_v2_1 {
         params,
         requiredParams: ['merchantId'],
         pathParams: ['merchantId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$DatafeedsListResponse>(parameters, callback);
@@ -6672,7 +6683,7 @@ export namespace content_v2_1 {
         params,
         requiredParams: ['merchantId', 'datafeedId'],
         pathParams: ['datafeedId', 'merchantId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Datafeed>(parameters, callback);
@@ -6806,7 +6817,10 @@ export namespace content_v2_1 {
 
 
   export class Resource$Datafeedstatuses {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -6877,7 +6891,7 @@ export namespace content_v2_1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$DatafeedstatusesCustomBatchResponse>(
@@ -6947,7 +6961,7 @@ export namespace content_v2_1 {
         params,
         requiredParams: ['merchantId', 'datafeedId'],
         pathParams: ['datafeedId', 'merchantId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$DatafeedStatus>(parameters, callback);
@@ -7022,7 +7036,7 @@ export namespace content_v2_1 {
         params,
         requiredParams: ['merchantId'],
         pathParams: ['merchantId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$DatafeedstatusesListResponse>(
@@ -7103,7 +7117,10 @@ export namespace content_v2_1 {
 
 
   export class Resource$Liasettings {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -7170,7 +7187,7 @@ export namespace content_v2_1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$LiasettingsCustomBatchResponse>(
@@ -7236,7 +7253,7 @@ export namespace content_v2_1 {
         params,
         requiredParams: ['merchantId', 'accountId'],
         pathParams: ['accountId', 'merchantId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$LiaSettings>(parameters, callback);
@@ -7314,7 +7331,7 @@ export namespace content_v2_1 {
         params,
         requiredParams: ['merchantId', 'accountId'],
         pathParams: ['accountId', 'merchantId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$LiasettingsGetAccessibleGmbAccountsResponse>(
@@ -7385,7 +7402,7 @@ export namespace content_v2_1 {
         params,
         requiredParams: ['merchantId'],
         pathParams: ['merchantId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$LiasettingsListResponse>(parameters, callback);
@@ -7458,7 +7475,7 @@ export namespace content_v2_1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$LiasettingsListPosDataProvidersResponse>(
@@ -7541,7 +7558,7 @@ export namespace content_v2_1 {
         params,
         requiredParams: ['merchantId', 'accountId', 'gmbEmail'],
         pathParams: ['accountId', 'merchantId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$LiasettingsRequestGmbAccessResponse>(
@@ -7623,7 +7640,7 @@ export namespace content_v2_1 {
         params,
         requiredParams: ['merchantId', 'accountId', 'country'],
         pathParams: ['accountId', 'country', 'merchantId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<
@@ -7715,7 +7732,7 @@ export namespace content_v2_1 {
           'language'
         ],
         pathParams: ['accountId', 'merchantId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<
@@ -7802,7 +7819,7 @@ export namespace content_v2_1 {
         params,
         requiredParams: ['merchantId', 'accountId', 'country'],
         pathParams: ['accountId', 'merchantId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$LiasettingsSetPosDataProviderResponse>(
@@ -7874,7 +7891,7 @@ export namespace content_v2_1 {
         params,
         requiredParams: ['merchantId', 'accountId'],
         pathParams: ['accountId', 'merchantId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$LiaSettings>(parameters, callback);
@@ -8097,7 +8114,10 @@ export namespace content_v2_1 {
 
 
   export class Resource$Orderinvoices {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -8168,7 +8188,7 @@ export namespace content_v2_1 {
         params,
         requiredParams: ['merchantId', 'orderId'],
         pathParams: ['merchantId', 'orderId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$OrderinvoicesCreateChargeInvoiceResponse>(
@@ -8251,7 +8271,7 @@ export namespace content_v2_1 {
         params,
         requiredParams: ['merchantId', 'orderId'],
         pathParams: ['merchantId', 'orderId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$OrderinvoicesCreateRefundInvoiceResponse>(
@@ -8310,7 +8330,10 @@ export namespace content_v2_1 {
 
 
   export class Resource$Orderreports {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -8386,7 +8409,7 @@ export namespace content_v2_1 {
         params,
         requiredParams: ['merchantId', 'disbursementStartDate'],
         pathParams: ['merchantId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$OrderreportsListDisbursementsResponse>(
@@ -8474,7 +8497,7 @@ export namespace content_v2_1 {
         requiredParams:
             ['merchantId', 'disbursementId', 'transactionStartDate'],
         pathParams: ['disbursementId', 'merchantId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$OrderreportsListTransactionsResponse>(
@@ -8555,7 +8578,10 @@ export namespace content_v2_1 {
 
 
   export class Resource$Orderreturns {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -8612,7 +8638,7 @@ export namespace content_v2_1 {
         params,
         requiredParams: ['merchantId', 'returnId'],
         pathParams: ['merchantId', 'returnId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$MerchantOrderReturn>(parameters, callback);
@@ -8684,7 +8710,7 @@ export namespace content_v2_1 {
         params,
         requiredParams: ['merchantId'],
         pathParams: ['merchantId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$OrderreturnsListResponse>(parameters, callback);
@@ -8750,7 +8776,10 @@ export namespace content_v2_1 {
 
 
   export class Resource$Orders {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -8815,7 +8844,7 @@ export namespace content_v2_1 {
         params,
         requiredParams: ['merchantId', 'orderId'],
         pathParams: ['merchantId', 'orderId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$OrdersAcknowledgeResponse>(
@@ -8892,7 +8921,7 @@ export namespace content_v2_1 {
         params,
         requiredParams: ['merchantId', 'orderId'],
         pathParams: ['merchantId', 'orderId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$OrdersAdvanceTestOrderResponse>(
@@ -8963,7 +8992,7 @@ export namespace content_v2_1 {
         params,
         requiredParams: ['merchantId', 'orderId'],
         pathParams: ['merchantId', 'orderId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$OrdersCancelResponse>(parameters, callback);
@@ -9040,7 +9069,7 @@ export namespace content_v2_1 {
         params,
         requiredParams: ['merchantId', 'orderId'],
         pathParams: ['merchantId', 'orderId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$OrdersCancelLineItemResponse>(
@@ -9121,7 +9150,7 @@ export namespace content_v2_1 {
         params,
         requiredParams: ['merchantId', 'orderId'],
         pathParams: ['merchantId', 'orderId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$OrdersCancelTestOrderByCustomerResponse>(
@@ -9197,7 +9226,7 @@ export namespace content_v2_1 {
         params,
         requiredParams: ['merchantId'],
         pathParams: ['merchantId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$OrdersCreateTestOrderResponse>(
@@ -9275,7 +9304,7 @@ export namespace content_v2_1 {
         params,
         requiredParams: ['merchantId', 'orderId'],
         pathParams: ['merchantId', 'orderId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$OrdersCreateTestReturnResponse>(
@@ -9339,7 +9368,7 @@ export namespace content_v2_1 {
         params,
         requiredParams: ['merchantId', 'orderId'],
         pathParams: ['merchantId', 'orderId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Order>(parameters, callback);
@@ -9419,7 +9448,7 @@ export namespace content_v2_1 {
         params,
         requiredParams: ['merchantId', 'merchantOrderId'],
         pathParams: ['merchantId', 'merchantOrderId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$OrdersGetByMerchantOrderIdResponse>(
@@ -9503,7 +9532,7 @@ export namespace content_v2_1 {
         params,
         requiredParams: ['merchantId', 'templateName'],
         pathParams: ['merchantId', 'templateName'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$OrdersGetTestOrderTemplateResponse>(
@@ -9594,7 +9623,7 @@ export namespace content_v2_1 {
         params,
         requiredParams: ['merchantId', 'orderId'],
         pathParams: ['merchantId', 'orderId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$OrdersInStoreRefundLineItemResponse>(
@@ -9668,7 +9697,7 @@ export namespace content_v2_1 {
         params,
         requiredParams: ['merchantId'],
         pathParams: ['merchantId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$OrdersListResponse>(parameters, callback);
@@ -9749,7 +9778,7 @@ export namespace content_v2_1 {
         params,
         requiredParams: ['merchantId', 'orderId'],
         pathParams: ['merchantId', 'orderId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$OrdersRejectReturnLineItemResponse>(
@@ -9833,7 +9862,7 @@ export namespace content_v2_1 {
         params,
         requiredParams: ['merchantId', 'orderId'],
         pathParams: ['merchantId', 'orderId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$OrdersReturnRefundLineItemResponse>(
@@ -9920,7 +9949,7 @@ export namespace content_v2_1 {
         params,
         requiredParams: ['merchantId', 'orderId'],
         pathParams: ['merchantId', 'orderId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$OrdersSetLineItemMetadataResponse>(
@@ -9997,7 +10026,7 @@ export namespace content_v2_1 {
         params,
         requiredParams: ['merchantId', 'orderId'],
         pathParams: ['merchantId', 'orderId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$OrdersShipLineItemsResponse>(
@@ -10077,7 +10106,7 @@ export namespace content_v2_1 {
         params,
         requiredParams: ['merchantId', 'orderId'],
         pathParams: ['merchantId', 'orderId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$OrdersUpdateLineItemShippingDetailsResponse>(
@@ -10160,7 +10189,7 @@ export namespace content_v2_1 {
         params,
         requiredParams: ['merchantId', 'orderId'],
         pathParams: ['merchantId', 'orderId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$OrdersUpdateMerchantOrderIdResponse>(
@@ -10239,7 +10268,7 @@ export namespace content_v2_1 {
         params,
         requiredParams: ['merchantId', 'orderId'],
         pathParams: ['merchantId', 'orderId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$OrdersUpdateShipmentResponse>(
@@ -10684,7 +10713,10 @@ export namespace content_v2_1 {
 
 
   export class Resource$Pos {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -10745,7 +10777,7 @@ export namespace content_v2_1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$PosCustomBatchResponse>(parameters, callback);
@@ -10812,7 +10844,7 @@ export namespace content_v2_1 {
         params,
         requiredParams: ['merchantId', 'targetMerchantId', 'storeCode'],
         pathParams: ['merchantId', 'storeCode', 'targetMerchantId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -10877,7 +10909,7 @@ export namespace content_v2_1 {
         params,
         requiredParams: ['merchantId', 'targetMerchantId', 'storeCode'],
         pathParams: ['merchantId', 'storeCode', 'targetMerchantId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$PosStore>(parameters, callback);
@@ -10944,7 +10976,7 @@ export namespace content_v2_1 {
         params,
         requiredParams: ['merchantId', 'targetMerchantId'],
         pathParams: ['merchantId', 'targetMerchantId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$PosStore>(parameters, callback);
@@ -11015,7 +11047,7 @@ export namespace content_v2_1 {
         params,
         requiredParams: ['merchantId', 'targetMerchantId'],
         pathParams: ['merchantId', 'targetMerchantId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$PosInventoryResponse>(parameters, callback);
@@ -11082,7 +11114,7 @@ export namespace content_v2_1 {
         params,
         requiredParams: ['merchantId', 'targetMerchantId'],
         pathParams: ['merchantId', 'targetMerchantId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$PosListResponse>(parameters, callback);
@@ -11150,7 +11182,7 @@ export namespace content_v2_1 {
         params,
         requiredParams: ['merchantId', 'targetMerchantId'],
         pathParams: ['merchantId', 'targetMerchantId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$PosSaleResponse>(parameters, callback);
@@ -11288,7 +11320,10 @@ export namespace content_v2_1 {
 
 
   export class Resource$Products {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -11354,7 +11389,7 @@ export namespace content_v2_1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ProductsCustomBatchResponse>(
@@ -11419,7 +11454,7 @@ export namespace content_v2_1 {
         params,
         requiredParams: ['merchantId', 'productId'],
         pathParams: ['merchantId', 'productId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -11481,7 +11516,7 @@ export namespace content_v2_1 {
         params,
         requiredParams: ['merchantId', 'productId'],
         pathParams: ['merchantId', 'productId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Product>(parameters, callback);
@@ -11548,7 +11583,7 @@ export namespace content_v2_1 {
         params,
         requiredParams: ['merchantId'],
         pathParams: ['merchantId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Product>(parameters, callback);
@@ -11616,7 +11651,7 @@ export namespace content_v2_1 {
         params,
         requiredParams: ['merchantId'],
         pathParams: ['merchantId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ProductsListResponse>(parameters, callback);
@@ -11712,7 +11747,10 @@ export namespace content_v2_1 {
 
 
   export class Resource$Productstatuses {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -11782,7 +11820,7 @@ export namespace content_v2_1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ProductstatusesCustomBatchResponse>(
@@ -11850,7 +11888,7 @@ export namespace content_v2_1 {
         params,
         requiredParams: ['merchantId', 'productId'],
         pathParams: ['merchantId', 'productId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ProductStatus>(parameters, callback);
@@ -11924,7 +11962,7 @@ export namespace content_v2_1 {
         params,
         requiredParams: ['merchantId'],
         pathParams: ['merchantId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ProductstatusesListResponse>(
@@ -12000,7 +12038,10 @@ export namespace content_v2_1 {
 
 
   export class Resource$Regionalinventory {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -12071,7 +12112,7 @@ export namespace content_v2_1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$RegionalinventoryCustomBatchResponse>(
@@ -12146,7 +12187,7 @@ export namespace content_v2_1 {
         params,
         requiredParams: ['merchantId', 'productId'],
         pathParams: ['merchantId', 'productId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$RegionalInventory>(parameters, callback);
@@ -12194,7 +12235,10 @@ export namespace content_v2_1 {
 
 
   export class Resource$Shippingsettings {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -12265,7 +12309,7 @@ export namespace content_v2_1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ShippingsettingsCustomBatchResponse>(
@@ -12332,7 +12376,7 @@ export namespace content_v2_1 {
         params,
         requiredParams: ['merchantId', 'accountId'],
         pathParams: ['accountId', 'merchantId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ShippingSettings>(parameters, callback);
@@ -12408,7 +12452,7 @@ export namespace content_v2_1 {
         params,
         requiredParams: ['merchantId'],
         pathParams: ['merchantId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ShippingsettingsGetSupportedCarriersResponse>(
@@ -12486,7 +12530,7 @@ export namespace content_v2_1 {
         params,
         requiredParams: ['merchantId'],
         pathParams: ['merchantId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ShippingsettingsGetSupportedHolidaysResponse>(
@@ -12563,7 +12607,7 @@ export namespace content_v2_1 {
         params,
         requiredParams: ['merchantId'],
         pathParams: ['merchantId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ShippingsettingsListResponse>(
@@ -12635,7 +12679,7 @@ export namespace content_v2_1 {
         params,
         requiredParams: ['merchantId', 'accountId'],
         pathParams: ['accountId', 'merchantId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ShippingSettings>(parameters, callback);

--- a/src/apis/content/v2.ts
+++ b/src/apis/content/v2.ts
@@ -29,8 +29,6 @@ export namespace content_v2 {
     version: 'v2';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * Data format for the response.
@@ -82,6 +80,7 @@ export namespace content_v2 {
    * @param {object=} options Options for Content
    */
   export class Content {
+    context: APIRequestContext;
     accounts: Resource$Accounts;
     accountstatuses: Resource$Accountstatuses;
     accounttax: Resource$Accounttax;
@@ -100,24 +99,24 @@ export namespace content_v2 {
     shippingsettings: Resource$Shippingsettings;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.accounts = new Resource$Accounts();
-      this.accountstatuses = new Resource$Accountstatuses();
-      this.accounttax = new Resource$Accounttax();
-      this.datafeeds = new Resource$Datafeeds();
-      this.datafeedstatuses = new Resource$Datafeedstatuses();
-      this.inventory = new Resource$Inventory();
-      this.liasettings = new Resource$Liasettings();
-      this.orderinvoices = new Resource$Orderinvoices();
-      this.orderpayments = new Resource$Orderpayments();
-      this.orderreports = new Resource$Orderreports();
-      this.orderreturns = new Resource$Orderreturns();
-      this.orders = new Resource$Orders();
-      this.pos = new Resource$Pos();
-      this.products = new Resource$Products();
-      this.productstatuses = new Resource$Productstatuses();
-      this.shippingsettings = new Resource$Shippingsettings();
+      this.accounts = new Resource$Accounts(this.context);
+      this.accountstatuses = new Resource$Accountstatuses(this.context);
+      this.accounttax = new Resource$Accounttax(this.context);
+      this.datafeeds = new Resource$Datafeeds(this.context);
+      this.datafeedstatuses = new Resource$Datafeedstatuses(this.context);
+      this.inventory = new Resource$Inventory(this.context);
+      this.liasettings = new Resource$Liasettings(this.context);
+      this.orderinvoices = new Resource$Orderinvoices(this.context);
+      this.orderpayments = new Resource$Orderpayments(this.context);
+      this.orderreports = new Resource$Orderreports(this.context);
+      this.orderreturns = new Resource$Orderreturns(this.context);
+      this.orders = new Resource$Orders(this.context);
+      this.pos = new Resource$Pos(this.context);
+      this.products = new Resource$Products(this.context);
+      this.productstatuses = new Resource$Productstatuses(this.context);
+      this.shippingsettings = new Resource$Shippingsettings(this.context);
     }
   }
 
@@ -5804,7 +5803,10 @@ export namespace content_v2 {
 
 
   export class Resource$Accounts {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -5865,7 +5867,7 @@ export namespace content_v2 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AccountsAuthInfoResponse>(parameters, callback);
@@ -5942,7 +5944,7 @@ export namespace content_v2 {
         params,
         requiredParams: ['merchantId', 'accountId'],
         pathParams: ['accountId', 'merchantId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AccountsClaimWebsiteResponse>(
@@ -6018,7 +6020,7 @@ export namespace content_v2 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AccountsCustomBatchResponse>(
@@ -6085,7 +6087,7 @@ export namespace content_v2 {
         params,
         requiredParams: ['merchantId', 'accountId'],
         pathParams: ['accountId', 'merchantId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -6147,7 +6149,7 @@ export namespace content_v2 {
         params,
         requiredParams: ['merchantId', 'accountId'],
         pathParams: ['accountId', 'merchantId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Account>(parameters, callback);
@@ -6213,7 +6215,7 @@ export namespace content_v2 {
         params,
         requiredParams: ['merchantId'],
         pathParams: ['merchantId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Account>(parameters, callback);
@@ -6283,7 +6285,7 @@ export namespace content_v2 {
         params,
         requiredParams: ['merchantId', 'accountId'],
         pathParams: ['accountId', 'merchantId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AccountsLinkResponse>(parameters, callback);
@@ -6351,7 +6353,7 @@ export namespace content_v2 {
         params,
         requiredParams: ['merchantId'],
         pathParams: ['merchantId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AccountsListResponse>(parameters, callback);
@@ -6419,7 +6421,7 @@ export namespace content_v2 {
         params,
         requiredParams: ['merchantId', 'accountId'],
         pathParams: ['accountId', 'merchantId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Account>(parameters, callback);
@@ -6486,7 +6488,7 @@ export namespace content_v2 {
         params,
         requiredParams: ['merchantId', 'accountId'],
         pathParams: ['accountId', 'merchantId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Account>(parameters, callback);
@@ -6712,7 +6714,10 @@ export namespace content_v2 {
 
 
   export class Resource$Accountstatuses {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -6783,7 +6788,7 @@ export namespace content_v2 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AccountstatusesCustomBatchResponse>(
@@ -6852,7 +6857,7 @@ export namespace content_v2 {
         params,
         requiredParams: ['merchantId', 'accountId'],
         pathParams: ['accountId', 'merchantId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AccountStatus>(parameters, callback);
@@ -6927,7 +6932,7 @@ export namespace content_v2 {
         params,
         requiredParams: ['merchantId'],
         pathParams: ['merchantId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AccountstatusesListResponse>(
@@ -7003,7 +7008,10 @@ export namespace content_v2 {
 
 
   export class Resource$Accounttax {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -7071,7 +7079,7 @@ export namespace content_v2 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AccounttaxCustomBatchResponse>(
@@ -7136,7 +7144,7 @@ export namespace content_v2 {
         params,
         requiredParams: ['merchantId', 'accountId'],
         pathParams: ['accountId', 'merchantId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AccountTax>(parameters, callback);
@@ -7205,7 +7213,7 @@ export namespace content_v2 {
         params,
         requiredParams: ['merchantId'],
         pathParams: ['merchantId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AccounttaxListResponse>(parameters, callback);
@@ -7274,7 +7282,7 @@ export namespace content_v2 {
         params,
         requiredParams: ['merchantId', 'accountId'],
         pathParams: ['accountId', 'merchantId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AccountTax>(parameters, callback);
@@ -7343,7 +7351,7 @@ export namespace content_v2 {
         params,
         requiredParams: ['merchantId', 'accountId'],
         pathParams: ['accountId', 'merchantId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AccountTax>(parameters, callback);
@@ -7469,7 +7477,10 @@ export namespace content_v2 {
 
 
   export class Resource$Datafeeds {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -7537,7 +7548,7 @@ export namespace content_v2 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$DatafeedsCustomBatchResponse>(
@@ -7604,7 +7615,7 @@ export namespace content_v2 {
         params,
         requiredParams: ['merchantId', 'datafeedId'],
         pathParams: ['datafeedId', 'merchantId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -7676,7 +7687,7 @@ export namespace content_v2 {
         params,
         requiredParams: ['merchantId', 'datafeedId'],
         pathParams: ['datafeedId', 'merchantId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$DatafeedsFetchNowResponse>(
@@ -7740,7 +7751,7 @@ export namespace content_v2 {
         params,
         requiredParams: ['merchantId', 'datafeedId'],
         pathParams: ['datafeedId', 'merchantId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Datafeed>(parameters, callback);
@@ -7807,7 +7818,7 @@ export namespace content_v2 {
         params,
         requiredParams: ['merchantId'],
         pathParams: ['merchantId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Datafeed>(parameters, callback);
@@ -7876,7 +7887,7 @@ export namespace content_v2 {
         params,
         requiredParams: ['merchantId'],
         pathParams: ['merchantId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$DatafeedsListResponse>(parameters, callback);
@@ -7944,7 +7955,7 @@ export namespace content_v2 {
         params,
         requiredParams: ['merchantId', 'datafeedId'],
         pathParams: ['datafeedId', 'merchantId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Datafeed>(parameters, callback);
@@ -8011,7 +8022,7 @@ export namespace content_v2 {
         params,
         requiredParams: ['merchantId', 'datafeedId'],
         pathParams: ['datafeedId', 'merchantId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Datafeed>(parameters, callback);
@@ -8202,7 +8213,10 @@ export namespace content_v2 {
 
 
   export class Resource$Datafeedstatuses {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -8273,7 +8287,7 @@ export namespace content_v2 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$DatafeedstatusesCustomBatchResponse>(
@@ -8343,7 +8357,7 @@ export namespace content_v2 {
         params,
         requiredParams: ['merchantId', 'datafeedId'],
         pathParams: ['datafeedId', 'merchantId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$DatafeedStatus>(parameters, callback);
@@ -8418,7 +8432,7 @@ export namespace content_v2 {
         params,
         requiredParams: ['merchantId'],
         pathParams: ['merchantId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$DatafeedstatusesListResponse>(
@@ -8499,7 +8513,10 @@ export namespace content_v2 {
 
 
   export class Resource$Inventory {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -8568,7 +8585,7 @@ export namespace content_v2 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$InventoryCustomBatchResponse>(
@@ -8640,7 +8657,7 @@ export namespace content_v2 {
         params,
         requiredParams: ['merchantId', 'storeCode', 'productId'],
         pathParams: ['merchantId', 'productId', 'storeCode'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$InventorySetResponse>(parameters, callback);
@@ -8704,7 +8721,10 @@ export namespace content_v2 {
 
 
   export class Resource$Liasettings {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -8772,7 +8792,7 @@ export namespace content_v2 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$LiasettingsCustomBatchResponse>(
@@ -8838,7 +8858,7 @@ export namespace content_v2 {
         params,
         requiredParams: ['merchantId', 'accountId'],
         pathParams: ['accountId', 'merchantId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$LiaSettings>(parameters, callback);
@@ -8916,7 +8936,7 @@ export namespace content_v2 {
         params,
         requiredParams: ['merchantId', 'accountId'],
         pathParams: ['accountId', 'merchantId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$LiasettingsGetAccessibleGmbAccountsResponse>(
@@ -8987,7 +9007,7 @@ export namespace content_v2 {
         params,
         requiredParams: ['merchantId'],
         pathParams: ['merchantId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$LiasettingsListResponse>(parameters, callback);
@@ -9060,7 +9080,7 @@ export namespace content_v2 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$LiasettingsListPosDataProvidersResponse>(
@@ -9133,7 +9153,7 @@ export namespace content_v2 {
         params,
         requiredParams: ['merchantId', 'accountId'],
         pathParams: ['accountId', 'merchantId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$LiaSettings>(parameters, callback);
@@ -9214,7 +9234,7 @@ export namespace content_v2 {
         params,
         requiredParams: ['merchantId', 'accountId', 'gmbEmail'],
         pathParams: ['accountId', 'merchantId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$LiasettingsRequestGmbAccessResponse>(
@@ -9296,7 +9316,7 @@ export namespace content_v2 {
         params,
         requiredParams: ['merchantId', 'accountId', 'country'],
         pathParams: ['accountId', 'country', 'merchantId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<
@@ -9388,7 +9408,7 @@ export namespace content_v2 {
           'language'
         ],
         pathParams: ['accountId', 'merchantId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<
@@ -9475,7 +9495,7 @@ export namespace content_v2 {
         params,
         requiredParams: ['merchantId', 'accountId', 'country'],
         pathParams: ['accountId', 'merchantId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$LiasettingsSetPosDataProviderResponse>(
@@ -9548,7 +9568,7 @@ export namespace content_v2 {
         params,
         requiredParams: ['merchantId', 'accountId'],
         pathParams: ['accountId', 'merchantId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$LiaSettings>(parameters, callback);
@@ -9812,7 +9832,10 @@ export namespace content_v2 {
 
 
   export class Resource$Orderinvoices {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -9883,7 +9906,7 @@ export namespace content_v2 {
         params,
         requiredParams: ['merchantId', 'orderId'],
         pathParams: ['merchantId', 'orderId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$OrderinvoicesCreateChargeInvoiceResponse>(
@@ -9966,7 +9989,7 @@ export namespace content_v2 {
         params,
         requiredParams: ['merchantId', 'orderId'],
         pathParams: ['merchantId', 'orderId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$OrderinvoicesCreateRefundInvoiceResponse>(
@@ -10025,7 +10048,10 @@ export namespace content_v2 {
 
 
   export class Resource$Orderpayments {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -10096,7 +10122,7 @@ export namespace content_v2 {
         params,
         requiredParams: ['merchantId', 'orderId'],
         pathParams: ['merchantId', 'orderId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$OrderpaymentsNotifyAuthApprovedResponse>(
@@ -10175,7 +10201,7 @@ export namespace content_v2 {
         params,
         requiredParams: ['merchantId', 'orderId'],
         pathParams: ['merchantId', 'orderId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$OrderpaymentsNotifyAuthDeclinedResponse>(
@@ -10258,7 +10284,7 @@ export namespace content_v2 {
         params,
         requiredParams: ['merchantId', 'orderId'],
         pathParams: ['merchantId', 'orderId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$OrderpaymentsNotifyChargeResponse>(
@@ -10341,7 +10367,7 @@ export namespace content_v2 {
         params,
         requiredParams: ['merchantId', 'orderId'],
         pathParams: ['merchantId', 'orderId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$OrderpaymentsNotifyRefundResponse>(
@@ -10444,7 +10470,10 @@ export namespace content_v2 {
 
 
   export class Resource$Orderreports {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -10520,7 +10549,7 @@ export namespace content_v2 {
         params,
         requiredParams: ['merchantId', 'disbursementStartDate'],
         pathParams: ['merchantId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$OrderreportsListDisbursementsResponse>(
@@ -10608,7 +10637,7 @@ export namespace content_v2 {
         requiredParams:
             ['merchantId', 'disbursementId', 'transactionStartDate'],
         pathParams: ['disbursementId', 'merchantId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$OrderreportsListTransactionsResponse>(
@@ -10689,7 +10718,10 @@ export namespace content_v2 {
 
 
   export class Resource$Orderreturns {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -10746,7 +10778,7 @@ export namespace content_v2 {
         params,
         requiredParams: ['merchantId', 'returnId'],
         pathParams: ['merchantId', 'returnId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$MerchantOrderReturn>(parameters, callback);
@@ -10818,7 +10850,7 @@ export namespace content_v2 {
         params,
         requiredParams: ['merchantId'],
         pathParams: ['merchantId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$OrderreturnsListResponse>(parameters, callback);
@@ -10884,7 +10916,10 @@ export namespace content_v2 {
 
 
   export class Resource$Orders {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -10949,7 +10984,7 @@ export namespace content_v2 {
         params,
         requiredParams: ['merchantId', 'orderId'],
         pathParams: ['merchantId', 'orderId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$OrdersAcknowledgeResponse>(
@@ -11026,7 +11061,7 @@ export namespace content_v2 {
         params,
         requiredParams: ['merchantId', 'orderId'],
         pathParams: ['merchantId', 'orderId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$OrdersAdvanceTestOrderResponse>(
@@ -11097,7 +11132,7 @@ export namespace content_v2 {
         params,
         requiredParams: ['merchantId', 'orderId'],
         pathParams: ['merchantId', 'orderId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$OrdersCancelResponse>(parameters, callback);
@@ -11173,7 +11208,7 @@ export namespace content_v2 {
         params,
         requiredParams: ['merchantId', 'orderId'],
         pathParams: ['merchantId', 'orderId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$OrdersCancelLineItemResponse>(
@@ -11254,7 +11289,7 @@ export namespace content_v2 {
         params,
         requiredParams: ['merchantId', 'orderId'],
         pathParams: ['merchantId', 'orderId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$OrdersCancelTestOrderByCustomerResponse>(
@@ -11330,7 +11365,7 @@ export namespace content_v2 {
         params,
         requiredParams: ['merchantId'],
         pathParams: ['merchantId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$OrdersCreateTestOrderResponse>(
@@ -11408,7 +11443,7 @@ export namespace content_v2 {
         params,
         requiredParams: ['merchantId', 'orderId'],
         pathParams: ['merchantId', 'orderId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$OrdersCreateTestReturnResponse>(
@@ -11479,7 +11514,7 @@ export namespace content_v2 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$OrdersCustomBatchResponse>(
@@ -11542,7 +11577,7 @@ export namespace content_v2 {
         params,
         requiredParams: ['merchantId', 'orderId'],
         pathParams: ['merchantId', 'orderId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Order>(parameters, callback);
@@ -11622,7 +11657,7 @@ export namespace content_v2 {
         params,
         requiredParams: ['merchantId', 'merchantOrderId'],
         pathParams: ['merchantId', 'merchantOrderId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$OrdersGetByMerchantOrderIdResponse>(
@@ -11706,7 +11741,7 @@ export namespace content_v2 {
         params,
         requiredParams: ['merchantId', 'templateName'],
         pathParams: ['merchantId', 'templateName'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$OrdersGetTestOrderTemplateResponse>(
@@ -11797,7 +11832,7 @@ export namespace content_v2 {
         params,
         requiredParams: ['merchantId', 'orderId'],
         pathParams: ['merchantId', 'orderId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$OrdersInStoreRefundLineItemResponse>(
@@ -11871,7 +11906,7 @@ export namespace content_v2 {
         params,
         requiredParams: ['merchantId'],
         pathParams: ['merchantId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$OrdersListResponse>(parameters, callback);
@@ -11940,7 +11975,7 @@ export namespace content_v2 {
         params,
         requiredParams: ['merchantId', 'orderId'],
         pathParams: ['merchantId', 'orderId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$OrdersRefundResponse>(parameters, callback);
@@ -12021,7 +12056,7 @@ export namespace content_v2 {
         params,
         requiredParams: ['merchantId', 'orderId'],
         pathParams: ['merchantId', 'orderId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$OrdersRejectReturnLineItemResponse>(
@@ -12099,7 +12134,7 @@ export namespace content_v2 {
         params,
         requiredParams: ['merchantId', 'orderId'],
         pathParams: ['merchantId', 'orderId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$OrdersReturnLineItemResponse>(
@@ -12183,7 +12218,7 @@ export namespace content_v2 {
         params,
         requiredParams: ['merchantId', 'orderId'],
         pathParams: ['merchantId', 'orderId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$OrdersReturnRefundLineItemResponse>(
@@ -12270,7 +12305,7 @@ export namespace content_v2 {
         params,
         requiredParams: ['merchantId', 'orderId'],
         pathParams: ['merchantId', 'orderId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$OrdersSetLineItemMetadataResponse>(
@@ -12347,7 +12382,7 @@ export namespace content_v2 {
         params,
         requiredParams: ['merchantId', 'orderId'],
         pathParams: ['merchantId', 'orderId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$OrdersShipLineItemsResponse>(
@@ -12427,7 +12462,7 @@ export namespace content_v2 {
         params,
         requiredParams: ['merchantId', 'orderId'],
         pathParams: ['merchantId', 'orderId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$OrdersUpdateLineItemShippingDetailsResponse>(
@@ -12510,7 +12545,7 @@ export namespace content_v2 {
         params,
         requiredParams: ['merchantId', 'orderId'],
         pathParams: ['merchantId', 'orderId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$OrdersUpdateMerchantOrderIdResponse>(
@@ -12588,7 +12623,7 @@ export namespace content_v2 {
         params,
         requiredParams: ['merchantId', 'orderId'],
         pathParams: ['merchantId', 'orderId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$OrdersUpdateShipmentResponse>(
@@ -13089,7 +13124,10 @@ export namespace content_v2 {
 
 
   export class Resource$Pos {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -13151,7 +13189,7 @@ export namespace content_v2 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$PosCustomBatchResponse>(parameters, callback);
@@ -13219,7 +13257,7 @@ export namespace content_v2 {
         params,
         requiredParams: ['merchantId', 'targetMerchantId', 'storeCode'],
         pathParams: ['merchantId', 'storeCode', 'targetMerchantId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -13284,7 +13322,7 @@ export namespace content_v2 {
         params,
         requiredParams: ['merchantId', 'targetMerchantId', 'storeCode'],
         pathParams: ['merchantId', 'storeCode', 'targetMerchantId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$PosStore>(parameters, callback);
@@ -13352,7 +13390,7 @@ export namespace content_v2 {
         params,
         requiredParams: ['merchantId', 'targetMerchantId'],
         pathParams: ['merchantId', 'targetMerchantId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$PosStore>(parameters, callback);
@@ -13423,7 +13461,7 @@ export namespace content_v2 {
         params,
         requiredParams: ['merchantId', 'targetMerchantId'],
         pathParams: ['merchantId', 'targetMerchantId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$PosInventoryResponse>(parameters, callback);
@@ -13490,7 +13528,7 @@ export namespace content_v2 {
         params,
         requiredParams: ['merchantId', 'targetMerchantId'],
         pathParams: ['merchantId', 'targetMerchantId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$PosListResponse>(parameters, callback);
@@ -13559,7 +13597,7 @@ export namespace content_v2 {
         params,
         requiredParams: ['merchantId', 'targetMerchantId'],
         pathParams: ['merchantId', 'targetMerchantId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$PosSaleResponse>(parameters, callback);
@@ -13727,7 +13765,10 @@ export namespace content_v2 {
 
 
   export class Resource$Products {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -13794,7 +13835,7 @@ export namespace content_v2 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ProductsCustomBatchResponse>(
@@ -13860,7 +13901,7 @@ export namespace content_v2 {
         params,
         requiredParams: ['merchantId', 'productId'],
         pathParams: ['merchantId', 'productId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -13922,7 +13963,7 @@ export namespace content_v2 {
         params,
         requiredParams: ['merchantId', 'productId'],
         pathParams: ['merchantId', 'productId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Product>(parameters, callback);
@@ -13990,7 +14031,7 @@ export namespace content_v2 {
         params,
         requiredParams: ['merchantId'],
         pathParams: ['merchantId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Product>(parameters, callback);
@@ -14059,7 +14100,7 @@ export namespace content_v2 {
         params,
         requiredParams: ['merchantId'],
         pathParams: ['merchantId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ProductsListResponse>(parameters, callback);
@@ -14179,7 +14220,10 @@ export namespace content_v2 {
 
 
   export class Resource$Productstatuses {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -14250,7 +14294,7 @@ export namespace content_v2 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ProductstatusesCustomBatchResponse>(
@@ -14319,7 +14363,7 @@ export namespace content_v2 {
         params,
         requiredParams: ['merchantId', 'productId'],
         pathParams: ['merchantId', 'productId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ProductStatus>(parameters, callback);
@@ -14395,7 +14439,7 @@ export namespace content_v2 {
         params,
         requiredParams: ['merchantId'],
         pathParams: ['merchantId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ProductstatusesListResponse>(
@@ -14492,7 +14536,10 @@ export namespace content_v2 {
 
 
   export class Resource$Shippingsettings {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -14564,7 +14611,7 @@ export namespace content_v2 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ShippingsettingsCustomBatchResponse>(
@@ -14631,7 +14678,7 @@ export namespace content_v2 {
         params,
         requiredParams: ['merchantId', 'accountId'],
         pathParams: ['accountId', 'merchantId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ShippingSettings>(parameters, callback);
@@ -14707,7 +14754,7 @@ export namespace content_v2 {
         params,
         requiredParams: ['merchantId'],
         pathParams: ['merchantId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ShippingsettingsGetSupportedCarriersResponse>(
@@ -14785,7 +14832,7 @@ export namespace content_v2 {
         params,
         requiredParams: ['merchantId'],
         pathParams: ['merchantId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ShippingsettingsGetSupportedHolidaysResponse>(
@@ -14862,7 +14909,7 @@ export namespace content_v2 {
         params,
         requiredParams: ['merchantId'],
         pathParams: ['merchantId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ShippingsettingsListResponse>(
@@ -14936,7 +14983,7 @@ export namespace content_v2 {
         params,
         requiredParams: ['merchantId', 'accountId'],
         pathParams: ['accountId', 'merchantId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ShippingSettings>(parameters, callback);
@@ -15007,7 +15054,7 @@ export namespace content_v2 {
         params,
         requiredParams: ['merchantId', 'accountId'],
         pathParams: ['accountId', 'merchantId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ShippingSettings>(parameters, callback);

--- a/src/apis/customsearch/v1.ts
+++ b/src/apis/customsearch/v1.ts
@@ -29,8 +29,6 @@ export namespace customsearch_v1 {
     version: 'v1';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * Data format for the response.
@@ -81,12 +79,13 @@ export namespace customsearch_v1 {
    * @param {object=} options Options for Customsearch
    */
   export class Customsearch {
+    context: APIRequestContext;
     cse: Resource$Cse;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.cse = new Resource$Cse();
+      this.cse = new Resource$Cse(this.context);
     }
   }
 
@@ -186,9 +185,11 @@ export namespace customsearch_v1 {
 
 
   export class Resource$Cse {
+    context: APIRequestContext;
     siterestrict: Resource$Cse$Siterestrict;
-    constructor() {
-      this.siterestrict = new Resource$Cse$Siterestrict();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.siterestrict = new Resource$Cse$Siterestrict(this.context);
     }
 
 
@@ -276,7 +277,7 @@ export namespace customsearch_v1 {
         params,
         requiredParams: ['q'],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Search>(parameters, callback);
@@ -434,7 +435,10 @@ export namespace customsearch_v1 {
   }
 
   export class Resource$Cse$Siterestrict {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -525,7 +529,7 @@ export namespace customsearch_v1 {
         params,
         requiredParams: ['q'],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Search>(parameters, callback);

--- a/src/apis/dataflow/v1b3.ts
+++ b/src/apis/dataflow/v1b3.ts
@@ -29,8 +29,6 @@ export namespace dataflow_v1b3 {
     version: 'v1b3';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * V1 error format.
@@ -98,12 +96,13 @@ export namespace dataflow_v1b3 {
    * @param {object=} options Options for Dataflow
    */
   export class Dataflow {
+    context: APIRequestContext;
     projects: Resource$Projects;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.projects = new Resource$Projects();
+      this.projects = new Resource$Projects(this.context);
     }
   }
 
@@ -3578,13 +3577,15 @@ export namespace dataflow_v1b3 {
 
 
   export class Resource$Projects {
+    context: APIRequestContext;
     jobs: Resource$Projects$Jobs;
     locations: Resource$Projects$Locations;
     templates: Resource$Projects$Templates;
-    constructor() {
-      this.jobs = new Resource$Projects$Jobs();
-      this.locations = new Resource$Projects$Locations();
-      this.templates = new Resource$Projects$Templates();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.jobs = new Resource$Projects$Jobs(this.context);
+      this.locations = new Resource$Projects$Locations(this.context);
+      this.templates = new Resource$Projects$Templates(this.context);
     }
 
 
@@ -3652,7 +3653,7 @@ export namespace dataflow_v1b3 {
         params,
         requiredParams: ['projectId'],
         pathParams: ['projectId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$SendWorkerMessagesResponse>(
@@ -3682,13 +3683,15 @@ export namespace dataflow_v1b3 {
   }
 
   export class Resource$Projects$Jobs {
+    context: APIRequestContext;
     debug: Resource$Projects$Jobs$Debug;
     messages: Resource$Projects$Jobs$Messages;
     workItems: Resource$Projects$Jobs$Workitems;
-    constructor() {
-      this.debug = new Resource$Projects$Jobs$Debug();
-      this.messages = new Resource$Projects$Jobs$Messages();
-      this.workItems = new Resource$Projects$Jobs$Workitems();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.debug = new Resource$Projects$Jobs$Debug(this.context);
+      this.messages = new Resource$Projects$Jobs$Messages(this.context);
+      this.workItems = new Resource$Projects$Jobs$Workitems(this.context);
     }
 
 
@@ -3754,7 +3757,7 @@ export namespace dataflow_v1b3 {
         params,
         requiredParams: ['projectId'],
         pathParams: ['projectId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListJobsResponse>(parameters, callback);
@@ -3828,7 +3831,7 @@ export namespace dataflow_v1b3 {
         params,
         requiredParams: ['projectId'],
         pathParams: ['projectId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Job>(parameters, callback);
@@ -3898,7 +3901,7 @@ export namespace dataflow_v1b3 {
         params,
         requiredParams: ['projectId', 'jobId'],
         pathParams: ['jobId', 'projectId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Job>(parameters, callback);
@@ -3973,7 +3976,7 @@ export namespace dataflow_v1b3 {
         params,
         requiredParams: ['projectId', 'jobId'],
         pathParams: ['jobId', 'projectId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$JobMetrics>(parameters, callback);
@@ -4050,7 +4053,7 @@ export namespace dataflow_v1b3 {
         params,
         requiredParams: ['projectId'],
         pathParams: ['projectId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListJobsResponse>(parameters, callback);
@@ -4119,7 +4122,7 @@ export namespace dataflow_v1b3 {
         params,
         requiredParams: ['projectId', 'jobId'],
         pathParams: ['jobId', 'projectId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Snapshot>(parameters, callback);
@@ -4193,7 +4196,7 @@ export namespace dataflow_v1b3 {
         params,
         requiredParams: ['projectId', 'jobId'],
         pathParams: ['jobId', 'projectId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Job>(parameters, callback);
@@ -4413,7 +4416,10 @@ export namespace dataflow_v1b3 {
   }
 
   export class Resource$Projects$Jobs$Debug {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -4478,7 +4484,7 @@ export namespace dataflow_v1b3 {
         params,
         requiredParams: ['projectId', 'jobId'],
         pathParams: ['jobId', 'projectId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GetDebugConfigResponse>(parameters, callback);
@@ -4551,7 +4557,7 @@ export namespace dataflow_v1b3 {
         params,
         requiredParams: ['projectId', 'jobId'],
         pathParams: ['jobId', 'projectId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$SendDebugCaptureResponse>(parameters, callback);
@@ -4606,7 +4612,10 @@ export namespace dataflow_v1b3 {
 
 
   export class Resource$Projects$Jobs$Messages {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -4680,7 +4689,7 @@ export namespace dataflow_v1b3 {
         params,
         requiredParams: ['projectId', 'jobId'],
         pathParams: ['jobId', 'projectId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListJobMessagesResponse>(parameters, callback);
@@ -4740,7 +4749,10 @@ export namespace dataflow_v1b3 {
 
 
   export class Resource$Projects$Jobs$Workitems {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -4804,7 +4816,7 @@ export namespace dataflow_v1b3 {
         params,
         requiredParams: ['projectId', 'jobId'],
         pathParams: ['jobId', 'projectId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$LeaseWorkItemResponse>(parameters, callback);
@@ -4881,7 +4893,7 @@ export namespace dataflow_v1b3 {
         params,
         requiredParams: ['projectId', 'jobId'],
         pathParams: ['jobId', 'projectId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ReportWorkItemStatusResponse>(
@@ -4939,11 +4951,13 @@ export namespace dataflow_v1b3 {
 
 
   export class Resource$Projects$Locations {
+    context: APIRequestContext;
     jobs: Resource$Projects$Locations$Jobs;
     templates: Resource$Projects$Locations$Templates;
-    constructor() {
-      this.jobs = new Resource$Projects$Locations$Jobs();
-      this.templates = new Resource$Projects$Locations$Templates();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.jobs = new Resource$Projects$Locations$Jobs(this.context);
+      this.templates = new Resource$Projects$Locations$Templates(this.context);
     }
 
 
@@ -5014,7 +5028,7 @@ export namespace dataflow_v1b3 {
         params,
         requiredParams: ['projectId', 'location'],
         pathParams: ['location', 'projectId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$SendWorkerMessagesResponse>(
@@ -5050,13 +5064,17 @@ export namespace dataflow_v1b3 {
   }
 
   export class Resource$Projects$Locations$Jobs {
+    context: APIRequestContext;
     debug: Resource$Projects$Locations$Jobs$Debug;
     messages: Resource$Projects$Locations$Jobs$Messages;
     workItems: Resource$Projects$Locations$Jobs$Workitems;
-    constructor() {
-      this.debug = new Resource$Projects$Locations$Jobs$Debug();
-      this.messages = new Resource$Projects$Locations$Jobs$Messages();
-      this.workItems = new Resource$Projects$Locations$Jobs$Workitems();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.debug = new Resource$Projects$Locations$Jobs$Debug(this.context);
+      this.messages =
+          new Resource$Projects$Locations$Jobs$Messages(this.context);
+      this.workItems =
+          new Resource$Projects$Locations$Jobs$Workitems(this.context);
     }
 
 
@@ -5125,7 +5143,7 @@ export namespace dataflow_v1b3 {
         params,
         requiredParams: ['projectId', 'location'],
         pathParams: ['location', 'projectId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Job>(parameters, callback);
@@ -5197,7 +5215,7 @@ export namespace dataflow_v1b3 {
         params,
         requiredParams: ['projectId', 'location', 'jobId'],
         pathParams: ['jobId', 'location', 'projectId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Job>(parameters, callback);
@@ -5274,7 +5292,7 @@ export namespace dataflow_v1b3 {
         params,
         requiredParams: ['projectId', 'location', 'jobId'],
         pathParams: ['jobId', 'location', 'projectId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$JobMetrics>(parameters, callback);
@@ -5353,7 +5371,7 @@ export namespace dataflow_v1b3 {
         params,
         requiredParams: ['projectId', 'location'],
         pathParams: ['location', 'projectId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListJobsResponse>(parameters, callback);
@@ -5424,7 +5442,7 @@ export namespace dataflow_v1b3 {
         params,
         requiredParams: ['projectId', 'location', 'jobId'],
         pathParams: ['jobId', 'location', 'projectId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Snapshot>(parameters, callback);
@@ -5500,7 +5518,7 @@ export namespace dataflow_v1b3 {
         params,
         requiredParams: ['projectId', 'location', 'jobId'],
         pathParams: ['jobId', 'location', 'projectId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Job>(parameters, callback);
@@ -5686,7 +5704,10 @@ export namespace dataflow_v1b3 {
   }
 
   export class Resource$Projects$Locations$Jobs$Debug {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -5754,7 +5775,7 @@ export namespace dataflow_v1b3 {
         params,
         requiredParams: ['projectId', 'location', 'jobId'],
         pathParams: ['jobId', 'location', 'projectId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GetDebugConfigResponse>(parameters, callback);
@@ -5831,7 +5852,7 @@ export namespace dataflow_v1b3 {
         params,
         requiredParams: ['projectId', 'location', 'jobId'],
         pathParams: ['jobId', 'location', 'projectId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$SendDebugCaptureResponse>(parameters, callback);
@@ -5898,7 +5919,10 @@ export namespace dataflow_v1b3 {
 
 
   export class Resource$Projects$Locations$Jobs$Messages {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -5974,7 +5998,7 @@ export namespace dataflow_v1b3 {
         params,
         requiredParams: ['projectId', 'location', 'jobId'],
         pathParams: ['jobId', 'location', 'projectId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListJobMessagesResponse>(parameters, callback);
@@ -6034,7 +6058,10 @@ export namespace dataflow_v1b3 {
 
 
   export class Resource$Projects$Locations$Jobs$Workitems {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -6101,7 +6128,7 @@ export namespace dataflow_v1b3 {
         params,
         requiredParams: ['projectId', 'location', 'jobId'],
         pathParams: ['jobId', 'location', 'projectId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$LeaseWorkItemResponse>(parameters, callback);
@@ -6181,7 +6208,7 @@ export namespace dataflow_v1b3 {
         params,
         requiredParams: ['projectId', 'location', 'jobId'],
         pathParams: ['jobId', 'location', 'projectId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ReportWorkItemStatusResponse>(
@@ -6251,7 +6278,10 @@ export namespace dataflow_v1b3 {
 
 
   export class Resource$Projects$Locations$Templates {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -6313,7 +6343,7 @@ export namespace dataflow_v1b3 {
         params,
         requiredParams: ['projectId', 'location'],
         pathParams: ['location', 'projectId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Job>(parameters, callback);
@@ -6381,7 +6411,7 @@ export namespace dataflow_v1b3 {
         params,
         requiredParams: ['projectId', 'location'],
         pathParams: ['location', 'projectId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GetTemplateResponse>(parameters, callback);
@@ -6457,7 +6487,7 @@ export namespace dataflow_v1b3 {
         params,
         requiredParams: ['projectId', 'location'],
         pathParams: ['location', 'projectId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$LaunchTemplateResponse>(parameters, callback);
@@ -6564,7 +6594,10 @@ export namespace dataflow_v1b3 {
 
 
   export class Resource$Projects$Templates {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -6624,7 +6657,7 @@ export namespace dataflow_v1b3 {
         params,
         requiredParams: ['projectId'],
         pathParams: ['projectId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Job>(parameters, callback);
@@ -6690,7 +6723,7 @@ export namespace dataflow_v1b3 {
         params,
         requiredParams: ['projectId'],
         pathParams: ['projectId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GetTemplateResponse>(parameters, callback);
@@ -6764,7 +6797,7 @@ export namespace dataflow_v1b3 {
         params,
         requiredParams: ['projectId'],
         pathParams: ['projectId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$LaunchTemplateResponse>(parameters, callback);

--- a/src/apis/dataproc/v1.ts
+++ b/src/apis/dataproc/v1.ts
@@ -29,8 +29,6 @@ export namespace dataproc_v1 {
     version: 'v1';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * V1 error format.
@@ -98,12 +96,13 @@ export namespace dataproc_v1 {
    * @param {object=} options Options for Dataproc
    */
   export class Dataproc {
+    context: APIRequestContext;
     projects: Resource$Projects;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.projects = new Resource$Projects();
+      this.projects = new Resource$Projects(this.context);
     }
   }
 
@@ -1744,26 +1743,33 @@ export namespace dataproc_v1 {
 
 
   export class Resource$Projects {
+    context: APIRequestContext;
     locations: Resource$Projects$Locations;
     regions: Resource$Projects$Regions;
-    constructor() {
-      this.locations = new Resource$Projects$Locations();
-      this.regions = new Resource$Projects$Regions();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.locations = new Resource$Projects$Locations(this.context);
+      this.regions = new Resource$Projects$Regions(this.context);
     }
   }
 
 
   export class Resource$Projects$Locations {
+    context: APIRequestContext;
     workflowTemplates: Resource$Projects$Locations$Workflowtemplates;
-    constructor() {
+    constructor(context: APIRequestContext) {
+      this.context = context;
       this.workflowTemplates =
-          new Resource$Projects$Locations$Workflowtemplates();
+          new Resource$Projects$Locations$Workflowtemplates(this.context);
     }
   }
 
 
   export class Resource$Projects$Locations$Workflowtemplates {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1826,7 +1832,7 @@ export namespace dataproc_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$WorkflowTemplate>(parameters, callback);
@@ -1895,7 +1901,7 @@ export namespace dataproc_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -1960,7 +1966,7 @@ export namespace dataproc_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$WorkflowTemplate>(parameters, callback);
@@ -2033,7 +2039,7 @@ export namespace dataproc_v1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -2112,7 +2118,7 @@ export namespace dataproc_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -2195,7 +2201,7 @@ export namespace dataproc_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -2271,7 +2277,7 @@ export namespace dataproc_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListWorkflowTemplatesResponse>(
@@ -2346,7 +2352,7 @@ export namespace dataproc_v1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -2429,7 +2435,7 @@ export namespace dataproc_v1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TestIamPermissionsResponse>(
@@ -2500,7 +2506,7 @@ export namespace dataproc_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$WorkflowTemplate>(parameters, callback);
@@ -2716,22 +2722,27 @@ export namespace dataproc_v1 {
 
 
   export class Resource$Projects$Regions {
+    context: APIRequestContext;
     clusters: Resource$Projects$Regions$Clusters;
     jobs: Resource$Projects$Regions$Jobs;
     operations: Resource$Projects$Regions$Operations;
     workflowTemplates: Resource$Projects$Regions$Workflowtemplates;
-    constructor() {
-      this.clusters = new Resource$Projects$Regions$Clusters();
-      this.jobs = new Resource$Projects$Regions$Jobs();
-      this.operations = new Resource$Projects$Regions$Operations();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.clusters = new Resource$Projects$Regions$Clusters(this.context);
+      this.jobs = new Resource$Projects$Regions$Jobs(this.context);
+      this.operations = new Resource$Projects$Regions$Operations(this.context);
       this.workflowTemplates =
-          new Resource$Projects$Regions$Workflowtemplates();
+          new Resource$Projects$Regions$Workflowtemplates(this.context);
     }
   }
 
 
   export class Resource$Projects$Regions$Clusters {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -2854,7 +2865,7 @@ export namespace dataproc_v1 {
         params,
         requiredParams: ['projectId', 'region'],
         pathParams: ['projectId', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -2985,7 +2996,7 @@ export namespace dataproc_v1 {
         params,
         requiredParams: ['projectId', 'region', 'clusterName'],
         pathParams: ['clusterName', 'projectId', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -3120,7 +3131,7 @@ export namespace dataproc_v1 {
         params,
         requiredParams: ['projectId', 'region', 'clusterName'],
         pathParams: ['clusterName', 'projectId', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -3244,7 +3255,7 @@ export namespace dataproc_v1 {
         params,
         requiredParams: ['projectId', 'region', 'clusterName'],
         pathParams: ['clusterName', 'projectId', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Cluster>(parameters, callback);
@@ -3313,7 +3324,7 @@ export namespace dataproc_v1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -3456,7 +3467,7 @@ export namespace dataproc_v1 {
         params,
         requiredParams: ['projectId', 'region'],
         pathParams: ['projectId', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListClustersResponse>(parameters, callback);
@@ -3595,7 +3606,7 @@ export namespace dataproc_v1 {
         params,
         requiredParams: ['projectId', 'region', 'clusterName'],
         pathParams: ['clusterName', 'projectId', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -3664,7 +3675,7 @@ export namespace dataproc_v1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -3744,7 +3755,7 @@ export namespace dataproc_v1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TestIamPermissionsResponse>(
@@ -4037,7 +4048,10 @@ export namespace dataproc_v1 {
 
 
   export class Resource$Projects$Regions$Jobs {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -4165,7 +4179,7 @@ export namespace dataproc_v1 {
         params,
         requiredParams: ['projectId', 'region', 'jobId'],
         pathParams: ['jobId', 'projectId', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Job>(parameters, callback);
@@ -4292,7 +4306,7 @@ export namespace dataproc_v1 {
         params,
         requiredParams: ['projectId', 'region', 'jobId'],
         pathParams: ['jobId', 'projectId', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -4417,7 +4431,7 @@ export namespace dataproc_v1 {
         params,
         requiredParams: ['projectId', 'region', 'jobId'],
         pathParams: ['jobId', 'projectId', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Job>(parameters, callback);
@@ -4485,7 +4499,7 @@ export namespace dataproc_v1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -4628,7 +4642,7 @@ export namespace dataproc_v1 {
         params,
         requiredParams: ['projectId', 'region'],
         pathParams: ['projectId', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListJobsResponse>(parameters, callback);
@@ -4765,7 +4779,7 @@ export namespace dataproc_v1 {
         params,
         requiredParams: ['projectId', 'region', 'jobId'],
         pathParams: ['jobId', 'projectId', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Job>(parameters, callback);
@@ -4833,7 +4847,7 @@ export namespace dataproc_v1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -4961,7 +4975,7 @@ export namespace dataproc_v1 {
         params,
         requiredParams: ['projectId', 'region'],
         pathParams: ['projectId', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Job>(parameters, callback);
@@ -5040,7 +5054,7 @@ export namespace dataproc_v1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TestIamPermissionsResponse>(
@@ -5280,7 +5294,10 @@ export namespace dataproc_v1 {
 
 
   export class Resource$Projects$Regions$Operations {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -5399,7 +5416,7 @@ export namespace dataproc_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -5519,7 +5536,7 @@ export namespace dataproc_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -5636,7 +5653,7 @@ export namespace dataproc_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -5705,7 +5722,7 @@ export namespace dataproc_v1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -5851,7 +5868,7 @@ export namespace dataproc_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListOperationsResponse>(parameters, callback);
@@ -5920,7 +5937,7 @@ export namespace dataproc_v1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -6000,7 +6017,7 @@ export namespace dataproc_v1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TestIamPermissionsResponse>(
@@ -6128,7 +6145,10 @@ export namespace dataproc_v1 {
 
 
   export class Resource$Projects$Regions$Workflowtemplates {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -6191,7 +6211,7 @@ export namespace dataproc_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$WorkflowTemplate>(parameters, callback);
@@ -6260,7 +6280,7 @@ export namespace dataproc_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -6325,7 +6345,7 @@ export namespace dataproc_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$WorkflowTemplate>(parameters, callback);
@@ -6396,7 +6416,7 @@ export namespace dataproc_v1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -6472,7 +6492,7 @@ export namespace dataproc_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -6555,7 +6575,7 @@ export namespace dataproc_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -6630,7 +6650,7 @@ export namespace dataproc_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListWorkflowTemplatesResponse>(
@@ -6703,7 +6723,7 @@ export namespace dataproc_v1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -6786,7 +6806,7 @@ export namespace dataproc_v1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TestIamPermissionsResponse>(
@@ -6857,7 +6877,7 @@ export namespace dataproc_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$WorkflowTemplate>(parameters, callback);

--- a/src/apis/dataproc/v1beta2.ts
+++ b/src/apis/dataproc/v1beta2.ts
@@ -29,8 +29,6 @@ export namespace dataproc_v1beta2 {
     version: 'v1beta2';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * V1 error format.
@@ -98,12 +96,13 @@ export namespace dataproc_v1beta2 {
    * @param {object=} options Options for Dataproc
    */
   export class Dataproc {
+    context: APIRequestContext;
     projects: Resource$Projects;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.projects = new Resource$Projects();
+      this.projects = new Resource$Projects(this.context);
     }
   }
 
@@ -2144,29 +2143,36 @@ export namespace dataproc_v1beta2 {
 
 
   export class Resource$Projects {
+    context: APIRequestContext;
     locations: Resource$Projects$Locations;
     regions: Resource$Projects$Regions;
-    constructor() {
-      this.locations = new Resource$Projects$Locations();
-      this.regions = new Resource$Projects$Regions();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.locations = new Resource$Projects$Locations(this.context);
+      this.regions = new Resource$Projects$Regions(this.context);
     }
   }
 
 
   export class Resource$Projects$Locations {
+    context: APIRequestContext;
     autoscalingPolicies: Resource$Projects$Locations$Autoscalingpolicies;
     workflowTemplates: Resource$Projects$Locations$Workflowtemplates;
-    constructor() {
+    constructor(context: APIRequestContext) {
+      this.context = context;
       this.autoscalingPolicies =
-          new Resource$Projects$Locations$Autoscalingpolicies();
+          new Resource$Projects$Locations$Autoscalingpolicies(this.context);
       this.workflowTemplates =
-          new Resource$Projects$Locations$Workflowtemplates();
+          new Resource$Projects$Locations$Workflowtemplates(this.context);
     }
   }
 
 
   export class Resource$Projects$Locations$Autoscalingpolicies {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -2229,7 +2235,7 @@ export namespace dataproc_v1beta2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AutoscalingPolicy>(parameters, callback);
@@ -2297,7 +2303,7 @@ export namespace dataproc_v1beta2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -2361,7 +2367,7 @@ export namespace dataproc_v1beta2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AutoscalingPolicy>(parameters, callback);
@@ -2433,7 +2439,7 @@ export namespace dataproc_v1beta2 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -2511,7 +2517,7 @@ export namespace dataproc_v1beta2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListAutoscalingPoliciesResponse>(
@@ -2586,7 +2592,7 @@ export namespace dataproc_v1beta2 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -2669,7 +2675,7 @@ export namespace dataproc_v1beta2 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TestIamPermissionsResponse>(
@@ -2740,7 +2746,7 @@ export namespace dataproc_v1beta2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AutoscalingPolicy>(parameters, callback);
@@ -2891,7 +2897,10 @@ export namespace dataproc_v1beta2 {
 
 
   export class Resource$Projects$Locations$Workflowtemplates {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -2954,7 +2963,7 @@ export namespace dataproc_v1beta2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$WorkflowTemplate>(parameters, callback);
@@ -3023,7 +3032,7 @@ export namespace dataproc_v1beta2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -3088,7 +3097,7 @@ export namespace dataproc_v1beta2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$WorkflowTemplate>(parameters, callback);
@@ -3160,7 +3169,7 @@ export namespace dataproc_v1beta2 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -3239,7 +3248,7 @@ export namespace dataproc_v1beta2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -3323,7 +3332,7 @@ export namespace dataproc_v1beta2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -3399,7 +3408,7 @@ export namespace dataproc_v1beta2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListWorkflowTemplatesResponse>(
@@ -3474,7 +3483,7 @@ export namespace dataproc_v1beta2 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -3557,7 +3566,7 @@ export namespace dataproc_v1beta2 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TestIamPermissionsResponse>(
@@ -3628,7 +3637,7 @@ export namespace dataproc_v1beta2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$WorkflowTemplate>(parameters, callback);
@@ -3843,25 +3852,30 @@ export namespace dataproc_v1beta2 {
 
 
   export class Resource$Projects$Regions {
+    context: APIRequestContext;
     autoscalingPolicies: Resource$Projects$Regions$Autoscalingpolicies;
     clusters: Resource$Projects$Regions$Clusters;
     jobs: Resource$Projects$Regions$Jobs;
     operations: Resource$Projects$Regions$Operations;
     workflowTemplates: Resource$Projects$Regions$Workflowtemplates;
-    constructor() {
+    constructor(context: APIRequestContext) {
+      this.context = context;
       this.autoscalingPolicies =
-          new Resource$Projects$Regions$Autoscalingpolicies();
-      this.clusters = new Resource$Projects$Regions$Clusters();
-      this.jobs = new Resource$Projects$Regions$Jobs();
-      this.operations = new Resource$Projects$Regions$Operations();
+          new Resource$Projects$Regions$Autoscalingpolicies(this.context);
+      this.clusters = new Resource$Projects$Regions$Clusters(this.context);
+      this.jobs = new Resource$Projects$Regions$Jobs(this.context);
+      this.operations = new Resource$Projects$Regions$Operations(this.context);
       this.workflowTemplates =
-          new Resource$Projects$Regions$Workflowtemplates();
+          new Resource$Projects$Regions$Workflowtemplates(this.context);
     }
   }
 
 
   export class Resource$Projects$Regions$Autoscalingpolicies {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -3924,7 +3938,7 @@ export namespace dataproc_v1beta2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AutoscalingPolicy>(parameters, callback);
@@ -3992,7 +4006,7 @@ export namespace dataproc_v1beta2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -4055,7 +4069,7 @@ export namespace dataproc_v1beta2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AutoscalingPolicy>(parameters, callback);
@@ -4128,7 +4142,7 @@ export namespace dataproc_v1beta2 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -4206,7 +4220,7 @@ export namespace dataproc_v1beta2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListAutoscalingPoliciesResponse>(
@@ -4281,7 +4295,7 @@ export namespace dataproc_v1beta2 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -4364,7 +4378,7 @@ export namespace dataproc_v1beta2 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TestIamPermissionsResponse>(
@@ -4435,7 +4449,7 @@ export namespace dataproc_v1beta2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AutoscalingPolicy>(parameters, callback);
@@ -4591,7 +4605,10 @@ export namespace dataproc_v1beta2 {
 
 
   export class Resource$Projects$Regions$Clusters {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -4655,7 +4672,7 @@ export namespace dataproc_v1beta2 {
         params,
         requiredParams: ['projectId', 'region'],
         pathParams: ['projectId', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -4728,7 +4745,7 @@ export namespace dataproc_v1beta2 {
         params,
         requiredParams: ['projectId', 'region', 'clusterName'],
         pathParams: ['clusterName', 'projectId', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -4801,7 +4818,7 @@ export namespace dataproc_v1beta2 {
         params,
         requiredParams: ['projectId', 'region', 'clusterName'],
         pathParams: ['clusterName', 'projectId', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -4867,7 +4884,7 @@ export namespace dataproc_v1beta2 {
         params,
         requiredParams: ['projectId', 'region', 'clusterName'],
         pathParams: ['clusterName', 'projectId', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Cluster>(parameters, callback);
@@ -4935,7 +4952,7 @@ export namespace dataproc_v1beta2 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -5008,7 +5025,7 @@ export namespace dataproc_v1beta2 {
         params,
         requiredParams: ['projectId', 'region'],
         pathParams: ['projectId', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListClustersResponse>(parameters, callback);
@@ -5083,7 +5100,7 @@ export namespace dataproc_v1beta2 {
         params,
         requiredParams: ['projectId', 'region', 'clusterName'],
         pathParams: ['clusterName', 'projectId', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -5152,7 +5169,7 @@ export namespace dataproc_v1beta2 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -5232,7 +5249,7 @@ export namespace dataproc_v1beta2 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TestIamPermissionsResponse>(
@@ -5527,7 +5544,10 @@ export namespace dataproc_v1beta2 {
 
 
   export class Resource$Projects$Regions$Jobs {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -5593,7 +5613,7 @@ export namespace dataproc_v1beta2 {
         params,
         requiredParams: ['projectId', 'region', 'jobId'],
         pathParams: ['jobId', 'projectId', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Job>(parameters, callback);
@@ -5664,7 +5684,7 @@ export namespace dataproc_v1beta2 {
         params,
         requiredParams: ['projectId', 'region', 'jobId'],
         pathParams: ['jobId', 'projectId', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -5730,7 +5750,7 @@ export namespace dataproc_v1beta2 {
         params,
         requiredParams: ['projectId', 'region', 'jobId'],
         pathParams: ['jobId', 'projectId', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Job>(parameters, callback);
@@ -5797,7 +5817,7 @@ export namespace dataproc_v1beta2 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -5871,7 +5891,7 @@ export namespace dataproc_v1beta2 {
         params,
         requiredParams: ['projectId', 'region'],
         pathParams: ['projectId', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListJobsResponse>(parameters, callback);
@@ -5943,7 +5963,7 @@ export namespace dataproc_v1beta2 {
         params,
         requiredParams: ['projectId', 'region', 'jobId'],
         pathParams: ['jobId', 'projectId', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Job>(parameters, callback);
@@ -6011,7 +6031,7 @@ export namespace dataproc_v1beta2 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -6081,7 +6101,7 @@ export namespace dataproc_v1beta2 {
         params,
         requiredParams: ['projectId', 'region'],
         pathParams: ['projectId', 'region'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Job>(parameters, callback);
@@ -6160,7 +6180,7 @@ export namespace dataproc_v1beta2 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TestIamPermissionsResponse>(
@@ -6395,7 +6415,10 @@ export namespace dataproc_v1beta2 {
 
 
   export class Resource$Projects$Regions$Operations {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -6462,7 +6485,7 @@ export namespace dataproc_v1beta2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -6530,7 +6553,7 @@ export namespace dataproc_v1beta2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -6594,7 +6617,7 @@ export namespace dataproc_v1beta2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -6662,7 +6685,7 @@ export namespace dataproc_v1beta2 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -6740,7 +6763,7 @@ export namespace dataproc_v1beta2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListOperationsResponse>(parameters, callback);
@@ -6809,7 +6832,7 @@ export namespace dataproc_v1beta2 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -6889,7 +6912,7 @@ export namespace dataproc_v1beta2 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TestIamPermissionsResponse>(
@@ -7012,7 +7035,10 @@ export namespace dataproc_v1beta2 {
 
 
   export class Resource$Projects$Regions$Workflowtemplates {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -7075,7 +7101,7 @@ export namespace dataproc_v1beta2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$WorkflowTemplate>(parameters, callback);
@@ -7144,7 +7170,7 @@ export namespace dataproc_v1beta2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -7209,7 +7235,7 @@ export namespace dataproc_v1beta2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$WorkflowTemplate>(parameters, callback);
@@ -7279,7 +7305,7 @@ export namespace dataproc_v1beta2 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -7355,7 +7381,7 @@ export namespace dataproc_v1beta2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -7439,7 +7465,7 @@ export namespace dataproc_v1beta2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -7514,7 +7540,7 @@ export namespace dataproc_v1beta2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListWorkflowTemplatesResponse>(
@@ -7587,7 +7613,7 @@ export namespace dataproc_v1beta2 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -7670,7 +7696,7 @@ export namespace dataproc_v1beta2 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TestIamPermissionsResponse>(
@@ -7741,7 +7767,7 @@ export namespace dataproc_v1beta2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$WorkflowTemplate>(parameters, callback);

--- a/src/apis/datastore/v1.ts
+++ b/src/apis/datastore/v1.ts
@@ -29,8 +29,6 @@ export namespace datastore_v1 {
     version: 'v1';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * V1 error format.
@@ -99,12 +97,13 @@ export namespace datastore_v1 {
    * @param {object=} options Options for Datastore
    */
   export class Datastore {
+    context: APIRequestContext;
     projects: Resource$Projects;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.projects = new Resource$Projects();
+      this.projects = new Resource$Projects(this.context);
     }
   }
 
@@ -1342,11 +1341,13 @@ export namespace datastore_v1 {
 
 
   export class Resource$Projects {
+    context: APIRequestContext;
     indexes: Resource$Projects$Indexes;
     operations: Resource$Projects$Operations;
-    constructor() {
-      this.indexes = new Resource$Projects$Indexes();
-      this.operations = new Resource$Projects$Operations();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.indexes = new Resource$Projects$Indexes(this.context);
+      this.operations = new Resource$Projects$Operations(this.context);
     }
 
 
@@ -1410,7 +1411,7 @@ export namespace datastore_v1 {
         params,
         requiredParams: ['projectId'],
         pathParams: ['projectId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AllocateIdsResponse>(parameters, callback);
@@ -1481,7 +1482,7 @@ export namespace datastore_v1 {
         params,
         requiredParams: ['projectId'],
         pathParams: ['projectId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$BeginTransactionResponse>(parameters, callback);
@@ -1548,7 +1549,7 @@ export namespace datastore_v1 {
         params,
         requiredParams: ['projectId'],
         pathParams: ['projectId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$CommitResponse>(parameters, callback);
@@ -1625,7 +1626,7 @@ export namespace datastore_v1 {
         params,
         requiredParams: ['projectId'],
         pathParams: ['projectId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleLongrunningOperation>(
@@ -1670,7 +1671,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Import|BodyResponseCallback<S
     options = {};
                                                                                                                                                                                                                                                                                                                                               }
 
-                                                                                                                                                                                                                                                                                                                                              const rootUrl = options.rootUrl || 'https://datastore.googleapis.com/'; const parameters = {options: Object.assign({url: (rootUrl + '/v1/projects/{projectId}:import').replace(/([^:]\/)\/+/g, '$1'), method: 'POST'}, options), params, requiredParams: ['projectId'], pathParams: ['projectId'], context}; if(callback) {
+                                                                                                                                                                                                                                                                                                                                              const rootUrl = options.rootUrl || 'https://datastore.googleapis.com/'; const parameters = {options: Object.assign({url: (rootUrl + '/v1/projects/{projectId}:import').replace(/([^:]\/)\/+/g, '$1'), method: 'POST'}, options), params, requiredParams: ['projectId'], pathParams: ['projectId'], context: this.context}; if(callback) {
     createAPIRequest<Schema$GoogleLongrunningOperation>(parameters, callback);
                                                                                                                                                                                                                                                                                                                                               } else {
     return createAPIRequest<Schema$GoogleLongrunningOperation>(parameters);
@@ -1732,7 +1733,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Import|BodyResponseCallback<S
         params,
         requiredParams: ['projectId'],
         pathParams: ['projectId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$LookupResponse>(parameters, callback);
@@ -1801,7 +1802,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Import|BodyResponseCallback<S
         params,
         requiredParams: ['projectId'],
         pathParams: ['projectId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ReserveIdsResponse>(parameters, callback);
@@ -1869,7 +1870,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Import|BodyResponseCallback<S
         params,
         requiredParams: ['projectId'],
         pathParams: ['projectId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$RollbackResponse>(parameters, callback);
@@ -1937,7 +1938,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Import|BodyResponseCallback<S
         params,
         requiredParams: ['projectId'],
         pathParams: ['projectId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$RunQueryResponse>(parameters, callback);
@@ -2098,7 +2099,10 @@ import(paramsOrCallback?: Params$Resource$Projects$Import|BodyResponseCallback<S
   }
 
   export class Resource$Projects$Indexes {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -2159,7 +2163,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Import|BodyResponseCallback<S
         params,
         requiredParams: ['projectId', 'indexId'],
         pathParams: ['indexId', 'projectId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleDatastoreAdminV1Index>(
@@ -2238,7 +2242,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Import|BodyResponseCallback<S
         params,
         requiredParams: ['projectId'],
         pathParams: ['projectId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleDatastoreAdminV1ListIndexesResponse>(
@@ -2294,7 +2298,10 @@ import(paramsOrCallback?: Params$Resource$Projects$Import|BodyResponseCallback<S
 
 
   export class Resource$Projects$Operations {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -2361,7 +2368,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Import|BodyResponseCallback<S
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -2429,7 +2436,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Import|BodyResponseCallback<S
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -2498,7 +2505,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Import|BodyResponseCallback<S
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleLongrunningOperation>(
@@ -2583,7 +2590,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Import|BodyResponseCallback<S
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleLongrunningListOperationsResponse>(

--- a/src/apis/datastore/v1beta1.ts
+++ b/src/apis/datastore/v1beta1.ts
@@ -29,8 +29,6 @@ export namespace datastore_v1beta1 {
     version: 'v1beta1';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * V1 error format.
@@ -99,12 +97,13 @@ export namespace datastore_v1beta1 {
    * @param {object=} options Options for Datastore
    */
   export class Datastore {
+    context: APIRequestContext;
     projects: Resource$Projects;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.projects = new Resource$Projects();
+      this.projects = new Resource$Projects(this.context);
     }
   }
 
@@ -554,7 +553,10 @@ export namespace datastore_v1beta1 {
 
 
   export class Resource$Projects {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -624,7 +626,7 @@ export namespace datastore_v1beta1 {
         params,
         requiredParams: ['projectId'],
         pathParams: ['projectId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleLongrunningOperation>(
@@ -680,7 +682,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Import|BodyResponseCallback<S
     params,
         requiredParams: ['projectId'],
     pathParams: ['projectId'],
-    context
+    context: this.context
   };
     if (callback) {
       createAPIRequest<Schema$GoogleLongrunningOperation>(parameters, callback);

--- a/src/apis/datastore/v1beta3.ts
+++ b/src/apis/datastore/v1beta3.ts
@@ -29,8 +29,6 @@ export namespace datastore_v1beta3 {
     version: 'v1beta3';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * V1 error format.
@@ -99,12 +97,13 @@ export namespace datastore_v1beta3 {
    * @param {object=} options Options for Datastore
    */
   export class Datastore {
+    context: APIRequestContext;
     projects: Resource$Projects;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.projects = new Resource$Projects();
+      this.projects = new Resource$Projects(this.context);
     }
   }
 
@@ -1111,7 +1110,10 @@ export namespace datastore_v1beta3 {
 
 
   export class Resource$Projects {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1174,7 +1176,7 @@ export namespace datastore_v1beta3 {
         params,
         requiredParams: ['projectId'],
         pathParams: ['projectId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AllocateIdsResponse>(parameters, callback);
@@ -1245,7 +1247,7 @@ export namespace datastore_v1beta3 {
         params,
         requiredParams: ['projectId'],
         pathParams: ['projectId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$BeginTransactionResponse>(parameters, callback);
@@ -1312,7 +1314,7 @@ export namespace datastore_v1beta3 {
         params,
         requiredParams: ['projectId'],
         pathParams: ['projectId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$CommitResponse>(parameters, callback);
@@ -1378,7 +1380,7 @@ export namespace datastore_v1beta3 {
         params,
         requiredParams: ['projectId'],
         pathParams: ['projectId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$LookupResponse>(parameters, callback);
@@ -1447,7 +1449,7 @@ export namespace datastore_v1beta3 {
         params,
         requiredParams: ['projectId'],
         pathParams: ['projectId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ReserveIdsResponse>(parameters, callback);
@@ -1515,7 +1517,7 @@ export namespace datastore_v1beta3 {
         params,
         requiredParams: ['projectId'],
         pathParams: ['projectId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$RollbackResponse>(parameters, callback);
@@ -1583,7 +1585,7 @@ export namespace datastore_v1beta3 {
         params,
         requiredParams: ['projectId'],
         pathParams: ['projectId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$RunQueryResponse>(parameters, callback);

--- a/src/apis/deploymentmanager/alpha.ts
+++ b/src/apis/deploymentmanager/alpha.ts
@@ -29,8 +29,6 @@ export namespace deploymentmanager_alpha {
     version: 'alpha';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * Data format for the response.
@@ -82,6 +80,7 @@ export namespace deploymentmanager_alpha {
    * @param {object=} options Options for Deploymentmanager
    */
   export class Deploymentmanager {
+    context: APIRequestContext;
     compositeTypes: Resource$Compositetypes;
     deployments: Resource$Deployments;
     manifests: Resource$Manifests;
@@ -91,15 +90,15 @@ export namespace deploymentmanager_alpha {
     types: Resource$Types;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.compositeTypes = new Resource$Compositetypes();
-      this.deployments = new Resource$Deployments();
-      this.manifests = new Resource$Manifests();
-      this.operations = new Resource$Operations();
-      this.resources = new Resource$Resources();
-      this.typeProviders = new Resource$Typeproviders();
-      this.types = new Resource$Types();
+      this.compositeTypes = new Resource$Compositetypes(this.context);
+      this.deployments = new Resource$Deployments(this.context);
+      this.manifests = new Resource$Manifests(this.context);
+      this.operations = new Resource$Operations(this.context);
+      this.resources = new Resource$Resources(this.context);
+      this.typeProviders = new Resource$Typeproviders(this.context);
+      this.types = new Resource$Types(this.context);
     }
   }
 
@@ -1492,7 +1491,10 @@ export namespace deploymentmanager_alpha {
 
 
   export class Resource$Compositetypes {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1555,7 +1557,7 @@ export namespace deploymentmanager_alpha {
         params,
         requiredParams: ['project', 'compositeType'],
         pathParams: ['compositeType', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -1621,7 +1623,7 @@ export namespace deploymentmanager_alpha {
         params,
         requiredParams: ['project', 'compositeType'],
         pathParams: ['compositeType', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$CompositeType>(parameters, callback);
@@ -1691,7 +1693,7 @@ export namespace deploymentmanager_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -1767,7 +1769,7 @@ export namespace deploymentmanager_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$CompositeTypesListResponse>(
@@ -1839,7 +1841,7 @@ export namespace deploymentmanager_alpha {
         params,
         requiredParams: ['project', 'compositeType'],
         pathParams: ['compositeType', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -1910,7 +1912,7 @@ export namespace deploymentmanager_alpha {
         params,
         requiredParams: ['project', 'compositeType'],
         pathParams: ['compositeType', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -2069,7 +2071,10 @@ export namespace deploymentmanager_alpha {
 
 
   export class Resource$Deployments {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -2134,7 +2139,7 @@ export namespace deploymentmanager_alpha {
         params,
         requiredParams: ['project', 'deployment'],
         pathParams: ['deployment', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -2205,7 +2210,7 @@ export namespace deploymentmanager_alpha {
         params,
         requiredParams: ['project', 'deployment'],
         pathParams: ['deployment', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -2270,7 +2275,7 @@ export namespace deploymentmanager_alpha {
         params,
         requiredParams: ['project', 'deployment'],
         pathParams: ['deployment', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Deployment>(parameters, callback);
@@ -2340,7 +2345,7 @@ export namespace deploymentmanager_alpha {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -2413,7 +2418,7 @@ export namespace deploymentmanager_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -2485,7 +2490,7 @@ export namespace deploymentmanager_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$DeploymentsListResponse>(parameters, callback);
@@ -2559,7 +2564,7 @@ export namespace deploymentmanager_alpha {
         params,
         requiredParams: ['project', 'deployment'],
         pathParams: ['deployment', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -2630,7 +2635,7 @@ export namespace deploymentmanager_alpha {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -2700,7 +2705,7 @@ export namespace deploymentmanager_alpha {
         params,
         requiredParams: ['project', 'deployment'],
         pathParams: ['deployment', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -2773,7 +2778,7 @@ export namespace deploymentmanager_alpha {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -2848,7 +2853,7 @@ export namespace deploymentmanager_alpha {
         params,
         requiredParams: ['project', 'deployment'],
         pathParams: ['deployment', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -3164,7 +3169,10 @@ export namespace deploymentmanager_alpha {
 
 
   export class Resource$Manifests {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -3222,7 +3230,7 @@ export namespace deploymentmanager_alpha {
         params,
         requiredParams: ['project', 'deployment', 'manifest'],
         pathParams: ['deployment', 'manifest', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Manifest>(parameters, callback);
@@ -3295,7 +3303,7 @@ export namespace deploymentmanager_alpha {
         params,
         requiredParams: ['project', 'deployment'],
         pathParams: ['deployment', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ManifestsListResponse>(parameters, callback);
@@ -3385,7 +3393,10 @@ export namespace deploymentmanager_alpha {
 
 
   export class Resource$Operations {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -3443,7 +3454,7 @@ export namespace deploymentmanager_alpha {
         params,
         requiredParams: ['project', 'operation'],
         pathParams: ['operation', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -3515,7 +3526,7 @@ export namespace deploymentmanager_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$OperationsListResponse>(parameters, callback);
@@ -3597,7 +3608,10 @@ export namespace deploymentmanager_alpha {
 
 
   export class Resource$Resources {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -3655,7 +3669,7 @@ export namespace deploymentmanager_alpha {
         params,
         requiredParams: ['project', 'deployment', 'resource'],
         pathParams: ['deployment', 'project', 'resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Resource>(parameters, callback);
@@ -3728,7 +3742,7 @@ export namespace deploymentmanager_alpha {
         params,
         requiredParams: ['project', 'deployment'],
         pathParams: ['deployment', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ResourcesListResponse>(parameters, callback);
@@ -3818,7 +3832,10 @@ export namespace deploymentmanager_alpha {
 
 
   export class Resource$Typeproviders {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -3881,7 +3898,7 @@ export namespace deploymentmanager_alpha {
         params,
         requiredParams: ['project', 'typeProvider'],
         pathParams: ['project', 'typeProvider'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -3947,7 +3964,7 @@ export namespace deploymentmanager_alpha {
         params,
         requiredParams: ['project', 'typeProvider'],
         pathParams: ['project', 'typeProvider'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TypeProvider>(parameters, callback);
@@ -4017,7 +4034,7 @@ export namespace deploymentmanager_alpha {
         params,
         requiredParams: ['project', 'typeProvider', 'type'],
         pathParams: ['project', 'type', 'typeProvider'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TypeInfo>(parameters, callback);
@@ -4087,7 +4104,7 @@ export namespace deploymentmanager_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -4161,7 +4178,7 @@ export namespace deploymentmanager_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TypeProvidersListResponse>(
@@ -4242,7 +4259,7 @@ export namespace deploymentmanager_alpha {
         params,
         requiredParams: ['project', 'typeProvider'],
         pathParams: ['project', 'typeProvider'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TypeProvidersListTypesResponse>(
@@ -4315,7 +4332,7 @@ export namespace deploymentmanager_alpha {
         params,
         requiredParams: ['project', 'typeProvider'],
         pathParams: ['project', 'typeProvider'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -4386,7 +4403,7 @@ export namespace deploymentmanager_alpha {
         params,
         requiredParams: ['project', 'typeProvider'],
         pathParams: ['project', 'typeProvider'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -4624,7 +4641,10 @@ export namespace deploymentmanager_alpha {
 
 
   export class Resource$Types {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -4685,7 +4705,7 @@ export namespace deploymentmanager_alpha {
         params,
         requiredParams: ['project', 'type'],
         pathParams: ['project', 'type'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -4749,7 +4769,7 @@ export namespace deploymentmanager_alpha {
         params,
         requiredParams: ['project', 'type'],
         pathParams: ['project', 'type'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Type>(parameters, callback);
@@ -4816,7 +4836,7 @@ export namespace deploymentmanager_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -4886,7 +4906,7 @@ export namespace deploymentmanager_alpha {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TypesListResponse>(parameters, callback);
@@ -4955,7 +4975,7 @@ export namespace deploymentmanager_alpha {
         params,
         requiredParams: ['project', 'type'],
         pathParams: ['project', 'type'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -5024,7 +5044,7 @@ export namespace deploymentmanager_alpha {
         params,
         requiredParams: ['project', 'type'],
         pathParams: ['project', 'type'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);

--- a/src/apis/deploymentmanager/v2.ts
+++ b/src/apis/deploymentmanager/v2.ts
@@ -29,8 +29,6 @@ export namespace deploymentmanager_v2 {
     version: 'v2';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * Data format for the response.
@@ -82,6 +80,7 @@ export namespace deploymentmanager_v2 {
    * @param {object=} options Options for Deploymentmanager
    */
   export class Deploymentmanager {
+    context: APIRequestContext;
     deployments: Resource$Deployments;
     manifests: Resource$Manifests;
     operations: Resource$Operations;
@@ -89,13 +88,13 @@ export namespace deploymentmanager_v2 {
     types: Resource$Types;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.deployments = new Resource$Deployments();
-      this.manifests = new Resource$Manifests();
-      this.operations = new Resource$Operations();
-      this.resources = new Resource$Resources();
-      this.types = new Resource$Types();
+      this.deployments = new Resource$Deployments(this.context);
+      this.manifests = new Resource$Manifests(this.context);
+      this.operations = new Resource$Operations(this.context);
+      this.resources = new Resource$Resources(this.context);
+      this.types = new Resource$Types(this.context);
     }
   }
 
@@ -988,7 +987,10 @@ export namespace deploymentmanager_v2 {
 
 
   export class Resource$Deployments {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1111,7 +1113,7 @@ export namespace deploymentmanager_v2 {
         params,
         requiredParams: ['project', 'deployment'],
         pathParams: ['deployment', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -1238,7 +1240,7 @@ export namespace deploymentmanager_v2 {
         params,
         requiredParams: ['project', 'deployment'],
         pathParams: ['deployment', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -1359,7 +1361,7 @@ export namespace deploymentmanager_v2 {
         params,
         requiredParams: ['project', 'deployment'],
         pathParams: ['deployment', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Deployment>(parameters, callback);
@@ -1483,7 +1485,7 @@ export namespace deploymentmanager_v2 {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -1613,7 +1615,7 @@ export namespace deploymentmanager_v2 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -1752,7 +1754,7 @@ export namespace deploymentmanager_v2 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$DeploymentsListResponse>(parameters, callback);
@@ -1888,7 +1890,7 @@ export namespace deploymentmanager_v2 {
         params,
         requiredParams: ['project', 'deployment'],
         pathParams: ['deployment', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -2017,7 +2019,7 @@ export namespace deploymentmanager_v2 {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -2147,7 +2149,7 @@ export namespace deploymentmanager_v2 {
         params,
         requiredParams: ['project', 'deployment'],
         pathParams: ['deployment', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -2278,7 +2280,7 @@ export namespace deploymentmanager_v2 {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -2415,7 +2417,7 @@ export namespace deploymentmanager_v2 {
         params,
         requiredParams: ['project', 'deployment'],
         pathParams: ['deployment', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -2731,7 +2733,10 @@ export namespace deploymentmanager_v2 {
 
 
   export class Resource$Manifests {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -2848,7 +2853,7 @@ export namespace deploymentmanager_v2 {
         params,
         requiredParams: ['project', 'deployment', 'manifest'],
         pathParams: ['deployment', 'manifest', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Manifest>(parameters, callback);
@@ -2990,7 +2995,7 @@ export namespace deploymentmanager_v2 {
         params,
         requiredParams: ['project', 'deployment'],
         pathParams: ['deployment', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ManifestsListResponse>(parameters, callback);
@@ -3080,7 +3085,10 @@ export namespace deploymentmanager_v2 {
 
 
   export class Resource$Operations {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -3194,7 +3202,7 @@ export namespace deploymentmanager_v2 {
         params,
         requiredParams: ['project', 'operation'],
         pathParams: ['operation', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -3333,7 +3341,7 @@ export namespace deploymentmanager_v2 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$OperationsListResponse>(parameters, callback);
@@ -3415,7 +3423,10 @@ export namespace deploymentmanager_v2 {
 
 
   export class Resource$Resources {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -3532,7 +3543,7 @@ export namespace deploymentmanager_v2 {
         params,
         requiredParams: ['project', 'deployment', 'resource'],
         pathParams: ['deployment', 'project', 'resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Resource>(parameters, callback);
@@ -3674,7 +3685,7 @@ export namespace deploymentmanager_v2 {
         params,
         requiredParams: ['project', 'deployment'],
         pathParams: ['deployment', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ResourcesListResponse>(parameters, callback);
@@ -3764,7 +3775,10 @@ export namespace deploymentmanager_v2 {
 
 
   export class Resource$Types {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -3893,7 +3907,7 @@ export namespace deploymentmanager_v2 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TypesListResponse>(parameters, callback);

--- a/src/apis/deploymentmanager/v2beta.ts
+++ b/src/apis/deploymentmanager/v2beta.ts
@@ -29,8 +29,6 @@ export namespace deploymentmanager_v2beta {
     version: 'v2beta';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * Data format for the response.
@@ -82,6 +80,7 @@ export namespace deploymentmanager_v2beta {
    * @param {object=} options Options for Deploymentmanager
    */
   export class Deploymentmanager {
+    context: APIRequestContext;
     compositeTypes: Resource$Compositetypes;
     deployments: Resource$Deployments;
     manifests: Resource$Manifests;
@@ -91,15 +90,15 @@ export namespace deploymentmanager_v2beta {
     types: Resource$Types;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.compositeTypes = new Resource$Compositetypes();
-      this.deployments = new Resource$Deployments();
-      this.manifests = new Resource$Manifests();
-      this.operations = new Resource$Operations();
-      this.resources = new Resource$Resources();
-      this.typeProviders = new Resource$Typeproviders();
-      this.types = new Resource$Types();
+      this.compositeTypes = new Resource$Compositetypes(this.context);
+      this.deployments = new Resource$Deployments(this.context);
+      this.manifests = new Resource$Manifests(this.context);
+      this.operations = new Resource$Operations(this.context);
+      this.resources = new Resource$Resources(this.context);
+      this.typeProviders = new Resource$Typeproviders(this.context);
+      this.types = new Resource$Types(this.context);
     }
   }
 
@@ -1424,7 +1423,10 @@ export namespace deploymentmanager_v2beta {
 
 
   export class Resource$Compositetypes {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1487,7 +1489,7 @@ export namespace deploymentmanager_v2beta {
         params,
         requiredParams: ['project', 'compositeType'],
         pathParams: ['compositeType', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -1553,7 +1555,7 @@ export namespace deploymentmanager_v2beta {
         params,
         requiredParams: ['project', 'compositeType'],
         pathParams: ['compositeType', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$CompositeType>(parameters, callback);
@@ -1623,7 +1625,7 @@ export namespace deploymentmanager_v2beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -1699,7 +1701,7 @@ export namespace deploymentmanager_v2beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$CompositeTypesListResponse>(
@@ -1771,7 +1773,7 @@ export namespace deploymentmanager_v2beta {
         params,
         requiredParams: ['project', 'compositeType'],
         pathParams: ['compositeType', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -1842,7 +1844,7 @@ export namespace deploymentmanager_v2beta {
         params,
         requiredParams: ['project', 'compositeType'],
         pathParams: ['compositeType', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -2001,7 +2003,10 @@ export namespace deploymentmanager_v2beta {
 
 
   export class Resource$Deployments {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -2066,7 +2071,7 @@ export namespace deploymentmanager_v2beta {
         params,
         requiredParams: ['project', 'deployment'],
         pathParams: ['deployment', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -2137,7 +2142,7 @@ export namespace deploymentmanager_v2beta {
         params,
         requiredParams: ['project', 'deployment'],
         pathParams: ['deployment', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -2202,7 +2207,7 @@ export namespace deploymentmanager_v2beta {
         params,
         requiredParams: ['project', 'deployment'],
         pathParams: ['deployment', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Deployment>(parameters, callback);
@@ -2272,7 +2277,7 @@ export namespace deploymentmanager_v2beta {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -2345,7 +2350,7 @@ export namespace deploymentmanager_v2beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -2417,7 +2422,7 @@ export namespace deploymentmanager_v2beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$DeploymentsListResponse>(parameters, callback);
@@ -2491,7 +2496,7 @@ export namespace deploymentmanager_v2beta {
         params,
         requiredParams: ['project', 'deployment'],
         pathParams: ['deployment', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -2562,7 +2567,7 @@ export namespace deploymentmanager_v2beta {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -2632,7 +2637,7 @@ export namespace deploymentmanager_v2beta {
         params,
         requiredParams: ['project', 'deployment'],
         pathParams: ['deployment', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -2705,7 +2710,7 @@ export namespace deploymentmanager_v2beta {
         params,
         requiredParams: ['project', 'resource'],
         pathParams: ['project', 'resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TestPermissionsResponse>(parameters, callback);
@@ -2780,7 +2785,7 @@ export namespace deploymentmanager_v2beta {
         params,
         requiredParams: ['project', 'deployment'],
         pathParams: ['deployment', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -3096,7 +3101,10 @@ export namespace deploymentmanager_v2beta {
 
 
   export class Resource$Manifests {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -3154,7 +3162,7 @@ export namespace deploymentmanager_v2beta {
         params,
         requiredParams: ['project', 'deployment', 'manifest'],
         pathParams: ['deployment', 'manifest', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Manifest>(parameters, callback);
@@ -3227,7 +3235,7 @@ export namespace deploymentmanager_v2beta {
         params,
         requiredParams: ['project', 'deployment'],
         pathParams: ['deployment', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ManifestsListResponse>(parameters, callback);
@@ -3317,7 +3325,10 @@ export namespace deploymentmanager_v2beta {
 
 
   export class Resource$Operations {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -3375,7 +3386,7 @@ export namespace deploymentmanager_v2beta {
         params,
         requiredParams: ['project', 'operation'],
         pathParams: ['operation', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -3447,7 +3458,7 @@ export namespace deploymentmanager_v2beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$OperationsListResponse>(parameters, callback);
@@ -3529,7 +3540,10 @@ export namespace deploymentmanager_v2beta {
 
 
   export class Resource$Resources {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -3587,7 +3601,7 @@ export namespace deploymentmanager_v2beta {
         params,
         requiredParams: ['project', 'deployment', 'resource'],
         pathParams: ['deployment', 'project', 'resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Resource>(parameters, callback);
@@ -3660,7 +3674,7 @@ export namespace deploymentmanager_v2beta {
         params,
         requiredParams: ['project', 'deployment'],
         pathParams: ['deployment', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ResourcesListResponse>(parameters, callback);
@@ -3750,7 +3764,10 @@ export namespace deploymentmanager_v2beta {
 
 
   export class Resource$Typeproviders {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -3813,7 +3830,7 @@ export namespace deploymentmanager_v2beta {
         params,
         requiredParams: ['project', 'typeProvider'],
         pathParams: ['project', 'typeProvider'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -3879,7 +3896,7 @@ export namespace deploymentmanager_v2beta {
         params,
         requiredParams: ['project', 'typeProvider'],
         pathParams: ['project', 'typeProvider'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TypeProvider>(parameters, callback);
@@ -3949,7 +3966,7 @@ export namespace deploymentmanager_v2beta {
         params,
         requiredParams: ['project', 'typeProvider', 'type'],
         pathParams: ['project', 'type', 'typeProvider'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TypeInfo>(parameters, callback);
@@ -4019,7 +4036,7 @@ export namespace deploymentmanager_v2beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -4093,7 +4110,7 @@ export namespace deploymentmanager_v2beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TypeProvidersListResponse>(
@@ -4174,7 +4191,7 @@ export namespace deploymentmanager_v2beta {
         params,
         requiredParams: ['project', 'typeProvider'],
         pathParams: ['project', 'typeProvider'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TypeProvidersListTypesResponse>(
@@ -4247,7 +4264,7 @@ export namespace deploymentmanager_v2beta {
         params,
         requiredParams: ['project', 'typeProvider'],
         pathParams: ['project', 'typeProvider'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -4318,7 +4335,7 @@ export namespace deploymentmanager_v2beta {
         params,
         requiredParams: ['project', 'typeProvider'],
         pathParams: ['project', 'typeProvider'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -4556,7 +4573,10 @@ export namespace deploymentmanager_v2beta {
 
 
   export class Resource$Types {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -4619,7 +4639,7 @@ export namespace deploymentmanager_v2beta {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TypesListResponse>(parameters, callback);

--- a/src/apis/dfareporting/v3.1.ts
+++ b/src/apis/dfareporting/v3.1.ts
@@ -29,8 +29,6 @@ export namespace dfareporting_v3_1 {
     version: 'v3_1';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * Data format for the response.
@@ -81,6 +79,7 @@ export namespace dfareporting_v3_1 {
    * @param {object=} options Options for Dfareporting
    */
   export class Dfareporting {
+    context: APIRequestContext;
     accountActiveAdSummaries: Resource$Accountactiveadsummaries;
     accountPermissionGroups: Resource$Accountpermissiongroups;
     accountPermissions: Resource$Accountpermissions;
@@ -144,71 +143,82 @@ export namespace dfareporting_v3_1 {
     videoFormats: Resource$Videoformats;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.accountActiveAdSummaries = new Resource$Accountactiveadsummaries();
-      this.accountPermissionGroups = new Resource$Accountpermissiongroups();
-      this.accountPermissions = new Resource$Accountpermissions();
-      this.accounts = new Resource$Accounts();
-      this.accountUserProfiles = new Resource$Accountuserprofiles();
-      this.ads = new Resource$Ads();
-      this.advertiserGroups = new Resource$Advertisergroups();
-      this.advertiserLandingPages = new Resource$Advertiserlandingpages();
-      this.advertisers = new Resource$Advertisers();
-      this.browsers = new Resource$Browsers();
+      this.accountActiveAdSummaries =
+          new Resource$Accountactiveadsummaries(this.context);
+      this.accountPermissionGroups =
+          new Resource$Accountpermissiongroups(this.context);
+      this.accountPermissions = new Resource$Accountpermissions(this.context);
+      this.accounts = new Resource$Accounts(this.context);
+      this.accountUserProfiles = new Resource$Accountuserprofiles(this.context);
+      this.ads = new Resource$Ads(this.context);
+      this.advertiserGroups = new Resource$Advertisergroups(this.context);
+      this.advertiserLandingPages =
+          new Resource$Advertiserlandingpages(this.context);
+      this.advertisers = new Resource$Advertisers(this.context);
+      this.browsers = new Resource$Browsers(this.context);
       this.campaignCreativeAssociations =
-          new Resource$Campaigncreativeassociations();
-      this.campaigns = new Resource$Campaigns();
-      this.changeLogs = new Resource$Changelogs();
-      this.cities = new Resource$Cities();
-      this.connectionTypes = new Resource$Connectiontypes();
-      this.contentCategories = new Resource$Contentcategories();
-      this.conversions = new Resource$Conversions();
-      this.countries = new Resource$Countries();
-      this.creativeAssets = new Resource$Creativeassets();
-      this.creativeFields = new Resource$Creativefields();
-      this.creativeFieldValues = new Resource$Creativefieldvalues();
-      this.creativeGroups = new Resource$Creativegroups();
-      this.creatives = new Resource$Creatives();
-      this.dimensionValues = new Resource$Dimensionvalues();
-      this.directorySiteContacts = new Resource$Directorysitecontacts();
-      this.directorySites = new Resource$Directorysites();
-      this.dynamicTargetingKeys = new Resource$Dynamictargetingkeys();
-      this.eventTags = new Resource$Eventtags();
-      this.files = new Resource$Files();
-      this.floodlightActivities = new Resource$Floodlightactivities();
-      this.floodlightActivityGroups = new Resource$Floodlightactivitygroups();
-      this.floodlightConfigurations = new Resource$Floodlightconfigurations();
-      this.inventoryItems = new Resource$Inventoryitems();
-      this.languages = new Resource$Languages();
-      this.metros = new Resource$Metros();
-      this.mobileApps = new Resource$Mobileapps();
-      this.mobileCarriers = new Resource$Mobilecarriers();
-      this.operatingSystems = new Resource$Operatingsystems();
-      this.operatingSystemVersions = new Resource$Operatingsystemversions();
-      this.orderDocuments = new Resource$Orderdocuments();
-      this.orders = new Resource$Orders();
-      this.placementGroups = new Resource$Placementgroups();
-      this.placements = new Resource$Placements();
-      this.placementStrategies = new Resource$Placementstrategies();
-      this.platformTypes = new Resource$Platformtypes();
-      this.postalCodes = new Resource$Postalcodes();
-      this.projects = new Resource$Projects();
-      this.regions = new Resource$Regions();
-      this.remarketingLists = new Resource$Remarketinglists();
-      this.remarketingListShares = new Resource$Remarketinglistshares();
-      this.reports = new Resource$Reports();
-      this.sites = new Resource$Sites();
-      this.sizes = new Resource$Sizes();
-      this.subaccounts = new Resource$Subaccounts();
+          new Resource$Campaigncreativeassociations(this.context);
+      this.campaigns = new Resource$Campaigns(this.context);
+      this.changeLogs = new Resource$Changelogs(this.context);
+      this.cities = new Resource$Cities(this.context);
+      this.connectionTypes = new Resource$Connectiontypes(this.context);
+      this.contentCategories = new Resource$Contentcategories(this.context);
+      this.conversions = new Resource$Conversions(this.context);
+      this.countries = new Resource$Countries(this.context);
+      this.creativeAssets = new Resource$Creativeassets(this.context);
+      this.creativeFields = new Resource$Creativefields(this.context);
+      this.creativeFieldValues = new Resource$Creativefieldvalues(this.context);
+      this.creativeGroups = new Resource$Creativegroups(this.context);
+      this.creatives = new Resource$Creatives(this.context);
+      this.dimensionValues = new Resource$Dimensionvalues(this.context);
+      this.directorySiteContacts =
+          new Resource$Directorysitecontacts(this.context);
+      this.directorySites = new Resource$Directorysites(this.context);
+      this.dynamicTargetingKeys =
+          new Resource$Dynamictargetingkeys(this.context);
+      this.eventTags = new Resource$Eventtags(this.context);
+      this.files = new Resource$Files(this.context);
+      this.floodlightActivities =
+          new Resource$Floodlightactivities(this.context);
+      this.floodlightActivityGroups =
+          new Resource$Floodlightactivitygroups(this.context);
+      this.floodlightConfigurations =
+          new Resource$Floodlightconfigurations(this.context);
+      this.inventoryItems = new Resource$Inventoryitems(this.context);
+      this.languages = new Resource$Languages(this.context);
+      this.metros = new Resource$Metros(this.context);
+      this.mobileApps = new Resource$Mobileapps(this.context);
+      this.mobileCarriers = new Resource$Mobilecarriers(this.context);
+      this.operatingSystems = new Resource$Operatingsystems(this.context);
+      this.operatingSystemVersions =
+          new Resource$Operatingsystemversions(this.context);
+      this.orderDocuments = new Resource$Orderdocuments(this.context);
+      this.orders = new Resource$Orders(this.context);
+      this.placementGroups = new Resource$Placementgroups(this.context);
+      this.placements = new Resource$Placements(this.context);
+      this.placementStrategies = new Resource$Placementstrategies(this.context);
+      this.platformTypes = new Resource$Platformtypes(this.context);
+      this.postalCodes = new Resource$Postalcodes(this.context);
+      this.projects = new Resource$Projects(this.context);
+      this.regions = new Resource$Regions(this.context);
+      this.remarketingLists = new Resource$Remarketinglists(this.context);
+      this.remarketingListShares =
+          new Resource$Remarketinglistshares(this.context);
+      this.reports = new Resource$Reports(this.context);
+      this.sites = new Resource$Sites(this.context);
+      this.sizes = new Resource$Sizes(this.context);
+      this.subaccounts = new Resource$Subaccounts(this.context);
       this.targetableRemarketingLists =
-          new Resource$Targetableremarketinglists();
-      this.targetingTemplates = new Resource$Targetingtemplates();
-      this.userProfiles = new Resource$Userprofiles();
-      this.userRolePermissionGroups = new Resource$Userrolepermissiongroups();
-      this.userRolePermissions = new Resource$Userrolepermissions();
-      this.userRoles = new Resource$Userroles();
-      this.videoFormats = new Resource$Videoformats();
+          new Resource$Targetableremarketinglists(this.context);
+      this.targetingTemplates = new Resource$Targetingtemplates(this.context);
+      this.userProfiles = new Resource$Userprofiles(this.context);
+      this.userRolePermissionGroups =
+          new Resource$Userrolepermissiongroups(this.context);
+      this.userRolePermissions = new Resource$Userrolepermissions(this.context);
+      this.userRoles = new Resource$Userroles(this.context);
+      this.videoFormats = new Resource$Videoformats(this.context);
     }
   }
 
@@ -7707,7 +7717,10 @@ export namespace dfareporting_v3_1 {
 
 
   export class Resource$Accountactiveadsummaries {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -7767,7 +7780,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId', 'summaryAccountId'],
         pathParams: ['profileId', 'summaryAccountId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AccountActiveAdSummary>(parameters, callback);
@@ -7796,7 +7809,10 @@ export namespace dfareporting_v3_1 {
 
 
   export class Resource$Accountpermissiongroups {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -7856,7 +7872,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AccountPermissionGroup>(parameters, callback);
@@ -7934,7 +7950,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AccountPermissionGroupsListResponse>(
@@ -7977,7 +7993,10 @@ export namespace dfareporting_v3_1 {
 
 
   export class Resource$Accountpermissions {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -8036,7 +8055,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AccountPermission>(parameters, callback);
@@ -8110,7 +8129,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AccountPermissionsListResponse>(
@@ -8153,7 +8172,10 @@ export namespace dfareporting_v3_1 {
 
 
   export class Resource$Accounts {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -8209,7 +8231,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Account>(parameters, callback);
@@ -8284,7 +8306,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AccountsListResponse>(parameters, callback);
@@ -8351,7 +8373,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Account>(parameters, callback);
@@ -8417,7 +8439,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Account>(parameters, callback);
@@ -8526,7 +8548,10 @@ export namespace dfareporting_v3_1 {
 
 
   export class Resource$Accountuserprofiles {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -8585,7 +8610,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AccountUserProfile>(parameters, callback);
@@ -8655,7 +8680,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AccountUserProfile>(parameters, callback);
@@ -8741,7 +8766,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AccountUserProfilesListResponse>(
@@ -8815,7 +8840,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AccountUserProfile>(parameters, callback);
@@ -8885,7 +8910,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AccountUserProfile>(parameters, callback);
@@ -9023,7 +9048,10 @@ export namespace dfareporting_v3_1 {
 
 
   export class Resource$Ads {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -9079,7 +9107,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Ad>(parameters, callback);
@@ -9144,7 +9172,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Ad>(parameters, callback);
@@ -9233,7 +9261,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AdsListResponse>(parameters, callback);
@@ -9299,7 +9327,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Ad>(parameters, callback);
@@ -9364,7 +9392,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Ad>(parameters, callback);
@@ -9560,7 +9588,10 @@ export namespace dfareporting_v3_1 {
 
 
   export class Resource$Advertisergroups {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -9621,7 +9652,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -9687,7 +9718,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AdvertiserGroup>(parameters, callback);
@@ -9757,7 +9788,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AdvertiserGroup>(parameters, callback);
@@ -9838,7 +9869,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AdvertiserGroupsListResponse>(
@@ -9912,7 +9943,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AdvertiserGroup>(parameters, callback);
@@ -9982,7 +10013,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AdvertiserGroup>(parameters, callback);
@@ -10124,7 +10155,10 @@ export namespace dfareporting_v3_1 {
 
 
   export class Resource$Advertiserlandingpages {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -10183,7 +10217,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$LandingPage>(parameters, callback);
@@ -10253,7 +10287,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$LandingPage>(parameters, callback);
@@ -10340,7 +10374,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AdvertiserLandingPagesListResponse>(
@@ -10414,7 +10448,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$LandingPage>(parameters, callback);
@@ -10484,7 +10518,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$LandingPage>(parameters, callback);
@@ -10623,7 +10657,10 @@ export namespace dfareporting_v3_1 {
 
 
   export class Resource$Advertisers {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -10681,7 +10718,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Advertiser>(parameters, callback);
@@ -10750,7 +10787,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Advertiser>(parameters, callback);
@@ -10830,7 +10867,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AdvertisersListResponse>(parameters, callback);
@@ -10900,7 +10937,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Advertiser>(parameters, callback);
@@ -10969,7 +11006,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Advertiser>(parameters, callback);
@@ -11118,7 +11155,10 @@ export namespace dfareporting_v3_1 {
 
 
   export class Resource$Browsers {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -11178,7 +11218,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$BrowsersListResponse>(parameters, callback);
@@ -11202,7 +11242,10 @@ export namespace dfareporting_v3_1 {
 
 
   export class Resource$Campaigncreativeassociations {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -11273,7 +11316,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId', 'campaignId'],
         pathParams: ['campaignId', 'profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$CampaignCreativeAssociation>(
@@ -11354,7 +11397,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId', 'campaignId'],
         pathParams: ['campaignId', 'profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$CampaignCreativeAssociationsListResponse>(
@@ -11418,7 +11461,10 @@ export namespace dfareporting_v3_1 {
 
 
   export class Resource$Campaigns {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -11475,7 +11521,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Campaign>(parameters, callback);
@@ -11541,7 +11587,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Campaign>(parameters, callback);
@@ -11622,7 +11668,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$CampaignsListResponse>(parameters, callback);
@@ -11689,7 +11735,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Campaign>(parameters, callback);
@@ -11755,7 +11801,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Campaign>(parameters, callback);
@@ -11906,7 +11952,10 @@ export namespace dfareporting_v3_1 {
 
 
   export class Resource$Changelogs {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -11964,7 +12013,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ChangeLog>(parameters, callback);
@@ -12041,7 +12090,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ChangeLogsListResponse>(parameters, callback);
@@ -12131,7 +12180,10 @@ export namespace dfareporting_v3_1 {
 
 
   export class Resource$Cities {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -12194,7 +12246,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$CitiesListResponse>(parameters, callback);
@@ -12234,7 +12286,10 @@ export namespace dfareporting_v3_1 {
 
 
   export class Resource$Connectiontypes {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -12293,7 +12348,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ConnectionType>(parameters, callback);
@@ -12366,7 +12421,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ConnectionTypesListResponse>(
@@ -12408,7 +12463,10 @@ export namespace dfareporting_v3_1 {
 
 
   export class Resource$Contentcategories {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -12469,7 +12527,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -12535,7 +12593,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ContentCategory>(parameters, callback);
@@ -12605,7 +12663,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ContentCategory>(parameters, callback);
@@ -12686,7 +12744,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ContentCategoriesListResponse>(
@@ -12760,7 +12818,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ContentCategory>(parameters, callback);
@@ -12830,7 +12888,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ContentCategory>(parameters, callback);
@@ -12972,7 +13030,10 @@ export namespace dfareporting_v3_1 {
 
 
   export class Resource$Conversions {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -13041,7 +13102,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ConversionsBatchInsertResponse>(
@@ -13119,7 +13180,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ConversionsBatchUpdateResponse>(
@@ -13168,7 +13229,10 @@ export namespace dfareporting_v3_1 {
 
 
   export class Resource$Countries {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -13225,7 +13289,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId', 'dartId'],
         pathParams: ['dartId', 'profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Country>(parameters, callback);
@@ -13292,7 +13356,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$CountriesListResponse>(parameters, callback);
@@ -13331,7 +13395,10 @@ export namespace dfareporting_v3_1 {
 
 
   export class Resource$Creativeassets {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -13403,7 +13470,7 @@ export namespace dfareporting_v3_1 {
                 .replace(/([^:]\/)\/+/g, '$1'),
         requiredParams: ['profileId', 'advertiserId'],
         pathParams: ['advertiserId', 'profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$CreativeAssetMetadata>(parameters, callback);
@@ -13452,7 +13519,10 @@ export namespace dfareporting_v3_1 {
 
 
   export class Resource$Creativefields {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -13513,7 +13583,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -13579,7 +13649,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$CreativeField>(parameters, callback);
@@ -13649,7 +13719,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$CreativeField>(parameters, callback);
@@ -13729,7 +13799,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$CreativeFieldsListResponse>(
@@ -13802,7 +13872,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$CreativeField>(parameters, callback);
@@ -13872,7 +13942,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$CreativeField>(parameters, callback);
@@ -14018,7 +14088,10 @@ export namespace dfareporting_v3_1 {
 
 
   export class Resource$Creativefieldvalues {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -14080,7 +14153,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId', 'creativeFieldId', 'id'],
         pathParams: ['creativeFieldId', 'id', 'profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -14147,7 +14220,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId', 'creativeFieldId', 'id'],
         pathParams: ['creativeFieldId', 'id', 'profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$CreativeFieldValue>(parameters, callback);
@@ -14218,7 +14291,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId', 'creativeFieldId'],
         pathParams: ['creativeFieldId', 'profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$CreativeFieldValue>(parameters, callback);
@@ -14302,7 +14375,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId', 'creativeFieldId'],
         pathParams: ['creativeFieldId', 'profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$CreativeFieldValuesListResponse>(
@@ -14377,7 +14450,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId', 'creativeFieldId', 'id'],
         pathParams: ['creativeFieldId', 'profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$CreativeFieldValue>(parameters, callback);
@@ -14448,7 +14521,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId', 'creativeFieldId'],
         pathParams: ['creativeFieldId', 'profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$CreativeFieldValue>(parameters, callback);
@@ -14609,7 +14682,10 @@ export namespace dfareporting_v3_1 {
 
 
   export class Resource$Creativegroups {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -14668,7 +14744,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$CreativeGroup>(parameters, callback);
@@ -14738,7 +14814,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$CreativeGroup>(parameters, callback);
@@ -14819,7 +14895,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$CreativeGroupsListResponse>(
@@ -14892,7 +14968,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$CreativeGroup>(parameters, callback);
@@ -14962,7 +15038,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$CreativeGroup>(parameters, callback);
@@ -15096,7 +15172,10 @@ export namespace dfareporting_v3_1 {
 
 
   export class Resource$Creatives {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -15153,7 +15232,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Creative>(parameters, callback);
@@ -15219,7 +15298,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Creative>(parameters, callback);
@@ -15303,7 +15382,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$CreativesListResponse>(parameters, callback);
@@ -15370,7 +15449,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Creative>(parameters, callback);
@@ -15436,7 +15515,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Creative>(parameters, callback);
@@ -15599,7 +15678,10 @@ export namespace dfareporting_v3_1 {
 
 
   export class Resource$Dimensionvalues {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -15664,7 +15746,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$DimensionValueList>(parameters, callback);
@@ -15702,7 +15784,10 @@ export namespace dfareporting_v3_1 {
 
 
   export class Resource$Directorysitecontacts {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -15762,7 +15847,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$DirectorySiteContact>(parameters, callback);
@@ -15848,7 +15933,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$DirectorySiteContactsListResponse>(
@@ -15927,7 +16012,10 @@ export namespace dfareporting_v3_1 {
 
 
   export class Resource$Directorysites {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -15986,7 +16074,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$DirectorySite>(parameters, callback);
@@ -16056,7 +16144,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$DirectorySite>(parameters, callback);
@@ -16142,7 +16230,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$DirectorySitesListResponse>(
@@ -16263,7 +16351,10 @@ export namespace dfareporting_v3_1 {
 
 
   export class Resource$Dynamictargetingkeys {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -16326,7 +16417,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId', 'objectId', 'name', 'objectType'],
         pathParams: ['objectId', 'profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -16400,7 +16491,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$DynamicTargetingKey>(parameters, callback);
@@ -16482,7 +16573,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$DynamicTargetingKeysListResponse>(
@@ -16569,7 +16660,10 @@ export namespace dfareporting_v3_1 {
 
 
   export class Resource$Eventtags {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -16628,7 +16722,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -16692,7 +16786,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$EventTag>(parameters, callback);
@@ -16758,7 +16852,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$EventTag>(parameters, callback);
@@ -16835,7 +16929,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$EventTagsListResponse>(parameters, callback);
@@ -16903,7 +16997,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$EventTag>(parameters, callback);
@@ -16969,7 +17063,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$EventTag>(parameters, callback);
@@ -17135,7 +17229,10 @@ export namespace dfareporting_v3_1 {
 
 
   export class Resource$Files {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -17192,7 +17289,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['reportId', 'fileId'],
         pathParams: ['fileId', 'reportId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$File>(parameters, callback);
@@ -17262,7 +17359,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$FileList>(parameters, callback);
@@ -17321,7 +17418,10 @@ export namespace dfareporting_v3_1 {
 
 
   export class Resource$Floodlightactivities {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -17382,7 +17482,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -17458,7 +17558,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$FloodlightActivitiesGenerateTagResponse>(
@@ -17526,7 +17626,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$FloodlightActivity>(parameters, callback);
@@ -17596,7 +17696,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$FloodlightActivity>(parameters, callback);
@@ -17688,7 +17788,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$FloodlightActivitiesListResponse>(
@@ -17762,7 +17862,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$FloodlightActivity>(parameters, callback);
@@ -17832,7 +17932,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$FloodlightActivity>(parameters, callback);
@@ -18029,7 +18129,10 @@ export namespace dfareporting_v3_1 {
 
 
   export class Resource$Floodlightactivitygroups {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -18089,7 +18192,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$FloodlightActivityGroup>(parameters, callback);
@@ -18161,7 +18264,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$FloodlightActivityGroup>(parameters, callback);
@@ -18249,7 +18352,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$FloodlightActivityGroupsListResponse>(
@@ -18324,7 +18427,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$FloodlightActivityGroup>(parameters, callback);
@@ -18396,7 +18499,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$FloodlightActivityGroup>(parameters, callback);
@@ -18542,7 +18645,10 @@ export namespace dfareporting_v3_1 {
 
 
   export class Resource$Floodlightconfigurations {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -18602,7 +18708,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$FloodlightConfiguration>(parameters, callback);
@@ -18681,7 +18787,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$FloodlightConfigurationsListResponse>(
@@ -18756,7 +18862,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$FloodlightConfiguration>(parameters, callback);
@@ -18828,7 +18934,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$FloodlightConfiguration>(parameters, callback);
@@ -18912,7 +19018,10 @@ export namespace dfareporting_v3_1 {
 
 
   export class Resource$Inventoryitems {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -18972,7 +19081,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId', 'projectId', 'id'],
         pathParams: ['id', 'profileId', 'projectId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$InventoryItem>(parameters, callback);
@@ -19055,7 +19164,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId', 'projectId'],
         pathParams: ['profileId', 'projectId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$InventoryItemsListResponse>(
@@ -19141,7 +19250,10 @@ export namespace dfareporting_v3_1 {
 
 
   export class Resource$Languages {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -19201,7 +19313,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$LanguagesListResponse>(parameters, callback);
@@ -19225,7 +19337,10 @@ export namespace dfareporting_v3_1 {
 
 
   export class Resource$Metros {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -19284,7 +19399,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$MetrosListResponse>(parameters, callback);
@@ -19308,7 +19423,10 @@ export namespace dfareporting_v3_1 {
 
 
   export class Resource$Mobileapps {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -19366,7 +19484,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$MobileApp>(parameters, callback);
@@ -19438,7 +19556,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$MobileAppsListResponse>(parameters, callback);
@@ -19502,7 +19620,10 @@ export namespace dfareporting_v3_1 {
 
 
   export class Resource$Mobilecarriers {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -19561,7 +19682,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$MobileCarrier>(parameters, callback);
@@ -19633,7 +19754,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$MobileCarriersListResponse>(
@@ -19675,7 +19796,10 @@ export namespace dfareporting_v3_1 {
 
 
   export class Resource$Operatingsystems {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -19734,7 +19858,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId', 'dartId'],
         pathParams: ['dartId', 'profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$OperatingSystem>(parameters, callback);
@@ -19808,7 +19932,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$OperatingSystemsListResponse>(
@@ -19851,7 +19975,10 @@ export namespace dfareporting_v3_1 {
 
 
   export class Resource$Operatingsystemversions {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -19911,7 +20038,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$OperatingSystemVersion>(parameters, callback);
@@ -19989,7 +20116,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$OperatingSystemVersionsListResponse>(
@@ -20032,7 +20159,10 @@ export namespace dfareporting_v3_1 {
 
 
   export class Resource$Orderdocuments {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -20092,7 +20222,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId', 'projectId', 'id'],
         pathParams: ['id', 'profileId', 'projectId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$OrderDocument>(parameters, callback);
@@ -20175,7 +20305,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId', 'projectId'],
         pathParams: ['profileId', 'projectId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$OrderDocumentsListResponse>(
@@ -20267,7 +20397,10 @@ export namespace dfareporting_v3_1 {
 
 
   export class Resource$Orders {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -20325,7 +20458,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId', 'projectId', 'id'],
         pathParams: ['id', 'profileId', 'projectId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Order>(parameters, callback);
@@ -20401,7 +20534,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId', 'projectId'],
         pathParams: ['profileId', 'projectId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$OrdersListResponse>(parameters, callback);
@@ -20481,7 +20614,10 @@ export namespace dfareporting_v3_1 {
 
 
   export class Resource$Placementgroups {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -20540,7 +20676,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$PlacementGroup>(parameters, callback);
@@ -20610,7 +20746,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$PlacementGroup>(parameters, callback);
@@ -20703,7 +20839,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$PlacementGroupsListResponse>(
@@ -20776,7 +20912,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$PlacementGroup>(parameters, callback);
@@ -20846,7 +20982,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$PlacementGroup>(parameters, callback);
@@ -21039,7 +21175,10 @@ export namespace dfareporting_v3_1 {
 
 
   export class Resource$Placements {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -21110,7 +21249,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$PlacementsGenerateTagsResponse>(
@@ -21177,7 +21316,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Placement>(parameters, callback);
@@ -21245,7 +21384,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Placement>(parameters, callback);
@@ -21335,7 +21474,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$PlacementsListResponse>(parameters, callback);
@@ -21404,7 +21543,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Placement>(parameters, callback);
@@ -21472,7 +21611,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Placement>(parameters, callback);
@@ -21696,7 +21835,10 @@ export namespace dfareporting_v3_1 {
 
 
   export class Resource$Placementstrategies {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -21757,7 +21899,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -21823,7 +21965,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$PlacementStrategy>(parameters, callback);
@@ -21893,7 +22035,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$PlacementStrategy>(parameters, callback);
@@ -21976,7 +22118,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$PlacementStrategiesListResponse>(
@@ -22050,7 +22192,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$PlacementStrategy>(parameters, callback);
@@ -22120,7 +22262,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$PlacementStrategy>(parameters, callback);
@@ -22263,7 +22405,10 @@ export namespace dfareporting_v3_1 {
 
 
   export class Resource$Platformtypes {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -22322,7 +22467,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$PlatformType>(parameters, callback);
@@ -22391,7 +22536,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$PlatformTypesListResponse>(
@@ -22433,7 +22578,10 @@ export namespace dfareporting_v3_1 {
 
 
   export class Resource$Postalcodes {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -22491,7 +22639,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId', 'code'],
         pathParams: ['code', 'profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$PostalCode>(parameters, callback);
@@ -22558,7 +22706,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$PostalCodesListResponse>(parameters, callback);
@@ -22597,7 +22745,10 @@ export namespace dfareporting_v3_1 {
 
 
   export class Resource$Projects {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -22653,7 +22804,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Project>(parameters, callback);
@@ -22728,7 +22879,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ProjectsListResponse>(parameters, callback);
@@ -22800,7 +22951,10 @@ export namespace dfareporting_v3_1 {
 
 
   export class Resource$Regions {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -22859,7 +23013,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$RegionsListResponse>(parameters, callback);
@@ -22883,7 +23037,10 @@ export namespace dfareporting_v3_1 {
 
 
   export class Resource$Remarketinglists {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -22942,7 +23099,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$RemarketingList>(parameters, callback);
@@ -23012,7 +23169,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$RemarketingList>(parameters, callback);
@@ -23095,7 +23252,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId', 'advertiserId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$RemarketingListsListResponse>(
@@ -23169,7 +23326,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$RemarketingList>(parameters, callback);
@@ -23239,7 +23396,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$RemarketingList>(parameters, callback);
@@ -23373,7 +23530,10 @@ export namespace dfareporting_v3_1 {
 
 
   export class Resource$Remarketinglistshares {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -23433,7 +23593,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId', 'remarketingListId'],
         pathParams: ['profileId', 'remarketingListId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$RemarketingListShare>(parameters, callback);
@@ -23506,7 +23666,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId', 'remarketingListId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$RemarketingListShare>(parameters, callback);
@@ -23577,7 +23737,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$RemarketingListShare>(parameters, callback);
@@ -23644,11 +23804,14 @@ export namespace dfareporting_v3_1 {
 
 
   export class Resource$Reports {
+    context: APIRequestContext;
     compatibleFields: Resource$Reports$Compatiblefields;
     files: Resource$Reports$Files;
-    constructor() {
-      this.compatibleFields = new Resource$Reports$Compatiblefields();
-      this.files = new Resource$Reports$Files();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.compatibleFields =
+          new Resource$Reports$Compatiblefields(this.context);
+      this.files = new Resource$Reports$Files(this.context);
     }
 
 
@@ -23708,7 +23871,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId', 'reportId'],
         pathParams: ['profileId', 'reportId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -23772,7 +23935,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId', 'reportId'],
         pathParams: ['profileId', 'reportId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Report>(parameters, callback);
@@ -23838,7 +24001,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Report>(parameters, callback);
@@ -23909,7 +24072,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ReportList>(parameters, callback);
@@ -23977,7 +24140,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId', 'reportId'],
         pathParams: ['profileId', 'reportId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Report>(parameters, callback);
@@ -24042,7 +24205,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId', 'reportId'],
         pathParams: ['profileId', 'reportId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$File>(parameters, callback);
@@ -24110,7 +24273,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId', 'reportId'],
         pathParams: ['profileId', 'reportId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Report>(parameters, callback);
@@ -24258,7 +24421,10 @@ export namespace dfareporting_v3_1 {
   }
 
   export class Resource$Reports$Compatiblefields {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -24323,7 +24489,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$CompatibleFields>(parameters, callback);
@@ -24353,7 +24519,10 @@ export namespace dfareporting_v3_1 {
 
 
   export class Resource$Reports$Files {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -24412,7 +24581,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId', 'reportId', 'fileId'],
         pathParams: ['fileId', 'profileId', 'reportId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$File>(parameters, callback);
@@ -24484,7 +24653,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId', 'reportId'],
         pathParams: ['profileId', 'reportId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$FileList>(parameters, callback);
@@ -24550,7 +24719,10 @@ export namespace dfareporting_v3_1 {
 
 
   export class Resource$Sites {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -24606,7 +24778,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Site>(parameters, callback);
@@ -24672,7 +24844,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Site>(parameters, callback);
@@ -24754,7 +24926,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$SitesListResponse>(parameters, callback);
@@ -24821,7 +24993,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Site>(parameters, callback);
@@ -24887,7 +25059,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Site>(parameters, callback);
@@ -25045,7 +25217,10 @@ export namespace dfareporting_v3_1 {
 
 
   export class Resource$Sizes {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -25101,7 +25276,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Size>(parameters, callback);
@@ -25167,7 +25342,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Size>(parameters, callback);
@@ -25240,7 +25415,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$SizesListResponse>(parameters, callback);
@@ -25311,7 +25486,10 @@ export namespace dfareporting_v3_1 {
 
 
   export class Resource$Subaccounts {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -25369,7 +25547,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Subaccount>(parameters, callback);
@@ -25438,7 +25616,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Subaccount>(parameters, callback);
@@ -25512,7 +25690,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$SubaccountsListResponse>(parameters, callback);
@@ -25582,7 +25760,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Subaccount>(parameters, callback);
@@ -25651,7 +25829,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Subaccount>(parameters, callback);
@@ -25775,7 +25953,10 @@ export namespace dfareporting_v3_1 {
 
 
   export class Resource$Targetableremarketinglists {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -25836,7 +26017,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TargetableRemarketingList>(
@@ -25920,7 +26101,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId', 'advertiserId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TargetableRemarketingListsListResponse>(
@@ -25997,7 +26178,10 @@ export namespace dfareporting_v3_1 {
 
 
   export class Resource$Targetingtemplates {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -26056,7 +26240,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TargetingTemplate>(parameters, callback);
@@ -26126,7 +26310,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TargetingTemplate>(parameters, callback);
@@ -26208,7 +26392,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TargetingTemplatesListResponse>(
@@ -26282,7 +26466,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TargetingTemplate>(parameters, callback);
@@ -26352,7 +26536,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TargetingTemplate>(parameters, callback);
@@ -26482,7 +26666,10 @@ export namespace dfareporting_v3_1 {
 
 
   export class Resource$Userprofiles {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -26537,7 +26724,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$UserProfile>(parameters, callback);
@@ -26602,7 +26789,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$UserProfileList>(parameters, callback);
@@ -26633,7 +26820,10 @@ export namespace dfareporting_v3_1 {
 
 
   export class Resource$Userrolepermissiongroups {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -26693,7 +26883,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$UserRolePermissionGroup>(parameters, callback);
@@ -26771,7 +26961,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$UserRolePermissionGroupsListResponse>(
@@ -26814,7 +27004,10 @@ export namespace dfareporting_v3_1 {
 
 
   export class Resource$Userrolepermissions {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -26873,7 +27066,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$UserRolePermission>(parameters, callback);
@@ -26950,7 +27143,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$UserRolePermissionsListResponse>(
@@ -26997,7 +27190,10 @@ export namespace dfareporting_v3_1 {
 
 
   export class Resource$Userroles {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -27056,7 +27252,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -27120,7 +27316,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$UserRole>(parameters, callback);
@@ -27186,7 +27382,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$UserRole>(parameters, callback);
@@ -27262,7 +27458,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$UserRolesListResponse>(parameters, callback);
@@ -27330,7 +27526,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$UserRole>(parameters, callback);
@@ -27396,7 +27592,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$UserRole>(parameters, callback);
@@ -27541,7 +27737,10 @@ export namespace dfareporting_v3_1 {
 
 
   export class Resource$Videoformats {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -27599,7 +27798,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$VideoFormat>(parameters, callback);
@@ -27667,7 +27866,7 @@ export namespace dfareporting_v3_1 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$VideoFormatsListResponse>(parameters, callback);

--- a/src/apis/dfareporting/v3.2.ts
+++ b/src/apis/dfareporting/v3.2.ts
@@ -29,8 +29,6 @@ export namespace dfareporting_v3_2 {
     version: 'v3_2';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * Data format for the response.
@@ -81,6 +79,7 @@ export namespace dfareporting_v3_2 {
    * @param {object=} options Options for Dfareporting
    */
   export class Dfareporting {
+    context: APIRequestContext;
     accountActiveAdSummaries: Resource$Accountactiveadsummaries;
     accountPermissionGroups: Resource$Accountpermissiongroups;
     accountPermissions: Resource$Accountpermissions;
@@ -144,71 +143,82 @@ export namespace dfareporting_v3_2 {
     videoFormats: Resource$Videoformats;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.accountActiveAdSummaries = new Resource$Accountactiveadsummaries();
-      this.accountPermissionGroups = new Resource$Accountpermissiongroups();
-      this.accountPermissions = new Resource$Accountpermissions();
-      this.accounts = new Resource$Accounts();
-      this.accountUserProfiles = new Resource$Accountuserprofiles();
-      this.ads = new Resource$Ads();
-      this.advertiserGroups = new Resource$Advertisergroups();
-      this.advertiserLandingPages = new Resource$Advertiserlandingpages();
-      this.advertisers = new Resource$Advertisers();
-      this.browsers = new Resource$Browsers();
+      this.accountActiveAdSummaries =
+          new Resource$Accountactiveadsummaries(this.context);
+      this.accountPermissionGroups =
+          new Resource$Accountpermissiongroups(this.context);
+      this.accountPermissions = new Resource$Accountpermissions(this.context);
+      this.accounts = new Resource$Accounts(this.context);
+      this.accountUserProfiles = new Resource$Accountuserprofiles(this.context);
+      this.ads = new Resource$Ads(this.context);
+      this.advertiserGroups = new Resource$Advertisergroups(this.context);
+      this.advertiserLandingPages =
+          new Resource$Advertiserlandingpages(this.context);
+      this.advertisers = new Resource$Advertisers(this.context);
+      this.browsers = new Resource$Browsers(this.context);
       this.campaignCreativeAssociations =
-          new Resource$Campaigncreativeassociations();
-      this.campaigns = new Resource$Campaigns();
-      this.changeLogs = new Resource$Changelogs();
-      this.cities = new Resource$Cities();
-      this.connectionTypes = new Resource$Connectiontypes();
-      this.contentCategories = new Resource$Contentcategories();
-      this.conversions = new Resource$Conversions();
-      this.countries = new Resource$Countries();
-      this.creativeAssets = new Resource$Creativeassets();
-      this.creativeFields = new Resource$Creativefields();
-      this.creativeFieldValues = new Resource$Creativefieldvalues();
-      this.creativeGroups = new Resource$Creativegroups();
-      this.creatives = new Resource$Creatives();
-      this.dimensionValues = new Resource$Dimensionvalues();
-      this.directorySiteContacts = new Resource$Directorysitecontacts();
-      this.directorySites = new Resource$Directorysites();
-      this.dynamicTargetingKeys = new Resource$Dynamictargetingkeys();
-      this.eventTags = new Resource$Eventtags();
-      this.files = new Resource$Files();
-      this.floodlightActivities = new Resource$Floodlightactivities();
-      this.floodlightActivityGroups = new Resource$Floodlightactivitygroups();
-      this.floodlightConfigurations = new Resource$Floodlightconfigurations();
-      this.inventoryItems = new Resource$Inventoryitems();
-      this.languages = new Resource$Languages();
-      this.metros = new Resource$Metros();
-      this.mobileApps = new Resource$Mobileapps();
-      this.mobileCarriers = new Resource$Mobilecarriers();
-      this.operatingSystems = new Resource$Operatingsystems();
-      this.operatingSystemVersions = new Resource$Operatingsystemversions();
-      this.orderDocuments = new Resource$Orderdocuments();
-      this.orders = new Resource$Orders();
-      this.placementGroups = new Resource$Placementgroups();
-      this.placements = new Resource$Placements();
-      this.placementStrategies = new Resource$Placementstrategies();
-      this.platformTypes = new Resource$Platformtypes();
-      this.postalCodes = new Resource$Postalcodes();
-      this.projects = new Resource$Projects();
-      this.regions = new Resource$Regions();
-      this.remarketingLists = new Resource$Remarketinglists();
-      this.remarketingListShares = new Resource$Remarketinglistshares();
-      this.reports = new Resource$Reports();
-      this.sites = new Resource$Sites();
-      this.sizes = new Resource$Sizes();
-      this.subaccounts = new Resource$Subaccounts();
+          new Resource$Campaigncreativeassociations(this.context);
+      this.campaigns = new Resource$Campaigns(this.context);
+      this.changeLogs = new Resource$Changelogs(this.context);
+      this.cities = new Resource$Cities(this.context);
+      this.connectionTypes = new Resource$Connectiontypes(this.context);
+      this.contentCategories = new Resource$Contentcategories(this.context);
+      this.conversions = new Resource$Conversions(this.context);
+      this.countries = new Resource$Countries(this.context);
+      this.creativeAssets = new Resource$Creativeassets(this.context);
+      this.creativeFields = new Resource$Creativefields(this.context);
+      this.creativeFieldValues = new Resource$Creativefieldvalues(this.context);
+      this.creativeGroups = new Resource$Creativegroups(this.context);
+      this.creatives = new Resource$Creatives(this.context);
+      this.dimensionValues = new Resource$Dimensionvalues(this.context);
+      this.directorySiteContacts =
+          new Resource$Directorysitecontacts(this.context);
+      this.directorySites = new Resource$Directorysites(this.context);
+      this.dynamicTargetingKeys =
+          new Resource$Dynamictargetingkeys(this.context);
+      this.eventTags = new Resource$Eventtags(this.context);
+      this.files = new Resource$Files(this.context);
+      this.floodlightActivities =
+          new Resource$Floodlightactivities(this.context);
+      this.floodlightActivityGroups =
+          new Resource$Floodlightactivitygroups(this.context);
+      this.floodlightConfigurations =
+          new Resource$Floodlightconfigurations(this.context);
+      this.inventoryItems = new Resource$Inventoryitems(this.context);
+      this.languages = new Resource$Languages(this.context);
+      this.metros = new Resource$Metros(this.context);
+      this.mobileApps = new Resource$Mobileapps(this.context);
+      this.mobileCarriers = new Resource$Mobilecarriers(this.context);
+      this.operatingSystems = new Resource$Operatingsystems(this.context);
+      this.operatingSystemVersions =
+          new Resource$Operatingsystemversions(this.context);
+      this.orderDocuments = new Resource$Orderdocuments(this.context);
+      this.orders = new Resource$Orders(this.context);
+      this.placementGroups = new Resource$Placementgroups(this.context);
+      this.placements = new Resource$Placements(this.context);
+      this.placementStrategies = new Resource$Placementstrategies(this.context);
+      this.platformTypes = new Resource$Platformtypes(this.context);
+      this.postalCodes = new Resource$Postalcodes(this.context);
+      this.projects = new Resource$Projects(this.context);
+      this.regions = new Resource$Regions(this.context);
+      this.remarketingLists = new Resource$Remarketinglists(this.context);
+      this.remarketingListShares =
+          new Resource$Remarketinglistshares(this.context);
+      this.reports = new Resource$Reports(this.context);
+      this.sites = new Resource$Sites(this.context);
+      this.sizes = new Resource$Sizes(this.context);
+      this.subaccounts = new Resource$Subaccounts(this.context);
       this.targetableRemarketingLists =
-          new Resource$Targetableremarketinglists();
-      this.targetingTemplates = new Resource$Targetingtemplates();
-      this.userProfiles = new Resource$Userprofiles();
-      this.userRolePermissionGroups = new Resource$Userrolepermissiongroups();
-      this.userRolePermissions = new Resource$Userrolepermissions();
-      this.userRoles = new Resource$Userroles();
-      this.videoFormats = new Resource$Videoformats();
+          new Resource$Targetableremarketinglists(this.context);
+      this.targetingTemplates = new Resource$Targetingtemplates(this.context);
+      this.userProfiles = new Resource$Userprofiles(this.context);
+      this.userRolePermissionGroups =
+          new Resource$Userrolepermissiongroups(this.context);
+      this.userRolePermissions = new Resource$Userrolepermissions(this.context);
+      this.userRoles = new Resource$Userroles(this.context);
+      this.videoFormats = new Resource$Videoformats(this.context);
     }
   }
 
@@ -7736,7 +7746,10 @@ export namespace dfareporting_v3_2 {
 
 
   export class Resource$Accountactiveadsummaries {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -7796,7 +7809,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId', 'summaryAccountId'],
         pathParams: ['profileId', 'summaryAccountId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AccountActiveAdSummary>(parameters, callback);
@@ -7825,7 +7838,10 @@ export namespace dfareporting_v3_2 {
 
 
   export class Resource$Accountpermissiongroups {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -7885,7 +7901,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AccountPermissionGroup>(parameters, callback);
@@ -7963,7 +7979,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AccountPermissionGroupsListResponse>(
@@ -8006,7 +8022,10 @@ export namespace dfareporting_v3_2 {
 
 
   export class Resource$Accountpermissions {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -8065,7 +8084,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AccountPermission>(parameters, callback);
@@ -8139,7 +8158,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AccountPermissionsListResponse>(
@@ -8182,7 +8201,10 @@ export namespace dfareporting_v3_2 {
 
 
   export class Resource$Accounts {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -8238,7 +8260,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Account>(parameters, callback);
@@ -8313,7 +8335,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AccountsListResponse>(parameters, callback);
@@ -8380,7 +8402,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Account>(parameters, callback);
@@ -8446,7 +8468,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Account>(parameters, callback);
@@ -8555,7 +8577,10 @@ export namespace dfareporting_v3_2 {
 
 
   export class Resource$Accountuserprofiles {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -8614,7 +8639,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AccountUserProfile>(parameters, callback);
@@ -8684,7 +8709,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AccountUserProfile>(parameters, callback);
@@ -8770,7 +8795,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AccountUserProfilesListResponse>(
@@ -8844,7 +8869,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AccountUserProfile>(parameters, callback);
@@ -8914,7 +8939,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AccountUserProfile>(parameters, callback);
@@ -9052,7 +9077,10 @@ export namespace dfareporting_v3_2 {
 
 
   export class Resource$Ads {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -9108,7 +9136,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Ad>(parameters, callback);
@@ -9173,7 +9201,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Ad>(parameters, callback);
@@ -9262,7 +9290,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AdsListResponse>(parameters, callback);
@@ -9328,7 +9356,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Ad>(parameters, callback);
@@ -9393,7 +9421,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Ad>(parameters, callback);
@@ -9589,7 +9617,10 @@ export namespace dfareporting_v3_2 {
 
 
   export class Resource$Advertisergroups {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -9650,7 +9681,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -9716,7 +9747,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AdvertiserGroup>(parameters, callback);
@@ -9786,7 +9817,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AdvertiserGroup>(parameters, callback);
@@ -9867,7 +9898,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AdvertiserGroupsListResponse>(
@@ -9941,7 +9972,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AdvertiserGroup>(parameters, callback);
@@ -10011,7 +10042,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AdvertiserGroup>(parameters, callback);
@@ -10153,7 +10184,10 @@ export namespace dfareporting_v3_2 {
 
 
   export class Resource$Advertiserlandingpages {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -10212,7 +10246,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$LandingPage>(parameters, callback);
@@ -10282,7 +10316,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$LandingPage>(parameters, callback);
@@ -10370,7 +10404,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AdvertiserLandingPagesListResponse>(
@@ -10444,7 +10478,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$LandingPage>(parameters, callback);
@@ -10514,7 +10548,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$LandingPage>(parameters, callback);
@@ -10657,7 +10691,10 @@ export namespace dfareporting_v3_2 {
 
 
   export class Resource$Advertisers {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -10715,7 +10752,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Advertiser>(parameters, callback);
@@ -10784,7 +10821,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Advertiser>(parameters, callback);
@@ -10864,7 +10901,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AdvertisersListResponse>(parameters, callback);
@@ -10934,7 +10971,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Advertiser>(parameters, callback);
@@ -11003,7 +11040,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Advertiser>(parameters, callback);
@@ -11152,7 +11189,10 @@ export namespace dfareporting_v3_2 {
 
 
   export class Resource$Browsers {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -11212,7 +11252,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$BrowsersListResponse>(parameters, callback);
@@ -11236,7 +11276,10 @@ export namespace dfareporting_v3_2 {
 
 
   export class Resource$Campaigncreativeassociations {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -11307,7 +11350,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId', 'campaignId'],
         pathParams: ['campaignId', 'profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$CampaignCreativeAssociation>(
@@ -11388,7 +11431,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId', 'campaignId'],
         pathParams: ['campaignId', 'profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$CampaignCreativeAssociationsListResponse>(
@@ -11452,7 +11495,10 @@ export namespace dfareporting_v3_2 {
 
 
   export class Resource$Campaigns {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -11509,7 +11555,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Campaign>(parameters, callback);
@@ -11575,7 +11621,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Campaign>(parameters, callback);
@@ -11656,7 +11702,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$CampaignsListResponse>(parameters, callback);
@@ -11723,7 +11769,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Campaign>(parameters, callback);
@@ -11789,7 +11835,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Campaign>(parameters, callback);
@@ -11940,7 +11986,10 @@ export namespace dfareporting_v3_2 {
 
 
   export class Resource$Changelogs {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -11998,7 +12047,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ChangeLog>(parameters, callback);
@@ -12075,7 +12124,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ChangeLogsListResponse>(parameters, callback);
@@ -12165,7 +12214,10 @@ export namespace dfareporting_v3_2 {
 
 
   export class Resource$Cities {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -12228,7 +12280,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$CitiesListResponse>(parameters, callback);
@@ -12268,7 +12320,10 @@ export namespace dfareporting_v3_2 {
 
 
   export class Resource$Connectiontypes {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -12327,7 +12382,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ConnectionType>(parameters, callback);
@@ -12400,7 +12455,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ConnectionTypesListResponse>(
@@ -12442,7 +12497,10 @@ export namespace dfareporting_v3_2 {
 
 
   export class Resource$Contentcategories {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -12503,7 +12561,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -12569,7 +12627,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ContentCategory>(parameters, callback);
@@ -12639,7 +12697,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ContentCategory>(parameters, callback);
@@ -12720,7 +12778,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ContentCategoriesListResponse>(
@@ -12794,7 +12852,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ContentCategory>(parameters, callback);
@@ -12864,7 +12922,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ContentCategory>(parameters, callback);
@@ -13006,7 +13064,10 @@ export namespace dfareporting_v3_2 {
 
 
   export class Resource$Conversions {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -13075,7 +13136,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ConversionsBatchInsertResponse>(
@@ -13153,7 +13214,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ConversionsBatchUpdateResponse>(
@@ -13202,7 +13263,10 @@ export namespace dfareporting_v3_2 {
 
 
   export class Resource$Countries {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -13259,7 +13323,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId', 'dartId'],
         pathParams: ['dartId', 'profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Country>(parameters, callback);
@@ -13326,7 +13390,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$CountriesListResponse>(parameters, callback);
@@ -13365,7 +13429,10 @@ export namespace dfareporting_v3_2 {
 
 
   export class Resource$Creativeassets {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -13437,7 +13504,7 @@ export namespace dfareporting_v3_2 {
                 .replace(/([^:]\/)\/+/g, '$1'),
         requiredParams: ['profileId', 'advertiserId'],
         pathParams: ['advertiserId', 'profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$CreativeAssetMetadata>(parameters, callback);
@@ -13486,7 +13553,10 @@ export namespace dfareporting_v3_2 {
 
 
   export class Resource$Creativefields {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -13547,7 +13617,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -13613,7 +13683,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$CreativeField>(parameters, callback);
@@ -13683,7 +13753,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$CreativeField>(parameters, callback);
@@ -13763,7 +13833,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$CreativeFieldsListResponse>(
@@ -13836,7 +13906,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$CreativeField>(parameters, callback);
@@ -13906,7 +13976,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$CreativeField>(parameters, callback);
@@ -14052,7 +14122,10 @@ export namespace dfareporting_v3_2 {
 
 
   export class Resource$Creativefieldvalues {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -14114,7 +14187,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId', 'creativeFieldId', 'id'],
         pathParams: ['creativeFieldId', 'id', 'profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -14181,7 +14254,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId', 'creativeFieldId', 'id'],
         pathParams: ['creativeFieldId', 'id', 'profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$CreativeFieldValue>(parameters, callback);
@@ -14252,7 +14325,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId', 'creativeFieldId'],
         pathParams: ['creativeFieldId', 'profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$CreativeFieldValue>(parameters, callback);
@@ -14336,7 +14409,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId', 'creativeFieldId'],
         pathParams: ['creativeFieldId', 'profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$CreativeFieldValuesListResponse>(
@@ -14411,7 +14484,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId', 'creativeFieldId', 'id'],
         pathParams: ['creativeFieldId', 'profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$CreativeFieldValue>(parameters, callback);
@@ -14482,7 +14555,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId', 'creativeFieldId'],
         pathParams: ['creativeFieldId', 'profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$CreativeFieldValue>(parameters, callback);
@@ -14643,7 +14716,10 @@ export namespace dfareporting_v3_2 {
 
 
   export class Resource$Creativegroups {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -14702,7 +14778,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$CreativeGroup>(parameters, callback);
@@ -14772,7 +14848,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$CreativeGroup>(parameters, callback);
@@ -14853,7 +14929,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$CreativeGroupsListResponse>(
@@ -14926,7 +15002,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$CreativeGroup>(parameters, callback);
@@ -14996,7 +15072,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$CreativeGroup>(parameters, callback);
@@ -15130,7 +15206,10 @@ export namespace dfareporting_v3_2 {
 
 
   export class Resource$Creatives {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -15187,7 +15266,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Creative>(parameters, callback);
@@ -15253,7 +15332,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Creative>(parameters, callback);
@@ -15337,7 +15416,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$CreativesListResponse>(parameters, callback);
@@ -15404,7 +15483,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Creative>(parameters, callback);
@@ -15470,7 +15549,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Creative>(parameters, callback);
@@ -15633,7 +15712,10 @@ export namespace dfareporting_v3_2 {
 
 
   export class Resource$Dimensionvalues {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -15698,7 +15780,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$DimensionValueList>(parameters, callback);
@@ -15736,7 +15818,10 @@ export namespace dfareporting_v3_2 {
 
 
   export class Resource$Directorysitecontacts {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -15796,7 +15881,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$DirectorySiteContact>(parameters, callback);
@@ -15882,7 +15967,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$DirectorySiteContactsListResponse>(
@@ -15961,7 +16046,10 @@ export namespace dfareporting_v3_2 {
 
 
   export class Resource$Directorysites {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -16020,7 +16108,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$DirectorySite>(parameters, callback);
@@ -16090,7 +16178,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$DirectorySite>(parameters, callback);
@@ -16176,7 +16264,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$DirectorySitesListResponse>(
@@ -16297,7 +16385,10 @@ export namespace dfareporting_v3_2 {
 
 
   export class Resource$Dynamictargetingkeys {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -16360,7 +16451,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId', 'objectId', 'name', 'objectType'],
         pathParams: ['objectId', 'profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -16434,7 +16525,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$DynamicTargetingKey>(parameters, callback);
@@ -16516,7 +16607,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$DynamicTargetingKeysListResponse>(
@@ -16603,7 +16694,10 @@ export namespace dfareporting_v3_2 {
 
 
   export class Resource$Eventtags {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -16662,7 +16756,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -16726,7 +16820,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$EventTag>(parameters, callback);
@@ -16792,7 +16886,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$EventTag>(parameters, callback);
@@ -16869,7 +16963,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$EventTagsListResponse>(parameters, callback);
@@ -16937,7 +17031,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$EventTag>(parameters, callback);
@@ -17003,7 +17097,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$EventTag>(parameters, callback);
@@ -17169,7 +17263,10 @@ export namespace dfareporting_v3_2 {
 
 
   export class Resource$Files {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -17226,7 +17323,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['reportId', 'fileId'],
         pathParams: ['fileId', 'reportId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$File>(parameters, callback);
@@ -17296,7 +17393,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$FileList>(parameters, callback);
@@ -17355,7 +17452,10 @@ export namespace dfareporting_v3_2 {
 
 
   export class Resource$Floodlightactivities {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -17416,7 +17516,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -17492,7 +17592,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$FloodlightActivitiesGenerateTagResponse>(
@@ -17560,7 +17660,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$FloodlightActivity>(parameters, callback);
@@ -17630,7 +17730,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$FloodlightActivity>(parameters, callback);
@@ -17722,7 +17822,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$FloodlightActivitiesListResponse>(
@@ -17796,7 +17896,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$FloodlightActivity>(parameters, callback);
@@ -17866,7 +17966,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$FloodlightActivity>(parameters, callback);
@@ -18063,7 +18163,10 @@ export namespace dfareporting_v3_2 {
 
 
   export class Resource$Floodlightactivitygroups {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -18123,7 +18226,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$FloodlightActivityGroup>(parameters, callback);
@@ -18195,7 +18298,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$FloodlightActivityGroup>(parameters, callback);
@@ -18283,7 +18386,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$FloodlightActivityGroupsListResponse>(
@@ -18358,7 +18461,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$FloodlightActivityGroup>(parameters, callback);
@@ -18430,7 +18533,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$FloodlightActivityGroup>(parameters, callback);
@@ -18576,7 +18679,10 @@ export namespace dfareporting_v3_2 {
 
 
   export class Resource$Floodlightconfigurations {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -18636,7 +18742,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$FloodlightConfiguration>(parameters, callback);
@@ -18715,7 +18821,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$FloodlightConfigurationsListResponse>(
@@ -18790,7 +18896,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$FloodlightConfiguration>(parameters, callback);
@@ -18862,7 +18968,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$FloodlightConfiguration>(parameters, callback);
@@ -18946,7 +19052,10 @@ export namespace dfareporting_v3_2 {
 
 
   export class Resource$Inventoryitems {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -19006,7 +19115,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId', 'projectId', 'id'],
         pathParams: ['id', 'profileId', 'projectId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$InventoryItem>(parameters, callback);
@@ -19089,7 +19198,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId', 'projectId'],
         pathParams: ['profileId', 'projectId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$InventoryItemsListResponse>(
@@ -19175,7 +19284,10 @@ export namespace dfareporting_v3_2 {
 
 
   export class Resource$Languages {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -19235,7 +19347,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$LanguagesListResponse>(parameters, callback);
@@ -19259,7 +19371,10 @@ export namespace dfareporting_v3_2 {
 
 
   export class Resource$Metros {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -19318,7 +19433,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$MetrosListResponse>(parameters, callback);
@@ -19342,7 +19457,10 @@ export namespace dfareporting_v3_2 {
 
 
   export class Resource$Mobileapps {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -19400,7 +19518,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$MobileApp>(parameters, callback);
@@ -19472,7 +19590,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$MobileAppsListResponse>(parameters, callback);
@@ -19536,7 +19654,10 @@ export namespace dfareporting_v3_2 {
 
 
   export class Resource$Mobilecarriers {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -19595,7 +19716,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$MobileCarrier>(parameters, callback);
@@ -19667,7 +19788,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$MobileCarriersListResponse>(
@@ -19709,7 +19830,10 @@ export namespace dfareporting_v3_2 {
 
 
   export class Resource$Operatingsystems {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -19768,7 +19892,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId', 'dartId'],
         pathParams: ['dartId', 'profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$OperatingSystem>(parameters, callback);
@@ -19842,7 +19966,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$OperatingSystemsListResponse>(
@@ -19885,7 +20009,10 @@ export namespace dfareporting_v3_2 {
 
 
   export class Resource$Operatingsystemversions {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -19945,7 +20072,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$OperatingSystemVersion>(parameters, callback);
@@ -20023,7 +20150,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$OperatingSystemVersionsListResponse>(
@@ -20066,7 +20193,10 @@ export namespace dfareporting_v3_2 {
 
 
   export class Resource$Orderdocuments {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -20126,7 +20256,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId', 'projectId', 'id'],
         pathParams: ['id', 'profileId', 'projectId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$OrderDocument>(parameters, callback);
@@ -20209,7 +20339,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId', 'projectId'],
         pathParams: ['profileId', 'projectId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$OrderDocumentsListResponse>(
@@ -20301,7 +20431,10 @@ export namespace dfareporting_v3_2 {
 
 
   export class Resource$Orders {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -20359,7 +20492,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId', 'projectId', 'id'],
         pathParams: ['id', 'profileId', 'projectId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Order>(parameters, callback);
@@ -20435,7 +20568,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId', 'projectId'],
         pathParams: ['profileId', 'projectId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$OrdersListResponse>(parameters, callback);
@@ -20515,7 +20648,10 @@ export namespace dfareporting_v3_2 {
 
 
   export class Resource$Placementgroups {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -20574,7 +20710,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$PlacementGroup>(parameters, callback);
@@ -20644,7 +20780,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$PlacementGroup>(parameters, callback);
@@ -20737,7 +20873,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$PlacementGroupsListResponse>(
@@ -20810,7 +20946,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$PlacementGroup>(parameters, callback);
@@ -20880,7 +21016,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$PlacementGroup>(parameters, callback);
@@ -21073,7 +21209,10 @@ export namespace dfareporting_v3_2 {
 
 
   export class Resource$Placements {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -21144,7 +21283,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$PlacementsGenerateTagsResponse>(
@@ -21211,7 +21350,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Placement>(parameters, callback);
@@ -21279,7 +21418,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Placement>(parameters, callback);
@@ -21369,7 +21508,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$PlacementsListResponse>(parameters, callback);
@@ -21438,7 +21577,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Placement>(parameters, callback);
@@ -21506,7 +21645,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Placement>(parameters, callback);
@@ -21730,7 +21869,10 @@ export namespace dfareporting_v3_2 {
 
 
   export class Resource$Placementstrategies {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -21791,7 +21933,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -21857,7 +21999,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$PlacementStrategy>(parameters, callback);
@@ -21927,7 +22069,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$PlacementStrategy>(parameters, callback);
@@ -22010,7 +22152,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$PlacementStrategiesListResponse>(
@@ -22084,7 +22226,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$PlacementStrategy>(parameters, callback);
@@ -22154,7 +22296,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$PlacementStrategy>(parameters, callback);
@@ -22297,7 +22439,10 @@ export namespace dfareporting_v3_2 {
 
 
   export class Resource$Platformtypes {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -22356,7 +22501,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$PlatformType>(parameters, callback);
@@ -22425,7 +22570,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$PlatformTypesListResponse>(
@@ -22467,7 +22612,10 @@ export namespace dfareporting_v3_2 {
 
 
   export class Resource$Postalcodes {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -22525,7 +22673,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId', 'code'],
         pathParams: ['code', 'profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$PostalCode>(parameters, callback);
@@ -22592,7 +22740,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$PostalCodesListResponse>(parameters, callback);
@@ -22631,7 +22779,10 @@ export namespace dfareporting_v3_2 {
 
 
   export class Resource$Projects {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -22687,7 +22838,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Project>(parameters, callback);
@@ -22762,7 +22913,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ProjectsListResponse>(parameters, callback);
@@ -22834,7 +22985,10 @@ export namespace dfareporting_v3_2 {
 
 
   export class Resource$Regions {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -22893,7 +23047,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$RegionsListResponse>(parameters, callback);
@@ -22917,7 +23071,10 @@ export namespace dfareporting_v3_2 {
 
 
   export class Resource$Remarketinglists {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -22976,7 +23133,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$RemarketingList>(parameters, callback);
@@ -23046,7 +23203,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$RemarketingList>(parameters, callback);
@@ -23129,7 +23286,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId', 'advertiserId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$RemarketingListsListResponse>(
@@ -23203,7 +23360,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$RemarketingList>(parameters, callback);
@@ -23273,7 +23430,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$RemarketingList>(parameters, callback);
@@ -23407,7 +23564,10 @@ export namespace dfareporting_v3_2 {
 
 
   export class Resource$Remarketinglistshares {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -23467,7 +23627,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId', 'remarketingListId'],
         pathParams: ['profileId', 'remarketingListId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$RemarketingListShare>(parameters, callback);
@@ -23540,7 +23700,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId', 'remarketingListId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$RemarketingListShare>(parameters, callback);
@@ -23611,7 +23771,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$RemarketingListShare>(parameters, callback);
@@ -23678,11 +23838,14 @@ export namespace dfareporting_v3_2 {
 
 
   export class Resource$Reports {
+    context: APIRequestContext;
     compatibleFields: Resource$Reports$Compatiblefields;
     files: Resource$Reports$Files;
-    constructor() {
-      this.compatibleFields = new Resource$Reports$Compatiblefields();
-      this.files = new Resource$Reports$Files();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.compatibleFields =
+          new Resource$Reports$Compatiblefields(this.context);
+      this.files = new Resource$Reports$Files(this.context);
     }
 
 
@@ -23742,7 +23905,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId', 'reportId'],
         pathParams: ['profileId', 'reportId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -23806,7 +23969,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId', 'reportId'],
         pathParams: ['profileId', 'reportId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Report>(parameters, callback);
@@ -23872,7 +24035,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Report>(parameters, callback);
@@ -23943,7 +24106,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ReportList>(parameters, callback);
@@ -24011,7 +24174,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId', 'reportId'],
         pathParams: ['profileId', 'reportId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Report>(parameters, callback);
@@ -24076,7 +24239,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId', 'reportId'],
         pathParams: ['profileId', 'reportId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$File>(parameters, callback);
@@ -24144,7 +24307,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId', 'reportId'],
         pathParams: ['profileId', 'reportId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Report>(parameters, callback);
@@ -24292,7 +24455,10 @@ export namespace dfareporting_v3_2 {
   }
 
   export class Resource$Reports$Compatiblefields {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -24357,7 +24523,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$CompatibleFields>(parameters, callback);
@@ -24387,7 +24553,10 @@ export namespace dfareporting_v3_2 {
 
 
   export class Resource$Reports$Files {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -24446,7 +24615,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId', 'reportId', 'fileId'],
         pathParams: ['fileId', 'profileId', 'reportId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$File>(parameters, callback);
@@ -24518,7 +24687,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId', 'reportId'],
         pathParams: ['profileId', 'reportId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$FileList>(parameters, callback);
@@ -24584,7 +24753,10 @@ export namespace dfareporting_v3_2 {
 
 
   export class Resource$Sites {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -24640,7 +24812,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Site>(parameters, callback);
@@ -24706,7 +24878,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Site>(parameters, callback);
@@ -24788,7 +24960,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$SitesListResponse>(parameters, callback);
@@ -24855,7 +25027,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Site>(parameters, callback);
@@ -24921,7 +25093,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Site>(parameters, callback);
@@ -25079,7 +25251,10 @@ export namespace dfareporting_v3_2 {
 
 
   export class Resource$Sizes {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -25135,7 +25310,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Size>(parameters, callback);
@@ -25201,7 +25376,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Size>(parameters, callback);
@@ -25274,7 +25449,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$SizesListResponse>(parameters, callback);
@@ -25345,7 +25520,10 @@ export namespace dfareporting_v3_2 {
 
 
   export class Resource$Subaccounts {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -25403,7 +25581,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Subaccount>(parameters, callback);
@@ -25472,7 +25650,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Subaccount>(parameters, callback);
@@ -25546,7 +25724,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$SubaccountsListResponse>(parameters, callback);
@@ -25616,7 +25794,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Subaccount>(parameters, callback);
@@ -25685,7 +25863,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Subaccount>(parameters, callback);
@@ -25809,7 +25987,10 @@ export namespace dfareporting_v3_2 {
 
 
   export class Resource$Targetableremarketinglists {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -25870,7 +26051,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TargetableRemarketingList>(
@@ -25954,7 +26135,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId', 'advertiserId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TargetableRemarketingListsListResponse>(
@@ -26031,7 +26212,10 @@ export namespace dfareporting_v3_2 {
 
 
   export class Resource$Targetingtemplates {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -26090,7 +26274,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TargetingTemplate>(parameters, callback);
@@ -26160,7 +26344,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TargetingTemplate>(parameters, callback);
@@ -26242,7 +26426,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TargetingTemplatesListResponse>(
@@ -26316,7 +26500,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TargetingTemplate>(parameters, callback);
@@ -26386,7 +26570,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TargetingTemplate>(parameters, callback);
@@ -26516,7 +26700,10 @@ export namespace dfareporting_v3_2 {
 
 
   export class Resource$Userprofiles {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -26571,7 +26758,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$UserProfile>(parameters, callback);
@@ -26636,7 +26823,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$UserProfileList>(parameters, callback);
@@ -26667,7 +26854,10 @@ export namespace dfareporting_v3_2 {
 
 
   export class Resource$Userrolepermissiongroups {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -26727,7 +26917,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$UserRolePermissionGroup>(parameters, callback);
@@ -26805,7 +26995,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$UserRolePermissionGroupsListResponse>(
@@ -26848,7 +27038,10 @@ export namespace dfareporting_v3_2 {
 
 
   export class Resource$Userrolepermissions {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -26907,7 +27100,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$UserRolePermission>(parameters, callback);
@@ -26984,7 +27177,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$UserRolePermissionsListResponse>(
@@ -27031,7 +27224,10 @@ export namespace dfareporting_v3_2 {
 
 
   export class Resource$Userroles {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -27090,7 +27286,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -27154,7 +27350,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$UserRole>(parameters, callback);
@@ -27220,7 +27416,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$UserRole>(parameters, callback);
@@ -27296,7 +27492,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$UserRolesListResponse>(parameters, callback);
@@ -27364,7 +27560,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$UserRole>(parameters, callback);
@@ -27430,7 +27626,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$UserRole>(parameters, callback);
@@ -27575,7 +27771,10 @@ export namespace dfareporting_v3_2 {
 
 
   export class Resource$Videoformats {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -27633,7 +27832,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$VideoFormat>(parameters, callback);
@@ -27701,7 +27900,7 @@ export namespace dfareporting_v3_2 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$VideoFormatsListResponse>(parameters, callback);

--- a/src/apis/dfareporting/v3.3.ts
+++ b/src/apis/dfareporting/v3.3.ts
@@ -29,8 +29,6 @@ export namespace dfareporting_v3_3 {
     version: 'v3_3';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * Data format for the response.
@@ -81,6 +79,7 @@ export namespace dfareporting_v3_3 {
    * @param {object=} options Options for Dfareporting
    */
   export class Dfareporting {
+    context: APIRequestContext;
     accountActiveAdSummaries: Resource$Accountactiveadsummaries;
     accountPermissionGroups: Resource$Accountpermissiongroups;
     accountPermissions: Resource$Accountpermissions;
@@ -143,70 +142,80 @@ export namespace dfareporting_v3_3 {
     videoFormats: Resource$Videoformats;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.accountActiveAdSummaries = new Resource$Accountactiveadsummaries();
-      this.accountPermissionGroups = new Resource$Accountpermissiongroups();
-      this.accountPermissions = new Resource$Accountpermissions();
-      this.accounts = new Resource$Accounts();
-      this.accountUserProfiles = new Resource$Accountuserprofiles();
-      this.ads = new Resource$Ads();
-      this.advertiserGroups = new Resource$Advertisergroups();
-      this.advertiserLandingPages = new Resource$Advertiserlandingpages();
-      this.advertisers = new Resource$Advertisers();
-      this.browsers = new Resource$Browsers();
+      this.accountActiveAdSummaries =
+          new Resource$Accountactiveadsummaries(this.context);
+      this.accountPermissionGroups =
+          new Resource$Accountpermissiongroups(this.context);
+      this.accountPermissions = new Resource$Accountpermissions(this.context);
+      this.accounts = new Resource$Accounts(this.context);
+      this.accountUserProfiles = new Resource$Accountuserprofiles(this.context);
+      this.ads = new Resource$Ads(this.context);
+      this.advertiserGroups = new Resource$Advertisergroups(this.context);
+      this.advertiserLandingPages =
+          new Resource$Advertiserlandingpages(this.context);
+      this.advertisers = new Resource$Advertisers(this.context);
+      this.browsers = new Resource$Browsers(this.context);
       this.campaignCreativeAssociations =
-          new Resource$Campaigncreativeassociations();
-      this.campaigns = new Resource$Campaigns();
-      this.changeLogs = new Resource$Changelogs();
-      this.cities = new Resource$Cities();
-      this.connectionTypes = new Resource$Connectiontypes();
-      this.contentCategories = new Resource$Contentcategories();
-      this.conversions = new Resource$Conversions();
-      this.countries = new Resource$Countries();
-      this.creativeAssets = new Resource$Creativeassets();
-      this.creativeFields = new Resource$Creativefields();
-      this.creativeFieldValues = new Resource$Creativefieldvalues();
-      this.creativeGroups = new Resource$Creativegroups();
-      this.creatives = new Resource$Creatives();
-      this.dimensionValues = new Resource$Dimensionvalues();
-      this.directorySites = new Resource$Directorysites();
-      this.dynamicTargetingKeys = new Resource$Dynamictargetingkeys();
-      this.eventTags = new Resource$Eventtags();
-      this.files = new Resource$Files();
-      this.floodlightActivities = new Resource$Floodlightactivities();
-      this.floodlightActivityGroups = new Resource$Floodlightactivitygroups();
-      this.floodlightConfigurations = new Resource$Floodlightconfigurations();
-      this.inventoryItems = new Resource$Inventoryitems();
-      this.languages = new Resource$Languages();
-      this.metros = new Resource$Metros();
-      this.mobileApps = new Resource$Mobileapps();
-      this.mobileCarriers = new Resource$Mobilecarriers();
-      this.operatingSystems = new Resource$Operatingsystems();
-      this.operatingSystemVersions = new Resource$Operatingsystemversions();
-      this.orderDocuments = new Resource$Orderdocuments();
-      this.orders = new Resource$Orders();
-      this.placementGroups = new Resource$Placementgroups();
-      this.placements = new Resource$Placements();
-      this.placementStrategies = new Resource$Placementstrategies();
-      this.platformTypes = new Resource$Platformtypes();
-      this.postalCodes = new Resource$Postalcodes();
-      this.projects = new Resource$Projects();
-      this.regions = new Resource$Regions();
-      this.remarketingLists = new Resource$Remarketinglists();
-      this.remarketingListShares = new Resource$Remarketinglistshares();
-      this.reports = new Resource$Reports();
-      this.sites = new Resource$Sites();
-      this.sizes = new Resource$Sizes();
-      this.subaccounts = new Resource$Subaccounts();
+          new Resource$Campaigncreativeassociations(this.context);
+      this.campaigns = new Resource$Campaigns(this.context);
+      this.changeLogs = new Resource$Changelogs(this.context);
+      this.cities = new Resource$Cities(this.context);
+      this.connectionTypes = new Resource$Connectiontypes(this.context);
+      this.contentCategories = new Resource$Contentcategories(this.context);
+      this.conversions = new Resource$Conversions(this.context);
+      this.countries = new Resource$Countries(this.context);
+      this.creativeAssets = new Resource$Creativeassets(this.context);
+      this.creativeFields = new Resource$Creativefields(this.context);
+      this.creativeFieldValues = new Resource$Creativefieldvalues(this.context);
+      this.creativeGroups = new Resource$Creativegroups(this.context);
+      this.creatives = new Resource$Creatives(this.context);
+      this.dimensionValues = new Resource$Dimensionvalues(this.context);
+      this.directorySites = new Resource$Directorysites(this.context);
+      this.dynamicTargetingKeys =
+          new Resource$Dynamictargetingkeys(this.context);
+      this.eventTags = new Resource$Eventtags(this.context);
+      this.files = new Resource$Files(this.context);
+      this.floodlightActivities =
+          new Resource$Floodlightactivities(this.context);
+      this.floodlightActivityGroups =
+          new Resource$Floodlightactivitygroups(this.context);
+      this.floodlightConfigurations =
+          new Resource$Floodlightconfigurations(this.context);
+      this.inventoryItems = new Resource$Inventoryitems(this.context);
+      this.languages = new Resource$Languages(this.context);
+      this.metros = new Resource$Metros(this.context);
+      this.mobileApps = new Resource$Mobileapps(this.context);
+      this.mobileCarriers = new Resource$Mobilecarriers(this.context);
+      this.operatingSystems = new Resource$Operatingsystems(this.context);
+      this.operatingSystemVersions =
+          new Resource$Operatingsystemversions(this.context);
+      this.orderDocuments = new Resource$Orderdocuments(this.context);
+      this.orders = new Resource$Orders(this.context);
+      this.placementGroups = new Resource$Placementgroups(this.context);
+      this.placements = new Resource$Placements(this.context);
+      this.placementStrategies = new Resource$Placementstrategies(this.context);
+      this.platformTypes = new Resource$Platformtypes(this.context);
+      this.postalCodes = new Resource$Postalcodes(this.context);
+      this.projects = new Resource$Projects(this.context);
+      this.regions = new Resource$Regions(this.context);
+      this.remarketingLists = new Resource$Remarketinglists(this.context);
+      this.remarketingListShares =
+          new Resource$Remarketinglistshares(this.context);
+      this.reports = new Resource$Reports(this.context);
+      this.sites = new Resource$Sites(this.context);
+      this.sizes = new Resource$Sizes(this.context);
+      this.subaccounts = new Resource$Subaccounts(this.context);
       this.targetableRemarketingLists =
-          new Resource$Targetableremarketinglists();
-      this.targetingTemplates = new Resource$Targetingtemplates();
-      this.userProfiles = new Resource$Userprofiles();
-      this.userRolePermissionGroups = new Resource$Userrolepermissiongroups();
-      this.userRolePermissions = new Resource$Userrolepermissions();
-      this.userRoles = new Resource$Userroles();
-      this.videoFormats = new Resource$Videoformats();
+          new Resource$Targetableremarketinglists(this.context);
+      this.targetingTemplates = new Resource$Targetingtemplates(this.context);
+      this.userProfiles = new Resource$Userprofiles(this.context);
+      this.userRolePermissionGroups =
+          new Resource$Userrolepermissiongroups(this.context);
+      this.userRolePermissions = new Resource$Userrolepermissions(this.context);
+      this.userRoles = new Resource$Userroles(this.context);
+      this.videoFormats = new Resource$Videoformats(this.context);
     }
   }
 
@@ -7737,7 +7746,10 @@ export namespace dfareporting_v3_3 {
 
 
   export class Resource$Accountactiveadsummaries {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -7797,7 +7809,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId', 'summaryAccountId'],
         pathParams: ['profileId', 'summaryAccountId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AccountActiveAdSummary>(parameters, callback);
@@ -7826,7 +7838,10 @@ export namespace dfareporting_v3_3 {
 
 
   export class Resource$Accountpermissiongroups {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -7886,7 +7901,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AccountPermissionGroup>(parameters, callback);
@@ -7964,7 +7979,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AccountPermissionGroupsListResponse>(
@@ -8007,7 +8022,10 @@ export namespace dfareporting_v3_3 {
 
 
   export class Resource$Accountpermissions {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -8066,7 +8084,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AccountPermission>(parameters, callback);
@@ -8140,7 +8158,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AccountPermissionsListResponse>(
@@ -8183,7 +8201,10 @@ export namespace dfareporting_v3_3 {
 
 
   export class Resource$Accounts {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -8239,7 +8260,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Account>(parameters, callback);
@@ -8314,7 +8335,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AccountsListResponse>(parameters, callback);
@@ -8381,7 +8402,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Account>(parameters, callback);
@@ -8447,7 +8468,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Account>(parameters, callback);
@@ -8556,7 +8577,10 @@ export namespace dfareporting_v3_3 {
 
 
   export class Resource$Accountuserprofiles {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -8615,7 +8639,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AccountUserProfile>(parameters, callback);
@@ -8685,7 +8709,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AccountUserProfile>(parameters, callback);
@@ -8771,7 +8795,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AccountUserProfilesListResponse>(
@@ -8845,7 +8869,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AccountUserProfile>(parameters, callback);
@@ -8915,7 +8939,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AccountUserProfile>(parameters, callback);
@@ -9053,7 +9077,10 @@ export namespace dfareporting_v3_3 {
 
 
   export class Resource$Ads {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -9109,7 +9136,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Ad>(parameters, callback);
@@ -9174,7 +9201,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Ad>(parameters, callback);
@@ -9263,7 +9290,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AdsListResponse>(parameters, callback);
@@ -9329,7 +9356,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Ad>(parameters, callback);
@@ -9394,7 +9421,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Ad>(parameters, callback);
@@ -9590,7 +9617,10 @@ export namespace dfareporting_v3_3 {
 
 
   export class Resource$Advertisergroups {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -9651,7 +9681,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -9717,7 +9747,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AdvertiserGroup>(parameters, callback);
@@ -9787,7 +9817,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AdvertiserGroup>(parameters, callback);
@@ -9868,7 +9898,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AdvertiserGroupsListResponse>(
@@ -9942,7 +9972,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AdvertiserGroup>(parameters, callback);
@@ -10012,7 +10042,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AdvertiserGroup>(parameters, callback);
@@ -10154,7 +10184,10 @@ export namespace dfareporting_v3_3 {
 
 
   export class Resource$Advertiserlandingpages {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -10213,7 +10246,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$LandingPage>(parameters, callback);
@@ -10283,7 +10316,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$LandingPage>(parameters, callback);
@@ -10371,7 +10404,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AdvertiserLandingPagesListResponse>(
@@ -10445,7 +10478,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$LandingPage>(parameters, callback);
@@ -10515,7 +10548,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$LandingPage>(parameters, callback);
@@ -10658,7 +10691,10 @@ export namespace dfareporting_v3_3 {
 
 
   export class Resource$Advertisers {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -10716,7 +10752,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Advertiser>(parameters, callback);
@@ -10785,7 +10821,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Advertiser>(parameters, callback);
@@ -10865,7 +10901,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AdvertisersListResponse>(parameters, callback);
@@ -10935,7 +10971,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Advertiser>(parameters, callback);
@@ -11004,7 +11040,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Advertiser>(parameters, callback);
@@ -11153,7 +11189,10 @@ export namespace dfareporting_v3_3 {
 
 
   export class Resource$Browsers {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -11213,7 +11252,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$BrowsersListResponse>(parameters, callback);
@@ -11237,7 +11276,10 @@ export namespace dfareporting_v3_3 {
 
 
   export class Resource$Campaigncreativeassociations {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -11308,7 +11350,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId', 'campaignId'],
         pathParams: ['campaignId', 'profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$CampaignCreativeAssociation>(
@@ -11389,7 +11431,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId', 'campaignId'],
         pathParams: ['campaignId', 'profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$CampaignCreativeAssociationsListResponse>(
@@ -11453,7 +11495,10 @@ export namespace dfareporting_v3_3 {
 
 
   export class Resource$Campaigns {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -11510,7 +11555,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Campaign>(parameters, callback);
@@ -11576,7 +11621,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Campaign>(parameters, callback);
@@ -11657,7 +11702,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$CampaignsListResponse>(parameters, callback);
@@ -11724,7 +11769,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Campaign>(parameters, callback);
@@ -11790,7 +11835,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Campaign>(parameters, callback);
@@ -11941,7 +11986,10 @@ export namespace dfareporting_v3_3 {
 
 
   export class Resource$Changelogs {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -11999,7 +12047,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ChangeLog>(parameters, callback);
@@ -12076,7 +12124,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ChangeLogsListResponse>(parameters, callback);
@@ -12166,7 +12214,10 @@ export namespace dfareporting_v3_3 {
 
 
   export class Resource$Cities {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -12229,7 +12280,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$CitiesListResponse>(parameters, callback);
@@ -12269,7 +12320,10 @@ export namespace dfareporting_v3_3 {
 
 
   export class Resource$Connectiontypes {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -12328,7 +12382,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ConnectionType>(parameters, callback);
@@ -12401,7 +12455,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ConnectionTypesListResponse>(
@@ -12443,7 +12497,10 @@ export namespace dfareporting_v3_3 {
 
 
   export class Resource$Contentcategories {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -12504,7 +12561,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -12570,7 +12627,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ContentCategory>(parameters, callback);
@@ -12640,7 +12697,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ContentCategory>(parameters, callback);
@@ -12721,7 +12778,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ContentCategoriesListResponse>(
@@ -12795,7 +12852,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ContentCategory>(parameters, callback);
@@ -12865,7 +12922,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ContentCategory>(parameters, callback);
@@ -13007,7 +13064,10 @@ export namespace dfareporting_v3_3 {
 
 
   export class Resource$Conversions {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -13076,7 +13136,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ConversionsBatchInsertResponse>(
@@ -13154,7 +13214,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ConversionsBatchUpdateResponse>(
@@ -13203,7 +13263,10 @@ export namespace dfareporting_v3_3 {
 
 
   export class Resource$Countries {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -13260,7 +13323,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId', 'dartId'],
         pathParams: ['dartId', 'profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Country>(parameters, callback);
@@ -13327,7 +13390,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$CountriesListResponse>(parameters, callback);
@@ -13366,7 +13429,10 @@ export namespace dfareporting_v3_3 {
 
 
   export class Resource$Creativeassets {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -13438,7 +13504,7 @@ export namespace dfareporting_v3_3 {
                 .replace(/([^:]\/)\/+/g, '$1'),
         requiredParams: ['profileId', 'advertiserId'],
         pathParams: ['advertiserId', 'profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$CreativeAssetMetadata>(parameters, callback);
@@ -13487,7 +13553,10 @@ export namespace dfareporting_v3_3 {
 
 
   export class Resource$Creativefields {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -13548,7 +13617,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -13614,7 +13683,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$CreativeField>(parameters, callback);
@@ -13684,7 +13753,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$CreativeField>(parameters, callback);
@@ -13764,7 +13833,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$CreativeFieldsListResponse>(
@@ -13837,7 +13906,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$CreativeField>(parameters, callback);
@@ -13907,7 +13976,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$CreativeField>(parameters, callback);
@@ -14053,7 +14122,10 @@ export namespace dfareporting_v3_3 {
 
 
   export class Resource$Creativefieldvalues {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -14115,7 +14187,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId', 'creativeFieldId', 'id'],
         pathParams: ['creativeFieldId', 'id', 'profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -14182,7 +14254,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId', 'creativeFieldId', 'id'],
         pathParams: ['creativeFieldId', 'id', 'profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$CreativeFieldValue>(parameters, callback);
@@ -14253,7 +14325,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId', 'creativeFieldId'],
         pathParams: ['creativeFieldId', 'profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$CreativeFieldValue>(parameters, callback);
@@ -14337,7 +14409,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId', 'creativeFieldId'],
         pathParams: ['creativeFieldId', 'profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$CreativeFieldValuesListResponse>(
@@ -14412,7 +14484,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId', 'creativeFieldId', 'id'],
         pathParams: ['creativeFieldId', 'profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$CreativeFieldValue>(parameters, callback);
@@ -14483,7 +14555,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId', 'creativeFieldId'],
         pathParams: ['creativeFieldId', 'profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$CreativeFieldValue>(parameters, callback);
@@ -14644,7 +14716,10 @@ export namespace dfareporting_v3_3 {
 
 
   export class Resource$Creativegroups {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -14703,7 +14778,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$CreativeGroup>(parameters, callback);
@@ -14773,7 +14848,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$CreativeGroup>(parameters, callback);
@@ -14854,7 +14929,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$CreativeGroupsListResponse>(
@@ -14927,7 +15002,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$CreativeGroup>(parameters, callback);
@@ -14997,7 +15072,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$CreativeGroup>(parameters, callback);
@@ -15131,7 +15206,10 @@ export namespace dfareporting_v3_3 {
 
 
   export class Resource$Creatives {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -15188,7 +15266,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Creative>(parameters, callback);
@@ -15254,7 +15332,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Creative>(parameters, callback);
@@ -15338,7 +15416,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$CreativesListResponse>(parameters, callback);
@@ -15405,7 +15483,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Creative>(parameters, callback);
@@ -15471,7 +15549,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Creative>(parameters, callback);
@@ -15634,7 +15712,10 @@ export namespace dfareporting_v3_3 {
 
 
   export class Resource$Dimensionvalues {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -15699,7 +15780,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$DimensionValueList>(parameters, callback);
@@ -15737,7 +15818,10 @@ export namespace dfareporting_v3_3 {
 
 
   export class Resource$Directorysites {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -15796,7 +15880,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$DirectorySite>(parameters, callback);
@@ -15866,7 +15950,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$DirectorySite>(parameters, callback);
@@ -15950,7 +16034,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$DirectorySitesListResponse>(
@@ -16063,7 +16147,10 @@ export namespace dfareporting_v3_3 {
 
 
   export class Resource$Dynamictargetingkeys {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -16126,7 +16213,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId', 'objectId', 'name', 'objectType'],
         pathParams: ['objectId', 'profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -16200,7 +16287,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$DynamicTargetingKey>(parameters, callback);
@@ -16282,7 +16369,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$DynamicTargetingKeysListResponse>(
@@ -16369,7 +16456,10 @@ export namespace dfareporting_v3_3 {
 
 
   export class Resource$Eventtags {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -16428,7 +16518,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -16492,7 +16582,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$EventTag>(parameters, callback);
@@ -16558,7 +16648,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$EventTag>(parameters, callback);
@@ -16635,7 +16725,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$EventTagsListResponse>(parameters, callback);
@@ -16703,7 +16793,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$EventTag>(parameters, callback);
@@ -16769,7 +16859,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$EventTag>(parameters, callback);
@@ -16935,7 +17025,10 @@ export namespace dfareporting_v3_3 {
 
 
   export class Resource$Files {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -16992,7 +17085,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['reportId', 'fileId'],
         pathParams: ['fileId', 'reportId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$File>(parameters, callback);
@@ -17062,7 +17155,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$FileList>(parameters, callback);
@@ -17121,7 +17214,10 @@ export namespace dfareporting_v3_3 {
 
 
   export class Resource$Floodlightactivities {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -17182,7 +17278,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -17258,7 +17354,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$FloodlightActivitiesGenerateTagResponse>(
@@ -17326,7 +17422,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$FloodlightActivity>(parameters, callback);
@@ -17396,7 +17492,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$FloodlightActivity>(parameters, callback);
@@ -17488,7 +17584,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$FloodlightActivitiesListResponse>(
@@ -17562,7 +17658,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$FloodlightActivity>(parameters, callback);
@@ -17632,7 +17728,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$FloodlightActivity>(parameters, callback);
@@ -17829,7 +17925,10 @@ export namespace dfareporting_v3_3 {
 
 
   export class Resource$Floodlightactivitygroups {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -17889,7 +17988,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$FloodlightActivityGroup>(parameters, callback);
@@ -17961,7 +18060,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$FloodlightActivityGroup>(parameters, callback);
@@ -18049,7 +18148,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$FloodlightActivityGroupsListResponse>(
@@ -18124,7 +18223,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$FloodlightActivityGroup>(parameters, callback);
@@ -18196,7 +18295,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$FloodlightActivityGroup>(parameters, callback);
@@ -18342,7 +18441,10 @@ export namespace dfareporting_v3_3 {
 
 
   export class Resource$Floodlightconfigurations {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -18402,7 +18504,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$FloodlightConfiguration>(parameters, callback);
@@ -18481,7 +18583,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$FloodlightConfigurationsListResponse>(
@@ -18556,7 +18658,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$FloodlightConfiguration>(parameters, callback);
@@ -18628,7 +18730,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$FloodlightConfiguration>(parameters, callback);
@@ -18712,7 +18814,10 @@ export namespace dfareporting_v3_3 {
 
 
   export class Resource$Inventoryitems {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -18772,7 +18877,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId', 'projectId', 'id'],
         pathParams: ['id', 'profileId', 'projectId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$InventoryItem>(parameters, callback);
@@ -18855,7 +18960,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId', 'projectId'],
         pathParams: ['profileId', 'projectId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$InventoryItemsListResponse>(
@@ -18941,7 +19046,10 @@ export namespace dfareporting_v3_3 {
 
 
   export class Resource$Languages {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -19001,7 +19109,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$LanguagesListResponse>(parameters, callback);
@@ -19025,7 +19133,10 @@ export namespace dfareporting_v3_3 {
 
 
   export class Resource$Metros {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -19084,7 +19195,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$MetrosListResponse>(parameters, callback);
@@ -19108,7 +19219,10 @@ export namespace dfareporting_v3_3 {
 
 
   export class Resource$Mobileapps {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -19166,7 +19280,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$MobileApp>(parameters, callback);
@@ -19238,7 +19352,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$MobileAppsListResponse>(parameters, callback);
@@ -19302,7 +19416,10 @@ export namespace dfareporting_v3_3 {
 
 
   export class Resource$Mobilecarriers {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -19361,7 +19478,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$MobileCarrier>(parameters, callback);
@@ -19433,7 +19550,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$MobileCarriersListResponse>(
@@ -19475,7 +19592,10 @@ export namespace dfareporting_v3_3 {
 
 
   export class Resource$Operatingsystems {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -19534,7 +19654,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId', 'dartId'],
         pathParams: ['dartId', 'profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$OperatingSystem>(parameters, callback);
@@ -19608,7 +19728,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$OperatingSystemsListResponse>(
@@ -19651,7 +19771,10 @@ export namespace dfareporting_v3_3 {
 
 
   export class Resource$Operatingsystemversions {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -19711,7 +19834,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$OperatingSystemVersion>(parameters, callback);
@@ -19789,7 +19912,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$OperatingSystemVersionsListResponse>(
@@ -19832,7 +19955,10 @@ export namespace dfareporting_v3_3 {
 
 
   export class Resource$Orderdocuments {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -19892,7 +20018,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId', 'projectId', 'id'],
         pathParams: ['id', 'profileId', 'projectId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$OrderDocument>(parameters, callback);
@@ -19975,7 +20101,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId', 'projectId'],
         pathParams: ['profileId', 'projectId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$OrderDocumentsListResponse>(
@@ -20067,7 +20193,10 @@ export namespace dfareporting_v3_3 {
 
 
   export class Resource$Orders {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -20125,7 +20254,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId', 'projectId', 'id'],
         pathParams: ['id', 'profileId', 'projectId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Order>(parameters, callback);
@@ -20201,7 +20330,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId', 'projectId'],
         pathParams: ['profileId', 'projectId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$OrdersListResponse>(parameters, callback);
@@ -20281,7 +20410,10 @@ export namespace dfareporting_v3_3 {
 
 
   export class Resource$Placementgroups {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -20340,7 +20472,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$PlacementGroup>(parameters, callback);
@@ -20410,7 +20542,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$PlacementGroup>(parameters, callback);
@@ -20503,7 +20635,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$PlacementGroupsListResponse>(
@@ -20576,7 +20708,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$PlacementGroup>(parameters, callback);
@@ -20646,7 +20778,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$PlacementGroup>(parameters, callback);
@@ -20839,7 +20971,10 @@ export namespace dfareporting_v3_3 {
 
 
   export class Resource$Placements {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -20910,7 +21045,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$PlacementsGenerateTagsResponse>(
@@ -20977,7 +21112,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Placement>(parameters, callback);
@@ -21045,7 +21180,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Placement>(parameters, callback);
@@ -21135,7 +21270,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$PlacementsListResponse>(parameters, callback);
@@ -21204,7 +21339,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Placement>(parameters, callback);
@@ -21272,7 +21407,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Placement>(parameters, callback);
@@ -21496,7 +21631,10 @@ export namespace dfareporting_v3_3 {
 
 
   export class Resource$Placementstrategies {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -21557,7 +21695,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -21623,7 +21761,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$PlacementStrategy>(parameters, callback);
@@ -21693,7 +21831,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$PlacementStrategy>(parameters, callback);
@@ -21776,7 +21914,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$PlacementStrategiesListResponse>(
@@ -21850,7 +21988,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$PlacementStrategy>(parameters, callback);
@@ -21920,7 +22058,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$PlacementStrategy>(parameters, callback);
@@ -22063,7 +22201,10 @@ export namespace dfareporting_v3_3 {
 
 
   export class Resource$Platformtypes {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -22122,7 +22263,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$PlatformType>(parameters, callback);
@@ -22191,7 +22332,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$PlatformTypesListResponse>(
@@ -22233,7 +22374,10 @@ export namespace dfareporting_v3_3 {
 
 
   export class Resource$Postalcodes {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -22291,7 +22435,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId', 'code'],
         pathParams: ['code', 'profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$PostalCode>(parameters, callback);
@@ -22358,7 +22502,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$PostalCodesListResponse>(parameters, callback);
@@ -22397,7 +22541,10 @@ export namespace dfareporting_v3_3 {
 
 
   export class Resource$Projects {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -22453,7 +22600,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Project>(parameters, callback);
@@ -22528,7 +22675,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ProjectsListResponse>(parameters, callback);
@@ -22600,7 +22747,10 @@ export namespace dfareporting_v3_3 {
 
 
   export class Resource$Regions {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -22659,7 +22809,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$RegionsListResponse>(parameters, callback);
@@ -22683,7 +22833,10 @@ export namespace dfareporting_v3_3 {
 
 
   export class Resource$Remarketinglists {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -22742,7 +22895,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$RemarketingList>(parameters, callback);
@@ -22812,7 +22965,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$RemarketingList>(parameters, callback);
@@ -22895,7 +23048,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId', 'advertiserId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$RemarketingListsListResponse>(
@@ -22969,7 +23122,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$RemarketingList>(parameters, callback);
@@ -23039,7 +23192,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$RemarketingList>(parameters, callback);
@@ -23173,7 +23326,10 @@ export namespace dfareporting_v3_3 {
 
 
   export class Resource$Remarketinglistshares {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -23233,7 +23389,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId', 'remarketingListId'],
         pathParams: ['profileId', 'remarketingListId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$RemarketingListShare>(parameters, callback);
@@ -23306,7 +23462,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId', 'remarketingListId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$RemarketingListShare>(parameters, callback);
@@ -23377,7 +23533,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$RemarketingListShare>(parameters, callback);
@@ -23444,11 +23600,14 @@ export namespace dfareporting_v3_3 {
 
 
   export class Resource$Reports {
+    context: APIRequestContext;
     compatibleFields: Resource$Reports$Compatiblefields;
     files: Resource$Reports$Files;
-    constructor() {
-      this.compatibleFields = new Resource$Reports$Compatiblefields();
-      this.files = new Resource$Reports$Files();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.compatibleFields =
+          new Resource$Reports$Compatiblefields(this.context);
+      this.files = new Resource$Reports$Files(this.context);
     }
 
 
@@ -23508,7 +23667,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId', 'reportId'],
         pathParams: ['profileId', 'reportId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -23572,7 +23731,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId', 'reportId'],
         pathParams: ['profileId', 'reportId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Report>(parameters, callback);
@@ -23638,7 +23797,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Report>(parameters, callback);
@@ -23709,7 +23868,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ReportList>(parameters, callback);
@@ -23777,7 +23936,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId', 'reportId'],
         pathParams: ['profileId', 'reportId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Report>(parameters, callback);
@@ -23842,7 +24001,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId', 'reportId'],
         pathParams: ['profileId', 'reportId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$File>(parameters, callback);
@@ -23910,7 +24069,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId', 'reportId'],
         pathParams: ['profileId', 'reportId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Report>(parameters, callback);
@@ -24058,7 +24217,10 @@ export namespace dfareporting_v3_3 {
   }
 
   export class Resource$Reports$Compatiblefields {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -24123,7 +24285,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$CompatibleFields>(parameters, callback);
@@ -24153,7 +24315,10 @@ export namespace dfareporting_v3_3 {
 
 
   export class Resource$Reports$Files {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -24212,7 +24377,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId', 'reportId', 'fileId'],
         pathParams: ['fileId', 'profileId', 'reportId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$File>(parameters, callback);
@@ -24284,7 +24449,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId', 'reportId'],
         pathParams: ['profileId', 'reportId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$FileList>(parameters, callback);
@@ -24350,7 +24515,10 @@ export namespace dfareporting_v3_3 {
 
 
   export class Resource$Sites {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -24406,7 +24574,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Site>(parameters, callback);
@@ -24472,7 +24640,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Site>(parameters, callback);
@@ -24554,7 +24722,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$SitesListResponse>(parameters, callback);
@@ -24621,7 +24789,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Site>(parameters, callback);
@@ -24687,7 +24855,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Site>(parameters, callback);
@@ -24845,7 +25013,10 @@ export namespace dfareporting_v3_3 {
 
 
   export class Resource$Sizes {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -24901,7 +25072,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Size>(parameters, callback);
@@ -24967,7 +25138,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Size>(parameters, callback);
@@ -25040,7 +25211,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$SizesListResponse>(parameters, callback);
@@ -25111,7 +25282,10 @@ export namespace dfareporting_v3_3 {
 
 
   export class Resource$Subaccounts {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -25169,7 +25343,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Subaccount>(parameters, callback);
@@ -25238,7 +25412,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Subaccount>(parameters, callback);
@@ -25312,7 +25486,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$SubaccountsListResponse>(parameters, callback);
@@ -25382,7 +25556,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Subaccount>(parameters, callback);
@@ -25451,7 +25625,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Subaccount>(parameters, callback);
@@ -25575,7 +25749,10 @@ export namespace dfareporting_v3_3 {
 
 
   export class Resource$Targetableremarketinglists {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -25636,7 +25813,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TargetableRemarketingList>(
@@ -25720,7 +25897,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId', 'advertiserId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TargetableRemarketingListsListResponse>(
@@ -25797,7 +25974,10 @@ export namespace dfareporting_v3_3 {
 
 
   export class Resource$Targetingtemplates {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -25856,7 +26036,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TargetingTemplate>(parameters, callback);
@@ -25926,7 +26106,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TargetingTemplate>(parameters, callback);
@@ -26008,7 +26188,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TargetingTemplatesListResponse>(
@@ -26082,7 +26262,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TargetingTemplate>(parameters, callback);
@@ -26152,7 +26332,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TargetingTemplate>(parameters, callback);
@@ -26282,7 +26462,10 @@ export namespace dfareporting_v3_3 {
 
 
   export class Resource$Userprofiles {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -26337,7 +26520,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$UserProfile>(parameters, callback);
@@ -26402,7 +26585,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$UserProfileList>(parameters, callback);
@@ -26433,7 +26616,10 @@ export namespace dfareporting_v3_3 {
 
 
   export class Resource$Userrolepermissiongroups {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -26493,7 +26679,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$UserRolePermissionGroup>(parameters, callback);
@@ -26571,7 +26757,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$UserRolePermissionGroupsListResponse>(
@@ -26614,7 +26800,10 @@ export namespace dfareporting_v3_3 {
 
 
   export class Resource$Userrolepermissions {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -26673,7 +26862,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$UserRolePermission>(parameters, callback);
@@ -26750,7 +26939,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$UserRolePermissionsListResponse>(
@@ -26797,7 +26986,10 @@ export namespace dfareporting_v3_3 {
 
 
   export class Resource$Userroles {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -26856,7 +27048,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -26920,7 +27112,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$UserRole>(parameters, callback);
@@ -26986,7 +27178,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$UserRole>(parameters, callback);
@@ -27062,7 +27254,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$UserRolesListResponse>(parameters, callback);
@@ -27130,7 +27322,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$UserRole>(parameters, callback);
@@ -27196,7 +27388,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$UserRole>(parameters, callback);
@@ -27341,7 +27533,10 @@ export namespace dfareporting_v3_3 {
 
 
   export class Resource$Videoformats {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -27399,7 +27594,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId', 'id'],
         pathParams: ['id', 'profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$VideoFormat>(parameters, callback);
@@ -27467,7 +27662,7 @@ export namespace dfareporting_v3_3 {
         params,
         requiredParams: ['profileId'],
         pathParams: ['profileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$VideoFormatsListResponse>(parameters, callback);

--- a/src/apis/dialogflow/v2.ts
+++ b/src/apis/dialogflow/v2.ts
@@ -29,8 +29,6 @@ export namespace dialogflow_v2 {
     version: 'v2';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * V1 error format.
@@ -99,12 +97,13 @@ export namespace dialogflow_v2 {
    * @param {object=} options Options for Dialogflow
    */
   export class Dialogflow {
+    context: APIRequestContext;
     projects: Resource$Projects;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.projects = new Resource$Projects();
+      this.projects = new Resource$Projects(this.context);
     }
   }
 
@@ -2721,11 +2720,13 @@ export namespace dialogflow_v2 {
 
 
   export class Resource$Projects {
+    context: APIRequestContext;
     agent: Resource$Projects$Agent;
     operations: Resource$Projects$Operations;
-    constructor() {
-      this.agent = new Resource$Projects$Agent();
-      this.operations = new Resource$Projects$Operations();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.agent = new Resource$Projects$Agent(this.context);
+      this.operations = new Resource$Projects$Operations(this.context);
     }
 
 
@@ -2791,7 +2792,7 @@ export namespace dialogflow_v2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleCloudDialogflowV2Agent>(
@@ -2818,13 +2819,15 @@ export namespace dialogflow_v2 {
   }
 
   export class Resource$Projects$Agent {
+    context: APIRequestContext;
     entityTypes: Resource$Projects$Agent$Entitytypes;
     intents: Resource$Projects$Agent$Intents;
     sessions: Resource$Projects$Agent$Sessions;
-    constructor() {
-      this.entityTypes = new Resource$Projects$Agent$Entitytypes();
-      this.intents = new Resource$Projects$Agent$Intents();
-      this.sessions = new Resource$Projects$Agent$Sessions();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.entityTypes = new Resource$Projects$Agent$Entitytypes(this.context);
+      this.intents = new Resource$Projects$Agent$Intents(this.context);
+      this.sessions = new Resource$Projects$Agent$Sessions(this.context);
     }
 
 
@@ -2892,7 +2895,7 @@ export namespace dialogflow_v2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleLongrunningOperation>(
@@ -2936,7 +2939,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
     options = {};
                                                                                                                                                                                                                                                                                                                                                     }
 
-                                                                                                                                                                                                                                                                                                                                                    const rootUrl = options.rootUrl || 'https://dialogflow.googleapis.com/'; const parameters = {options: Object.assign({url: (rootUrl + '/v2/{+parent}/agent:import').replace(/([^:]\/)\/+/g, '$1'), method: 'POST'}, options), params, requiredParams: ['parent'], pathParams: ['parent'], context}; if(callback) {
+                                                                                                                                                                                                                                                                                                                                                    const rootUrl = options.rootUrl || 'https://dialogflow.googleapis.com/'; const parameters = {options: Object.assign({url: (rootUrl + '/v2/{+parent}/agent:import').replace(/([^:]\/)\/+/g, '$1'), method: 'POST'}, options), params, requiredParams: ['parent'], pathParams: ['parent'], context: this.context}; if(callback) {
     createAPIRequest<Schema$GoogleLongrunningOperation>(parameters, callback);
                                                                                                                                                                                                                                                                                                                                                     } else {
     return createAPIRequest<Schema$GoogleLongrunningOperation>(parameters);
@@ -3003,7 +3006,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleLongrunningOperation>(
@@ -3084,7 +3087,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleCloudDialogflowV2SearchAgentsResponse>(
@@ -3159,7 +3162,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleLongrunningOperation>(
@@ -3267,9 +3270,12 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
   }
 
   export class Resource$Projects$Agent$Entitytypes {
+    context: APIRequestContext;
     entities: Resource$Projects$Agent$Entitytypes$Entities;
-    constructor() {
-      this.entities = new Resource$Projects$Agent$Entitytypes$Entities();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.entities =
+          new Resource$Projects$Agent$Entitytypes$Entities(this.context);
     }
 
 
@@ -3339,7 +3345,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleLongrunningOperation>(
@@ -3416,7 +3422,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleLongrunningOperation>(
@@ -3495,7 +3501,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleCloudDialogflowV2EntityType>(
@@ -3563,7 +3569,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleProtobufEmpty>(parameters, callback);
@@ -3635,7 +3641,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleCloudDialogflowV2EntityType>(
@@ -3714,7 +3720,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleCloudDialogflowV2ListEntityTypesResponse>(
@@ -3794,7 +3800,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleCloudDialogflowV2EntityType>(
@@ -3967,7 +3973,10 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
   }
 
   export class Resource$Projects$Agent$Entitytypes$Entities {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -4038,7 +4047,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleLongrunningOperation>(
@@ -4117,7 +4126,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleLongrunningOperation>(
@@ -4198,7 +4207,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleLongrunningOperation>(
@@ -4267,7 +4276,10 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
 
 
   export class Resource$Projects$Agent$Intents {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -4335,7 +4347,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleLongrunningOperation>(
@@ -4411,7 +4423,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleLongrunningOperation>(
@@ -4488,7 +4500,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleCloudDialogflowV2Intent>(
@@ -4557,7 +4569,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleProtobufEmpty>(parameters, callback);
@@ -4626,7 +4638,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleCloudDialogflowV2Intent>(
@@ -4705,7 +4717,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleCloudDialogflowV2ListIntentsResponse>(
@@ -4782,7 +4794,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleCloudDialogflowV2Intent>(
@@ -4976,11 +4988,15 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
 
 
   export class Resource$Projects$Agent$Sessions {
+    context: APIRequestContext;
     contexts: Resource$Projects$Agent$Sessions$Contexts;
     entityTypes: Resource$Projects$Agent$Sessions$Entitytypes;
-    constructor() {
-      this.contexts = new Resource$Projects$Agent$Sessions$Contexts();
-      this.entityTypes = new Resource$Projects$Agent$Sessions$Entitytypes();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.contexts =
+          new Resource$Projects$Agent$Sessions$Contexts(this.context);
+      this.entityTypes =
+          new Resource$Projects$Agent$Sessions$Entitytypes(this.context);
     }
 
 
@@ -5043,7 +5059,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleProtobufEmpty>(parameters, callback);
@@ -5121,7 +5137,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['session'],
         pathParams: ['session'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleCloudDialogflowV2DetectIntentResponse>(
@@ -5169,7 +5185,10 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
   }
 
   export class Resource$Projects$Agent$Sessions$Contexts {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -5238,7 +5257,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleCloudDialogflowV2Context>(
@@ -5307,7 +5326,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleProtobufEmpty>(parameters, callback);
@@ -5374,7 +5393,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleCloudDialogflowV2Context>(
@@ -5453,7 +5472,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleCloudDialogflowV2ListContextsResponse>(
@@ -5530,7 +5549,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleCloudDialogflowV2Context>(
@@ -5636,7 +5655,10 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
 
 
   export class Resource$Projects$Agent$Sessions$Entitytypes {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -5706,7 +5728,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleCloudDialogflowV2SessionEntityType>(
@@ -5776,7 +5798,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleProtobufEmpty>(parameters, callback);
@@ -5845,7 +5867,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleCloudDialogflowV2SessionEntityType>(
@@ -5929,7 +5951,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<
@@ -6009,7 +6031,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleCloudDialogflowV2SessionEntityType>(
@@ -6118,7 +6140,10 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
 
 
   export class Resource$Projects$Operations {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -6180,7 +6205,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleLongrunningOperation>(

--- a/src/apis/dialogflow/v2beta1.ts
+++ b/src/apis/dialogflow/v2beta1.ts
@@ -29,8 +29,6 @@ export namespace dialogflow_v2beta1 {
     version: 'v2beta1';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * V1 error format.
@@ -99,12 +97,13 @@ export namespace dialogflow_v2beta1 {
    * @param {object=} options Options for Dialogflow
    */
   export class Dialogflow {
+    context: APIRequestContext;
     projects: Resource$Projects;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.projects = new Resource$Projects();
+      this.projects = new Resource$Projects(this.context);
     }
   }
 
@@ -2972,13 +2971,15 @@ export namespace dialogflow_v2beta1 {
 
 
   export class Resource$Projects {
+    context: APIRequestContext;
     agent: Resource$Projects$Agent;
     knowledgeBases: Resource$Projects$Knowledgebases;
     operations: Resource$Projects$Operations;
-    constructor() {
-      this.agent = new Resource$Projects$Agent();
-      this.knowledgeBases = new Resource$Projects$Knowledgebases();
-      this.operations = new Resource$Projects$Operations();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.agent = new Resource$Projects$Agent(this.context);
+      this.knowledgeBases = new Resource$Projects$Knowledgebases(this.context);
+      this.operations = new Resource$Projects$Operations(this.context);
     }
 
 
@@ -3048,7 +3049,7 @@ export namespace dialogflow_v2beta1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleCloudDialogflowV2beta1Agent>(
@@ -3075,17 +3076,21 @@ export namespace dialogflow_v2beta1 {
   }
 
   export class Resource$Projects$Agent {
+    context: APIRequestContext;
     entityTypes: Resource$Projects$Agent$Entitytypes;
     environments: Resource$Projects$Agent$Environments;
     intents: Resource$Projects$Agent$Intents;
     knowledgeBases: Resource$Projects$Agent$Knowledgebases;
     sessions: Resource$Projects$Agent$Sessions;
-    constructor() {
-      this.entityTypes = new Resource$Projects$Agent$Entitytypes();
-      this.environments = new Resource$Projects$Agent$Environments();
-      this.intents = new Resource$Projects$Agent$Intents();
-      this.knowledgeBases = new Resource$Projects$Agent$Knowledgebases();
-      this.sessions = new Resource$Projects$Agent$Sessions();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.entityTypes = new Resource$Projects$Agent$Entitytypes(this.context);
+      this.environments =
+          new Resource$Projects$Agent$Environments(this.context);
+      this.intents = new Resource$Projects$Agent$Intents(this.context);
+      this.knowledgeBases =
+          new Resource$Projects$Agent$Knowledgebases(this.context);
+      this.sessions = new Resource$Projects$Agent$Sessions(this.context);
     }
 
 
@@ -3153,7 +3158,7 @@ export namespace dialogflow_v2beta1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleLongrunningOperation>(
@@ -3197,7 +3202,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
     options = {};
                                                                                                                                                                                                                                                                                                                                                     }
 
-                                                                                                                                                                                                                                                                                                                                                    const rootUrl = options.rootUrl || 'https://dialogflow.googleapis.com/'; const parameters = {options: Object.assign({url: (rootUrl + '/v2beta1/{+parent}/agent:import').replace(/([^:]\/)\/+/g, '$1'), method: 'POST'}, options), params, requiredParams: ['parent'], pathParams: ['parent'], context}; if(callback) {
+                                                                                                                                                                                                                                                                                                                                                    const rootUrl = options.rootUrl || 'https://dialogflow.googleapis.com/'; const parameters = {options: Object.assign({url: (rootUrl + '/v2beta1/{+parent}/agent:import').replace(/([^:]\/)\/+/g, '$1'), method: 'POST'}, options), params, requiredParams: ['parent'], pathParams: ['parent'], context: this.context}; if(callback) {
     createAPIRequest<Schema$GoogleLongrunningOperation>(parameters, callback);
                                                                                                                                                                                                                                                                                                                                                     } else {
     return createAPIRequest<Schema$GoogleLongrunningOperation>(parameters);
@@ -3264,7 +3269,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleLongrunningOperation>(
@@ -3345,7 +3350,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<
@@ -3422,7 +3427,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleLongrunningOperation>(
@@ -3530,9 +3535,12 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
   }
 
   export class Resource$Projects$Agent$Entitytypes {
+    context: APIRequestContext;
     entities: Resource$Projects$Agent$Entitytypes$Entities;
-    constructor() {
-      this.entities = new Resource$Projects$Agent$Entitytypes$Entities();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.entities =
+          new Resource$Projects$Agent$Entitytypes$Entities(this.context);
     }
 
 
@@ -3602,7 +3610,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleLongrunningOperation>(
@@ -3679,7 +3687,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleLongrunningOperation>(
@@ -3755,7 +3763,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleCloudDialogflowV2beta1EntityType>(
@@ -3823,7 +3831,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleProtobufEmpty>(parameters, callback);
@@ -3892,7 +3900,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleCloudDialogflowV2beta1EntityType>(
@@ -3973,7 +3981,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<
@@ -4052,7 +4060,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleCloudDialogflowV2beta1EntityType>(
@@ -4227,7 +4235,10 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
   }
 
   export class Resource$Projects$Agent$Entitytypes$Entities {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -4298,7 +4309,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleLongrunningOperation>(
@@ -4377,7 +4388,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleLongrunningOperation>(
@@ -4458,7 +4469,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleLongrunningOperation>(
@@ -4527,30 +4538,39 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
 
 
   export class Resource$Projects$Agent$Environments {
+    context: APIRequestContext;
     users: Resource$Projects$Agent$Environments$Users;
-    constructor() {
-      this.users = new Resource$Projects$Agent$Environments$Users();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.users = new Resource$Projects$Agent$Environments$Users(this.context);
     }
   }
 
 
   export class Resource$Projects$Agent$Environments$Users {
+    context: APIRequestContext;
     sessions: Resource$Projects$Agent$Environments$Users$Sessions;
-    constructor() {
-      this.sessions = new Resource$Projects$Agent$Environments$Users$Sessions();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.sessions =
+          new Resource$Projects$Agent$Environments$Users$Sessions(this.context);
     }
   }
 
 
   export class Resource$Projects$Agent$Environments$Users$Sessions {
+    context: APIRequestContext;
     contexts: Resource$Projects$Agent$Environments$Users$Sessions$Contexts;
     entityTypes:
         Resource$Projects$Agent$Environments$Users$Sessions$Entitytypes;
-    constructor() {
+    constructor(context: APIRequestContext) {
+      this.context = context;
       this.contexts =
-          new Resource$Projects$Agent$Environments$Users$Sessions$Contexts();
+          new Resource$Projects$Agent$Environments$Users$Sessions$Contexts(
+              this.context);
       this.entityTypes =
-          new Resource$Projects$Agent$Environments$Users$Sessions$Entitytypes();
+          new Resource$Projects$Agent$Environments$Users$Sessions$Entitytypes(
+              this.context);
     }
 
 
@@ -4618,7 +4638,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleProtobufEmpty>(parameters, callback);
@@ -4702,7 +4722,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['session'],
         pathParams: ['session'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<
@@ -4759,7 +4779,10 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
   }
 
   export class Resource$Projects$Agent$Environments$Users$Sessions$Contexts {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -4837,7 +4860,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleCloudDialogflowV2beta1Context>(
@@ -4911,7 +4934,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleProtobufEmpty>(parameters, callback);
@@ -4987,7 +5010,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleCloudDialogflowV2beta1Context>(
@@ -5071,7 +5094,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<
@@ -5158,7 +5181,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleCloudDialogflowV2beta1Context>(
@@ -5282,7 +5305,10 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
 
 
   export class Resource$Projects$Agent$Environments$Users$Sessions$Entitytypes {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -5357,7 +5383,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleCloudDialogflowV2beta1SessionEntityType>(
@@ -5431,7 +5457,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleProtobufEmpty>(parameters, callback);
@@ -5506,7 +5532,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleCloudDialogflowV2beta1SessionEntityType>(
@@ -5596,7 +5622,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<
@@ -5681,7 +5707,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleCloudDialogflowV2beta1SessionEntityType>(
@@ -5810,7 +5836,10 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
 
 
   export class Resource$Projects$Agent$Intents {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -5878,7 +5907,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleLongrunningOperation>(
@@ -5954,7 +5983,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleLongrunningOperation>(
@@ -6034,7 +6063,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleCloudDialogflowV2beta1Intent>(
@@ -6103,7 +6132,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleProtobufEmpty>(parameters, callback);
@@ -6176,7 +6205,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleCloudDialogflowV2beta1Intent>(
@@ -6256,7 +6285,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<
@@ -6338,7 +6367,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleCloudDialogflowV2beta1Intent>(
@@ -6532,9 +6561,12 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
 
 
   export class Resource$Projects$Agent$Knowledgebases {
+    context: APIRequestContext;
     documents: Resource$Projects$Agent$Knowledgebases$Documents;
-    constructor() {
-      this.documents = new Resource$Projects$Agent$Knowledgebases$Documents();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.documents =
+          new Resource$Projects$Agent$Knowledgebases$Documents(this.context);
     }
 
 
@@ -6602,7 +6634,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleCloudDialogflowV2beta1KnowledgeBase>(
@@ -6671,7 +6703,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleProtobufEmpty>(parameters, callback);
@@ -6739,7 +6771,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleCloudDialogflowV2beta1KnowledgeBase>(
@@ -6821,7 +6853,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<
@@ -6899,7 +6931,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleCloudDialogflowV2beta1KnowledgeBase>(
@@ -7010,7 +7042,10 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
   }
 
   export class Resource$Projects$Agent$Knowledgebases$Documents {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -7079,7 +7114,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleLongrunningOperation>(
@@ -7154,7 +7189,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleLongrunningOperation>(
@@ -7228,7 +7263,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleCloudDialogflowV2beta1Document>(
@@ -7309,7 +7344,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<
@@ -7389,7 +7424,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleLongrunningOperation>(
@@ -7470,7 +7505,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleLongrunningOperation>(
@@ -7595,11 +7630,15 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
 
 
   export class Resource$Projects$Agent$Sessions {
+    context: APIRequestContext;
     contexts: Resource$Projects$Agent$Sessions$Contexts;
     entityTypes: Resource$Projects$Agent$Sessions$Entitytypes;
-    constructor() {
-      this.contexts = new Resource$Projects$Agent$Sessions$Contexts();
-      this.entityTypes = new Resource$Projects$Agent$Sessions$Entitytypes();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.contexts =
+          new Resource$Projects$Agent$Sessions$Contexts(this.context);
+      this.entityTypes =
+          new Resource$Projects$Agent$Sessions$Entitytypes(this.context);
     }
 
 
@@ -7662,7 +7701,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleProtobufEmpty>(parameters, callback);
@@ -7741,7 +7780,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['session'],
         pathParams: ['session'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<
@@ -7798,7 +7837,10 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
   }
 
   export class Resource$Projects$Agent$Sessions$Contexts {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -7871,7 +7913,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleCloudDialogflowV2beta1Context>(
@@ -7940,7 +7982,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleProtobufEmpty>(parameters, callback);
@@ -8011,7 +8053,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleCloudDialogflowV2beta1Context>(
@@ -8090,7 +8132,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<
@@ -8172,7 +8214,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleCloudDialogflowV2beta1Context>(
@@ -8296,7 +8338,10 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
 
 
   export class Resource$Projects$Agent$Sessions$Entitytypes {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -8367,7 +8412,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleCloudDialogflowV2beta1SessionEntityType>(
@@ -8437,7 +8482,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleProtobufEmpty>(parameters, callback);
@@ -8507,7 +8552,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleCloudDialogflowV2beta1SessionEntityType>(
@@ -8592,7 +8637,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<
@@ -8673,7 +8718,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleCloudDialogflowV2beta1SessionEntityType>(
@@ -8802,9 +8847,12 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
 
 
   export class Resource$Projects$Knowledgebases {
+    context: APIRequestContext;
     documents: Resource$Projects$Knowledgebases$Documents;
-    constructor() {
-      this.documents = new Resource$Projects$Knowledgebases$Documents();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.documents =
+          new Resource$Projects$Knowledgebases$Documents(this.context);
     }
 
 
@@ -8872,7 +8920,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleCloudDialogflowV2beta1KnowledgeBase>(
@@ -8941,7 +8989,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleProtobufEmpty>(parameters, callback);
@@ -9009,7 +9057,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleCloudDialogflowV2beta1KnowledgeBase>(
@@ -9091,7 +9139,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<
@@ -9169,7 +9217,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleCloudDialogflowV2beta1KnowledgeBase>(
@@ -9280,7 +9328,10 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
   }
 
   export class Resource$Projects$Knowledgebases$Documents {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -9348,7 +9399,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleLongrunningOperation>(
@@ -9422,7 +9473,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleLongrunningOperation>(
@@ -9495,7 +9546,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleCloudDialogflowV2beta1Document>(
@@ -9575,7 +9626,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<
@@ -9654,7 +9705,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleLongrunningOperation>(
@@ -9734,7 +9785,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleLongrunningOperation>(
@@ -9859,7 +9910,10 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
 
 
   export class Resource$Projects$Operations {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -9921,7 +9975,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Agent$Import|BodyResponseCall
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleLongrunningOperation>(

--- a/src/apis/digitalassetlinks/v1.ts
+++ b/src/apis/digitalassetlinks/v1.ts
@@ -29,8 +29,6 @@ export namespace digitalassetlinks_v1 {
     version: 'v1';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * V1 error format.
@@ -99,14 +97,15 @@ export namespace digitalassetlinks_v1 {
    * @param {object=} options Options for Digitalassetlinks
    */
   export class Digitalassetlinks {
+    context: APIRequestContext;
     assetlinks: Resource$Assetlinks;
     statements: Resource$Statements;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.assetlinks = new Resource$Assetlinks();
-      this.statements = new Resource$Statements();
+      this.assetlinks = new Resource$Assetlinks(this.context);
+      this.statements = new Resource$Statements(this.context);
     }
   }
 
@@ -290,7 +289,10 @@ export namespace digitalassetlinks_v1 {
 
 
   export class Resource$Assetlinks {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -373,7 +375,7 @@ export namespace digitalassetlinks_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$CheckResponse>(parameters, callback);
@@ -493,7 +495,10 @@ export namespace digitalassetlinks_v1 {
 
 
   export class Resource$Statements {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -568,7 +573,7 @@ export namespace digitalassetlinks_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListResponse>(parameters, callback);

--- a/src/apis/discovery/v1.ts
+++ b/src/apis/discovery/v1.ts
@@ -29,8 +29,6 @@ export namespace discovery_v1 {
     version: 'v1';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * Data format for the response.
@@ -82,12 +80,13 @@ export namespace discovery_v1 {
    * @param {object=} options Options for Discovery
    */
   export class Discovery {
+    context: APIRequestContext;
     apis: Resource$Apis;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.apis = new Resource$Apis();
+      this.apis = new Resource$Apis(this.context);
     }
   }
 
@@ -428,7 +427,10 @@ export namespace discovery_v1 {
 
 
   export class Resource$Apis {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -487,7 +489,7 @@ export namespace discovery_v1 {
         params,
         requiredParams: ['api', 'version'],
         pathParams: ['api', 'version'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$RestDescription>(parameters, callback);
@@ -553,7 +555,7 @@ export namespace discovery_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$DirectoryList>(parameters, callback);

--- a/src/apis/dlp/v2.ts
+++ b/src/apis/dlp/v2.ts
@@ -29,8 +29,6 @@ export namespace dlp_v2 {
     version: 'v2';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * V1 error format.
@@ -100,16 +98,17 @@ export namespace dlp_v2 {
    * @param {object=} options Options for Dlp
    */
   export class Dlp {
+    context: APIRequestContext;
     infoTypes: Resource$Infotypes;
     organizations: Resource$Organizations;
     projects: Resource$Projects;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.infoTypes = new Resource$Infotypes();
-      this.organizations = new Resource$Organizations();
-      this.projects = new Resource$Projects();
+      this.infoTypes = new Resource$Infotypes(this.context);
+      this.organizations = new Resource$Organizations(this.context);
+      this.projects = new Resource$Projects(this.context);
     }
   }
 
@@ -3354,7 +3353,10 @@ export namespace dlp_v2 {
 
 
   export class Resource$Infotypes {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -3419,7 +3421,7 @@ export namespace dlp_v2 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GooglePrivacyDlpV2ListInfoTypesResponse>(
@@ -3452,20 +3454,27 @@ export namespace dlp_v2 {
 
 
   export class Resource$Organizations {
+    context: APIRequestContext;
     deidentifyTemplates: Resource$Organizations$Deidentifytemplates;
     inspectTemplates: Resource$Organizations$Inspecttemplates;
     storedInfoTypes: Resource$Organizations$Storedinfotypes;
-    constructor() {
+    constructor(context: APIRequestContext) {
+      this.context = context;
       this.deidentifyTemplates =
-          new Resource$Organizations$Deidentifytemplates();
-      this.inspectTemplates = new Resource$Organizations$Inspecttemplates();
-      this.storedInfoTypes = new Resource$Organizations$Storedinfotypes();
+          new Resource$Organizations$Deidentifytemplates(this.context);
+      this.inspectTemplates =
+          new Resource$Organizations$Inspecttemplates(this.context);
+      this.storedInfoTypes =
+          new Resource$Organizations$Storedinfotypes(this.context);
     }
   }
 
 
   export class Resource$Organizations$Deidentifytemplates {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -3539,7 +3548,7 @@ export namespace dlp_v2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GooglePrivacyDlpV2DeidentifyTemplate>(
@@ -3609,7 +3618,7 @@ export namespace dlp_v2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleProtobufEmpty>(parameters, callback);
@@ -3682,7 +3691,7 @@ export namespace dlp_v2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GooglePrivacyDlpV2DeidentifyTemplate>(
@@ -3764,7 +3773,7 @@ export namespace dlp_v2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<
@@ -3847,7 +3856,7 @@ export namespace dlp_v2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GooglePrivacyDlpV2DeidentifyTemplate>(
@@ -3961,7 +3970,10 @@ export namespace dlp_v2 {
 
 
   export class Resource$Organizations$Inspecttemplates {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -4034,7 +4046,7 @@ export namespace dlp_v2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GooglePrivacyDlpV2InspectTemplate>(
@@ -4104,7 +4116,7 @@ export namespace dlp_v2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleProtobufEmpty>(parameters, callback);
@@ -4176,7 +4188,7 @@ export namespace dlp_v2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GooglePrivacyDlpV2InspectTemplate>(
@@ -4256,7 +4268,7 @@ export namespace dlp_v2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GooglePrivacyDlpV2ListInspectTemplatesResponse>(
@@ -4335,7 +4347,7 @@ export namespace dlp_v2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GooglePrivacyDlpV2InspectTemplate>(
@@ -4449,7 +4461,10 @@ export namespace dlp_v2 {
 
 
   export class Resource$Organizations$Storedinfotypes {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -4521,7 +4536,7 @@ export namespace dlp_v2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GooglePrivacyDlpV2StoredInfoType>(
@@ -4591,7 +4606,7 @@ export namespace dlp_v2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleProtobufEmpty>(parameters, callback);
@@ -4664,7 +4679,7 @@ export namespace dlp_v2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GooglePrivacyDlpV2StoredInfoType>(
@@ -4745,7 +4760,7 @@ export namespace dlp_v2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GooglePrivacyDlpV2ListStoredInfoTypesResponse>(
@@ -4826,7 +4841,7 @@ export namespace dlp_v2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GooglePrivacyDlpV2StoredInfoType>(
@@ -4941,6 +4956,7 @@ export namespace dlp_v2 {
 
 
   export class Resource$Projects {
+    context: APIRequestContext;
     content: Resource$Projects$Content;
     deidentifyTemplates: Resource$Projects$Deidentifytemplates;
     dlpJobs: Resource$Projects$Dlpjobs;
@@ -4948,20 +4964,27 @@ export namespace dlp_v2 {
     inspectTemplates: Resource$Projects$Inspecttemplates;
     jobTriggers: Resource$Projects$Jobtriggers;
     storedInfoTypes: Resource$Projects$Storedinfotypes;
-    constructor() {
-      this.content = new Resource$Projects$Content();
-      this.deidentifyTemplates = new Resource$Projects$Deidentifytemplates();
-      this.dlpJobs = new Resource$Projects$Dlpjobs();
-      this.image = new Resource$Projects$Image();
-      this.inspectTemplates = new Resource$Projects$Inspecttemplates();
-      this.jobTriggers = new Resource$Projects$Jobtriggers();
-      this.storedInfoTypes = new Resource$Projects$Storedinfotypes();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.content = new Resource$Projects$Content(this.context);
+      this.deidentifyTemplates =
+          new Resource$Projects$Deidentifytemplates(this.context);
+      this.dlpJobs = new Resource$Projects$Dlpjobs(this.context);
+      this.image = new Resource$Projects$Image(this.context);
+      this.inspectTemplates =
+          new Resource$Projects$Inspecttemplates(this.context);
+      this.jobTriggers = new Resource$Projects$Jobtriggers(this.context);
+      this.storedInfoTypes =
+          new Resource$Projects$Storedinfotypes(this.context);
     }
   }
 
 
   export class Resource$Projects$Content {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -5035,7 +5058,7 @@ export namespace dlp_v2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GooglePrivacyDlpV2DeidentifyContentResponse>(
@@ -5117,7 +5140,7 @@ export namespace dlp_v2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GooglePrivacyDlpV2InspectContentResponse>(
@@ -5196,7 +5219,7 @@ export namespace dlp_v2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GooglePrivacyDlpV2ReidentifyContentResponse>(
@@ -5262,7 +5285,10 @@ export namespace dlp_v2 {
 
 
   export class Resource$Projects$Deidentifytemplates {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -5335,7 +5361,7 @@ export namespace dlp_v2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GooglePrivacyDlpV2DeidentifyTemplate>(
@@ -5404,7 +5430,7 @@ export namespace dlp_v2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleProtobufEmpty>(parameters, callback);
@@ -5476,7 +5502,7 @@ export namespace dlp_v2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GooglePrivacyDlpV2DeidentifyTemplate>(
@@ -5557,7 +5583,7 @@ export namespace dlp_v2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<
@@ -5639,7 +5665,7 @@ export namespace dlp_v2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GooglePrivacyDlpV2DeidentifyTemplate>(
@@ -5753,7 +5779,10 @@ export namespace dlp_v2 {
 
 
   export class Resource$Projects$Dlpjobs {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -5817,7 +5846,7 @@ export namespace dlp_v2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleProtobufEmpty>(parameters, callback);
@@ -5893,7 +5922,7 @@ export namespace dlp_v2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GooglePrivacyDlpV2DlpJob>(parameters, callback);
@@ -5963,7 +5992,7 @@ export namespace dlp_v2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleProtobufEmpty>(parameters, callback);
@@ -6028,7 +6057,7 @@ export namespace dlp_v2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GooglePrivacyDlpV2DlpJob>(parameters, callback);
@@ -6112,7 +6141,7 @@ export namespace dlp_v2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GooglePrivacyDlpV2ListDlpJobsResponse>(
@@ -6236,7 +6265,10 @@ export namespace dlp_v2 {
 
 
   export class Resource$Projects$Image {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -6313,7 +6345,7 @@ export namespace dlp_v2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GooglePrivacyDlpV2RedactImageResponse>(
@@ -6345,7 +6377,10 @@ export namespace dlp_v2 {
 
 
   export class Resource$Projects$Inspecttemplates {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -6417,7 +6452,7 @@ export namespace dlp_v2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GooglePrivacyDlpV2InspectTemplate>(
@@ -6486,7 +6521,7 @@ export namespace dlp_v2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleProtobufEmpty>(parameters, callback);
@@ -6558,7 +6593,7 @@ export namespace dlp_v2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GooglePrivacyDlpV2InspectTemplate>(
@@ -6638,7 +6673,7 @@ export namespace dlp_v2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GooglePrivacyDlpV2ListInspectTemplatesResponse>(
@@ -6717,7 +6752,7 @@ export namespace dlp_v2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GooglePrivacyDlpV2InspectTemplate>(
@@ -6831,7 +6866,10 @@ export namespace dlp_v2 {
 
 
   export class Resource$Projects$Jobtriggers {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -6896,7 +6934,7 @@ export namespace dlp_v2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GooglePrivacyDlpV2DlpJob>(parameters, callback);
@@ -6971,7 +7009,7 @@ export namespace dlp_v2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GooglePrivacyDlpV2JobTrigger>(
@@ -7040,7 +7078,7 @@ export namespace dlp_v2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleProtobufEmpty>(parameters, callback);
@@ -7108,7 +7146,7 @@ export namespace dlp_v2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GooglePrivacyDlpV2JobTrigger>(
@@ -7188,7 +7226,7 @@ export namespace dlp_v2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GooglePrivacyDlpV2ListJobTriggersResponse>(
@@ -7263,7 +7301,7 @@ export namespace dlp_v2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GooglePrivacyDlpV2JobTrigger>(
@@ -7409,7 +7447,10 @@ export namespace dlp_v2 {
 
 
   export class Resource$Projects$Storedinfotypes {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -7481,7 +7522,7 @@ export namespace dlp_v2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GooglePrivacyDlpV2StoredInfoType>(
@@ -7551,7 +7592,7 @@ export namespace dlp_v2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleProtobufEmpty>(parameters, callback);
@@ -7624,7 +7665,7 @@ export namespace dlp_v2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GooglePrivacyDlpV2StoredInfoType>(
@@ -7705,7 +7746,7 @@ export namespace dlp_v2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GooglePrivacyDlpV2ListStoredInfoTypesResponse>(
@@ -7786,7 +7827,7 @@ export namespace dlp_v2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GooglePrivacyDlpV2StoredInfoType>(

--- a/src/apis/dns/v1.ts
+++ b/src/apis/dns/v1.ts
@@ -29,8 +29,6 @@ export namespace dns_v1 {
     version: 'v1';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * Data format for the response.
@@ -81,6 +79,7 @@ export namespace dns_v1 {
    * @param {object=} options Options for Dns
    */
   export class Dns {
+    context: APIRequestContext;
     changes: Resource$Changes;
     dnsKeys: Resource$Dnskeys;
     managedZoneOperations: Resource$Managedzoneoperations;
@@ -89,14 +88,15 @@ export namespace dns_v1 {
     resourceRecordSets: Resource$Resourcerecordsets;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.changes = new Resource$Changes();
-      this.dnsKeys = new Resource$Dnskeys();
-      this.managedZoneOperations = new Resource$Managedzoneoperations();
-      this.managedZones = new Resource$Managedzones();
-      this.projects = new Resource$Projects();
-      this.resourceRecordSets = new Resource$Resourcerecordsets();
+      this.changes = new Resource$Changes(this.context);
+      this.dnsKeys = new Resource$Dnskeys(this.context);
+      this.managedZoneOperations =
+          new Resource$Managedzoneoperations(this.context);
+      this.managedZones = new Resource$Managedzones(this.context);
+      this.projects = new Resource$Projects(this.context);
+      this.resourceRecordSets = new Resource$Resourcerecordsets(this.context);
     }
   }
 
@@ -300,7 +300,10 @@ export namespace dns_v1 {
 
 
   export class Resource$Changes {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -422,7 +425,7 @@ export namespace dns_v1 {
         params,
         requiredParams: ['project', 'managedZone'],
         pathParams: ['managedZone', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Change>(parameters, callback);
@@ -548,7 +551,7 @@ export namespace dns_v1 {
         params,
         requiredParams: ['project', 'managedZone', 'changeId'],
         pathParams: ['changeId', 'managedZone', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Change>(parameters, callback);
@@ -689,7 +692,7 @@ export namespace dns_v1 {
         params,
         requiredParams: ['project', 'managedZone'],
         pathParams: ['managedZone', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ChangesListResponse>(parameters, callback);
@@ -780,7 +783,10 @@ export namespace dns_v1 {
 
 
   export class Resource$Dnskeys {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -839,7 +845,7 @@ export namespace dns_v1 {
         params,
         requiredParams: ['project', 'managedZone', 'dnsKeyId'],
         pathParams: ['dnsKeyId', 'managedZone', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$DnsKey>(parameters, callback);
@@ -909,7 +915,7 @@ export namespace dns_v1 {
         params,
         requiredParams: ['project', 'managedZone'],
         pathParams: ['managedZone', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$DnsKeysListResponse>(parameters, callback);
@@ -976,7 +982,10 @@ export namespace dns_v1 {
 
 
   export class Resource$Managedzoneoperations {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1036,7 +1045,7 @@ export namespace dns_v1 {
         params,
         requiredParams: ['project', 'managedZone', 'operation'],
         pathParams: ['managedZone', 'operation', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -1117,7 +1126,7 @@ export namespace dns_v1 {
         params,
         requiredParams: ['project', 'managedZone'],
         pathParams: ['managedZone', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ManagedZoneOperationsListResponse>(
@@ -1184,7 +1193,10 @@ export namespace dns_v1 {
 
 
   export class Resource$Managedzones {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1302,7 +1314,7 @@ export namespace dns_v1 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ManagedZone>(parameters, callback);
@@ -1423,7 +1435,7 @@ export namespace dns_v1 {
         params,
         requiredParams: ['project', 'managedZone'],
         pathParams: ['managedZone', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -1544,7 +1556,7 @@ export namespace dns_v1 {
         params,
         requiredParams: ['project', 'managedZone'],
         pathParams: ['managedZone', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ManagedZone>(parameters, callback);
@@ -1680,7 +1692,7 @@ export namespace dns_v1 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ManagedZonesListResponse>(parameters, callback);
@@ -1749,7 +1761,7 @@ export namespace dns_v1 {
         params,
         requiredParams: ['project', 'managedZone'],
         pathParams: ['managedZone', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -1819,7 +1831,7 @@ export namespace dns_v1 {
         params,
         requiredParams: ['project', 'managedZone'],
         pathParams: ['managedZone', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -1966,7 +1978,10 @@ export namespace dns_v1 {
 
 
   export class Resource$Projects {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -2073,7 +2088,7 @@ export namespace dns_v1 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Project>(parameters, callback);
@@ -2101,7 +2116,10 @@ export namespace dns_v1 {
 
 
   export class Resource$Resourcerecordsets {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -2242,7 +2260,7 @@ export namespace dns_v1 {
         params,
         requiredParams: ['project', 'managedZone'],
         pathParams: ['managedZone', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ResourceRecordSetsListResponse>(

--- a/src/apis/dns/v1beta2.ts
+++ b/src/apis/dns/v1beta2.ts
@@ -29,8 +29,6 @@ export namespace dns_v1beta2 {
     version: 'v1beta2';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * Data format for the response.
@@ -81,6 +79,7 @@ export namespace dns_v1beta2 {
    * @param {object=} options Options for Dns
    */
   export class Dns {
+    context: APIRequestContext;
     changes: Resource$Changes;
     dnsKeys: Resource$Dnskeys;
     managedZoneOperations: Resource$Managedzoneoperations;
@@ -90,15 +89,16 @@ export namespace dns_v1beta2 {
     resourceRecordSets: Resource$Resourcerecordsets;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.changes = new Resource$Changes();
-      this.dnsKeys = new Resource$Dnskeys();
-      this.managedZoneOperations = new Resource$Managedzoneoperations();
-      this.managedZones = new Resource$Managedzones();
-      this.policies = new Resource$Policies();
-      this.projects = new Resource$Projects();
-      this.resourceRecordSets = new Resource$Resourcerecordsets();
+      this.changes = new Resource$Changes(this.context);
+      this.dnsKeys = new Resource$Dnskeys(this.context);
+      this.managedZoneOperations =
+          new Resource$Managedzoneoperations(this.context);
+      this.managedZones = new Resource$Managedzones(this.context);
+      this.policies = new Resource$Policies(this.context);
+      this.projects = new Resource$Projects(this.context);
+      this.resourceRecordSets = new Resource$Resourcerecordsets(this.context);
     }
   }
 
@@ -378,7 +378,10 @@ export namespace dns_v1beta2 {
 
 
   export class Resource$Changes {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -439,7 +442,7 @@ export namespace dns_v1beta2 {
         params,
         requiredParams: ['project', 'managedZone'],
         pathParams: ['managedZone', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Change>(parameters, callback);
@@ -504,7 +507,7 @@ export namespace dns_v1beta2 {
         params,
         requiredParams: ['project', 'managedZone', 'changeId'],
         pathParams: ['changeId', 'managedZone', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Change>(parameters, callback);
@@ -575,7 +578,7 @@ export namespace dns_v1beta2 {
         params,
         requiredParams: ['project', 'managedZone'],
         pathParams: ['managedZone', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ChangesListResponse>(parameters, callback);
@@ -666,7 +669,10 @@ export namespace dns_v1beta2 {
 
 
   export class Resource$Dnskeys {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -725,7 +731,7 @@ export namespace dns_v1beta2 {
         params,
         requiredParams: ['project', 'managedZone', 'dnsKeyId'],
         pathParams: ['dnsKeyId', 'managedZone', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$DnsKey>(parameters, callback);
@@ -795,7 +801,7 @@ export namespace dns_v1beta2 {
         params,
         requiredParams: ['project', 'managedZone'],
         pathParams: ['managedZone', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$DnsKeysListResponse>(parameters, callback);
@@ -862,7 +868,10 @@ export namespace dns_v1beta2 {
 
 
   export class Resource$Managedzoneoperations {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -922,7 +931,7 @@ export namespace dns_v1beta2 {
         params,
         requiredParams: ['project', 'managedZone', 'operation'],
         pathParams: ['managedZone', 'operation', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -1003,7 +1012,7 @@ export namespace dns_v1beta2 {
         params,
         requiredParams: ['project', 'managedZone'],
         pathParams: ['managedZone', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ManagedZoneOperationsListResponse>(
@@ -1070,7 +1079,10 @@ export namespace dns_v1beta2 {
 
 
   export class Resource$Managedzones {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1131,7 +1143,7 @@ export namespace dns_v1beta2 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ManagedZone>(parameters, callback);
@@ -1199,7 +1211,7 @@ export namespace dns_v1beta2 {
         params,
         requiredParams: ['project', 'managedZone'],
         pathParams: ['managedZone', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -1264,7 +1276,7 @@ export namespace dns_v1beta2 {
         params,
         requiredParams: ['project', 'managedZone'],
         pathParams: ['managedZone', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ManagedZone>(parameters, callback);
@@ -1333,7 +1345,7 @@ export namespace dns_v1beta2 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ManagedZonesListResponse>(parameters, callback);
@@ -1403,7 +1415,7 @@ export namespace dns_v1beta2 {
         params,
         requiredParams: ['project', 'managedZone'],
         pathParams: ['managedZone', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -1474,7 +1486,7 @@ export namespace dns_v1beta2 {
         params,
         requiredParams: ['project', 'managedZone'],
         pathParams: ['managedZone', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -1621,7 +1633,10 @@ export namespace dns_v1beta2 {
 
 
   export class Resource$Policies {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1679,7 +1694,7 @@ export namespace dns_v1beta2 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -1744,7 +1759,7 @@ export namespace dns_v1beta2 {
         params,
         requiredParams: ['project', 'policy'],
         pathParams: ['policy', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -1807,7 +1822,7 @@ export namespace dns_v1beta2 {
         params,
         requiredParams: ['project', 'policy'],
         pathParams: ['policy', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -1874,7 +1889,7 @@ export namespace dns_v1beta2 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$PoliciesListResponse>(parameters, callback);
@@ -1943,7 +1958,7 @@ export namespace dns_v1beta2 {
         params,
         requiredParams: ['project', 'policy'],
         pathParams: ['policy', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$PoliciesPatchResponse>(parameters, callback);
@@ -2012,7 +2027,7 @@ export namespace dns_v1beta2 {
         params,
         requiredParams: ['project', 'policy'],
         pathParams: ['policy', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$PoliciesUpdateResponse>(parameters, callback);
@@ -2150,7 +2165,10 @@ export namespace dns_v1beta2 {
 
 
   export class Resource$Projects {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -2204,7 +2222,7 @@ export namespace dns_v1beta2 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Project>(parameters, callback);
@@ -2232,7 +2250,10 @@ export namespace dns_v1beta2 {
 
 
   export class Resource$Resourcerecordsets {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -2303,7 +2324,7 @@ export namespace dns_v1beta2 {
         params,
         requiredParams: ['project', 'managedZone'],
         pathParams: ['managedZone', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ResourceRecordSetsListResponse>(

--- a/src/apis/dns/v2beta1.ts
+++ b/src/apis/dns/v2beta1.ts
@@ -29,8 +29,6 @@ export namespace dns_v2beta1 {
     version: 'v2beta1';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * Data format for the response.
@@ -81,6 +79,7 @@ export namespace dns_v2beta1 {
    * @param {object=} options Options for Dns
    */
   export class Dns {
+    context: APIRequestContext;
     changes: Resource$Changes;
     dnsKeys: Resource$Dnskeys;
     managedZoneOperations: Resource$Managedzoneoperations;
@@ -89,14 +88,15 @@ export namespace dns_v2beta1 {
     resourceRecordSets: Resource$Resourcerecordsets;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.changes = new Resource$Changes();
-      this.dnsKeys = new Resource$Dnskeys();
-      this.managedZoneOperations = new Resource$Managedzoneoperations();
-      this.managedZones = new Resource$Managedzones();
-      this.projects = new Resource$Projects();
-      this.resourceRecordSets = new Resource$Resourcerecordsets();
+      this.changes = new Resource$Changes(this.context);
+      this.dnsKeys = new Resource$Dnskeys(this.context);
+      this.managedZoneOperations =
+          new Resource$Managedzoneoperations(this.context);
+      this.managedZones = new Resource$Managedzones(this.context);
+      this.projects = new Resource$Projects(this.context);
+      this.resourceRecordSets = new Resource$Resourcerecordsets(this.context);
     }
   }
 
@@ -300,7 +300,10 @@ export namespace dns_v2beta1 {
 
 
   export class Resource$Changes {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -422,7 +425,7 @@ export namespace dns_v2beta1 {
         params,
         requiredParams: ['project', 'managedZone'],
         pathParams: ['managedZone', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Change>(parameters, callback);
@@ -548,7 +551,7 @@ export namespace dns_v2beta1 {
         params,
         requiredParams: ['project', 'managedZone', 'changeId'],
         pathParams: ['changeId', 'managedZone', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Change>(parameters, callback);
@@ -689,7 +692,7 @@ export namespace dns_v2beta1 {
         params,
         requiredParams: ['project', 'managedZone'],
         pathParams: ['managedZone', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ChangesListResponse>(parameters, callback);
@@ -780,7 +783,10 @@ export namespace dns_v2beta1 {
 
 
   export class Resource$Dnskeys {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -899,7 +905,7 @@ export namespace dns_v2beta1 {
         params,
         requiredParams: ['project', 'managedZone', 'dnsKeyId'],
         pathParams: ['dnsKeyId', 'managedZone', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$DnsKey>(parameters, callback);
@@ -1039,7 +1045,7 @@ export namespace dns_v2beta1 {
         params,
         requiredParams: ['project', 'managedZone'],
         pathParams: ['managedZone', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$DnsKeysListResponse>(parameters, callback);
@@ -1106,7 +1112,10 @@ export namespace dns_v2beta1 {
 
 
   export class Resource$Managedzoneoperations {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1225,7 +1234,7 @@ export namespace dns_v2beta1 {
         params,
         requiredParams: ['project', 'managedZone', 'operation'],
         pathParams: ['managedZone', 'operation', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -1376,7 +1385,7 @@ export namespace dns_v2beta1 {
         params,
         requiredParams: ['project', 'managedZone'],
         pathParams: ['managedZone', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ManagedZoneOperationsListResponse>(
@@ -1443,7 +1452,10 @@ export namespace dns_v2beta1 {
 
 
   export class Resource$Managedzones {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1561,7 +1573,7 @@ export namespace dns_v2beta1 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ManagedZone>(parameters, callback);
@@ -1686,7 +1698,7 @@ export namespace dns_v2beta1 {
         params,
         requiredParams: ['project', 'managedZone'],
         pathParams: ['managedZone', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -1808,7 +1820,7 @@ export namespace dns_v2beta1 {
         params,
         requiredParams: ['project', 'managedZone'],
         pathParams: ['managedZone', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ManagedZone>(parameters, callback);
@@ -1944,7 +1956,7 @@ export namespace dns_v2beta1 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ManagedZonesListResponse>(parameters, callback);
@@ -2077,7 +2089,7 @@ export namespace dns_v2beta1 {
         params,
         requiredParams: ['project', 'managedZone'],
         pathParams: ['managedZone', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -2211,7 +2223,7 @@ export namespace dns_v2beta1 {
         params,
         requiredParams: ['project', 'managedZone'],
         pathParams: ['managedZone', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -2358,7 +2370,10 @@ export namespace dns_v2beta1 {
 
 
   export class Resource$Projects {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -2465,7 +2480,7 @@ export namespace dns_v2beta1 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Project>(parameters, callback);
@@ -2493,7 +2508,10 @@ export namespace dns_v2beta1 {
 
 
   export class Resource$Resourcerecordsets {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -2634,7 +2652,7 @@ export namespace dns_v2beta1 {
         params,
         requiredParams: ['project', 'managedZone'],
         pathParams: ['managedZone', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ResourceRecordSetsListResponse>(

--- a/src/apis/docs/v1.ts
+++ b/src/apis/docs/v1.ts
@@ -29,8 +29,6 @@ export namespace docs_v1 {
     version: 'v1';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * V1 error format.
@@ -98,12 +96,13 @@ export namespace docs_v1 {
    * @param {object=} options Options for Docs
    */
   export class Docs {
+    context: APIRequestContext;
     documents: Resource$Documents;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.documents = new Resource$Documents();
+      this.documents = new Resource$Documents(this.context);
     }
   }
 
@@ -3250,7 +3249,10 @@ export namespace docs_v1 {
 
 
   export class Resource$Documents {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -3330,7 +3332,7 @@ export namespace docs_v1 {
         params,
         requiredParams: ['documentId'],
         pathParams: ['documentId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$BatchUpdateDocumentResponse>(
@@ -3396,7 +3398,7 @@ export namespace docs_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Document>(parameters, callback);
@@ -3458,7 +3460,7 @@ export namespace docs_v1 {
         params,
         requiredParams: ['documentId'],
         pathParams: ['documentId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Document>(parameters, callback);

--- a/src/apis/doubleclickbidmanager/v1.ts
+++ b/src/apis/doubleclickbidmanager/v1.ts
@@ -29,8 +29,6 @@ export namespace doubleclickbidmanager_v1 {
     version: 'v1';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * Data format for the response.
@@ -81,18 +79,19 @@ export namespace doubleclickbidmanager_v1 {
    * @param {object=} options Options for Doubleclickbidmanager
    */
   export class Doubleclickbidmanager {
+    context: APIRequestContext;
     lineitems: Resource$Lineitems;
     queries: Resource$Queries;
     reports: Resource$Reports;
     sdf: Resource$Sdf;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.lineitems = new Resource$Lineitems();
-      this.queries = new Resource$Queries();
-      this.reports = new Resource$Reports();
-      this.sdf = new Resource$Sdf();
+      this.lineitems = new Resource$Lineitems(this.context);
+      this.queries = new Resource$Queries(this.context);
+      this.reports = new Resource$Reports(this.context);
+      this.sdf = new Resource$Sdf(this.context);
     }
   }
 
@@ -552,7 +551,10 @@ export namespace doubleclickbidmanager_v1 {
 
 
   export class Resource$Lineitems {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -617,7 +619,7 @@ export namespace doubleclickbidmanager_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$DownloadLineItemsResponse>(
@@ -689,7 +691,7 @@ export namespace doubleclickbidmanager_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$UploadLineItemsResponse>(parameters, callback);
@@ -728,7 +730,10 @@ export namespace doubleclickbidmanager_v1 {
 
 
   export class Resource$Queries {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -787,7 +792,7 @@ export namespace doubleclickbidmanager_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Query>(parameters, callback);
@@ -852,7 +857,7 @@ export namespace doubleclickbidmanager_v1 {
         params,
         requiredParams: ['queryId'],
         pathParams: ['queryId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -917,7 +922,7 @@ export namespace doubleclickbidmanager_v1 {
         params,
         requiredParams: ['queryId'],
         pathParams: ['queryId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Query>(parameters, callback);
@@ -984,7 +989,7 @@ export namespace doubleclickbidmanager_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListQueriesResponse>(parameters, callback);
@@ -1049,7 +1054,7 @@ export namespace doubleclickbidmanager_v1 {
         params,
         requiredParams: ['queryId'],
         pathParams: ['queryId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -1121,7 +1126,10 @@ export namespace doubleclickbidmanager_v1 {
 
 
   export class Resource$Reports {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1183,7 +1191,7 @@ export namespace doubleclickbidmanager_v1 {
         params,
         requiredParams: ['queryId'],
         pathParams: ['queryId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListReportsResponse>(parameters, callback);
@@ -1208,7 +1216,10 @@ export namespace doubleclickbidmanager_v1 {
 
 
   export class Resource$Sdf {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1266,7 +1277,7 @@ export namespace doubleclickbidmanager_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$DownloadResponse>(parameters, callback);

--- a/src/apis/doubleclicksearch/v2.ts
+++ b/src/apis/doubleclicksearch/v2.ts
@@ -29,8 +29,6 @@ export namespace doubleclicksearch_v2 {
     version: 'v2';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * Data format for the response.
@@ -82,16 +80,17 @@ export namespace doubleclicksearch_v2 {
    * @param {object=} options Options for Doubleclicksearch
    */
   export class Doubleclicksearch {
+    context: APIRequestContext;
     conversion: Resource$Conversion;
     reports: Resource$Reports;
     savedColumns: Resource$Savedcolumns;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.conversion = new Resource$Conversion();
-      this.reports = new Resource$Reports();
-      this.savedColumns = new Resource$Savedcolumns();
+      this.conversion = new Resource$Conversion(this.context);
+      this.reports = new Resource$Reports(this.context);
+      this.savedColumns = new Resource$Savedcolumns(this.context);
     }
   }
 
@@ -613,7 +612,10 @@ export namespace doubleclicksearch_v2 {
 
 
   export class Resource$Conversion {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -684,7 +686,7 @@ export namespace doubleclicksearch_v2 {
           'startDate', 'startRow'
         ],
         pathParams: ['advertiserId', 'agencyId', 'engineAccountId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ConversionList>(parameters, callback);
@@ -750,7 +752,7 @@ export namespace doubleclicksearch_v2 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ConversionList>(parameters, callback);
@@ -826,7 +828,7 @@ export namespace doubleclicksearch_v2 {
           'startDate', 'startRow'
         ],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ConversionList>(parameters, callback);
@@ -892,7 +894,7 @@ export namespace doubleclicksearch_v2 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ConversionList>(parameters, callback);
@@ -967,7 +969,7 @@ export namespace doubleclicksearch_v2 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$UpdateAvailabilityResponse>(
@@ -1115,7 +1117,10 @@ export namespace doubleclicksearch_v2 {
 
 
   export class Resource$Reports {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1173,7 +1178,7 @@ export namespace doubleclicksearch_v2 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Report>(parameters, callback);
@@ -1234,7 +1239,7 @@ export namespace doubleclicksearch_v2 {
         params,
         requiredParams: ['reportId'],
         pathParams: ['reportId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Report>(parameters, callback);
@@ -1300,7 +1305,7 @@ export namespace doubleclicksearch_v2 {
         params,
         requiredParams: ['reportId', 'reportFragment'],
         pathParams: ['reportFragment', 'reportId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -1364,7 +1369,7 @@ export namespace doubleclicksearch_v2 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Report>(parameters, callback);
@@ -1427,7 +1432,10 @@ export namespace doubleclicksearch_v2 {
 
 
   export class Resource$Savedcolumns {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1489,7 +1497,7 @@ export namespace doubleclicksearch_v2 {
         params,
         requiredParams: ['agencyId', 'advertiserId'],
         pathParams: ['advertiserId', 'agencyId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$SavedColumnList>(parameters, callback);

--- a/src/apis/drive/v2.ts
+++ b/src/apis/drive/v2.ts
@@ -29,8 +29,6 @@ export namespace drive_v2 {
     version: 'v2';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * Data format for the response.
@@ -82,6 +80,7 @@ export namespace drive_v2 {
    * @param {object=} options Options for Drive
    */
   export class Drive {
+    context: APIRequestContext;
     about: Resource$About;
     apps: Resource$Apps;
     changes: Resource$Changes;
@@ -98,22 +97,22 @@ export namespace drive_v2 {
     teamdrives: Resource$Teamdrives;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.about = new Resource$About();
-      this.apps = new Resource$Apps();
-      this.changes = new Resource$Changes();
-      this.channels = new Resource$Channels();
-      this.children = new Resource$Children();
-      this.comments = new Resource$Comments();
-      this.files = new Resource$Files();
-      this.parents = new Resource$Parents();
-      this.permissions = new Resource$Permissions();
-      this.properties = new Resource$Properties();
-      this.realtime = new Resource$Realtime();
-      this.replies = new Resource$Replies();
-      this.revisions = new Resource$Revisions();
-      this.teamdrives = new Resource$Teamdrives();
+      this.about = new Resource$About(this.context);
+      this.apps = new Resource$Apps(this.context);
+      this.changes = new Resource$Changes(this.context);
+      this.channels = new Resource$Channels(this.context);
+      this.children = new Resource$Children(this.context);
+      this.comments = new Resource$Comments(this.context);
+      this.files = new Resource$Files(this.context);
+      this.parents = new Resource$Parents(this.context);
+      this.permissions = new Resource$Permissions(this.context);
+      this.properties = new Resource$Properties(this.context);
+      this.realtime = new Resource$Realtime(this.context);
+      this.replies = new Resource$Replies(this.context);
+      this.revisions = new Resource$Revisions(this.context);
+      this.teamdrives = new Resource$Teamdrives(this.context);
     }
   }
 
@@ -1707,7 +1706,10 @@ export namespace drive_v2 {
 
 
   export class Resource$About {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1763,7 +1765,7 @@ export namespace drive_v2 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$About>(parameters, callback);
@@ -1799,7 +1801,10 @@ export namespace drive_v2 {
 
 
   export class Resource$Apps {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1853,7 +1858,7 @@ export namespace drive_v2 {
         params,
         requiredParams: ['appId'],
         pathParams: ['appId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$App>(parameters, callback);
@@ -1918,7 +1923,7 @@ export namespace drive_v2 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AppList>(parameters, callback);
@@ -1969,7 +1974,10 @@ export namespace drive_v2 {
 
 
   export class Resource$Changes {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -2026,7 +2034,7 @@ export namespace drive_v2 {
         params,
         requiredParams: ['changeId'],
         pathParams: ['changeId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Change>(parameters, callback);
@@ -2095,7 +2103,7 @@ export namespace drive_v2 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$StartPageToken>(parameters, callback);
@@ -2169,7 +2177,7 @@ export namespace drive_v2 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ChangeList>(parameters, callback);
@@ -2243,7 +2251,7 @@ export namespace drive_v2 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Channel>(parameters, callback);
@@ -2415,7 +2423,10 @@ export namespace drive_v2 {
 
 
   export class Resource$Channels {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -2471,7 +2482,7 @@ export namespace drive_v2 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -2496,7 +2507,10 @@ export namespace drive_v2 {
 
 
   export class Resource$Children {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -2553,7 +2567,7 @@ export namespace drive_v2 {
         params,
         requiredParams: ['folderId', 'childId'],
         pathParams: ['childId', 'folderId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -2616,7 +2630,7 @@ export namespace drive_v2 {
         params,
         requiredParams: ['folderId', 'childId'],
         pathParams: ['childId', 'folderId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ChildReference>(parameters, callback);
@@ -2683,7 +2697,7 @@ export namespace drive_v2 {
         params,
         requiredParams: ['folderId'],
         pathParams: ['folderId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ChildReference>(parameters, callback);
@@ -2752,7 +2766,7 @@ export namespace drive_v2 {
         params,
         requiredParams: ['folderId'],
         pathParams: ['folderId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ChildList>(parameters, callback);
@@ -2848,7 +2862,10 @@ export namespace drive_v2 {
 
 
   export class Resource$Comments {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -2905,7 +2922,7 @@ export namespace drive_v2 {
         params,
         requiredParams: ['fileId', 'commentId'],
         pathParams: ['commentId', 'fileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -2968,7 +2985,7 @@ export namespace drive_v2 {
         params,
         requiredParams: ['fileId', 'commentId'],
         pathParams: ['commentId', 'fileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Comment>(parameters, callback);
@@ -3033,7 +3050,7 @@ export namespace drive_v2 {
         params,
         requiredParams: ['fileId'],
         pathParams: ['fileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Comment>(parameters, callback);
@@ -3102,7 +3119,7 @@ export namespace drive_v2 {
         params,
         requiredParams: ['fileId'],
         pathParams: ['fileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$CommentList>(parameters, callback);
@@ -3168,7 +3185,7 @@ export namespace drive_v2 {
         params,
         requiredParams: ['fileId', 'commentId'],
         pathParams: ['commentId', 'fileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Comment>(parameters, callback);
@@ -3234,7 +3251,7 @@ export namespace drive_v2 {
         params,
         requiredParams: ['fileId', 'commentId'],
         pathParams: ['commentId', 'fileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Comment>(parameters, callback);
@@ -3370,7 +3387,10 @@ export namespace drive_v2 {
 
 
   export class Resource$Files {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -3436,7 +3456,7 @@ export namespace drive_v2 {
         params,
         requiredParams: ['fileId'],
         pathParams: ['fileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$File>(parameters, callback);
@@ -3502,7 +3522,7 @@ export namespace drive_v2 {
         params,
         requiredParams: ['fileId'],
         pathParams: ['fileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -3565,7 +3585,7 @@ export namespace drive_v2 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -3631,7 +3651,7 @@ export namespace drive_v2 {
         params,
         requiredParams: ['fileId', 'mimeType'],
         pathParams: ['fileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -3700,7 +3720,7 @@ export namespace drive_v2 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GeneratedIds>(parameters, callback);
@@ -3766,7 +3786,7 @@ export namespace drive_v2 {
         params,
         requiredParams: ['fileId'],
         pathParams: ['fileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$File>(parameters, callback);
@@ -3843,7 +3863,7 @@ export namespace drive_v2 {
             (rootUrl + '/upload/drive/v2/files').replace(/([^:]\/)\/+/g, '$1'),
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$File>(parameters, callback);
@@ -3916,7 +3936,7 @@ export namespace drive_v2 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$FileList>(parameters, callback);
@@ -3996,7 +4016,7 @@ export namespace drive_v2 {
         params,
         requiredParams: ['fileId'],
         pathParams: ['fileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$File>(parameters, callback);
@@ -4061,7 +4081,7 @@ export namespace drive_v2 {
         params,
         requiredParams: ['fileId'],
         pathParams: ['fileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$File>(parameters, callback);
@@ -4128,7 +4148,7 @@ export namespace drive_v2 {
         params,
         requiredParams: ['fileId'],
         pathParams: ['fileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$File>(parameters, callback);
@@ -4193,7 +4213,7 @@ export namespace drive_v2 {
         params,
         requiredParams: ['fileId'],
         pathParams: ['fileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$File>(parameters, callback);
@@ -4277,7 +4297,7 @@ export namespace drive_v2 {
                       .replace(/([^:]\/)\/+/g, '$1'),
         requiredParams: ['fileId'],
         pathParams: ['fileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$File>(parameters, callback);
@@ -4347,7 +4367,7 @@ export namespace drive_v2 {
         params,
         requiredParams: ['fileId'],
         pathParams: ['fileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Channel>(parameters, callback);
@@ -4899,7 +4919,10 @@ export namespace drive_v2 {
 
 
   export class Resource$Parents {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -4956,7 +4979,7 @@ export namespace drive_v2 {
         params,
         requiredParams: ['fileId', 'parentId'],
         pathParams: ['fileId', 'parentId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -5019,7 +5042,7 @@ export namespace drive_v2 {
         params,
         requiredParams: ['fileId', 'parentId'],
         pathParams: ['fileId', 'parentId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ParentReference>(parameters, callback);
@@ -5086,7 +5109,7 @@ export namespace drive_v2 {
         params,
         requiredParams: ['fileId'],
         pathParams: ['fileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ParentReference>(parameters, callback);
@@ -5151,7 +5174,7 @@ export namespace drive_v2 {
         params,
         requiredParams: ['fileId'],
         pathParams: ['fileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ParentList>(parameters, callback);
@@ -5225,7 +5248,10 @@ export namespace drive_v2 {
 
 
   export class Resource$Permissions {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -5287,7 +5313,7 @@ export namespace drive_v2 {
         params,
         requiredParams: ['fileId', 'permissionId'],
         pathParams: ['fileId', 'permissionId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -5353,7 +5379,7 @@ export namespace drive_v2 {
         params,
         requiredParams: ['fileId', 'permissionId'],
         pathParams: ['fileId', 'permissionId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Permission>(parameters, callback);
@@ -5420,7 +5446,7 @@ export namespace drive_v2 {
         params,
         requiredParams: ['email'],
         pathParams: ['email'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$PermissionId>(parameters, callback);
@@ -5492,7 +5518,7 @@ export namespace drive_v2 {
         params,
         requiredParams: ['fileId'],
         pathParams: ['fileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Permission>(parameters, callback);
@@ -5561,7 +5587,7 @@ export namespace drive_v2 {
         params,
         requiredParams: ['fileId'],
         pathParams: ['fileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$PermissionList>(parameters, callback);
@@ -5634,7 +5660,7 @@ export namespace drive_v2 {
         params,
         requiredParams: ['fileId', 'permissionId'],
         pathParams: ['fileId', 'permissionId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Permission>(parameters, callback);
@@ -5708,7 +5734,7 @@ export namespace drive_v2 {
         params,
         requiredParams: ['fileId', 'permissionId'],
         pathParams: ['fileId', 'permissionId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Permission>(parameters, callback);
@@ -5932,7 +5958,10 @@ export namespace drive_v2 {
 
 
   export class Resource$Properties {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -5992,7 +6021,7 @@ export namespace drive_v2 {
         params,
         requiredParams: ['fileId', 'propertyKey'],
         pathParams: ['fileId', 'propertyKey'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -6056,7 +6085,7 @@ export namespace drive_v2 {
         params,
         requiredParams: ['fileId', 'propertyKey'],
         pathParams: ['fileId', 'propertyKey'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Property>(parameters, callback);
@@ -6122,7 +6151,7 @@ export namespace drive_v2 {
         params,
         requiredParams: ['fileId'],
         pathParams: ['fileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Property>(parameters, callback);
@@ -6187,7 +6216,7 @@ export namespace drive_v2 {
         params,
         requiredParams: ['fileId'],
         pathParams: ['fileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$PropertyList>(parameters, callback);
@@ -6255,7 +6284,7 @@ export namespace drive_v2 {
         params,
         requiredParams: ['fileId', 'propertyKey'],
         pathParams: ['fileId', 'propertyKey'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Property>(parameters, callback);
@@ -6324,7 +6353,7 @@ export namespace drive_v2 {
         params,
         requiredParams: ['fileId', 'propertyKey'],
         pathParams: ['fileId', 'propertyKey'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Property>(parameters, callback);
@@ -6455,7 +6484,10 @@ export namespace drive_v2 {
 
 
   export class Resource$Realtime {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -6510,7 +6542,7 @@ export namespace drive_v2 {
         params,
         requiredParams: ['fileId'],
         pathParams: ['fileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -6580,7 +6612,7 @@ export namespace drive_v2 {
                       .replace(/([^:]\/)\/+/g, '$1'),
         requiredParams: ['fileId'],
         pathParams: ['fileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -6645,7 +6677,10 @@ export namespace drive_v2 {
 
 
   export class Resource$Replies {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -6705,7 +6740,7 @@ export namespace drive_v2 {
         params,
         requiredParams: ['fileId', 'commentId', 'replyId'],
         pathParams: ['commentId', 'fileId', 'replyId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -6772,7 +6807,7 @@ export namespace drive_v2 {
         params,
         requiredParams: ['fileId', 'commentId', 'replyId'],
         pathParams: ['commentId', 'fileId', 'replyId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$CommentReply>(parameters, callback);
@@ -6840,7 +6875,7 @@ export namespace drive_v2 {
         params,
         requiredParams: ['fileId', 'commentId'],
         pathParams: ['commentId', 'fileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$CommentReply>(parameters, callback);
@@ -6910,7 +6945,7 @@ export namespace drive_v2 {
         params,
         requiredParams: ['fileId', 'commentId'],
         pathParams: ['commentId', 'fileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$CommentReplyList>(parameters, callback);
@@ -6980,7 +7015,7 @@ export namespace drive_v2 {
         params,
         requiredParams: ['fileId', 'commentId', 'replyId'],
         pathParams: ['commentId', 'fileId', 'replyId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$CommentReply>(parameters, callback);
@@ -7050,7 +7085,7 @@ export namespace drive_v2 {
         params,
         requiredParams: ['fileId', 'commentId', 'replyId'],
         pathParams: ['commentId', 'fileId', 'replyId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$CommentReply>(parameters, callback);
@@ -7204,7 +7239,10 @@ export namespace drive_v2 {
 
 
   export class Resource$Revisions {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -7264,7 +7302,7 @@ export namespace drive_v2 {
         params,
         requiredParams: ['fileId', 'revisionId'],
         pathParams: ['fileId', 'revisionId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -7326,7 +7364,7 @@ export namespace drive_v2 {
         params,
         requiredParams: ['fileId', 'revisionId'],
         pathParams: ['fileId', 'revisionId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Revision>(parameters, callback);
@@ -7393,7 +7431,7 @@ export namespace drive_v2 {
         params,
         requiredParams: ['fileId'],
         pathParams: ['fileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$RevisionList>(parameters, callback);
@@ -7459,7 +7497,7 @@ export namespace drive_v2 {
         params,
         requiredParams: ['fileId', 'revisionId'],
         pathParams: ['fileId', 'revisionId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Revision>(parameters, callback);
@@ -7525,7 +7563,7 @@ export namespace drive_v2 {
         params,
         requiredParams: ['fileId', 'revisionId'],
         pathParams: ['fileId', 'revisionId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Revision>(parameters, callback);
@@ -7628,7 +7666,10 @@ export namespace drive_v2 {
 
 
   export class Resource$Teamdrives {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -7686,7 +7727,7 @@ export namespace drive_v2 {
         params,
         requiredParams: ['teamDriveId'],
         pathParams: ['teamDriveId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -7749,7 +7790,7 @@ export namespace drive_v2 {
         params,
         requiredParams: ['teamDriveId'],
         pathParams: ['teamDriveId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TeamDrive>(parameters, callback);
@@ -7816,7 +7857,7 @@ export namespace drive_v2 {
         params,
         requiredParams: ['requestId'],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TeamDrive>(parameters, callback);
@@ -7884,7 +7925,7 @@ export namespace drive_v2 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TeamDriveList>(parameters, callback);
@@ -7952,7 +7993,7 @@ export namespace drive_v2 {
         params,
         requiredParams: ['teamDriveId'],
         pathParams: ['teamDriveId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TeamDrive>(parameters, callback);

--- a/src/apis/drive/v3.ts
+++ b/src/apis/drive/v3.ts
@@ -29,8 +29,6 @@ export namespace drive_v3 {
     version: 'v3';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * Data format for the response.
@@ -82,6 +80,7 @@ export namespace drive_v3 {
    * @param {object=} options Options for Drive
    */
   export class Drive {
+    context: APIRequestContext;
     about: Resource$About;
     changes: Resource$Changes;
     channels: Resource$Channels;
@@ -93,17 +92,17 @@ export namespace drive_v3 {
     teamdrives: Resource$Teamdrives;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.about = new Resource$About();
-      this.changes = new Resource$Changes();
-      this.channels = new Resource$Channels();
-      this.comments = new Resource$Comments();
-      this.files = new Resource$Files();
-      this.permissions = new Resource$Permissions();
-      this.replies = new Resource$Replies();
-      this.revisions = new Resource$Revisions();
-      this.teamdrives = new Resource$Teamdrives();
+      this.about = new Resource$About(this.context);
+      this.changes = new Resource$Changes(this.context);
+      this.channels = new Resource$Channels(this.context);
+      this.comments = new Resource$Comments(this.context);
+      this.files = new Resource$Files(this.context);
+      this.permissions = new Resource$Permissions(this.context);
+      this.replies = new Resource$Replies(this.context);
+      this.revisions = new Resource$Revisions(this.context);
+      this.teamdrives = new Resource$Teamdrives(this.context);
     }
   }
 
@@ -1146,7 +1145,10 @@ export namespace drive_v3 {
 
 
   export class Resource$About {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1199,7 +1201,7 @@ export namespace drive_v3 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$About>(parameters, callback);
@@ -1218,7 +1220,10 @@ export namespace drive_v3 {
 
 
   export class Resource$Changes {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1280,7 +1285,7 @@ export namespace drive_v3 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$StartPageToken>(parameters, callback);
@@ -1353,7 +1358,7 @@ export namespace drive_v3 {
         params,
         requiredParams: ['pageToken'],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ChangeList>(parameters, callback);
@@ -1426,7 +1431,7 @@ export namespace drive_v3 {
         params,
         requiredParams: ['pageToken'],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Channel>(parameters, callback);
@@ -1569,7 +1574,10 @@ export namespace drive_v3 {
 
 
   export class Resource$Channels {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1625,7 +1633,7 @@ export namespace drive_v3 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -1650,7 +1658,10 @@ export namespace drive_v3 {
 
 
   export class Resource$Comments {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1708,7 +1719,7 @@ export namespace drive_v3 {
         params,
         requiredParams: ['fileId'],
         pathParams: ['fileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Comment>(parameters, callback);
@@ -1772,7 +1783,7 @@ export namespace drive_v3 {
         params,
         requiredParams: ['fileId', 'commentId'],
         pathParams: ['commentId', 'fileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -1835,7 +1846,7 @@ export namespace drive_v3 {
         params,
         requiredParams: ['fileId', 'commentId'],
         pathParams: ['commentId', 'fileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Comment>(parameters, callback);
@@ -1904,7 +1915,7 @@ export namespace drive_v3 {
         params,
         requiredParams: ['fileId'],
         pathParams: ['fileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$CommentList>(parameters, callback);
@@ -1970,7 +1981,7 @@ export namespace drive_v3 {
         params,
         requiredParams: ['fileId', 'commentId'],
         pathParams: ['commentId', 'fileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Comment>(parameters, callback);
@@ -2084,7 +2095,10 @@ export namespace drive_v3 {
 
 
   export class Resource$Files {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -2147,7 +2161,7 @@ export namespace drive_v3 {
         params,
         requiredParams: ['fileId'],
         pathParams: ['fileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$File>(parameters, callback);
@@ -2220,7 +2234,7 @@ export namespace drive_v3 {
             (rootUrl + '/upload/drive/v3/files').replace(/([^:]\/)\/+/g, '$1'),
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$File>(parameters, callback);
@@ -2287,7 +2301,7 @@ export namespace drive_v3 {
         params,
         requiredParams: ['fileId'],
         pathParams: ['fileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -2350,7 +2364,7 @@ export namespace drive_v3 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -2416,7 +2430,7 @@ export namespace drive_v3 {
         params,
         requiredParams: ['fileId', 'mimeType'],
         pathParams: ['fileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -2485,7 +2499,7 @@ export namespace drive_v3 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GeneratedIds>(parameters, callback);
@@ -2548,7 +2562,7 @@ export namespace drive_v3 {
         params,
         requiredParams: ['fileId'],
         pathParams: ['fileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$File>(parameters, callback);
@@ -2620,7 +2634,7 @@ export namespace drive_v3 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$FileList>(parameters, callback);
@@ -2696,7 +2710,7 @@ export namespace drive_v3 {
                       .replace(/([^:]\/)\/+/g, '$1'),
         requiredParams: ['fileId'],
         pathParams: ['fileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$File>(parameters, callback);
@@ -2763,7 +2777,7 @@ export namespace drive_v3 {
         params,
         requiredParams: ['fileId'],
         pathParams: ['fileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Channel>(parameters, callback);
@@ -3080,7 +3094,10 @@ export namespace drive_v3 {
 
 
   export class Resource$Permissions {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -3146,7 +3163,7 @@ export namespace drive_v3 {
         params,
         requiredParams: ['fileId'],
         pathParams: ['fileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Permission>(parameters, callback);
@@ -3215,7 +3232,7 @@ export namespace drive_v3 {
         params,
         requiredParams: ['fileId', 'permissionId'],
         pathParams: ['fileId', 'permissionId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -3281,7 +3298,7 @@ export namespace drive_v3 {
         params,
         requiredParams: ['fileId', 'permissionId'],
         pathParams: ['fileId', 'permissionId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Permission>(parameters, callback);
@@ -3350,7 +3367,7 @@ export namespace drive_v3 {
         params,
         requiredParams: ['fileId'],
         pathParams: ['fileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$PermissionList>(parameters, callback);
@@ -3424,7 +3441,7 @@ export namespace drive_v3 {
         params,
         requiredParams: ['fileId', 'permissionId'],
         pathParams: ['fileId', 'permissionId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Permission>(parameters, callback);
@@ -3604,7 +3621,10 @@ export namespace drive_v3 {
 
 
   export class Resource$Replies {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -3664,7 +3684,7 @@ export namespace drive_v3 {
         params,
         requiredParams: ['fileId', 'commentId'],
         pathParams: ['commentId', 'fileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Reply>(parameters, callback);
@@ -3731,7 +3751,7 @@ export namespace drive_v3 {
         params,
         requiredParams: ['fileId', 'commentId', 'replyId'],
         pathParams: ['commentId', 'fileId', 'replyId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -3797,7 +3817,7 @@ export namespace drive_v3 {
         params,
         requiredParams: ['fileId', 'commentId', 'replyId'],
         pathParams: ['commentId', 'fileId', 'replyId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Reply>(parameters, callback);
@@ -3867,7 +3887,7 @@ export namespace drive_v3 {
         params,
         requiredParams: ['fileId', 'commentId'],
         pathParams: ['commentId', 'fileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ReplyList>(parameters, callback);
@@ -3936,7 +3956,7 @@ export namespace drive_v3 {
         params,
         requiredParams: ['fileId', 'commentId', 'replyId'],
         pathParams: ['commentId', 'fileId', 'replyId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Reply>(parameters, callback);
@@ -4065,7 +4085,10 @@ export namespace drive_v3 {
 
 
   export class Resource$Revisions {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -4125,7 +4148,7 @@ export namespace drive_v3 {
         params,
         requiredParams: ['fileId', 'revisionId'],
         pathParams: ['fileId', 'revisionId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -4188,7 +4211,7 @@ export namespace drive_v3 {
         params,
         requiredParams: ['fileId', 'revisionId'],
         pathParams: ['fileId', 'revisionId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Revision>(parameters, callback);
@@ -4255,7 +4278,7 @@ export namespace drive_v3 {
         params,
         requiredParams: ['fileId'],
         pathParams: ['fileId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$RevisionList>(parameters, callback);
@@ -4321,7 +4344,7 @@ export namespace drive_v3 {
         params,
         requiredParams: ['fileId', 'revisionId'],
         pathParams: ['fileId', 'revisionId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Revision>(parameters, callback);
@@ -4409,7 +4432,10 @@ export namespace drive_v3 {
 
 
   export class Resource$Teamdrives {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -4469,7 +4495,7 @@ export namespace drive_v3 {
         params,
         requiredParams: ['requestId'],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TeamDrive>(parameters, callback);
@@ -4534,7 +4560,7 @@ export namespace drive_v3 {
         params,
         requiredParams: ['teamDriveId'],
         pathParams: ['teamDriveId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -4597,7 +4623,7 @@ export namespace drive_v3 {
         params,
         requiredParams: ['teamDriveId'],
         pathParams: ['teamDriveId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TeamDrive>(parameters, callback);
@@ -4665,7 +4691,7 @@ export namespace drive_v3 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TeamDriveList>(parameters, callback);
@@ -4733,7 +4759,7 @@ export namespace drive_v3 {
         params,
         requiredParams: ['teamDriveId'],
         pathParams: ['teamDriveId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TeamDrive>(parameters, callback);

--- a/src/apis/driveactivity/v2.ts
+++ b/src/apis/driveactivity/v2.ts
@@ -29,8 +29,6 @@ export namespace driveactivity_v2 {
     version: 'v2';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * V1 error format.
@@ -98,12 +96,13 @@ export namespace driveactivity_v2 {
    * @param {object=} options Options for Driveactivity
    */
   export class Driveactivity {
+    context: APIRequestContext;
     activity: Resource$Activity;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.activity = new Resource$Activity();
+      this.activity = new Resource$Activity(this.context);
     }
   }
 
@@ -840,7 +839,10 @@ export namespace driveactivity_v2 {
 
 
   export class Resource$Activity {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -903,7 +905,7 @@ export namespace driveactivity_v2 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$QueryDriveActivityResponse>(

--- a/src/apis/factchecktools/v1alpha1.ts
+++ b/src/apis/factchecktools/v1alpha1.ts
@@ -29,8 +29,6 @@ export namespace factchecktools_v1alpha1 {
     version: 'v1alpha1';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * V1 error format.
@@ -98,14 +96,15 @@ export namespace factchecktools_v1alpha1 {
    * @param {object=} options Options for Factchecktools
    */
   export class Factchecktools {
+    context: APIRequestContext;
     claims: Resource$Claims;
     pages: Resource$Pages;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.claims = new Resource$Claims();
-      this.pages = new Resource$Pages();
+      this.claims = new Resource$Claims(this.context);
+      this.pages = new Resource$Pages(this.context);
     }
   }
 
@@ -380,7 +379,10 @@ export namespace factchecktools_v1alpha1 {
 
 
   export class Resource$Claims {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -455,7 +457,7 @@ export namespace factchecktools_v1alpha1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<
@@ -518,7 +520,10 @@ export namespace factchecktools_v1alpha1 {
 
 
   export class Resource$Pages {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -586,7 +591,7 @@ export namespace factchecktools_v1alpha1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<
@@ -656,7 +661,7 @@ export namespace factchecktools_v1alpha1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleProtobufEmpty>(parameters, callback);
@@ -729,7 +734,7 @@ export namespace factchecktools_v1alpha1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<
@@ -812,7 +817,7 @@ export namespace factchecktools_v1alpha1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<
@@ -896,7 +901,7 @@ export namespace factchecktools_v1alpha1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<

--- a/src/apis/file/v1.ts
+++ b/src/apis/file/v1.ts
@@ -29,8 +29,6 @@ export namespace file_v1 {
     version: 'v1';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * V1 error format.
@@ -99,12 +97,13 @@ export namespace file_v1 {
    * @param {object=} options Options for File
    */
   export class File {
+    context: APIRequestContext;
     projects: Resource$Projects;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.projects = new Resource$Projects();
+      this.projects = new Resource$Projects(this.context);
     }
   }
 
@@ -425,19 +424,24 @@ export namespace file_v1 {
 
 
   export class Resource$Projects {
+    context: APIRequestContext;
     locations: Resource$Projects$Locations;
-    constructor() {
-      this.locations = new Resource$Projects$Locations();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.locations = new Resource$Projects$Locations(this.context);
     }
   }
 
 
   export class Resource$Projects$Locations {
+    context: APIRequestContext;
     instances: Resource$Projects$Locations$Instances;
     operations: Resource$Projects$Locations$Operations;
-    constructor() {
-      this.instances = new Resource$Projects$Locations$Instances();
-      this.operations = new Resource$Projects$Locations$Operations();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.instances = new Resource$Projects$Locations$Instances(this.context);
+      this.operations =
+          new Resource$Projects$Locations$Operations(this.context);
     }
 
 
@@ -492,7 +496,7 @@ export namespace file_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Location>(parameters, callback);
@@ -563,7 +567,7 @@ export namespace file_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListLocationsResponse>(parameters, callback);
@@ -611,7 +615,10 @@ export namespace file_v1 {
   }
 
   export class Resource$Projects$Locations$Instances {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -673,7 +680,7 @@ export namespace file_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -739,7 +746,7 @@ export namespace file_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -800,7 +807,7 @@ export namespace file_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Instance>(parameters, callback);
@@ -873,7 +880,7 @@ export namespace file_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListInstancesResponse>(parameters, callback);
@@ -941,7 +948,7 @@ export namespace file_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -1061,7 +1068,10 @@ export namespace file_v1 {
 
 
   export class Resource$Projects$Locations$Operations {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1129,7 +1139,7 @@ export namespace file_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -1197,7 +1207,7 @@ export namespace file_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -1261,7 +1271,7 @@ export namespace file_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -1340,7 +1350,7 @@ export namespace file_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListOperationsResponse>(parameters, callback);

--- a/src/apis/file/v1beta1.ts
+++ b/src/apis/file/v1beta1.ts
@@ -29,8 +29,6 @@ export namespace file_v1beta1 {
     version: 'v1beta1';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * V1 error format.
@@ -99,12 +97,13 @@ export namespace file_v1beta1 {
    * @param {object=} options Options for File
    */
   export class File {
+    context: APIRequestContext;
     projects: Resource$Projects;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.projects = new Resource$Projects();
+      this.projects = new Resource$Projects(this.context);
     }
   }
 
@@ -425,19 +424,24 @@ export namespace file_v1beta1 {
 
 
   export class Resource$Projects {
+    context: APIRequestContext;
     locations: Resource$Projects$Locations;
-    constructor() {
-      this.locations = new Resource$Projects$Locations();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.locations = new Resource$Projects$Locations(this.context);
     }
   }
 
 
   export class Resource$Projects$Locations {
+    context: APIRequestContext;
     instances: Resource$Projects$Locations$Instances;
     operations: Resource$Projects$Locations$Operations;
-    constructor() {
-      this.instances = new Resource$Projects$Locations$Instances();
-      this.operations = new Resource$Projects$Locations$Operations();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.instances = new Resource$Projects$Locations$Instances(this.context);
+      this.operations =
+          new Resource$Projects$Locations$Operations(this.context);
     }
 
 
@@ -492,7 +496,7 @@ export namespace file_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Location>(parameters, callback);
@@ -563,7 +567,7 @@ export namespace file_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListLocationsResponse>(parameters, callback);
@@ -611,7 +615,10 @@ export namespace file_v1beta1 {
   }
 
   export class Resource$Projects$Locations$Instances {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -673,7 +680,7 @@ export namespace file_v1beta1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -739,7 +746,7 @@ export namespace file_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -800,7 +807,7 @@ export namespace file_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Instance>(parameters, callback);
@@ -873,7 +880,7 @@ export namespace file_v1beta1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListInstancesResponse>(parameters, callback);
@@ -941,7 +948,7 @@ export namespace file_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -1061,7 +1068,10 @@ export namespace file_v1beta1 {
 
 
   export class Resource$Projects$Locations$Operations {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1129,7 +1139,7 @@ export namespace file_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -1197,7 +1207,7 @@ export namespace file_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -1261,7 +1271,7 @@ export namespace file_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -1340,7 +1350,7 @@ export namespace file_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListOperationsResponse>(parameters, callback);

--- a/src/apis/firebasedynamiclinks/v1.ts
+++ b/src/apis/firebasedynamiclinks/v1.ts
@@ -29,8 +29,6 @@ export namespace firebasedynamiclinks_v1 {
     version: 'v1';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * V1 error format.
@@ -98,16 +96,17 @@ export namespace firebasedynamiclinks_v1 {
    * @param {object=} options Options for Firebasedynamiclinks
    */
   export class Firebasedynamiclinks {
+    context: APIRequestContext;
     managedShortLinks: Resource$Managedshortlinks;
     shortLinks: Resource$Shortlinks;
     v1: Resource$V1;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.managedShortLinks = new Resource$Managedshortlinks();
-      this.shortLinks = new Resource$Shortlinks();
-      this.v1 = new Resource$V1();
+      this.managedShortLinks = new Resource$Managedshortlinks(this.context);
+      this.shortLinks = new Resource$Shortlinks(this.context);
+      this.v1 = new Resource$V1(this.context);
     }
   }
 
@@ -740,7 +739,10 @@ export namespace firebasedynamiclinks_v1 {
 
 
   export class Resource$Managedshortlinks {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -815,7 +817,7 @@ export namespace firebasedynamiclinks_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$CreateManagedShortLinkResponse>(
@@ -843,7 +845,10 @@ export namespace firebasedynamiclinks_v1 {
 
 
   export class Resource$Shortlinks {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -912,7 +917,7 @@ export namespace firebasedynamiclinks_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$CreateShortDynamicLinkResponse>(
@@ -940,7 +945,10 @@ export namespace firebasedynamiclinks_v1 {
 
 
   export class Resource$V1 {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1004,7 +1012,7 @@ export namespace firebasedynamiclinks_v1 {
         params,
         requiredParams: ['dynamicLink'],
         pathParams: ['dynamicLink'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$DynamicLinkStats>(parameters, callback);
@@ -1082,7 +1090,7 @@ export namespace firebasedynamiclinks_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GetIosPostInstallAttributionResponse>(
@@ -1158,7 +1166,7 @@ export namespace firebasedynamiclinks_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GetIosReopenAttributionResponse>(

--- a/src/apis/firebasehosting/v1beta1.ts
+++ b/src/apis/firebasehosting/v1beta1.ts
@@ -29,8 +29,6 @@ export namespace firebasehosting_v1beta1 {
     version: 'v1beta1';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * V1 error format.
@@ -100,12 +98,13 @@ export namespace firebasehosting_v1beta1 {
    * @param {object=} options Options for Firebasehosting
    */
   export class Firebasehosting {
+    context: APIRequestContext;
     sites: Resource$Sites;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.sites = new Resource$Sites();
+      this.sites = new Resource$Sites(this.context);
     }
   }
 
@@ -569,13 +568,15 @@ export namespace firebasehosting_v1beta1 {
 
 
   export class Resource$Sites {
+    context: APIRequestContext;
     domains: Resource$Sites$Domains;
     releases: Resource$Sites$Releases;
     versions: Resource$Sites$Versions;
-    constructor() {
-      this.domains = new Resource$Sites$Domains();
-      this.releases = new Resource$Sites$Releases();
-      this.versions = new Resource$Sites$Versions();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.domains = new Resource$Sites$Domains(this.context);
+      this.releases = new Resource$Sites$Releases(this.context);
+      this.versions = new Resource$Sites$Versions(this.context);
     }
 
 
@@ -635,7 +636,7 @@ export namespace firebasehosting_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$SiteConfig>(parameters, callback);
@@ -704,7 +705,7 @@ export namespace firebasehosting_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$SiteConfig>(parameters, callback);
@@ -753,7 +754,10 @@ export namespace firebasehosting_v1beta1 {
   }
 
   export class Resource$Sites$Domains {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -814,7 +818,7 @@ export namespace firebasehosting_v1beta1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Domain>(parameters, callback);
@@ -880,7 +884,7 @@ export namespace firebasehosting_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -942,7 +946,7 @@ export namespace firebasehosting_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Domain>(parameters, callback);
@@ -1011,7 +1015,7 @@ export namespace firebasehosting_v1beta1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListDomainsResponse>(parameters, callback);
@@ -1079,7 +1083,7 @@ export namespace firebasehosting_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Domain>(parameters, callback);
@@ -1173,7 +1177,10 @@ export namespace firebasehosting_v1beta1 {
 
 
   export class Resource$Sites$Releases {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1236,7 +1243,7 @@ export namespace firebasehosting_v1beta1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Release>(parameters, callback);
@@ -1306,7 +1313,7 @@ export namespace firebasehosting_v1beta1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListReleasesResponse>(parameters, callback);
@@ -1367,9 +1374,11 @@ export namespace firebasehosting_v1beta1 {
 
 
   export class Resource$Sites$Versions {
+    context: APIRequestContext;
     files: Resource$Sites$Versions$Files;
-    constructor() {
-      this.files = new Resource$Sites$Versions$Files();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.files = new Resource$Sites$Versions$Files(this.context);
     }
 
 
@@ -1433,7 +1442,7 @@ export namespace firebasehosting_v1beta1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Version>(parameters, callback);
@@ -1499,7 +1508,7 @@ export namespace firebasehosting_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -1572,7 +1581,7 @@ export namespace firebasehosting_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Version>(parameters, callback);
@@ -1647,7 +1656,7 @@ export namespace firebasehosting_v1beta1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$PopulateVersionFilesResponse>(
@@ -1747,7 +1756,10 @@ export namespace firebasehosting_v1beta1 {
   }
 
   export class Resource$Sites$Versions$Files {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1813,7 +1825,7 @@ export namespace firebasehosting_v1beta1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListVersionFilesResponse>(parameters, callback);

--- a/src/apis/firebaserules/v1.ts
+++ b/src/apis/firebaserules/v1.ts
@@ -29,8 +29,6 @@ export namespace firebaserules_v1 {
     version: 'v1';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * V1 error format.
@@ -99,12 +97,13 @@ export namespace firebaserules_v1 {
    * @param {object=} options Options for Firebaserules
    */
   export class Firebaserules {
+    context: APIRequestContext;
     projects: Resource$Projects;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.projects = new Resource$Projects();
+      this.projects = new Resource$Projects(this.context);
     }
   }
 
@@ -509,11 +508,13 @@ export namespace firebaserules_v1 {
 
 
   export class Resource$Projects {
+    context: APIRequestContext;
     releases: Resource$Projects$Releases;
     rulesets: Resource$Projects$Rulesets;
-    constructor() {
-      this.releases = new Resource$Projects$Releases();
-      this.rulesets = new Resource$Projects$Rulesets();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.releases = new Resource$Projects$Releases(this.context);
+      this.rulesets = new Resource$Projects$Rulesets(this.context);
     }
 
 
@@ -585,7 +586,7 @@ export namespace firebaserules_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TestRulesetResponse>(parameters, callback);
@@ -617,7 +618,10 @@ export namespace firebaserules_v1 {
   }
 
   export class Resource$Projects$Releases {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -692,7 +696,7 @@ export namespace firebaserules_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Release>(parameters, callback);
@@ -758,7 +762,7 @@ export namespace firebaserules_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -820,7 +824,7 @@ export namespace firebaserules_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Release>(parameters, callback);
@@ -895,7 +899,7 @@ export namespace firebaserules_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GetReleaseExecutableResponse>(
@@ -971,7 +975,7 @@ export namespace firebaserules_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListReleasesResponse>(parameters, callback);
@@ -1040,7 +1044,7 @@ export namespace firebaserules_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Release>(parameters, callback);
@@ -1178,7 +1182,10 @@ export namespace firebaserules_v1 {
 
 
   export class Resource$Projects$Rulesets {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1243,7 +1250,7 @@ export namespace firebaserules_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Ruleset>(parameters, callback);
@@ -1310,7 +1317,7 @@ export namespace firebaserules_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -1372,7 +1379,7 @@ export namespace firebaserules_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Ruleset>(parameters, callback);
@@ -1446,7 +1453,7 @@ export namespace firebaserules_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListRulesetsResponse>(parameters, callback);

--- a/src/apis/firestore/v1.ts
+++ b/src/apis/firestore/v1.ts
@@ -29,8 +29,6 @@ export namespace firestore_v1 {
     version: 'v1';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * V1 error format.
@@ -99,12 +97,13 @@ export namespace firestore_v1 {
    * @param {object=} options Options for Firestore
    */
   export class Firestore {
+    context: APIRequestContext;
     projects: Resource$Projects;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.projects = new Resource$Projects();
+      this.projects = new Resource$Projects(this.context);
     }
   }
 
@@ -1631,24 +1630,29 @@ export namespace firestore_v1 {
 
 
   export class Resource$Projects {
+    context: APIRequestContext;
     databases: Resource$Projects$Databases;
     locations: Resource$Projects$Locations;
-    constructor() {
-      this.databases = new Resource$Projects$Databases();
-      this.locations = new Resource$Projects$Locations();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.databases = new Resource$Projects$Databases(this.context);
+      this.locations = new Resource$Projects$Locations(this.context);
     }
   }
 
 
   export class Resource$Projects$Databases {
+    context: APIRequestContext;
     collectionGroups: Resource$Projects$Databases$Collectiongroups;
     documents: Resource$Projects$Databases$Documents;
     operations: Resource$Projects$Databases$Operations;
-    constructor() {
+    constructor(context: APIRequestContext) {
+      this.context = context;
       this.collectionGroups =
-          new Resource$Projects$Databases$Collectiongroups();
-      this.documents = new Resource$Projects$Databases$Documents();
-      this.operations = new Resource$Projects$Databases$Operations();
+          new Resource$Projects$Databases$Collectiongroups(this.context);
+      this.documents = new Resource$Projects$Databases$Documents(this.context);
+      this.operations =
+          new Resource$Projects$Databases$Operations(this.context);
     }
 
 
@@ -1723,7 +1727,7 @@ export namespace firestore_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleLongrunningOperation>(
@@ -1803,7 +1807,7 @@ export namespace firestore_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleLongrunningOperation>(
@@ -1852,17 +1856,24 @@ export namespace firestore_v1 {
   }
 
   export class Resource$Projects$Databases$Collectiongroups {
+    context: APIRequestContext;
     fields: Resource$Projects$Databases$Collectiongroups$Fields;
     indexes: Resource$Projects$Databases$Collectiongroups$Indexes;
-    constructor() {
-      this.fields = new Resource$Projects$Databases$Collectiongroups$Fields();
-      this.indexes = new Resource$Projects$Databases$Collectiongroups$Indexes();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.fields =
+          new Resource$Projects$Databases$Collectiongroups$Fields(this.context);
+      this.indexes = new Resource$Projects$Databases$Collectiongroups$Indexes(
+          this.context);
     }
   }
 
 
   export class Resource$Projects$Databases$Collectiongroups$Fields {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1924,7 +1935,7 @@ export namespace firestore_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleFirestoreAdminV1Field>(
@@ -2008,7 +2019,7 @@ export namespace firestore_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleFirestoreAdminV1ListFieldsResponse>(
@@ -2097,7 +2108,7 @@ export namespace firestore_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleLongrunningOperation>(
@@ -2193,7 +2204,10 @@ export namespace firestore_v1 {
 
 
   export class Resource$Projects$Databases$Collectiongroups$Indexes {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -2267,7 +2281,7 @@ export namespace firestore_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleLongrunningOperation>(
@@ -2338,7 +2352,7 @@ export namespace firestore_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -2408,7 +2422,7 @@ export namespace firestore_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleFirestoreAdminV1Index>(
@@ -2490,7 +2504,7 @@ export namespace firestore_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleFirestoreAdminV1ListIndexesResponse>(
@@ -2577,7 +2591,10 @@ export namespace firestore_v1 {
 
 
   export class Resource$Projects$Databases$Documents {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -2643,7 +2660,7 @@ export namespace firestore_v1 {
         params,
         requiredParams: ['database'],
         pathParams: ['database'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$BatchGetDocumentsResponse>(
@@ -2717,7 +2734,7 @@ export namespace firestore_v1 {
         params,
         requiredParams: ['database'],
         pathParams: ['database'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$BeginTransactionResponse>(parameters, callback);
@@ -2785,7 +2802,7 @@ export namespace firestore_v1 {
         params,
         requiredParams: ['database'],
         pathParams: ['database'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$CommitResponse>(parameters, callback);
@@ -2857,7 +2874,7 @@ export namespace firestore_v1 {
         params,
         requiredParams: ['parent', 'collectionId'],
         pathParams: ['collectionId', 'parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Document>(parameters, callback);
@@ -2924,7 +2941,7 @@ export namespace firestore_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -2988,7 +3005,7 @@ export namespace firestore_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Document>(parameters, callback);
@@ -3064,7 +3081,7 @@ export namespace firestore_v1 {
         params,
         requiredParams: ['parent', 'collectionId'],
         pathParams: ['collectionId', 'parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListDocumentsResponse>(parameters, callback);
@@ -3137,7 +3154,7 @@ export namespace firestore_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListCollectionIdsResponse>(
@@ -3206,7 +3223,7 @@ export namespace firestore_v1 {
         params,
         requiredParams: ['database'],
         pathParams: ['database'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListenResponse>(parameters, callback);
@@ -3276,7 +3293,7 @@ export namespace firestore_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Document>(parameters, callback);
@@ -3344,7 +3361,7 @@ export namespace firestore_v1 {
         params,
         requiredParams: ['database'],
         pathParams: ['database'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -3413,7 +3430,7 @@ export namespace firestore_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$RunQueryResponse>(parameters, callback);
@@ -3481,7 +3498,7 @@ export namespace firestore_v1 {
         params,
         requiredParams: ['database'],
         pathParams: ['database'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$WriteResponse>(parameters, callback);
@@ -3822,7 +3839,10 @@ export namespace firestore_v1 {
 
 
   export class Resource$Projects$Databases$Operations {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -3890,7 +3910,7 @@ export namespace firestore_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -3958,7 +3978,7 @@ export namespace firestore_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -4027,7 +4047,7 @@ export namespace firestore_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleLongrunningOperation>(
@@ -4112,7 +4132,7 @@ export namespace firestore_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleLongrunningListOperationsResponse>(
@@ -4193,7 +4213,10 @@ export namespace firestore_v1 {
 
 
   export class Resource$Projects$Locations {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -4247,7 +4270,7 @@ export namespace firestore_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Location>(parameters, callback);
@@ -4318,7 +4341,7 @@ export namespace firestore_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListLocationsResponse>(parameters, callback);

--- a/src/apis/firestore/v1beta1.ts
+++ b/src/apis/firestore/v1beta1.ts
@@ -29,8 +29,6 @@ export namespace firestore_v1beta1 {
     version: 'v1beta1';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * V1 error format.
@@ -99,12 +97,13 @@ export namespace firestore_v1beta1 {
    * @param {object=} options Options for Firestore
    */
   export class Firestore {
+    context: APIRequestContext;
     projects: Resource$Projects;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.projects = new Resource$Projects();
+      this.projects = new Resource$Projects(this.context);
     }
   }
 
@@ -1422,19 +1421,23 @@ export namespace firestore_v1beta1 {
 
 
   export class Resource$Projects {
+    context: APIRequestContext;
     databases: Resource$Projects$Databases;
-    constructor() {
-      this.databases = new Resource$Projects$Databases();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.databases = new Resource$Projects$Databases(this.context);
     }
   }
 
 
   export class Resource$Projects$Databases {
+    context: APIRequestContext;
     documents: Resource$Projects$Databases$Documents;
     indexes: Resource$Projects$Databases$Indexes;
-    constructor() {
-      this.documents = new Resource$Projects$Databases$Documents();
-      this.indexes = new Resource$Projects$Databases$Indexes();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.documents = new Resource$Projects$Databases$Documents(this.context);
+      this.indexes = new Resource$Projects$Databases$Indexes(this.context);
     }
 
 
@@ -1509,7 +1512,7 @@ export namespace firestore_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleLongrunningOperation>(
@@ -1589,7 +1592,7 @@ export namespace firestore_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleLongrunningOperation>(
@@ -1638,7 +1641,10 @@ export namespace firestore_v1beta1 {
   }
 
   export class Resource$Projects$Databases$Documents {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1704,7 +1710,7 @@ export namespace firestore_v1beta1 {
         params,
         requiredParams: ['database'],
         pathParams: ['database'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$BatchGetDocumentsResponse>(
@@ -1778,7 +1784,7 @@ export namespace firestore_v1beta1 {
         params,
         requiredParams: ['database'],
         pathParams: ['database'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$BeginTransactionResponse>(parameters, callback);
@@ -1846,7 +1852,7 @@ export namespace firestore_v1beta1 {
         params,
         requiredParams: ['database'],
         pathParams: ['database'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$CommitResponse>(parameters, callback);
@@ -1918,7 +1924,7 @@ export namespace firestore_v1beta1 {
         params,
         requiredParams: ['parent', 'collectionId'],
         pathParams: ['collectionId', 'parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Document>(parameters, callback);
@@ -1985,7 +1991,7 @@ export namespace firestore_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -2049,7 +2055,7 @@ export namespace firestore_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Document>(parameters, callback);
@@ -2125,7 +2131,7 @@ export namespace firestore_v1beta1 {
         params,
         requiredParams: ['parent', 'collectionId'],
         pathParams: ['collectionId', 'parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListDocumentsResponse>(parameters, callback);
@@ -2198,7 +2204,7 @@ export namespace firestore_v1beta1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListCollectionIdsResponse>(
@@ -2267,7 +2273,7 @@ export namespace firestore_v1beta1 {
         params,
         requiredParams: ['database'],
         pathParams: ['database'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListenResponse>(parameters, callback);
@@ -2337,7 +2343,7 @@ export namespace firestore_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Document>(parameters, callback);
@@ -2405,7 +2411,7 @@ export namespace firestore_v1beta1 {
         params,
         requiredParams: ['database'],
         pathParams: ['database'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -2474,7 +2480,7 @@ export namespace firestore_v1beta1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$RunQueryResponse>(parameters, callback);
@@ -2542,7 +2548,7 @@ export namespace firestore_v1beta1 {
         params,
         requiredParams: ['database'],
         pathParams: ['database'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$WriteResponse>(parameters, callback);
@@ -2883,7 +2889,10 @@ export namespace firestore_v1beta1 {
 
 
   export class Resource$Projects$Databases$Indexes {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -2957,7 +2966,7 @@ export namespace firestore_v1beta1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleLongrunningOperation>(
@@ -3023,7 +3032,7 @@ export namespace firestore_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -3094,7 +3103,7 @@ export namespace firestore_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleFirestoreAdminV1beta1Index>(
@@ -3173,7 +3182,7 @@ export namespace firestore_v1beta1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleFirestoreAdminV1beta1ListIndexesResponse>(

--- a/src/apis/firestore/v1beta2.ts
+++ b/src/apis/firestore/v1beta2.ts
@@ -29,8 +29,6 @@ export namespace firestore_v1beta2 {
     version: 'v1beta2';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * V1 error format.
@@ -99,12 +97,13 @@ export namespace firestore_v1beta2 {
    * @param {object=} options Options for Firestore
    */
   export class Firestore {
+    context: APIRequestContext;
     projects: Resource$Projects;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.projects = new Resource$Projects();
+      this.projects = new Resource$Projects(this.context);
     }
   }
 
@@ -576,18 +575,22 @@ export namespace firestore_v1beta2 {
 
 
   export class Resource$Projects {
+    context: APIRequestContext;
     databases: Resource$Projects$Databases;
-    constructor() {
-      this.databases = new Resource$Projects$Databases();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.databases = new Resource$Projects$Databases(this.context);
     }
   }
 
 
   export class Resource$Projects$Databases {
+    context: APIRequestContext;
     collectionGroups: Resource$Projects$Databases$Collectiongroups;
-    constructor() {
+    constructor(context: APIRequestContext) {
+      this.context = context;
       this.collectionGroups =
-          new Resource$Projects$Databases$Collectiongroups();
+          new Resource$Projects$Databases$Collectiongroups(this.context);
     }
 
 
@@ -662,7 +665,7 @@ export namespace firestore_v1beta2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleLongrunningOperation>(
@@ -742,7 +745,7 @@ export namespace firestore_v1beta2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleLongrunningOperation>(
@@ -791,17 +794,24 @@ export namespace firestore_v1beta2 {
   }
 
   export class Resource$Projects$Databases$Collectiongroups {
+    context: APIRequestContext;
     fields: Resource$Projects$Databases$Collectiongroups$Fields;
     indexes: Resource$Projects$Databases$Collectiongroups$Indexes;
-    constructor() {
-      this.fields = new Resource$Projects$Databases$Collectiongroups$Fields();
-      this.indexes = new Resource$Projects$Databases$Collectiongroups$Indexes();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.fields =
+          new Resource$Projects$Databases$Collectiongroups$Fields(this.context);
+      this.indexes = new Resource$Projects$Databases$Collectiongroups$Indexes(
+          this.context);
     }
   }
 
 
   export class Resource$Projects$Databases$Collectiongroups$Fields {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -867,7 +877,7 @@ export namespace firestore_v1beta2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleFirestoreAdminV1beta2Field>(
@@ -953,7 +963,7 @@ export namespace firestore_v1beta2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleFirestoreAdminV1beta2ListFieldsResponse>(
@@ -1042,7 +1052,7 @@ export namespace firestore_v1beta2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleLongrunningOperation>(
@@ -1138,7 +1148,10 @@ export namespace firestore_v1beta2 {
 
 
   export class Resource$Projects$Databases$Collectiongroups$Indexes {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1212,7 +1225,7 @@ export namespace firestore_v1beta2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleLongrunningOperation>(
@@ -1283,7 +1296,7 @@ export namespace firestore_v1beta2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -1357,7 +1370,7 @@ export namespace firestore_v1beta2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleFirestoreAdminV1beta2Index>(
@@ -1441,7 +1454,7 @@ export namespace firestore_v1beta2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleFirestoreAdminV1beta2ListIndexesResponse>(

--- a/src/apis/fitness/v1.ts
+++ b/src/apis/fitness/v1.ts
@@ -29,8 +29,6 @@ export namespace fitness_v1 {
     version: 'v1';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * Data format for the response.
@@ -82,12 +80,13 @@ export namespace fitness_v1 {
    * @param {object=} options Options for Fitness
    */
   export class Fitness {
+    context: APIRequestContext;
     users: Resource$Users;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.users = new Resource$Users();
+      this.users = new Resource$Users(this.context);
     }
   }
 
@@ -647,19 +646,24 @@ export namespace fitness_v1 {
 
 
   export class Resource$Users {
+    context: APIRequestContext;
     dataset: Resource$Users$Dataset;
     dataSources: Resource$Users$Datasources;
     sessions: Resource$Users$Sessions;
-    constructor() {
-      this.dataset = new Resource$Users$Dataset();
-      this.dataSources = new Resource$Users$Datasources();
-      this.sessions = new Resource$Users$Sessions();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.dataset = new Resource$Users$Dataset(this.context);
+      this.dataSources = new Resource$Users$Datasources(this.context);
+      this.sessions = new Resource$Users$Sessions(this.context);
     }
   }
 
 
   export class Resource$Users$Dataset {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -723,7 +727,7 @@ export namespace fitness_v1 {
         params,
         requiredParams: ['userId'],
         pathParams: ['userId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AggregateResponse>(parameters, callback);
@@ -754,11 +758,14 @@ export namespace fitness_v1 {
 
 
   export class Resource$Users$Datasources {
+    context: APIRequestContext;
     dataPointChanges: Resource$Users$Datasources$Datapointchanges;
     datasets: Resource$Users$Datasources$Datasets;
-    constructor() {
-      this.dataPointChanges = new Resource$Users$Datasources$Datapointchanges();
-      this.datasets = new Resource$Users$Datasources$Datasets();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.dataPointChanges =
+          new Resource$Users$Datasources$Datapointchanges(this.context);
+      this.datasets = new Resource$Users$Datasources$Datasets(this.context);
     }
 
 
@@ -827,7 +834,7 @@ export namespace fitness_v1 {
         params,
         requiredParams: ['userId'],
         pathParams: ['userId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$DataSource>(parameters, callback);
@@ -897,7 +904,7 @@ export namespace fitness_v1 {
         params,
         requiredParams: ['userId', 'dataSourceId'],
         pathParams: ['dataSourceId', 'userId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$DataSource>(parameters, callback);
@@ -962,7 +969,7 @@ export namespace fitness_v1 {
         params,
         requiredParams: ['userId', 'dataSourceId'],
         pathParams: ['dataSourceId', 'userId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$DataSource>(parameters, callback);
@@ -1034,7 +1041,7 @@ export namespace fitness_v1 {
         params,
         requiredParams: ['userId'],
         pathParams: ['userId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListDataSourcesResponse>(parameters, callback);
@@ -1107,7 +1114,7 @@ export namespace fitness_v1 {
         params,
         requiredParams: ['userId', 'dataSourceId'],
         pathParams: ['dataSourceId', 'userId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$DataSource>(parameters, callback);
@@ -1211,7 +1218,10 @@ export namespace fitness_v1 {
   }
 
   export class Resource$Users$Datasources$Datapointchanges {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1282,7 +1292,7 @@ export namespace fitness_v1 {
         params,
         requiredParams: ['userId', 'dataSourceId'],
         pathParams: ['dataSourceId', 'userId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListDataPointChangesResponse>(
@@ -1325,7 +1335,10 @@ export namespace fitness_v1 {
 
 
   export class Resource$Users$Datasources$Datasets {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1395,7 +1408,7 @@ export namespace fitness_v1 {
         params,
         requiredParams: ['userId', 'dataSourceId', 'datasetId'],
         pathParams: ['datasetId', 'dataSourceId', 'userId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -1467,7 +1480,7 @@ export namespace fitness_v1 {
         params,
         requiredParams: ['userId', 'dataSourceId', 'datasetId'],
         pathParams: ['datasetId', 'dataSourceId', 'userId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Dataset>(parameters, callback);
@@ -1542,7 +1555,7 @@ export namespace fitness_v1 {
         params,
         requiredParams: ['userId', 'dataSourceId', 'datasetId'],
         pathParams: ['datasetId', 'dataSourceId', 'userId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Dataset>(parameters, callback);
@@ -1661,7 +1674,10 @@ export namespace fitness_v1 {
 
 
   export class Resource$Users$Sessions {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1721,7 +1737,7 @@ export namespace fitness_v1 {
         params,
         requiredParams: ['userId', 'sessionId'],
         pathParams: ['sessionId', 'userId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -1792,7 +1808,7 @@ export namespace fitness_v1 {
         params,
         requiredParams: ['userId'],
         pathParams: ['userId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListSessionsResponse>(parameters, callback);
@@ -1861,7 +1877,7 @@ export namespace fitness_v1 {
         params,
         requiredParams: ['userId', 'sessionId'],
         pathParams: ['sessionId', 'userId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Session>(parameters, callback);

--- a/src/apis/fusiontables/v1.ts
+++ b/src/apis/fusiontables/v1.ts
@@ -29,8 +29,6 @@ export namespace fusiontables_v1 {
     version: 'v1';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * Data format for the response.
@@ -81,6 +79,7 @@ export namespace fusiontables_v1 {
    * @param {object=} options Options for Fusiontables
    */
   export class Fusiontables {
+    context: APIRequestContext;
     column: Resource$Column;
     query: Resource$Query;
     style: Resource$Style;
@@ -89,14 +88,14 @@ export namespace fusiontables_v1 {
     template: Resource$Template;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.column = new Resource$Column();
-      this.query = new Resource$Query();
-      this.style = new Resource$Style();
-      this.table = new Resource$Table();
-      this.task = new Resource$Task();
-      this.template = new Resource$Template();
+      this.column = new Resource$Column(this.context);
+      this.query = new Resource$Query(this.context);
+      this.style = new Resource$Style(this.context);
+      this.table = new Resource$Table(this.context);
+      this.task = new Resource$Task(this.context);
+      this.template = new Resource$Template(this.context);
     }
   }
 
@@ -626,7 +625,10 @@ export namespace fusiontables_v1 {
 
 
   export class Resource$Column {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -684,7 +686,7 @@ export namespace fusiontables_v1 {
         params,
         requiredParams: ['tableId', 'columnId'],
         pathParams: ['columnId', 'tableId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -747,7 +749,7 @@ export namespace fusiontables_v1 {
         params,
         requiredParams: ['tableId', 'columnId'],
         pathParams: ['columnId', 'tableId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Column>(parameters, callback);
@@ -812,7 +814,7 @@ export namespace fusiontables_v1 {
         params,
         requiredParams: ['tableId'],
         pathParams: ['tableId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Column>(parameters, callback);
@@ -879,7 +881,7 @@ export namespace fusiontables_v1 {
         params,
         requiredParams: ['tableId'],
         pathParams: ['tableId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ColumnList>(parameters, callback);
@@ -947,7 +949,7 @@ export namespace fusiontables_v1 {
         params,
         requiredParams: ['tableId', 'columnId'],
         pathParams: ['columnId', 'tableId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Column>(parameters, callback);
@@ -1014,7 +1016,7 @@ export namespace fusiontables_v1 {
         params,
         requiredParams: ['tableId', 'columnId'],
         pathParams: ['columnId', 'tableId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Column>(parameters, callback);
@@ -1132,7 +1134,10 @@ export namespace fusiontables_v1 {
 
 
   export class Resource$Query {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1190,7 +1195,7 @@ export namespace fusiontables_v1 {
         params,
         requiredParams: ['sql'],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Sqlresponse>(parameters, callback);
@@ -1257,7 +1262,7 @@ export namespace fusiontables_v1 {
         params,
         requiredParams: ['sql'],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Sqlresponse>(parameters, callback);
@@ -1310,7 +1315,10 @@ export namespace fusiontables_v1 {
 
 
   export class Resource$Style {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1368,7 +1376,7 @@ export namespace fusiontables_v1 {
         params,
         requiredParams: ['tableId', 'styleId'],
         pathParams: ['styleId', 'tableId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -1432,7 +1440,7 @@ export namespace fusiontables_v1 {
         params,
         requiredParams: ['tableId', 'styleId'],
         pathParams: ['styleId', 'tableId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$StyleSetting>(parameters, callback);
@@ -1498,7 +1506,7 @@ export namespace fusiontables_v1 {
         params,
         requiredParams: ['tableId'],
         pathParams: ['tableId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$StyleSetting>(parameters, callback);
@@ -1565,7 +1573,7 @@ export namespace fusiontables_v1 {
         params,
         requiredParams: ['tableId'],
         pathParams: ['tableId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$StyleSettingList>(parameters, callback);
@@ -1633,7 +1641,7 @@ export namespace fusiontables_v1 {
         params,
         requiredParams: ['tableId', 'styleId'],
         pathParams: ['styleId', 'tableId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$StyleSetting>(parameters, callback);
@@ -1701,7 +1709,7 @@ export namespace fusiontables_v1 {
         params,
         requiredParams: ['tableId', 'styleId'],
         pathParams: ['styleId', 'tableId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$StyleSetting>(parameters, callback);
@@ -1819,7 +1827,10 @@ export namespace fusiontables_v1 {
 
 
   export class Resource$Table {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1877,7 +1888,7 @@ export namespace fusiontables_v1 {
         params,
         requiredParams: ['tableId'],
         pathParams: ['tableId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Table>(parameters, callback);
@@ -1940,7 +1951,7 @@ export namespace fusiontables_v1 {
         params,
         requiredParams: ['tableId'],
         pathParams: ['tableId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -2001,7 +2012,7 @@ export namespace fusiontables_v1 {
         params,
         requiredParams: ['tableId'],
         pathParams: ['tableId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Table>(parameters, callback);
@@ -2076,7 +2087,7 @@ export namespace fusiontables_v1 {
                       .replace(/([^:]\/)\/+/g, '$1'),
         requiredParams: ['tableId'],
         pathParams: ['tableId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Import>(parameters, callback);
@@ -2149,7 +2160,7 @@ export namespace fusiontables_v1 {
                       .replace(/([^:]\/)\/+/g, '$1'),
         requiredParams: ['name'],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Table>(parameters, callback);
@@ -2213,7 +2224,7 @@ export namespace fusiontables_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Table>(parameters, callback);
@@ -2279,7 +2290,7 @@ export namespace fusiontables_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TableList>(parameters, callback);
@@ -2347,7 +2358,7 @@ export namespace fusiontables_v1 {
         params,
         requiredParams: ['tableId'],
         pathParams: ['tableId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Table>(parameters, callback);
@@ -2414,7 +2425,7 @@ export namespace fusiontables_v1 {
         params,
         requiredParams: ['tableId'],
         pathParams: ['tableId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Table>(parameters, callback);
@@ -2632,7 +2643,10 @@ export namespace fusiontables_v1 {
 
 
   export class Resource$Task {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -2690,7 +2704,7 @@ export namespace fusiontables_v1 {
         params,
         requiredParams: ['tableId', 'taskId'],
         pathParams: ['tableId', 'taskId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -2753,7 +2767,7 @@ export namespace fusiontables_v1 {
         params,
         requiredParams: ['tableId', 'taskId'],
         pathParams: ['tableId', 'taskId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Task>(parameters, callback);
@@ -2820,7 +2834,7 @@ export namespace fusiontables_v1 {
         params,
         requiredParams: ['tableId'],
         pathParams: ['tableId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TaskList>(parameters, callback);
@@ -2886,7 +2900,10 @@ export namespace fusiontables_v1 {
 
 
   export class Resource$Template {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -2944,7 +2961,7 @@ export namespace fusiontables_v1 {
         params,
         requiredParams: ['tableId', 'templateId'],
         pathParams: ['tableId', 'templateId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -3007,7 +3024,7 @@ export namespace fusiontables_v1 {
         params,
         requiredParams: ['tableId', 'templateId'],
         pathParams: ['tableId', 'templateId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Template>(parameters, callback);
@@ -3072,7 +3089,7 @@ export namespace fusiontables_v1 {
         params,
         requiredParams: ['tableId'],
         pathParams: ['tableId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Template>(parameters, callback);
@@ -3139,7 +3156,7 @@ export namespace fusiontables_v1 {
         params,
         requiredParams: ['tableId'],
         pathParams: ['tableId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TemplateList>(parameters, callback);
@@ -3206,7 +3223,7 @@ export namespace fusiontables_v1 {
         params,
         requiredParams: ['tableId', 'templateId'],
         pathParams: ['tableId', 'templateId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Template>(parameters, callback);
@@ -3273,7 +3290,7 @@ export namespace fusiontables_v1 {
         params,
         requiredParams: ['tableId', 'templateId'],
         pathParams: ['tableId', 'templateId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Template>(parameters, callback);

--- a/src/apis/fusiontables/v2.ts
+++ b/src/apis/fusiontables/v2.ts
@@ -29,8 +29,6 @@ export namespace fusiontables_v2 {
     version: 'v2';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * Data format for the response.
@@ -81,6 +79,7 @@ export namespace fusiontables_v2 {
    * @param {object=} options Options for Fusiontables
    */
   export class Fusiontables {
+    context: APIRequestContext;
     column: Resource$Column;
     query: Resource$Query;
     style: Resource$Style;
@@ -89,14 +88,14 @@ export namespace fusiontables_v2 {
     template: Resource$Template;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.column = new Resource$Column();
-      this.query = new Resource$Query();
-      this.style = new Resource$Style();
-      this.table = new Resource$Table();
-      this.task = new Resource$Task();
-      this.template = new Resource$Template();
+      this.column = new Resource$Column(this.context);
+      this.query = new Resource$Query(this.context);
+      this.style = new Resource$Style(this.context);
+      this.table = new Resource$Table(this.context);
+      this.task = new Resource$Task(this.context);
+      this.template = new Resource$Template(this.context);
     }
   }
 
@@ -684,7 +683,10 @@ export namespace fusiontables_v2 {
 
 
   export class Resource$Column {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -742,7 +744,7 @@ export namespace fusiontables_v2 {
         params,
         requiredParams: ['tableId', 'columnId'],
         pathParams: ['columnId', 'tableId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -805,7 +807,7 @@ export namespace fusiontables_v2 {
         params,
         requiredParams: ['tableId', 'columnId'],
         pathParams: ['columnId', 'tableId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Column>(parameters, callback);
@@ -870,7 +872,7 @@ export namespace fusiontables_v2 {
         params,
         requiredParams: ['tableId'],
         pathParams: ['tableId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Column>(parameters, callback);
@@ -937,7 +939,7 @@ export namespace fusiontables_v2 {
         params,
         requiredParams: ['tableId'],
         pathParams: ['tableId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ColumnList>(parameters, callback);
@@ -1005,7 +1007,7 @@ export namespace fusiontables_v2 {
         params,
         requiredParams: ['tableId', 'columnId'],
         pathParams: ['columnId', 'tableId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Column>(parameters, callback);
@@ -1072,7 +1074,7 @@ export namespace fusiontables_v2 {
         params,
         requiredParams: ['tableId', 'columnId'],
         pathParams: ['columnId', 'tableId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Column>(parameters, callback);
@@ -1190,7 +1192,10 @@ export namespace fusiontables_v2 {
 
 
   export class Resource$Query {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1248,7 +1253,7 @@ export namespace fusiontables_v2 {
         params,
         requiredParams: ['sql'],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Sqlresponse>(parameters, callback);
@@ -1316,7 +1321,7 @@ export namespace fusiontables_v2 {
         params,
         requiredParams: ['sql'],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Sqlresponse>(parameters, callback);
@@ -1370,7 +1375,10 @@ export namespace fusiontables_v2 {
 
 
   export class Resource$Style {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1428,7 +1436,7 @@ export namespace fusiontables_v2 {
         params,
         requiredParams: ['tableId', 'styleId'],
         pathParams: ['styleId', 'tableId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -1492,7 +1500,7 @@ export namespace fusiontables_v2 {
         params,
         requiredParams: ['tableId', 'styleId'],
         pathParams: ['styleId', 'tableId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$StyleSetting>(parameters, callback);
@@ -1558,7 +1566,7 @@ export namespace fusiontables_v2 {
         params,
         requiredParams: ['tableId'],
         pathParams: ['tableId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$StyleSetting>(parameters, callback);
@@ -1625,7 +1633,7 @@ export namespace fusiontables_v2 {
         params,
         requiredParams: ['tableId'],
         pathParams: ['tableId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$StyleSettingList>(parameters, callback);
@@ -1693,7 +1701,7 @@ export namespace fusiontables_v2 {
         params,
         requiredParams: ['tableId', 'styleId'],
         pathParams: ['styleId', 'tableId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$StyleSetting>(parameters, callback);
@@ -1761,7 +1769,7 @@ export namespace fusiontables_v2 {
         params,
         requiredParams: ['tableId', 'styleId'],
         pathParams: ['styleId', 'tableId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$StyleSetting>(parameters, callback);
@@ -1879,7 +1887,10 @@ export namespace fusiontables_v2 {
 
 
   export class Resource$Table {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1937,7 +1948,7 @@ export namespace fusiontables_v2 {
         params,
         requiredParams: ['tableId'],
         pathParams: ['tableId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Table>(parameters, callback);
@@ -2000,7 +2011,7 @@ export namespace fusiontables_v2 {
         params,
         requiredParams: ['tableId'],
         pathParams: ['tableId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -2061,7 +2072,7 @@ export namespace fusiontables_v2 {
         params,
         requiredParams: ['tableId'],
         pathParams: ['tableId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Table>(parameters, callback);
@@ -2136,7 +2147,7 @@ export namespace fusiontables_v2 {
                       .replace(/([^:]\/)\/+/g, '$1'),
         requiredParams: ['tableId'],
         pathParams: ['tableId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Import>(parameters, callback);
@@ -2209,7 +2220,7 @@ export namespace fusiontables_v2 {
                       .replace(/([^:]\/)\/+/g, '$1'),
         requiredParams: ['name'],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Table>(parameters, callback);
@@ -2273,7 +2284,7 @@ export namespace fusiontables_v2 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Table>(parameters, callback);
@@ -2339,7 +2350,7 @@ export namespace fusiontables_v2 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TableList>(parameters, callback);
@@ -2407,7 +2418,7 @@ export namespace fusiontables_v2 {
         params,
         requiredParams: ['tableId'],
         pathParams: ['tableId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Table>(parameters, callback);
@@ -2475,7 +2486,7 @@ export namespace fusiontables_v2 {
         params,
         requiredParams: ['tableId'],
         pathParams: ['tableId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Task>(parameters, callback);
@@ -2552,7 +2563,7 @@ export namespace fusiontables_v2 {
                       .replace(/([^:]\/)\/+/g, '$1'),
         requiredParams: ['tableId'],
         pathParams: ['tableId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Task>(parameters, callback);
@@ -2619,7 +2630,7 @@ export namespace fusiontables_v2 {
         params,
         requiredParams: ['tableId'],
         pathParams: ['tableId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Table>(parameters, callback);
@@ -2902,7 +2913,10 @@ export namespace fusiontables_v2 {
 
 
   export class Resource$Task {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -2961,7 +2975,7 @@ export namespace fusiontables_v2 {
         params,
         requiredParams: ['tableId', 'taskId'],
         pathParams: ['tableId', 'taskId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -3024,7 +3038,7 @@ export namespace fusiontables_v2 {
         params,
         requiredParams: ['tableId', 'taskId'],
         pathParams: ['tableId', 'taskId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Task>(parameters, callback);
@@ -3091,7 +3105,7 @@ export namespace fusiontables_v2 {
         params,
         requiredParams: ['tableId'],
         pathParams: ['tableId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TaskList>(parameters, callback);
@@ -3157,7 +3171,10 @@ export namespace fusiontables_v2 {
 
 
   export class Resource$Template {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -3215,7 +3232,7 @@ export namespace fusiontables_v2 {
         params,
         requiredParams: ['tableId', 'templateId'],
         pathParams: ['tableId', 'templateId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -3278,7 +3295,7 @@ export namespace fusiontables_v2 {
         params,
         requiredParams: ['tableId', 'templateId'],
         pathParams: ['tableId', 'templateId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Template>(parameters, callback);
@@ -3343,7 +3360,7 @@ export namespace fusiontables_v2 {
         params,
         requiredParams: ['tableId'],
         pathParams: ['tableId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Template>(parameters, callback);
@@ -3410,7 +3427,7 @@ export namespace fusiontables_v2 {
         params,
         requiredParams: ['tableId'],
         pathParams: ['tableId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TemplateList>(parameters, callback);
@@ -3477,7 +3494,7 @@ export namespace fusiontables_v2 {
         params,
         requiredParams: ['tableId', 'templateId'],
         pathParams: ['tableId', 'templateId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Template>(parameters, callback);
@@ -3544,7 +3561,7 @@ export namespace fusiontables_v2 {
         params,
         requiredParams: ['tableId', 'templateId'],
         pathParams: ['tableId', 'templateId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Template>(parameters, callback);

--- a/src/apis/games/v1.ts
+++ b/src/apis/games/v1.ts
@@ -29,8 +29,6 @@ export namespace games_v1 {
     version: 'v1';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * Data format for the response.
@@ -81,6 +79,7 @@ export namespace games_v1 {
    * @param {object=} options Options for Games
    */
   export class Games {
+    context: APIRequestContext;
     achievementDefinitions: Resource$Achievementdefinitions;
     achievements: Resource$Achievements;
     applications: Resource$Applications;
@@ -98,23 +97,24 @@ export namespace games_v1 {
     turnBasedMatches: Resource$Turnbasedmatches;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.achievementDefinitions = new Resource$Achievementdefinitions();
-      this.achievements = new Resource$Achievements();
-      this.applications = new Resource$Applications();
-      this.events = new Resource$Events();
-      this.leaderboards = new Resource$Leaderboards();
-      this.metagame = new Resource$Metagame();
-      this.players = new Resource$Players();
-      this.pushtokens = new Resource$Pushtokens();
-      this.questMilestones = new Resource$Questmilestones();
-      this.quests = new Resource$Quests();
-      this.revisions = new Resource$Revisions();
-      this.rooms = new Resource$Rooms();
-      this.scores = new Resource$Scores();
-      this.snapshots = new Resource$Snapshots();
-      this.turnBasedMatches = new Resource$Turnbasedmatches();
+      this.achievementDefinitions =
+          new Resource$Achievementdefinitions(this.context);
+      this.achievements = new Resource$Achievements(this.context);
+      this.applications = new Resource$Applications(this.context);
+      this.events = new Resource$Events(this.context);
+      this.leaderboards = new Resource$Leaderboards(this.context);
+      this.metagame = new Resource$Metagame(this.context);
+      this.players = new Resource$Players(this.context);
+      this.pushtokens = new Resource$Pushtokens(this.context);
+      this.questMilestones = new Resource$Questmilestones(this.context);
+      this.quests = new Resource$Quests(this.context);
+      this.revisions = new Resource$Revisions(this.context);
+      this.rooms = new Resource$Rooms(this.context);
+      this.scores = new Resource$Scores(this.context);
+      this.snapshots = new Resource$Snapshots(this.context);
+      this.turnBasedMatches = new Resource$Turnbasedmatches(this.context);
     }
   }
 
@@ -2945,7 +2945,10 @@ export namespace games_v1 {
 
 
   export class Resource$Achievementdefinitions {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -3016,7 +3019,7 @@ export namespace games_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AchievementDefinitionsListResponse>(
@@ -3053,7 +3056,10 @@ export namespace games_v1 {
 
 
   export class Resource$Achievements {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -3123,7 +3129,7 @@ export namespace games_v1 {
         params,
         requiredParams: ['achievementId', 'stepsToIncrement'],
         pathParams: ['achievementId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AchievementIncrementResponse>(
@@ -3200,7 +3206,7 @@ export namespace games_v1 {
         params,
         requiredParams: ['playerId'],
         pathParams: ['playerId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$PlayerAchievementListResponse>(
@@ -3272,7 +3278,7 @@ export namespace games_v1 {
         params,
         requiredParams: ['achievementId'],
         pathParams: ['achievementId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AchievementRevealResponse>(
@@ -3355,7 +3361,7 @@ export namespace games_v1 {
         params,
         requiredParams: ['achievementId', 'steps'],
         pathParams: ['achievementId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AchievementSetStepsAtLeastResponse>(
@@ -3427,7 +3433,7 @@ export namespace games_v1 {
         params,
         requiredParams: ['achievementId'],
         pathParams: ['achievementId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AchievementUnlockResponse>(
@@ -3507,7 +3513,7 @@ export namespace games_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AchievementUpdateMultipleResponse>(
@@ -3637,7 +3643,10 @@ export namespace games_v1 {
 
 
   export class Resource$Applications {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -3696,7 +3705,7 @@ export namespace games_v1 {
         params,
         requiredParams: ['applicationId'],
         pathParams: ['applicationId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Application>(parameters, callback);
@@ -3762,7 +3771,7 @@ export namespace games_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -3833,7 +3842,7 @@ export namespace games_v1 {
         params,
         requiredParams: ['applicationId'],
         pathParams: ['applicationId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ApplicationVerifyResponse>(
@@ -3890,7 +3899,10 @@ export namespace games_v1 {
 
 
   export class Resource$Events {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -3954,7 +3966,7 @@ export namespace games_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$PlayerEventListResponse>(parameters, callback);
@@ -4029,7 +4041,7 @@ export namespace games_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$EventDefinitionListResponse>(
@@ -4096,7 +4108,7 @@ export namespace games_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$EventUpdateResponse>(parameters, callback);
@@ -4169,7 +4181,10 @@ export namespace games_v1 {
 
 
   export class Resource$Leaderboards {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -4225,7 +4240,7 @@ export namespace games_v1 {
         params,
         requiredParams: ['leaderboardId'],
         pathParams: ['leaderboardId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Leaderboard>(parameters, callback);
@@ -4294,7 +4309,7 @@ export namespace games_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$LeaderboardListResponse>(parameters, callback);
@@ -4344,7 +4359,10 @@ export namespace games_v1 {
 
 
   export class Resource$Metagame {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -4404,7 +4422,7 @@ export namespace games_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$MetagameConfig>(parameters, callback);
@@ -4479,7 +4497,7 @@ export namespace games_v1 {
         params,
         requiredParams: ['playerId', 'collection'],
         pathParams: ['collection', 'playerId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$CategoryListResponse>(parameters, callback);
@@ -4530,7 +4548,10 @@ export namespace games_v1 {
 
 
   export class Resource$Players {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -4586,7 +4607,7 @@ export namespace games_v1 {
         params,
         requiredParams: ['playerId'],
         pathParams: ['playerId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Player>(parameters, callback);
@@ -4654,7 +4675,7 @@ export namespace games_v1 {
         params,
         requiredParams: ['collection'],
         pathParams: ['collection'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$PlayerListResponse>(parameters, callback);
@@ -4708,7 +4729,10 @@ export namespace games_v1 {
 
 
   export class Resource$Pushtokens {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -4766,7 +4790,7 @@ export namespace games_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -4830,7 +4854,7 @@ export namespace games_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -4869,7 +4893,10 @@ export namespace games_v1 {
 
 
   export class Resource$Questmilestones {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -4932,7 +4959,7 @@ export namespace games_v1 {
         params,
         requiredParams: ['questId', 'milestoneId', 'requestId'],
         pathParams: ['milestoneId', 'questId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -4966,7 +4993,10 @@ export namespace games_v1 {
 
 
   export class Resource$Quests {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -5025,7 +5055,7 @@ export namespace games_v1 {
         params,
         requiredParams: ['questId'],
         pathParams: ['questId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Quest>(parameters, callback);
@@ -5094,7 +5124,7 @@ export namespace games_v1 {
         params,
         requiredParams: ['playerId'],
         pathParams: ['playerId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$QuestListResponse>(parameters, callback);
@@ -5149,7 +5179,10 @@ export namespace games_v1 {
 
 
   export class Resource$Revisions {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -5208,7 +5241,7 @@ export namespace games_v1 {
         params,
         requiredParams: ['clientRevision'],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$RevisionCheckResponse>(parameters, callback);
@@ -5235,7 +5268,10 @@ export namespace games_v1 {
 
 
   export class Resource$Rooms {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -5294,7 +5330,7 @@ export namespace games_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Room>(parameters, callback);
@@ -5360,7 +5396,7 @@ export namespace games_v1 {
         params,
         requiredParams: ['roomId'],
         pathParams: ['roomId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Room>(parameters, callback);
@@ -5424,7 +5460,7 @@ export namespace games_v1 {
         params,
         requiredParams: ['roomId'],
         pathParams: ['roomId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -5486,7 +5522,7 @@ export namespace games_v1 {
         params,
         requiredParams: ['roomId'],
         pathParams: ['roomId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Room>(parameters, callback);
@@ -5553,7 +5589,7 @@ export namespace games_v1 {
         params,
         requiredParams: ['roomId'],
         pathParams: ['roomId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Room>(parameters, callback);
@@ -5620,7 +5656,7 @@ export namespace games_v1 {
         params,
         requiredParams: ['roomId'],
         pathParams: ['roomId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Room>(parameters, callback);
@@ -5685,7 +5721,7 @@ export namespace games_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$RoomList>(parameters, callback);
@@ -5756,7 +5792,7 @@ export namespace games_v1 {
         params,
         requiredParams: ['roomId'],
         pathParams: ['roomId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$RoomStatus>(parameters, callback);
@@ -5908,7 +5944,10 @@ export namespace games_v1 {
 
 
   export class Resource$Scores {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -5983,7 +6022,7 @@ export namespace games_v1 {
         params,
         requiredParams: ['playerId', 'leaderboardId', 'timeSpan'],
         pathParams: ['leaderboardId', 'playerId', 'timeSpan'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$PlayerLeaderboardScoreListResponse>(
@@ -6057,7 +6096,7 @@ export namespace games_v1 {
         params,
         requiredParams: ['leaderboardId', 'collection', 'timeSpan'],
         pathParams: ['collection', 'leaderboardId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$LeaderboardScores>(parameters, callback);
@@ -6134,7 +6173,7 @@ export namespace games_v1 {
         params,
         requiredParams: ['leaderboardId', 'collection', 'timeSpan'],
         pathParams: ['collection', 'leaderboardId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$LeaderboardScores>(parameters, callback);
@@ -6202,7 +6241,7 @@ export namespace games_v1 {
         params,
         requiredParams: ['leaderboardId', 'score'],
         pathParams: ['leaderboardId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$PlayerScoreResponse>(parameters, callback);
@@ -6272,7 +6311,7 @@ export namespace games_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$PlayerScoreListResponse>(parameters, callback);
@@ -6451,7 +6490,10 @@ export namespace games_v1 {
 
 
   export class Resource$Snapshots {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -6506,7 +6548,7 @@ export namespace games_v1 {
         params,
         requiredParams: ['snapshotId'],
         pathParams: ['snapshotId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Snapshot>(parameters, callback);
@@ -6576,7 +6618,7 @@ export namespace games_v1 {
         params,
         requiredParams: ['playerId'],
         pathParams: ['playerId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$SnapshotListResponse>(parameters, callback);
@@ -6630,7 +6672,10 @@ export namespace games_v1 {
 
 
   export class Resource$Turnbasedmatches {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -6688,7 +6733,7 @@ export namespace games_v1 {
         params,
         requiredParams: ['matchId'],
         pathParams: ['matchId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -6756,7 +6801,7 @@ export namespace games_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TurnBasedMatch>(parameters, callback);
@@ -6824,7 +6869,7 @@ export namespace games_v1 {
         params,
         requiredParams: ['matchId'],
         pathParams: ['matchId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TurnBasedMatch>(parameters, callback);
@@ -6890,7 +6935,7 @@ export namespace games_v1 {
         params,
         requiredParams: ['matchId'],
         pathParams: ['matchId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -6961,7 +7006,7 @@ export namespace games_v1 {
         params,
         requiredParams: ['matchId'],
         pathParams: ['matchId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TurnBasedMatch>(parameters, callback);
@@ -7026,7 +7071,7 @@ export namespace games_v1 {
         params,
         requiredParams: ['matchId'],
         pathParams: ['matchId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TurnBasedMatch>(parameters, callback);
@@ -7094,7 +7139,7 @@ export namespace games_v1 {
         params,
         requiredParams: ['matchId'],
         pathParams: ['matchId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TurnBasedMatch>(parameters, callback);
@@ -7163,7 +7208,7 @@ export namespace games_v1 {
         params,
         requiredParams: ['matchId'],
         pathParams: ['matchId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TurnBasedMatch>(parameters, callback);
@@ -7234,7 +7279,7 @@ export namespace games_v1 {
         params,
         requiredParams: ['matchId', 'matchVersion'],
         pathParams: ['matchId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TurnBasedMatch>(parameters, callback);
@@ -7305,7 +7350,7 @@ export namespace games_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TurnBasedMatchList>(parameters, callback);
@@ -7378,7 +7423,7 @@ export namespace games_v1 {
         params,
         requiredParams: ['matchId'],
         pathParams: ['matchId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TurnBasedMatchRematch>(parameters, callback);
@@ -7452,7 +7497,7 @@ export namespace games_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TurnBasedMatchSync>(parameters, callback);
@@ -7521,7 +7566,7 @@ export namespace games_v1 {
         params,
         requiredParams: ['matchId'],
         pathParams: ['matchId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TurnBasedMatch>(parameters, callback);

--- a/src/apis/gamesConfiguration/v1configuration.ts
+++ b/src/apis/gamesConfiguration/v1configuration.ts
@@ -29,8 +29,6 @@ export namespace gamesConfiguration_v1configuration {
     version: 'v1configuration';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * Data format for the response.
@@ -81,16 +79,19 @@ export namespace gamesConfiguration_v1configuration {
    * @param {object=} options Options for Gamesconfiguration
    */
   export class Gamesconfiguration {
+    context: APIRequestContext;
     achievementConfigurations: Resource$Achievementconfigurations;
     imageConfigurations: Resource$Imageconfigurations;
     leaderboardConfigurations: Resource$Leaderboardconfigurations;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.achievementConfigurations = new Resource$Achievementconfigurations();
-      this.imageConfigurations = new Resource$Imageconfigurations();
-      this.leaderboardConfigurations = new Resource$Leaderboardconfigurations();
+      this.achievementConfigurations =
+          new Resource$Achievementconfigurations(this.context);
+      this.imageConfigurations = new Resource$Imageconfigurations(this.context);
+      this.leaderboardConfigurations =
+          new Resource$Leaderboardconfigurations(this.context);
     }
   }
 
@@ -391,7 +392,10 @@ export namespace gamesConfiguration_v1configuration {
 
 
   export class Resource$Achievementconfigurations {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -450,7 +454,7 @@ export namespace gamesConfiguration_v1configuration {
         params,
         requiredParams: ['achievementId'],
         pathParams: ['achievementId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -517,7 +521,7 @@ export namespace gamesConfiguration_v1configuration {
         params,
         requiredParams: ['achievementId'],
         pathParams: ['achievementId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AchievementConfiguration>(parameters, callback);
@@ -590,7 +594,7 @@ export namespace gamesConfiguration_v1configuration {
         params,
         requiredParams: ['applicationId'],
         pathParams: ['applicationId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AchievementConfiguration>(parameters, callback);
@@ -671,7 +675,7 @@ export namespace gamesConfiguration_v1configuration {
         params,
         requiredParams: ['applicationId'],
         pathParams: ['applicationId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AchievementConfigurationListResponse>(
@@ -746,7 +750,7 @@ export namespace gamesConfiguration_v1configuration {
         params,
         requiredParams: ['achievementId'],
         pathParams: ['achievementId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AchievementConfiguration>(parameters, callback);
@@ -819,7 +823,7 @@ export namespace gamesConfiguration_v1configuration {
         params,
         requiredParams: ['achievementId'],
         pathParams: ['achievementId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AchievementConfiguration>(parameters, callback);
@@ -929,7 +933,10 @@ export namespace gamesConfiguration_v1configuration {
 
 
   export class Resource$Imageconfigurations {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -999,7 +1006,7 @@ export namespace gamesConfiguration_v1configuration {
                 .replace(/([^:]\/)\/+/g, '$1'),
         requiredParams: ['resourceId', 'imageType'],
         pathParams: ['imageType', 'resourceId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ImageConfiguration>(parameters, callback);
@@ -1044,7 +1051,10 @@ export namespace gamesConfiguration_v1configuration {
 
 
   export class Resource$Leaderboardconfigurations {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1103,7 +1113,7 @@ export namespace gamesConfiguration_v1configuration {
         params,
         requiredParams: ['leaderboardId'],
         pathParams: ['leaderboardId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -1170,7 +1180,7 @@ export namespace gamesConfiguration_v1configuration {
         params,
         requiredParams: ['leaderboardId'],
         pathParams: ['leaderboardId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$LeaderboardConfiguration>(parameters, callback);
@@ -1243,7 +1253,7 @@ export namespace gamesConfiguration_v1configuration {
         params,
         requiredParams: ['applicationId'],
         pathParams: ['applicationId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$LeaderboardConfiguration>(parameters, callback);
@@ -1324,7 +1334,7 @@ export namespace gamesConfiguration_v1configuration {
         params,
         requiredParams: ['applicationId'],
         pathParams: ['applicationId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$LeaderboardConfigurationListResponse>(
@@ -1399,7 +1409,7 @@ export namespace gamesConfiguration_v1configuration {
         params,
         requiredParams: ['leaderboardId'],
         pathParams: ['leaderboardId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$LeaderboardConfiguration>(parameters, callback);
@@ -1472,7 +1482,7 @@ export namespace gamesConfiguration_v1configuration {
         params,
         requiredParams: ['leaderboardId'],
         pathParams: ['leaderboardId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$LeaderboardConfiguration>(parameters, callback);

--- a/src/apis/gamesManagement/v1management.ts
+++ b/src/apis/gamesManagement/v1management.ts
@@ -29,8 +29,6 @@ export namespace gamesManagement_v1management {
     version: 'v1management';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * Data format for the response.
@@ -81,6 +79,7 @@ export namespace gamesManagement_v1management {
    * @param {object=} options Options for Gamesmanagement
    */
   export class Gamesmanagement {
+    context: APIRequestContext;
     achievements: Resource$Achievements;
     applications: Resource$Applications;
     events: Resource$Events;
@@ -91,16 +90,16 @@ export namespace gamesManagement_v1management {
     turnBasedMatches: Resource$Turnbasedmatches;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.achievements = new Resource$Achievements();
-      this.applications = new Resource$Applications();
-      this.events = new Resource$Events();
-      this.players = new Resource$Players();
-      this.quests = new Resource$Quests();
-      this.rooms = new Resource$Rooms();
-      this.scores = new Resource$Scores();
-      this.turnBasedMatches = new Resource$Turnbasedmatches();
+      this.achievements = new Resource$Achievements(this.context);
+      this.applications = new Resource$Applications(this.context);
+      this.events = new Resource$Events(this.context);
+      this.players = new Resource$Players(this.context);
+      this.quests = new Resource$Quests(this.context);
+      this.rooms = new Resource$Rooms(this.context);
+      this.scores = new Resource$Scores(this.context);
+      this.turnBasedMatches = new Resource$Turnbasedmatches(this.context);
     }
   }
 
@@ -406,7 +405,10 @@ export namespace gamesManagement_v1management {
 
 
   export class Resource$Achievements {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -470,7 +472,7 @@ export namespace gamesManagement_v1management {
         params,
         requiredParams: ['achievementId'],
         pathParams: ['achievementId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AchievementResetResponse>(parameters, callback);
@@ -544,7 +546,7 @@ export namespace gamesManagement_v1management {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AchievementResetAllResponse>(
@@ -611,7 +613,7 @@ export namespace gamesManagement_v1management {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -680,7 +682,7 @@ export namespace gamesManagement_v1management {
         params,
         requiredParams: ['achievementId'],
         pathParams: ['achievementId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -750,7 +752,7 @@ export namespace gamesManagement_v1management {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -814,7 +816,10 @@ export namespace gamesManagement_v1management {
 
 
   export class Resource$Applications {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -879,7 +884,7 @@ export namespace gamesManagement_v1management {
         params,
         requiredParams: ['applicationId'],
         pathParams: ['applicationId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$HiddenPlayerList>(parameters, callback);
@@ -914,7 +919,10 @@ export namespace gamesManagement_v1management {
 
 
   export class Resource$Events {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -973,7 +981,7 @@ export namespace gamesManagement_v1management {
         params,
         requiredParams: ['eventId'],
         pathParams: ['eventId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -1038,7 +1046,7 @@ export namespace gamesManagement_v1management {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -1105,7 +1113,7 @@ export namespace gamesManagement_v1management {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -1173,7 +1181,7 @@ export namespace gamesManagement_v1management {
         params,
         requiredParams: ['eventId'],
         pathParams: ['eventId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -1242,7 +1250,7 @@ export namespace gamesManagement_v1management {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -1304,7 +1312,10 @@ export namespace gamesManagement_v1management {
 
 
   export class Resource$Players {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1365,7 +1376,7 @@ export namespace gamesManagement_v1management {
         params,
         requiredParams: ['applicationId', 'playerId'],
         pathParams: ['applicationId', 'playerId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -1433,7 +1444,7 @@ export namespace gamesManagement_v1management {
         params,
         requiredParams: ['applicationId', 'playerId'],
         pathParams: ['applicationId', 'playerId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -1478,7 +1489,10 @@ export namespace gamesManagement_v1management {
 
 
   export class Resource$Quests {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1536,7 +1550,7 @@ export namespace gamesManagement_v1management {
         params,
         requiredParams: ['questId'],
         pathParams: ['questId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -1600,7 +1614,7 @@ export namespace gamesManagement_v1management {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -1666,7 +1680,7 @@ export namespace gamesManagement_v1management {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -1734,7 +1748,7 @@ export namespace gamesManagement_v1management {
         params,
         requiredParams: ['questId'],
         pathParams: ['questId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -1802,7 +1816,7 @@ export namespace gamesManagement_v1management {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -1864,7 +1878,10 @@ export namespace gamesManagement_v1management {
 
 
   export class Resource$Rooms {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1921,7 +1938,7 @@ export namespace gamesManagement_v1management {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -1987,7 +2004,7 @@ export namespace gamesManagement_v1management {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -2013,7 +2030,10 @@ export namespace gamesManagement_v1management {
 
 
   export class Resource$Scores {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -2077,7 +2097,7 @@ export namespace gamesManagement_v1management {
         params,
         requiredParams: ['leaderboardId'],
         pathParams: ['leaderboardId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$PlayerScoreResetResponse>(parameters, callback);
@@ -2148,7 +2168,7 @@ export namespace gamesManagement_v1management {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$PlayerScoreResetAllResponse>(
@@ -2215,7 +2235,7 @@ export namespace gamesManagement_v1management {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -2284,7 +2304,7 @@ export namespace gamesManagement_v1management {
         params,
         requiredParams: ['leaderboardId'],
         pathParams: ['leaderboardId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -2352,7 +2372,7 @@ export namespace gamesManagement_v1management {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -2414,7 +2434,10 @@ export namespace gamesManagement_v1management {
 
 
   export class Resource$Turnbasedmatches {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -2472,7 +2495,7 @@ export namespace gamesManagement_v1management {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -2539,7 +2562,7 @@ export namespace gamesManagement_v1management {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);

--- a/src/apis/genomics/v1.ts
+++ b/src/apis/genomics/v1.ts
@@ -29,8 +29,6 @@ export namespace genomics_v1 {
     version: 'v1';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * V1 error format.
@@ -98,12 +96,13 @@ export namespace genomics_v1 {
    * @param {object=} options Options for Genomics
    */
   export class Genomics {
+    context: APIRequestContext;
     operations: Resource$Operations;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.operations = new Resource$Operations();
+      this.operations = new Resource$Operations(this.context);
     }
   }
 
@@ -492,7 +491,10 @@ export namespace genomics_v1 {
 
 
   export class Resource$Operations {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -611,7 +613,7 @@ export namespace genomics_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -729,7 +731,7 @@ export namespace genomics_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -867,7 +869,7 @@ export namespace genomics_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListOperationsResponse>(parameters, callback);

--- a/src/apis/genomics/v1alpha2.ts
+++ b/src/apis/genomics/v1alpha2.ts
@@ -29,8 +29,6 @@ export namespace genomics_v1alpha2 {
     version: 'v1alpha2';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * V1 error format.
@@ -98,14 +96,15 @@ export namespace genomics_v1alpha2 {
    * @param {object=} options Options for Genomics
    */
   export class Genomics {
+    context: APIRequestContext;
     operations: Resource$Operations;
     pipelines: Resource$Pipelines;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.operations = new Resource$Operations();
-      this.pipelines = new Resource$Pipelines();
+      this.operations = new Resource$Operations(this.context);
+      this.pipelines = new Resource$Pipelines(this.context);
     }
   }
 
@@ -942,7 +941,10 @@ export namespace genomics_v1alpha2 {
 
 
   export class Resource$Operations {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1061,7 +1063,7 @@ export namespace genomics_v1alpha2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -1180,7 +1182,7 @@ export namespace genomics_v1alpha2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -1319,7 +1321,7 @@ export namespace genomics_v1alpha2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListOperationsResponse>(parameters, callback);
@@ -1401,7 +1403,10 @@ export namespace genomics_v1alpha2 {
 
 
   export class Resource$Pipelines {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1515,7 +1520,7 @@ export namespace genomics_v1alpha2 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Pipeline>(parameters, callback);
@@ -1632,7 +1637,7 @@ export namespace genomics_v1alpha2 {
         params,
         requiredParams: ['pipelineId'],
         pathParams: ['pipelineId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -1748,7 +1753,7 @@ export namespace genomics_v1alpha2 {
         params,
         requiredParams: ['pipelineId'],
         pathParams: ['pipelineId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Pipeline>(parameters, callback);
@@ -1866,7 +1871,7 @@ export namespace genomics_v1alpha2 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ControllerConfig>(parameters, callback);
@@ -1998,7 +2003,7 @@ export namespace genomics_v1alpha2 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListPipelinesResponse>(parameters, callback);
@@ -2120,7 +2125,7 @@ export namespace genomics_v1alpha2 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -2241,7 +2246,7 @@ export namespace genomics_v1alpha2 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);

--- a/src/apis/genomics/v2alpha1.ts
+++ b/src/apis/genomics/v2alpha1.ts
@@ -29,8 +29,6 @@ export namespace genomics_v2alpha1 {
     version: 'v2alpha1';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * V1 error format.
@@ -98,16 +96,17 @@ export namespace genomics_v2alpha1 {
    * @param {object=} options Options for Genomics
    */
   export class Genomics {
+    context: APIRequestContext;
     pipelines: Resource$Pipelines;
     projects: Resource$Projects;
     workers: Resource$Workers;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.pipelines = new Resource$Pipelines();
-      this.projects = new Resource$Projects();
-      this.workers = new Resource$Workers();
+      this.pipelines = new Resource$Pipelines(this.context);
+      this.projects = new Resource$Projects(this.context);
+      this.workers = new Resource$Workers(this.context);
     }
   }
 
@@ -986,7 +985,10 @@ export namespace genomics_v2alpha1 {
 
 
   export class Resource$Pipelines {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1048,7 +1050,7 @@ export namespace genomics_v2alpha1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -1073,15 +1075,20 @@ export namespace genomics_v2alpha1 {
 
 
   export class Resource$Projects {
+    context: APIRequestContext;
     operations: Resource$Projects$Operations;
-    constructor() {
-      this.operations = new Resource$Projects$Operations();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.operations = new Resource$Projects$Operations(this.context);
     }
   }
 
 
   export class Resource$Projects$Operations {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1147,7 +1154,7 @@ export namespace genomics_v2alpha1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -1214,7 +1221,7 @@ export namespace genomics_v2alpha1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -1288,7 +1295,7 @@ export namespace genomics_v2alpha1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListOperationsResponse>(parameters, callback);
@@ -1373,7 +1380,10 @@ export namespace genomics_v2alpha1 {
 
 
   export class Resource$Workers {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1433,7 +1443,7 @@ export namespace genomics_v2alpha1 {
         params,
         requiredParams: ['id'],
         pathParams: ['id'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$CheckInResponse>(parameters, callback);

--- a/src/apis/gmail/v1.ts
+++ b/src/apis/gmail/v1.ts
@@ -29,8 +29,6 @@ export namespace gmail_v1 {
     version: 'v1';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * Data format for the response.
@@ -81,12 +79,13 @@ export namespace gmail_v1 {
    * @param {object=} options Options for Gmail
    */
   export class Gmail {
+    context: APIRequestContext;
     users: Resource$Users;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.users = new Resource$Users();
+      this.users = new Resource$Users(this.context);
     }
   }
 
@@ -958,19 +957,21 @@ export namespace gmail_v1 {
 
 
   export class Resource$Users {
+    context: APIRequestContext;
     drafts: Resource$Users$Drafts;
     history: Resource$Users$History;
     labels: Resource$Users$Labels;
     messages: Resource$Users$Messages;
     settings: Resource$Users$Settings;
     threads: Resource$Users$Threads;
-    constructor() {
-      this.drafts = new Resource$Users$Drafts();
-      this.history = new Resource$Users$History();
-      this.labels = new Resource$Users$Labels();
-      this.messages = new Resource$Users$Messages();
-      this.settings = new Resource$Users$Settings();
-      this.threads = new Resource$Users$Threads();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.drafts = new Resource$Users$Drafts(this.context);
+      this.history = new Resource$Users$History(this.context);
+      this.labels = new Resource$Users$Labels(this.context);
+      this.messages = new Resource$Users$Messages(this.context);
+      this.settings = new Resource$Users$Settings(this.context);
+      this.threads = new Resource$Users$Threads(this.context);
     }
 
 
@@ -1029,7 +1030,7 @@ export namespace gmail_v1 {
         params,
         requiredParams: ['userId'],
         pathParams: ['userId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Profile>(parameters, callback);
@@ -1092,7 +1093,7 @@ export namespace gmail_v1 {
         params,
         requiredParams: ['userId'],
         pathParams: ['userId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -1159,7 +1160,7 @@ export namespace gmail_v1 {
         params,
         requiredParams: ['userId'],
         pathParams: ['userId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$WatchResponse>(parameters, callback);
@@ -1212,7 +1213,10 @@ export namespace gmail_v1 {
   }
 
   export class Resource$Users$Drafts {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1277,7 +1281,7 @@ export namespace gmail_v1 {
                       .replace(/([^:]\/)\/+/g, '$1'),
         requiredParams: ['userId'],
         pathParams: ['userId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Draft>(parameters, callback);
@@ -1344,7 +1348,7 @@ export namespace gmail_v1 {
         params,
         requiredParams: ['userId', 'id'],
         pathParams: ['id', 'userId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -1407,7 +1411,7 @@ export namespace gmail_v1 {
         params,
         requiredParams: ['userId', 'id'],
         pathParams: ['id', 'userId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Draft>(parameters, callback);
@@ -1477,7 +1481,7 @@ export namespace gmail_v1 {
         params,
         requiredParams: ['userId'],
         pathParams: ['userId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListDraftsResponse>(parameters, callback);
@@ -1549,7 +1553,7 @@ export namespace gmail_v1 {
                       .replace(/([^:]\/)\/+/g, '$1'),
         requiredParams: ['userId'],
         pathParams: ['userId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Message>(parameters, callback);
@@ -1622,7 +1626,7 @@ export namespace gmail_v1 {
                       .replace(/([^:]\/)\/+/g, '$1'),
         requiredParams: ['userId', 'id'],
         pathParams: ['id', 'userId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Draft>(parameters, callback);
@@ -1806,7 +1810,10 @@ export namespace gmail_v1 {
 
 
   export class Resource$Users$History {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1871,7 +1878,7 @@ export namespace gmail_v1 {
         params,
         requiredParams: ['userId'],
         pathParams: ['userId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListHistoryResponse>(parameters, callback);
@@ -1927,7 +1934,10 @@ export namespace gmail_v1 {
 
 
   export class Resource$Users$Labels {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1987,7 +1997,7 @@ export namespace gmail_v1 {
         params,
         requiredParams: ['userId'],
         pathParams: ['userId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Label>(parameters, callback);
@@ -2054,7 +2064,7 @@ export namespace gmail_v1 {
         params,
         requiredParams: ['userId', 'id'],
         pathParams: ['id', 'userId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -2116,7 +2126,7 @@ export namespace gmail_v1 {
         params,
         requiredParams: ['userId', 'id'],
         pathParams: ['id', 'userId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Label>(parameters, callback);
@@ -2182,7 +2192,7 @@ export namespace gmail_v1 {
         params,
         requiredParams: ['userId'],
         pathParams: ['userId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListLabelsResponse>(parameters, callback);
@@ -2249,7 +2259,7 @@ export namespace gmail_v1 {
         params,
         requiredParams: ['userId', 'id'],
         pathParams: ['id', 'userId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Label>(parameters, callback);
@@ -2317,7 +2327,7 @@ export namespace gmail_v1 {
         params,
         requiredParams: ['userId', 'id'],
         pathParams: ['id', 'userId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Label>(parameters, callback);
@@ -2438,9 +2448,11 @@ export namespace gmail_v1 {
 
 
   export class Resource$Users$Messages {
+    context: APIRequestContext;
     attachments: Resource$Users$Messages$Attachments;
-    constructor() {
-      this.attachments = new Resource$Users$Messages$Attachments();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.attachments = new Resource$Users$Messages$Attachments(this.context);
     }
 
 
@@ -2501,7 +2513,7 @@ export namespace gmail_v1 {
         params,
         requiredParams: ['userId'],
         pathParams: ['userId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -2567,7 +2579,7 @@ export namespace gmail_v1 {
         params,
         requiredParams: ['userId'],
         pathParams: ['userId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -2634,7 +2646,7 @@ export namespace gmail_v1 {
         params,
         requiredParams: ['userId', 'id'],
         pathParams: ['id', 'userId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -2699,7 +2711,7 @@ export namespace gmail_v1 {
         params,
         requiredParams: ['userId', 'id'],
         pathParams: ['id', 'userId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Message>(parameters, callback);
@@ -2748,7 +2760,7 @@ import(paramsOrCallback?: Params$Resource$Users$Messages$Import|BodyResponseCall
     options = {};
                                                                                                                                                                                                                                                                         }
 
-                                                                                                                                                                                                                                                                        const rootUrl = options.rootUrl || 'https://www.googleapis.com/'; const parameters = {options: Object.assign({url: (rootUrl + '/gmail/v1/users/{userId}/messages/import').replace(/([^:]\/)\/+/g, '$1'), method: 'POST'}, options), params, mediaUrl: (rootUrl + '/upload/gmail/v1/users/{userId}/messages/import').replace(/([^:]\/)\/+/g, '$1'), requiredParams: ['userId'], pathParams: ['userId'], context}; if(callback) {
+                                                                                                                                                                                                                                                                        const rootUrl = options.rootUrl || 'https://www.googleapis.com/'; const parameters = {options: Object.assign({url: (rootUrl + '/gmail/v1/users/{userId}/messages/import').replace(/([^:]\/)\/+/g, '$1'), method: 'POST'}, options), params, mediaUrl: (rootUrl + '/upload/gmail/v1/users/{userId}/messages/import').replace(/([^:]\/)\/+/g, '$1'), requiredParams: ['userId'], pathParams: ['userId'], context: this.context}; if(callback) {
     createAPIRequest<Schema$Message>(parameters, callback);
                                                                                                                                                                                                                                                                         } else {
     return createAPIRequest<Schema$Message>(parameters);
@@ -2817,7 +2829,7 @@ import(paramsOrCallback?: Params$Resource$Users$Messages$Import|BodyResponseCall
                       .replace(/([^:]\/)\/+/g, '$1'),
         requiredParams: ['userId'],
         pathParams: ['userId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Message>(parameters, callback);
@@ -2889,7 +2901,7 @@ import(paramsOrCallback?: Params$Resource$Users$Messages$Import|BodyResponseCall
         params,
         requiredParams: ['userId'],
         pathParams: ['userId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListMessagesResponse>(parameters, callback);
@@ -2957,7 +2969,7 @@ import(paramsOrCallback?: Params$Resource$Users$Messages$Import|BodyResponseCall
         params,
         requiredParams: ['userId', 'id'],
         pathParams: ['id', 'userId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Message>(parameters, callback);
@@ -3029,7 +3041,7 @@ import(paramsOrCallback?: Params$Resource$Users$Messages$Import|BodyResponseCall
                       .replace(/([^:]\/)\/+/g, '$1'),
         requiredParams: ['userId'],
         pathParams: ['userId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Message>(parameters, callback);
@@ -3096,7 +3108,7 @@ import(paramsOrCallback?: Params$Resource$Users$Messages$Import|BodyResponseCall
         params,
         requiredParams: ['userId', 'id'],
         pathParams: ['id', 'userId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Message>(parameters, callback);
@@ -3163,7 +3175,7 @@ import(paramsOrCallback?: Params$Resource$Users$Messages$Import|BodyResponseCall
         params,
         requiredParams: ['userId', 'id'],
         pathParams: ['id', 'userId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Message>(parameters, callback);
@@ -3474,7 +3486,10 @@ import(paramsOrCallback?: Params$Resource$Users$Messages$Import|BodyResponseCall
   }
 
   export class Resource$Users$Messages$Attachments {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -3534,7 +3549,7 @@ import(paramsOrCallback?: Params$Resource$Users$Messages$Import|BodyResponseCall
         params,
         requiredParams: ['userId', 'messageId', 'id'],
         pathParams: ['id', 'messageId', 'userId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$MessagePartBody>(parameters, callback);
@@ -3569,16 +3584,18 @@ import(paramsOrCallback?: Params$Resource$Users$Messages$Import|BodyResponseCall
 
 
   export class Resource$Users$Settings {
+    context: APIRequestContext;
     delegates: Resource$Users$Settings$Delegates;
     filters: Resource$Users$Settings$Filters;
     forwardingAddresses: Resource$Users$Settings$Forwardingaddresses;
     sendAs: Resource$Users$Settings$Sendas;
-    constructor() {
-      this.delegates = new Resource$Users$Settings$Delegates();
-      this.filters = new Resource$Users$Settings$Filters();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.delegates = new Resource$Users$Settings$Delegates(this.context);
+      this.filters = new Resource$Users$Settings$Filters(this.context);
       this.forwardingAddresses =
-          new Resource$Users$Settings$Forwardingaddresses();
-      this.sendAs = new Resource$Users$Settings$Sendas();
+          new Resource$Users$Settings$Forwardingaddresses(this.context);
+      this.sendAs = new Resource$Users$Settings$Sendas(this.context);
     }
 
 
@@ -3641,7 +3658,7 @@ import(paramsOrCallback?: Params$Resource$Users$Messages$Import|BodyResponseCall
         params,
         requiredParams: ['userId'],
         pathParams: ['userId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AutoForwarding>(parameters, callback);
@@ -3708,7 +3725,7 @@ import(paramsOrCallback?: Params$Resource$Users$Messages$Import|BodyResponseCall
         params,
         requiredParams: ['userId'],
         pathParams: ['userId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ImapSettings>(parameters, callback);
@@ -3775,7 +3792,7 @@ import(paramsOrCallback?: Params$Resource$Users$Messages$Import|BodyResponseCall
         params,
         requiredParams: ['userId'],
         pathParams: ['userId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$PopSettings>(parameters, callback);
@@ -3842,7 +3859,7 @@ import(paramsOrCallback?: Params$Resource$Users$Messages$Import|BodyResponseCall
         params,
         requiredParams: ['userId'],
         pathParams: ['userId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$VacationSettings>(parameters, callback);
@@ -3915,7 +3932,7 @@ import(paramsOrCallback?: Params$Resource$Users$Messages$Import|BodyResponseCall
         params,
         requiredParams: ['userId'],
         pathParams: ['userId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AutoForwarding>(parameters, callback);
@@ -3983,7 +4000,7 @@ import(paramsOrCallback?: Params$Resource$Users$Messages$Import|BodyResponseCall
         params,
         requiredParams: ['userId'],
         pathParams: ['userId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ImapSettings>(parameters, callback);
@@ -4051,7 +4068,7 @@ import(paramsOrCallback?: Params$Resource$Users$Messages$Import|BodyResponseCall
         params,
         requiredParams: ['userId'],
         pathParams: ['userId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$PopSettings>(parameters, callback);
@@ -4120,7 +4137,7 @@ import(paramsOrCallback?: Params$Resource$Users$Messages$Import|BodyResponseCall
         params,
         requiredParams: ['userId'],
         pathParams: ['userId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$VacationSettings>(parameters, callback);
@@ -4256,7 +4273,10 @@ import(paramsOrCallback?: Params$Resource$Users$Messages$Import|BodyResponseCall
   }
 
   export class Resource$Users$Settings$Delegates {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -4326,7 +4346,7 @@ import(paramsOrCallback?: Params$Resource$Users$Messages$Import|BodyResponseCall
         params,
         requiredParams: ['userId'],
         pathParams: ['userId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Delegate>(parameters, callback);
@@ -4398,7 +4418,7 @@ import(paramsOrCallback?: Params$Resource$Users$Messages$Import|BodyResponseCall
         params,
         requiredParams: ['userId', 'delegateEmail'],
         pathParams: ['delegateEmail', 'userId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -4466,7 +4486,7 @@ import(paramsOrCallback?: Params$Resource$Users$Messages$Import|BodyResponseCall
         params,
         requiredParams: ['userId', 'delegateEmail'],
         pathParams: ['delegateEmail', 'userId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Delegate>(parameters, callback);
@@ -4536,7 +4556,7 @@ import(paramsOrCallback?: Params$Resource$Users$Messages$Import|BodyResponseCall
         params,
         requiredParams: ['userId'],
         pathParams: ['userId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListDelegatesResponse>(parameters, callback);
@@ -4615,7 +4635,10 @@ import(paramsOrCallback?: Params$Resource$Users$Messages$Import|BodyResponseCall
 
 
   export class Resource$Users$Settings$Filters {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -4675,7 +4698,7 @@ import(paramsOrCallback?: Params$Resource$Users$Messages$Import|BodyResponseCall
         params,
         requiredParams: ['userId'],
         pathParams: ['userId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Filter>(parameters, callback);
@@ -4741,7 +4764,7 @@ import(paramsOrCallback?: Params$Resource$Users$Messages$Import|BodyResponseCall
         params,
         requiredParams: ['userId', 'id'],
         pathParams: ['id', 'userId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -4804,7 +4827,7 @@ import(paramsOrCallback?: Params$Resource$Users$Messages$Import|BodyResponseCall
         params,
         requiredParams: ['userId', 'id'],
         pathParams: ['id', 'userId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Filter>(parameters, callback);
@@ -4871,7 +4894,7 @@ import(paramsOrCallback?: Params$Resource$Users$Messages$Import|BodyResponseCall
         params,
         requiredParams: ['userId'],
         pathParams: ['userId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListFiltersResponse>(parameters, callback);
@@ -4949,7 +4972,10 @@ import(paramsOrCallback?: Params$Resource$Users$Messages$Import|BodyResponseCall
 
 
   export class Resource$Users$Settings$Forwardingaddresses {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -5018,7 +5044,7 @@ import(paramsOrCallback?: Params$Resource$Users$Messages$Import|BodyResponseCall
         params,
         requiredParams: ['userId'],
         pathParams: ['userId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ForwardingAddress>(parameters, callback);
@@ -5091,7 +5117,7 @@ import(paramsOrCallback?: Params$Resource$Users$Messages$Import|BodyResponseCall
         params,
         requiredParams: ['userId', 'forwardingEmail'],
         pathParams: ['forwardingEmail', 'userId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -5158,7 +5184,7 @@ import(paramsOrCallback?: Params$Resource$Users$Messages$Import|BodyResponseCall
         params,
         requiredParams: ['userId', 'forwardingEmail'],
         pathParams: ['forwardingEmail', 'userId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ForwardingAddress>(parameters, callback);
@@ -5234,7 +5260,7 @@ import(paramsOrCallback?: Params$Resource$Users$Messages$Import|BodyResponseCall
         params,
         requiredParams: ['userId'],
         pathParams: ['userId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListForwardingAddressesResponse>(
@@ -5314,9 +5340,12 @@ import(paramsOrCallback?: Params$Resource$Users$Messages$Import|BodyResponseCall
 
 
   export class Resource$Users$Settings$Sendas {
+    context: APIRequestContext;
     smimeInfo: Resource$Users$Settings$Sendas$Smimeinfo;
-    constructor() {
-      this.smimeInfo = new Resource$Users$Settings$Sendas$Smimeinfo();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.smimeInfo =
+          new Resource$Users$Settings$Sendas$Smimeinfo(this.context);
     }
 
 
@@ -5385,7 +5414,7 @@ import(paramsOrCallback?: Params$Resource$Users$Messages$Import|BodyResponseCall
         params,
         requiredParams: ['userId'],
         pathParams: ['userId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$SendAs>(parameters, callback);
@@ -5454,7 +5483,7 @@ import(paramsOrCallback?: Params$Resource$Users$Messages$Import|BodyResponseCall
         params,
         requiredParams: ['userId', 'sendAsEmail'],
         pathParams: ['sendAsEmail', 'userId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -5519,7 +5548,7 @@ import(paramsOrCallback?: Params$Resource$Users$Messages$Import|BodyResponseCall
         params,
         requiredParams: ['userId', 'sendAsEmail'],
         pathParams: ['sendAsEmail', 'userId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$SendAs>(parameters, callback);
@@ -5588,7 +5617,7 @@ import(paramsOrCallback?: Params$Resource$Users$Messages$Import|BodyResponseCall
         params,
         requiredParams: ['userId'],
         pathParams: ['userId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListSendAsResponse>(parameters, callback);
@@ -5661,7 +5690,7 @@ import(paramsOrCallback?: Params$Resource$Users$Messages$Import|BodyResponseCall
         params,
         requiredParams: ['userId', 'sendAsEmail'],
         pathParams: ['sendAsEmail', 'userId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$SendAs>(parameters, callback);
@@ -5733,7 +5762,7 @@ import(paramsOrCallback?: Params$Resource$Users$Messages$Import|BodyResponseCall
         params,
         requiredParams: ['userId', 'sendAsEmail'],
         pathParams: ['sendAsEmail', 'userId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$SendAs>(parameters, callback);
@@ -5804,7 +5833,7 @@ import(paramsOrCallback?: Params$Resource$Users$Messages$Import|BodyResponseCall
         params,
         requiredParams: ['userId', 'sendAsEmail'],
         pathParams: ['sendAsEmail', 'userId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -5942,7 +5971,10 @@ import(paramsOrCallback?: Params$Resource$Users$Messages$Import|BodyResponseCall
   }
 
   export class Resource$Users$Settings$Sendas$Smimeinfo {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -6006,7 +6038,7 @@ import(paramsOrCallback?: Params$Resource$Users$Messages$Import|BodyResponseCall
         params,
         requiredParams: ['userId', 'sendAsEmail', 'id'],
         pathParams: ['id', 'sendAsEmail', 'userId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -6073,7 +6105,7 @@ import(paramsOrCallback?: Params$Resource$Users$Messages$Import|BodyResponseCall
         params,
         requiredParams: ['userId', 'sendAsEmail', 'id'],
         pathParams: ['id', 'sendAsEmail', 'userId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$SmimeInfo>(parameters, callback);
@@ -6146,7 +6178,7 @@ import(paramsOrCallback?: Params$Resource$Users$Messages$Import|BodyResponseCall
         params,
         requiredParams: ['userId', 'sendAsEmail'],
         pathParams: ['sendAsEmail', 'userId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$SmimeInfo>(parameters, callback);
@@ -6217,7 +6249,7 @@ import(paramsOrCallback?: Params$Resource$Users$Messages$Import|BodyResponseCall
         params,
         requiredParams: ['userId', 'sendAsEmail'],
         pathParams: ['sendAsEmail', 'userId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListSmimeInfoResponse>(parameters, callback);
@@ -6288,7 +6320,7 @@ import(paramsOrCallback?: Params$Resource$Users$Messages$Import|BodyResponseCall
         params,
         requiredParams: ['userId', 'sendAsEmail', 'id'],
         pathParams: ['id', 'sendAsEmail', 'userId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -6409,7 +6441,10 @@ import(paramsOrCallback?: Params$Resource$Users$Messages$Import|BodyResponseCall
 
 
   export class Resource$Users$Threads {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -6469,7 +6504,7 @@ import(paramsOrCallback?: Params$Resource$Users$Messages$Import|BodyResponseCall
         params,
         requiredParams: ['userId', 'id'],
         pathParams: ['id', 'userId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -6534,7 +6569,7 @@ import(paramsOrCallback?: Params$Resource$Users$Messages$Import|BodyResponseCall
         params,
         requiredParams: ['userId', 'id'],
         pathParams: ['id', 'userId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Thread>(parameters, callback);
@@ -6605,7 +6640,7 @@ import(paramsOrCallback?: Params$Resource$Users$Messages$Import|BodyResponseCall
         params,
         requiredParams: ['userId'],
         pathParams: ['userId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListThreadsResponse>(parameters, callback);
@@ -6674,7 +6709,7 @@ import(paramsOrCallback?: Params$Resource$Users$Messages$Import|BodyResponseCall
         params,
         requiredParams: ['userId', 'id'],
         pathParams: ['id', 'userId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Thread>(parameters, callback);
@@ -6741,7 +6776,7 @@ import(paramsOrCallback?: Params$Resource$Users$Messages$Import|BodyResponseCall
         params,
         requiredParams: ['userId', 'id'],
         pathParams: ['id', 'userId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Thread>(parameters, callback);
@@ -6808,7 +6843,7 @@ import(paramsOrCallback?: Params$Resource$Users$Messages$Import|BodyResponseCall
         params,
         requiredParams: ['userId', 'id'],
         pathParams: ['id', 'userId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Thread>(parameters, callback);

--- a/src/apis/groupsmigration/v1.ts
+++ b/src/apis/groupsmigration/v1.ts
@@ -29,8 +29,6 @@ export namespace groupsmigration_v1 {
     version: 'v1';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * Data format for the response.
@@ -81,12 +79,13 @@ export namespace groupsmigration_v1 {
    * @param {object=} options Options for Groupsmigration
    */
   export class Groupsmigration {
+    context: APIRequestContext;
     archive: Resource$Archive;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.archive = new Resource$Archive();
+      this.archive = new Resource$Archive(this.context);
     }
   }
 
@@ -106,7 +105,10 @@ export namespace groupsmigration_v1 {
 
 
   export class Resource$Archive {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -168,7 +170,7 @@ export namespace groupsmigration_v1 {
                       .replace(/([^:]\/)\/+/g, '$1'),
         requiredParams: ['groupId'],
         pathParams: ['groupId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Groups>(parameters, callback);

--- a/src/apis/groupssettings/v1.ts
+++ b/src/apis/groupssettings/v1.ts
@@ -29,8 +29,6 @@ export namespace groupssettings_v1 {
     version: 'v1';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * Data format for the response.
@@ -81,12 +79,13 @@ export namespace groupssettings_v1 {
    * @param {object=} options Options for Groupssettings
    */
   export class Groupssettings {
+    context: APIRequestContext;
     groups: Resource$Groups;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.groups = new Resource$Groups();
+      this.groups = new Resource$Groups(this.context);
     }
   }
 
@@ -394,7 +393,10 @@ export namespace groupssettings_v1 {
 
 
   export class Resource$Groups {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -448,7 +450,7 @@ export namespace groupssettings_v1 {
         params,
         requiredParams: ['groupUniqueId'],
         pathParams: ['groupUniqueId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Groups>(parameters, callback);
@@ -513,7 +515,7 @@ export namespace groupssettings_v1 {
         params,
         requiredParams: ['groupUniqueId'],
         pathParams: ['groupUniqueId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Groups>(parameters, callback);
@@ -578,7 +580,7 @@ export namespace groupssettings_v1 {
         params,
         requiredParams: ['groupUniqueId'],
         pathParams: ['groupUniqueId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Groups>(parameters, callback);

--- a/src/apis/healthcare/v1alpha.ts
+++ b/src/apis/healthcare/v1alpha.ts
@@ -29,8 +29,6 @@ export namespace healthcare_v1alpha {
     version: 'v1alpha';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * V1 error format.
@@ -98,12 +96,13 @@ export namespace healthcare_v1alpha {
    * @param {object=} options Options for Healthcare
    */
   export class Healthcare {
+    context: APIRequestContext;
     projects: Resource$Projects;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.projects = new Resource$Projects();
+      this.projects = new Resource$Projects(this.context);
     }
   }
 
@@ -1415,17 +1414,21 @@ export namespace healthcare_v1alpha {
 
 
   export class Resource$Projects {
+    context: APIRequestContext;
     locations: Resource$Projects$Locations;
-    constructor() {
-      this.locations = new Resource$Projects$Locations();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.locations = new Resource$Projects$Locations(this.context);
     }
   }
 
 
   export class Resource$Projects$Locations {
+    context: APIRequestContext;
     datasets: Resource$Projects$Locations$Datasets;
-    constructor() {
-      this.datasets = new Resource$Projects$Locations$Datasets();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.datasets = new Resource$Projects$Locations$Datasets(this.context);
     }
 
 
@@ -1480,7 +1483,7 @@ export namespace healthcare_v1alpha {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Location>(parameters, callback);
@@ -1551,7 +1554,7 @@ export namespace healthcare_v1alpha {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListLocationsResponse>(parameters, callback);
@@ -1599,18 +1602,25 @@ export namespace healthcare_v1alpha {
   }
 
   export class Resource$Projects$Locations$Datasets {
+    context: APIRequestContext;
     annotationStores: Resource$Projects$Locations$Datasets$Annotationstores;
     dicomStores: Resource$Projects$Locations$Datasets$Dicomstores;
     fhirStores: Resource$Projects$Locations$Datasets$Fhirstores;
     hl7V2Stores: Resource$Projects$Locations$Datasets$Hl7v2stores;
     operations: Resource$Projects$Locations$Datasets$Operations;
-    constructor() {
+    constructor(context: APIRequestContext) {
+      this.context = context;
       this.annotationStores =
-          new Resource$Projects$Locations$Datasets$Annotationstores();
-      this.dicomStores = new Resource$Projects$Locations$Datasets$Dicomstores();
-      this.fhirStores = new Resource$Projects$Locations$Datasets$Fhirstores();
-      this.hl7V2Stores = new Resource$Projects$Locations$Datasets$Hl7v2stores();
-      this.operations = new Resource$Projects$Locations$Datasets$Operations();
+          new Resource$Projects$Locations$Datasets$Annotationstores(
+              this.context);
+      this.dicomStores =
+          new Resource$Projects$Locations$Datasets$Dicomstores(this.context);
+      this.fhirStores =
+          new Resource$Projects$Locations$Datasets$Fhirstores(this.context);
+      this.hl7V2Stores =
+          new Resource$Projects$Locations$Datasets$Hl7v2stores(this.context);
+      this.operations =
+          new Resource$Projects$Locations$Datasets$Operations(this.context);
     }
 
 
@@ -1672,7 +1682,7 @@ export namespace healthcare_v1alpha {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Dataset>(parameters, callback);
@@ -1744,7 +1754,7 @@ export namespace healthcare_v1alpha {
         params,
         requiredParams: ['sourceDataset'],
         pathParams: ['sourceDataset'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -1811,7 +1821,7 @@ export namespace healthcare_v1alpha {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -1872,7 +1882,7 @@ export namespace healthcare_v1alpha {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Dataset>(parameters, callback);
@@ -1940,7 +1950,7 @@ export namespace healthcare_v1alpha {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -2010,7 +2020,7 @@ export namespace healthcare_v1alpha {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListDatasetsResponse>(parameters, callback);
@@ -2077,7 +2087,7 @@ export namespace healthcare_v1alpha {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Dataset>(parameters, callback);
@@ -2146,7 +2156,7 @@ export namespace healthcare_v1alpha {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -2226,7 +2236,7 @@ export namespace healthcare_v1alpha {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TestIamPermissionsResponse>(
@@ -2401,11 +2411,14 @@ export namespace healthcare_v1alpha {
   }
 
   export class Resource$Projects$Locations$Datasets$Annotationstores {
+    context: APIRequestContext;
     annotations:
         Resource$Projects$Locations$Datasets$Annotationstores$Annotations;
-    constructor() {
+    constructor(context: APIRequestContext) {
+      this.context = context;
       this.annotations =
-          new Resource$Projects$Locations$Datasets$Annotationstores$Annotations();
+          new Resource$Projects$Locations$Datasets$Annotationstores$Annotations(
+              this.context);
     }
 
 
@@ -2473,7 +2486,7 @@ export namespace healthcare_v1alpha {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AnnotationStore>(parameters, callback);
@@ -2544,7 +2557,7 @@ export namespace healthcare_v1alpha {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -2612,7 +2625,7 @@ export namespace healthcare_v1alpha {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AnnotationStore>(parameters, callback);
@@ -2689,7 +2702,7 @@ export namespace healthcare_v1alpha {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -2770,7 +2783,7 @@ export namespace healthcare_v1alpha {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListAnnotationStoresResponse>(
@@ -2845,7 +2858,7 @@ export namespace healthcare_v1alpha {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AnnotationStore>(parameters, callback);
@@ -2920,7 +2933,7 @@ export namespace healthcare_v1alpha {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -3003,7 +3016,7 @@ export namespace healthcare_v1alpha {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TestIamPermissionsResponse>(
@@ -3169,7 +3182,10 @@ export namespace healthcare_v1alpha {
 
   export class
       Resource$Projects$Locations$Datasets$Annotationstores$Annotations {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -3238,7 +3254,7 @@ export namespace healthcare_v1alpha {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Annotation>(parameters, callback);
@@ -3309,7 +3325,7 @@ export namespace healthcare_v1alpha {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -3377,7 +3393,7 @@ export namespace healthcare_v1alpha {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Annotation>(parameters, callback);
@@ -3455,7 +3471,7 @@ export namespace healthcare_v1alpha {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListAnnotationsResponse>(parameters, callback);
@@ -3529,7 +3545,7 @@ export namespace healthcare_v1alpha {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Annotation>(parameters, callback);
@@ -3637,10 +3653,13 @@ export namespace healthcare_v1alpha {
 
 
   export class Resource$Projects$Locations$Datasets$Dicomstores {
+    context: APIRequestContext;
     dicomWeb: Resource$Projects$Locations$Datasets$Dicomstores$Dicomweb;
-    constructor() {
+    constructor(context: APIRequestContext) {
+      this.context = context;
       this.dicomWeb =
-          new Resource$Projects$Locations$Datasets$Dicomstores$Dicomweb();
+          new Resource$Projects$Locations$Datasets$Dicomstores$Dicomweb(
+              this.context);
     }
 
 
@@ -3705,7 +3724,7 @@ export namespace healthcare_v1alpha {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$DicomStore>(parameters, callback);
@@ -3773,7 +3792,7 @@ export namespace healthcare_v1alpha {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -3844,7 +3863,7 @@ export namespace healthcare_v1alpha {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -3908,7 +3927,7 @@ export namespace healthcare_v1alpha {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$DicomStore>(parameters, callback);
@@ -3980,7 +3999,7 @@ export namespace healthcare_v1alpha {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -4024,7 +4043,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Locations$Datasets$Dicomstore
     options = {};
                                                                                                                                                                                                                                                                                                          }
 
-                                                                                                                                                                                                                                                                                                         const rootUrl = options.rootUrl || 'https://healthcare.googleapis.com/'; const parameters = {options: Object.assign({url: (rootUrl + '/v1alpha/{+name}:import').replace(/([^:]\/)\/+/g, '$1'), method: 'POST'}, options), params, requiredParams: ['name'], pathParams: ['name'], context}; if(callback) {
+                                                                                                                                                                                                                                                                                                         const rootUrl = options.rootUrl || 'https://healthcare.googleapis.com/'; const parameters = {options: Object.assign({url: (rootUrl + '/v1alpha/{+name}:import').replace(/([^:]\/)\/+/g, '$1'), method: 'POST'}, options), params, requiredParams: ['name'], pathParams: ['name'], context: this.context}; if(callback) {
     createAPIRequest<Schema$Operation>(parameters, callback);
                                                                                                                                                                                                                                                                                                          } else {
     return createAPIRequest<Schema$Operation>(parameters);
@@ -4091,7 +4110,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Locations$Datasets$Dicomstore
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListDicomStoresResponse>(parameters, callback);
@@ -4161,7 +4180,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Locations$Datasets$Dicomstore
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$DicomStore>(parameters, callback);
@@ -4234,7 +4253,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Locations$Datasets$Dicomstore
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -4318,7 +4337,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Locations$Datasets$Dicomstore
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TestIamPermissionsResponse>(
@@ -4510,7 +4529,10 @@ import(paramsOrCallback?: Params$Resource$Projects$Locations$Datasets$Dicomstore
   }
 
   export class Resource$Projects$Locations$Datasets$Dicomstores$Dicomweb {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -4582,7 +4604,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Locations$Datasets$Dicomstore
         params,
         requiredParams: ['parent', 'dicomWebPath'],
         pathParams: ['dicomWebPath', 'parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -4661,7 +4683,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Locations$Datasets$Dicomstore
         params,
         requiredParams: ['parent', 'dicomWebPath'],
         pathParams: ['dicomWebPath', 'parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$HttpBody>(parameters, callback);
@@ -4741,7 +4763,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Locations$Datasets$Dicomstore
         params,
         requiredParams: ['parent', 'dicomWebPath'],
         pathParams: ['dicomWebPath', 'parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$HttpBody>(parameters, callback);
@@ -4813,14 +4835,18 @@ import(paramsOrCallback?: Params$Resource$Projects$Locations$Datasets$Dicomstore
 
 
   export class Resource$Projects$Locations$Datasets$Fhirstores {
+    context: APIRequestContext;
     resources: Resource$Projects$Locations$Datasets$Fhirstores$Resources;
     securityLabels:
         Resource$Projects$Locations$Datasets$Fhirstores$Securitylabels;
-    constructor() {
+    constructor(context: APIRequestContext) {
+      this.context = context;
       this.resources =
-          new Resource$Projects$Locations$Datasets$Fhirstores$Resources();
+          new Resource$Projects$Locations$Datasets$Fhirstores$Resources(
+              this.context);
       this.securityLabels =
-          new Resource$Projects$Locations$Datasets$Fhirstores$Securitylabels();
+          new Resource$Projects$Locations$Datasets$Fhirstores$Securitylabels(
+              this.context);
     }
 
 
@@ -4885,7 +4911,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Locations$Datasets$Dicomstore
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$FhirStore>(parameters, callback);
@@ -4953,7 +4979,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Locations$Datasets$Dicomstore
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -5025,7 +5051,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Locations$Datasets$Dicomstore
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$HttpBody>(parameters, callback);
@@ -5099,7 +5125,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Locations$Datasets$Dicomstore
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -5163,7 +5189,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Locations$Datasets$Dicomstore
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$FhirStore>(parameters, callback);
@@ -5240,7 +5266,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Locations$Datasets$Dicomstore
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -5311,7 +5337,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Locations$Datasets$Dicomstore
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$HttpBody>(parameters, callback);
@@ -5355,7 +5381,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Locations$Datasets$Fhirstores
     options = {};
                                                                                                                                                                                                                                                                                                         }
 
-                                                                                                                                                                                                                                                                                                        const rootUrl = options.rootUrl || 'https://healthcare.googleapis.com/'; const parameters = {options: Object.assign({url: (rootUrl + '/v1alpha/{+name}:import').replace(/([^:]\/)\/+/g, '$1'), method: 'POST'}, options), params, requiredParams: ['name'], pathParams: ['name'], context}; if(callback) {
+                                                                                                                                                                                                                                                                                                        const rootUrl = options.rootUrl || 'https://healthcare.googleapis.com/'; const parameters = {options: Object.assign({url: (rootUrl + '/v1alpha/{+name}:import').replace(/([^:]\/)\/+/g, '$1'), method: 'POST'}, options), params, requiredParams: ['name'], pathParams: ['name'], context: this.context}; if(callback) {
     createAPIRequest<Schema$Operation>(parameters, callback);
                                                                                                                                                                                                                                                                                                         } else {
     return createAPIRequest<Schema$Operation>(parameters);
@@ -5422,7 +5448,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Locations$Datasets$Fhirstores
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListFhirStoresResponse>(parameters, callback);
@@ -5492,7 +5518,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Locations$Datasets$Fhirstores
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$FhirStore>(parameters, callback);
@@ -5568,7 +5594,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Locations$Datasets$Fhirstores
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -5651,7 +5677,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Locations$Datasets$Fhirstores
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TestIamPermissionsResponse>(
@@ -5876,14 +5902,18 @@ import(paramsOrCallback?: Params$Resource$Projects$Locations$Datasets$Fhirstores
   }
 
   export class Resource$Projects$Locations$Datasets$Fhirstores$Resources {
+    context: APIRequestContext;
     Patient: Resource$Projects$Locations$Datasets$Fhirstores$Resources$Patient;
     _history:
         Resource$Projects$Locations$Datasets$Fhirstores$Resources$_history;
-    constructor() {
+    constructor(context: APIRequestContext) {
+      this.context = context;
       this.Patient =
-          new Resource$Projects$Locations$Datasets$Fhirstores$Resources$Patient();
+          new Resource$Projects$Locations$Datasets$Fhirstores$Resources$Patient(
+              this.context);
       this._history =
-          new Resource$Projects$Locations$Datasets$Fhirstores$Resources$_history();
+          new Resource$Projects$Locations$Datasets$Fhirstores$Resources$_history(
+              this.context);
     }
 
 
@@ -5956,7 +5986,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Locations$Datasets$Fhirstores
         params,
         requiredParams: ['parent', 'type'],
         pathParams: ['parent', 'type'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -6032,7 +6062,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Locations$Datasets$Fhirstores
         params,
         requiredParams: ['parent', 'type'],
         pathParams: ['parent', 'type'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$HttpBody>(parameters, callback);
@@ -6108,7 +6138,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Locations$Datasets$Fhirstores
         params,
         requiredParams: ['parent', 'type'],
         pathParams: ['parent', 'type'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$HttpBody>(parameters, callback);
@@ -6182,7 +6212,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Locations$Datasets$Fhirstores
         params,
         requiredParams: ['parent', 'type'],
         pathParams: ['parent', 'type'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$HttpBody>(parameters, callback);
@@ -6256,7 +6286,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Locations$Datasets$Fhirstores
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$HttpBody>(parameters, callback);
@@ -6330,7 +6360,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Locations$Datasets$Fhirstores
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -6396,7 +6426,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Locations$Datasets$Fhirstores
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$HttpBody>(parameters, callback);
@@ -6468,7 +6498,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Locations$Datasets$Fhirstores
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$HttpBody>(parameters, callback);
@@ -6539,7 +6569,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Locations$Datasets$Fhirstores
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$HttpBody>(parameters, callback);
@@ -6619,7 +6649,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Locations$Datasets$Fhirstores
         params,
         requiredParams: ['parent', 'resourceType'],
         pathParams: ['parent', 'resourceType'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$HttpBody>(parameters, callback);
@@ -6692,7 +6722,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Locations$Datasets$Fhirstores
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$HttpBody>(parameters, callback);
@@ -6772,7 +6802,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Locations$Datasets$Fhirstores
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$HttpBody>(parameters, callback);
@@ -6979,7 +7009,10 @@ import(paramsOrCallback?: Params$Resource$Projects$Locations$Datasets$Fhirstores
 
   export class
       Resource$Projects$Locations$Datasets$Fhirstores$Resources$Patient {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -7046,7 +7079,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Locations$Datasets$Fhirstores
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$HttpBody>(parameters, callback);
@@ -7082,7 +7115,10 @@ import(paramsOrCallback?: Params$Resource$Projects$Locations$Datasets$Fhirstores
 
   export class
       Resource$Projects$Locations$Datasets$Fhirstores$Resources$_history {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -7143,7 +7179,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Locations$Datasets$Fhirstores
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$HttpBody>(parameters, callback);
@@ -7220,7 +7256,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Locations$Datasets$Fhirstores
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$HttpBody>(parameters, callback);
@@ -7287,7 +7323,10 @@ import(paramsOrCallback?: Params$Resource$Projects$Locations$Datasets$Fhirstores
 
 
   export class Resource$Projects$Locations$Datasets$Fhirstores$Securitylabels {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -7358,7 +7397,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Locations$Datasets$Fhirstores
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -7435,7 +7474,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Locations$Datasets$Fhirstores
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -7485,10 +7524,13 @@ import(paramsOrCallback?: Params$Resource$Projects$Locations$Datasets$Fhirstores
 
 
   export class Resource$Projects$Locations$Datasets$Hl7v2stores {
+    context: APIRequestContext;
     messages: Resource$Projects$Locations$Datasets$Hl7v2stores$Messages;
-    constructor() {
+    constructor(context: APIRequestContext) {
+      this.context = context;
       this.messages =
-          new Resource$Projects$Locations$Datasets$Hl7v2stores$Messages();
+          new Resource$Projects$Locations$Datasets$Hl7v2stores$Messages(
+              this.context);
     }
 
 
@@ -7553,7 +7595,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Locations$Datasets$Fhirstores
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Hl7V2Store>(parameters, callback);
@@ -7621,7 +7663,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Locations$Datasets$Fhirstores
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -7685,7 +7727,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Locations$Datasets$Fhirstores
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Hl7V2Store>(parameters, callback);
@@ -7757,7 +7799,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Locations$Datasets$Fhirstores
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -7829,7 +7871,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Locations$Datasets$Fhirstores
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListHl7V2StoresResponse>(parameters, callback);
@@ -7899,7 +7941,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Locations$Datasets$Fhirstores
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Hl7V2Store>(parameters, callback);
@@ -7972,7 +8014,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Locations$Datasets$Fhirstores
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -8056,7 +8098,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Locations$Datasets$Fhirstores
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TestIamPermissionsResponse>(
@@ -8210,7 +8252,10 @@ import(paramsOrCallback?: Params$Resource$Projects$Locations$Datasets$Fhirstores
   }
 
   export class Resource$Projects$Locations$Datasets$Hl7v2stores$Messages {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -8280,7 +8325,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Locations$Datasets$Fhirstores
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Message>(parameters, callback);
@@ -8350,7 +8395,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Locations$Datasets$Fhirstores
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -8417,7 +8462,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Locations$Datasets$Fhirstores
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Message>(parameters, callback);
@@ -8495,7 +8540,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Locations$Datasets$Fhirstores
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$IngestMessageResponse>(parameters, callback);
@@ -8573,7 +8618,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Locations$Datasets$Fhirstores
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListMessagesResponse>(parameters, callback);
@@ -8645,7 +8690,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Locations$Datasets$Fhirstores
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Message>(parameters, callback);
@@ -8811,7 +8856,10 @@ import(paramsOrCallback?: Params$Resource$Projects$Locations$Datasets$Fhirstores
 
 
   export class Resource$Projects$Locations$Datasets$Operations {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -8870,7 +8918,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Locations$Datasets$Fhirstores
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -8951,7 +8999,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Locations$Datasets$Fhirstores
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListOperationsResponse>(parameters, callback);

--- a/src/apis/healthcare/v1alpha2.ts
+++ b/src/apis/healthcare/v1alpha2.ts
@@ -29,8 +29,6 @@ export namespace healthcare_v1alpha2 {
     version: 'v1alpha2';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * V1 error format.
@@ -98,12 +96,13 @@ export namespace healthcare_v1alpha2 {
    * @param {object=} options Options for Healthcare
    */
   export class Healthcare {
+    context: APIRequestContext;
     projects: Resource$Projects;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.projects = new Resource$Projects();
+      this.projects = new Resource$Projects(this.context);
     }
   }
 
@@ -1655,17 +1654,21 @@ export namespace healthcare_v1alpha2 {
 
 
   export class Resource$Projects {
+    context: APIRequestContext;
     locations: Resource$Projects$Locations;
-    constructor() {
-      this.locations = new Resource$Projects$Locations();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.locations = new Resource$Projects$Locations(this.context);
     }
   }
 
 
   export class Resource$Projects$Locations {
+    context: APIRequestContext;
     datasets: Resource$Projects$Locations$Datasets;
-    constructor() {
-      this.datasets = new Resource$Projects$Locations$Datasets();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.datasets = new Resource$Projects$Locations$Datasets(this.context);
     }
 
 
@@ -1721,7 +1724,7 @@ export namespace healthcare_v1alpha2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Location>(parameters, callback);
@@ -1792,7 +1795,7 @@ export namespace healthcare_v1alpha2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListLocationsResponse>(parameters, callback);
@@ -1840,18 +1843,25 @@ export namespace healthcare_v1alpha2 {
   }
 
   export class Resource$Projects$Locations$Datasets {
+    context: APIRequestContext;
     annotationStores: Resource$Projects$Locations$Datasets$Annotationstores;
     dicomStores: Resource$Projects$Locations$Datasets$Dicomstores;
     fhirStores: Resource$Projects$Locations$Datasets$Fhirstores;
     hl7V2Stores: Resource$Projects$Locations$Datasets$Hl7v2stores;
     operations: Resource$Projects$Locations$Datasets$Operations;
-    constructor() {
+    constructor(context: APIRequestContext) {
+      this.context = context;
       this.annotationStores =
-          new Resource$Projects$Locations$Datasets$Annotationstores();
-      this.dicomStores = new Resource$Projects$Locations$Datasets$Dicomstores();
-      this.fhirStores = new Resource$Projects$Locations$Datasets$Fhirstores();
-      this.hl7V2Stores = new Resource$Projects$Locations$Datasets$Hl7v2stores();
-      this.operations = new Resource$Projects$Locations$Datasets$Operations();
+          new Resource$Projects$Locations$Datasets$Annotationstores(
+              this.context);
+      this.dicomStores =
+          new Resource$Projects$Locations$Datasets$Dicomstores(this.context);
+      this.fhirStores =
+          new Resource$Projects$Locations$Datasets$Fhirstores(this.context);
+      this.hl7V2Stores =
+          new Resource$Projects$Locations$Datasets$Hl7v2stores(this.context);
+      this.operations =
+          new Resource$Projects$Locations$Datasets$Operations(this.context);
     }
 
 
@@ -1917,7 +1927,7 @@ export namespace healthcare_v1alpha2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -1989,7 +1999,7 @@ export namespace healthcare_v1alpha2 {
         params,
         requiredParams: ['sourceDataset'],
         pathParams: ['sourceDataset'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -2057,7 +2067,7 @@ export namespace healthcare_v1alpha2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -2119,7 +2129,7 @@ export namespace healthcare_v1alpha2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Dataset>(parameters, callback);
@@ -2187,7 +2197,7 @@ export namespace healthcare_v1alpha2 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -2257,7 +2267,7 @@ export namespace healthcare_v1alpha2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListDatasetsResponse>(parameters, callback);
@@ -2325,7 +2335,7 @@ export namespace healthcare_v1alpha2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Dataset>(parameters, callback);
@@ -2394,7 +2404,7 @@ export namespace healthcare_v1alpha2 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -2474,7 +2484,7 @@ export namespace healthcare_v1alpha2 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TestIamPermissionsResponse>(
@@ -2649,11 +2659,14 @@ export namespace healthcare_v1alpha2 {
   }
 
   export class Resource$Projects$Locations$Datasets$Annotationstores {
+    context: APIRequestContext;
     annotations:
         Resource$Projects$Locations$Datasets$Annotationstores$Annotations;
-    constructor() {
+    constructor(context: APIRequestContext) {
+      this.context = context;
       this.annotations =
-          new Resource$Projects$Locations$Datasets$Annotationstores$Annotations();
+          new Resource$Projects$Locations$Datasets$Annotationstores$Annotations(
+              this.context);
     }
 
 
@@ -2721,7 +2734,7 @@ export namespace healthcare_v1alpha2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AnnotationStore>(parameters, callback);
@@ -2793,7 +2806,7 @@ export namespace healthcare_v1alpha2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -2862,7 +2875,7 @@ export namespace healthcare_v1alpha2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AnnotationStore>(parameters, callback);
@@ -2939,7 +2952,7 @@ export namespace healthcare_v1alpha2 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -3020,7 +3033,7 @@ export namespace healthcare_v1alpha2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListAnnotationStoresResponse>(
@@ -3096,7 +3109,7 @@ export namespace healthcare_v1alpha2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AnnotationStore>(parameters, callback);
@@ -3171,7 +3184,7 @@ export namespace healthcare_v1alpha2 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -3254,7 +3267,7 @@ export namespace healthcare_v1alpha2 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TestIamPermissionsResponse>(
@@ -3420,7 +3433,10 @@ export namespace healthcare_v1alpha2 {
 
   export class
       Resource$Projects$Locations$Datasets$Annotationstores$Annotations {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -3489,7 +3505,7 @@ export namespace healthcare_v1alpha2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Annotation>(parameters, callback);
@@ -3561,7 +3577,7 @@ export namespace healthcare_v1alpha2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -3630,7 +3646,7 @@ export namespace healthcare_v1alpha2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Annotation>(parameters, callback);
@@ -3708,7 +3724,7 @@ export namespace healthcare_v1alpha2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListAnnotationsResponse>(parameters, callback);
@@ -3783,7 +3799,7 @@ export namespace healthcare_v1alpha2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Annotation>(parameters, callback);
@@ -3891,10 +3907,13 @@ export namespace healthcare_v1alpha2 {
 
 
   export class Resource$Projects$Locations$Datasets$Dicomstores {
+    context: APIRequestContext;
     dicomWeb: Resource$Projects$Locations$Datasets$Dicomstores$Dicomweb;
-    constructor() {
+    constructor(context: APIRequestContext) {
+      this.context = context;
       this.dicomWeb =
-          new Resource$Projects$Locations$Datasets$Dicomstores$Dicomweb();
+          new Resource$Projects$Locations$Datasets$Dicomstores$Dicomweb(
+              this.context);
     }
 
 
@@ -3959,7 +3978,7 @@ export namespace healthcare_v1alpha2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$DicomStore>(parameters, callback);
@@ -4028,7 +4047,7 @@ export namespace healthcare_v1alpha2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -4099,7 +4118,7 @@ export namespace healthcare_v1alpha2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -4164,7 +4183,7 @@ export namespace healthcare_v1alpha2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$DicomStore>(parameters, callback);
@@ -4236,7 +4255,7 @@ export namespace healthcare_v1alpha2 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -4280,7 +4299,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Locations$Datasets$Dicomstore
     options = {};
                                                                                                                                                                                                                                                                                                          }
 
-                                                                                                                                                                                                                                                                                                         const rootUrl = options.rootUrl || 'https://healthcare.googleapis.com/'; const parameters = {options: Object.assign({url: (rootUrl + '/v1alpha2/{+name}:import').replace(/([^:]\/)\/+/g, '$1'), method: 'POST'}, options), params, requiredParams: ['name'], pathParams: ['name'], context}; if(callback) {
+                                                                                                                                                                                                                                                                                                         const rootUrl = options.rootUrl || 'https://healthcare.googleapis.com/'; const parameters = {options: Object.assign({url: (rootUrl + '/v1alpha2/{+name}:import').replace(/([^:]\/)\/+/g, '$1'), method: 'POST'}, options), params, requiredParams: ['name'], pathParams: ['name'], context: this.context}; if(callback) {
     createAPIRequest<Schema$Operation>(parameters, callback);
                                                                                                                                                                                                                                                                                                          } else {
     return createAPIRequest<Schema$Operation>(parameters);
@@ -4348,7 +4367,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Locations$Datasets$Dicomstore
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListDicomStoresResponse>(parameters, callback);
@@ -4419,7 +4438,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Locations$Datasets$Dicomstore
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$DicomStore>(parameters, callback);
@@ -4492,7 +4511,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Locations$Datasets$Dicomstore
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -4576,7 +4595,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Locations$Datasets$Dicomstore
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TestIamPermissionsResponse>(
@@ -4774,10 +4793,13 @@ import(paramsOrCallback?: Params$Resource$Projects$Locations$Datasets$Dicomstore
   }
 
   export class Resource$Projects$Locations$Datasets$Dicomstores$Dicomweb {
+    context: APIRequestContext;
     studies: Resource$Projects$Locations$Datasets$Dicomstores$Dicomweb$Studies;
-    constructor() {
+    constructor(context: APIRequestContext) {
+      this.context = context;
       this.studies =
-          new Resource$Projects$Locations$Datasets$Dicomstores$Dicomweb$Studies();
+          new Resource$Projects$Locations$Datasets$Dicomstores$Dicomweb$Studies(
+              this.context);
     }
 
 
@@ -4845,7 +4867,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Locations$Datasets$Dicomstore
         params,
         requiredParams: ['parent', 'dicomWebPath'],
         pathParams: ['dicomWebPath', 'parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$HttpBody>(parameters, callback);
@@ -4919,7 +4941,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Locations$Datasets$Dicomstore
         params,
         requiredParams: ['parent', 'dicomWebPath'],
         pathParams: ['dicomWebPath', 'parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$HttpBody>(parameters, callback);
@@ -4993,7 +5015,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Locations$Datasets$Dicomstore
         params,
         requiredParams: ['parent', 'dicomWebPath'],
         pathParams: ['dicomWebPath', 'parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$HttpBody>(parameters, callback);
@@ -5069,7 +5091,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Locations$Datasets$Dicomstore
         params,
         requiredParams: ['parent', 'dicomWebPath'],
         pathParams: ['dicomWebPath', 'parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$HttpBody>(parameters, callback);
@@ -5159,11 +5181,14 @@ import(paramsOrCallback?: Params$Resource$Projects$Locations$Datasets$Dicomstore
 
   export class
       Resource$Projects$Locations$Datasets$Dicomstores$Dicomweb$Studies {
+    context: APIRequestContext;
     series:
         Resource$Projects$Locations$Datasets$Dicomstores$Dicomweb$Studies$Series;
-    constructor() {
+    constructor(context: APIRequestContext) {
+      this.context = context;
       this.series =
-          new Resource$Projects$Locations$Datasets$Dicomstores$Dicomweb$Studies$Series();
+          new Resource$Projects$Locations$Datasets$Dicomstores$Dicomweb$Studies$Series(
+              this.context);
     }
 
 
@@ -5232,7 +5257,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Locations$Datasets$Dicomstore
         params,
         requiredParams: ['parent', 'dicomWebPath'],
         pathParams: ['dicomWebPath', 'parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -5307,7 +5332,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Locations$Datasets$Dicomstore
         params,
         requiredParams: ['parent', 'dicomWebPath'],
         pathParams: ['dicomWebPath', 'parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$HttpBody>(parameters, callback);
@@ -5381,7 +5406,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Locations$Datasets$Dicomstore
         params,
         requiredParams: ['parent', 'dicomWebPath'],
         pathParams: ['dicomWebPath', 'parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$HttpBody>(parameters, callback);
@@ -5455,7 +5480,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Locations$Datasets$Dicomstore
         params,
         requiredParams: ['parent', 'dicomWebPath'],
         pathParams: ['dicomWebPath', 'parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$HttpBody>(parameters, callback);
@@ -5529,7 +5554,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Locations$Datasets$Dicomstore
         params,
         requiredParams: ['parent', 'dicomWebPath'],
         pathParams: ['dicomWebPath', 'parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$HttpBody>(parameters, callback);
@@ -5605,7 +5630,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Locations$Datasets$Dicomstore
         params,
         requiredParams: ['parent', 'dicomWebPath'],
         pathParams: ['dicomWebPath', 'parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$HttpBody>(parameters, callback);
@@ -5731,11 +5756,14 @@ import(paramsOrCallback?: Params$Resource$Projects$Locations$Datasets$Dicomstore
 
   export class
       Resource$Projects$Locations$Datasets$Dicomstores$Dicomweb$Studies$Series {
+    context: APIRequestContext;
     instances:
         Resource$Projects$Locations$Datasets$Dicomstores$Dicomweb$Studies$Series$Instances;
-    constructor() {
+    constructor(context: APIRequestContext) {
+      this.context = context;
       this.instances =
-          new Resource$Projects$Locations$Datasets$Dicomstores$Dicomweb$Studies$Series$Instances();
+          new Resource$Projects$Locations$Datasets$Dicomstores$Dicomweb$Studies$Series$Instances(
+              this.context);
     }
 
 
@@ -5804,7 +5832,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Locations$Datasets$Dicomstore
         params,
         requiredParams: ['parent', 'dicomWebPath'],
         pathParams: ['dicomWebPath', 'parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -5879,7 +5907,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Locations$Datasets$Dicomstore
         params,
         requiredParams: ['parent', 'dicomWebPath'],
         pathParams: ['dicomWebPath', 'parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$HttpBody>(parameters, callback);
@@ -5954,7 +5982,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Locations$Datasets$Dicomstore
         params,
         requiredParams: ['parent', 'dicomWebPath'],
         pathParams: ['dicomWebPath', 'parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$HttpBody>(parameters, callback);
@@ -6028,7 +6056,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Locations$Datasets$Dicomstore
         params,
         requiredParams: ['parent', 'dicomWebPath'],
         pathParams: ['dicomWebPath', 'parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$HttpBody>(parameters, callback);
@@ -6114,11 +6142,14 @@ import(paramsOrCallback?: Params$Resource$Projects$Locations$Datasets$Dicomstore
 
   export class
       Resource$Projects$Locations$Datasets$Dicomstores$Dicomweb$Studies$Series$Instances {
+    context: APIRequestContext;
     frames:
         Resource$Projects$Locations$Datasets$Dicomstores$Dicomweb$Studies$Series$Instances$Frames;
-    constructor() {
+    constructor(context: APIRequestContext) {
+      this.context = context;
       this.frames =
-          new Resource$Projects$Locations$Datasets$Dicomstores$Dicomweb$Studies$Series$Instances$Frames();
+          new Resource$Projects$Locations$Datasets$Dicomstores$Dicomweb$Studies$Series$Instances$Frames(
+              this.context);
     }
 
 
@@ -6187,7 +6218,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Locations$Datasets$Dicomstore
         params,
         requiredParams: ['parent', 'dicomWebPath'],
         pathParams: ['dicomWebPath', 'parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -6263,7 +6294,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Locations$Datasets$Dicomstore
         params,
         requiredParams: ['parent', 'dicomWebPath'],
         pathParams: ['dicomWebPath', 'parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$HttpBody>(parameters, callback);
@@ -6339,7 +6370,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Locations$Datasets$Dicomstore
         params,
         requiredParams: ['parent', 'dicomWebPath'],
         pathParams: ['dicomWebPath', 'parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$HttpBody>(parameters, callback);
@@ -6414,7 +6445,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Locations$Datasets$Dicomstore
         params,
         requiredParams: ['parent', 'dicomWebPath'],
         pathParams: ['dicomWebPath', 'parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$HttpBody>(parameters, callback);
@@ -6503,7 +6534,10 @@ import(paramsOrCallback?: Params$Resource$Projects$Locations$Datasets$Dicomstore
 
   export class
       Resource$Projects$Locations$Datasets$Dicomstores$Dicomweb$Studies$Series$Instances$Frames {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -6572,7 +6606,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Locations$Datasets$Dicomstore
         params,
         requiredParams: ['parent', 'dicomWebPath'],
         pathParams: ['dicomWebPath', 'parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$HttpBody>(parameters, callback);
@@ -6647,7 +6681,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Locations$Datasets$Dicomstore
         params,
         requiredParams: ['parent', 'dicomWebPath'],
         pathParams: ['dicomWebPath', 'parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$HttpBody>(parameters, callback);
@@ -6699,13 +6733,17 @@ import(paramsOrCallback?: Params$Resource$Projects$Locations$Datasets$Dicomstore
 
 
   export class Resource$Projects$Locations$Datasets$Fhirstores {
+    context: APIRequestContext;
     fhir: Resource$Projects$Locations$Datasets$Fhirstores$Fhir;
     securityLabels:
         Resource$Projects$Locations$Datasets$Fhirstores$Securitylabels;
-    constructor() {
-      this.fhir = new Resource$Projects$Locations$Datasets$Fhirstores$Fhir();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.fhir = new Resource$Projects$Locations$Datasets$Fhirstores$Fhir(
+          this.context);
       this.securityLabels =
-          new Resource$Projects$Locations$Datasets$Fhirstores$Securitylabels();
+          new Resource$Projects$Locations$Datasets$Fhirstores$Securitylabels(
+              this.context);
     }
 
 
@@ -6770,7 +6808,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Locations$Datasets$Dicomstore
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$FhirStore>(parameters, callback);
@@ -6839,7 +6877,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Locations$Datasets$Dicomstore
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -6911,7 +6949,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Locations$Datasets$Dicomstore
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$HttpBody>(parameters, callback);
@@ -6986,7 +7024,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Locations$Datasets$Dicomstore
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -7051,7 +7089,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Locations$Datasets$Dicomstore
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$FhirStore>(parameters, callback);
@@ -7127,7 +7165,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Locations$Datasets$Dicomstore
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -7199,7 +7237,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Locations$Datasets$Dicomstore
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$HttpBody>(parameters, callback);
@@ -7254,7 +7292,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Locations$Datasets$Fhirstores
     options = {};
                                                                                                                                                                                                                                                                                                         }
 
-                                                                                                                                                                                                                                                                                                        const rootUrl = options.rootUrl || 'https://healthcare.googleapis.com/'; const parameters = {options: Object.assign({url: (rootUrl + '/v1alpha2/{+name}:import').replace(/([^:]\/)\/+/g, '$1'), method: 'POST'}, options), params, requiredParams: ['name'], pathParams: ['name'], context}; if(callback) {
+                                                                                                                                                                                                                                                                                                        const rootUrl = options.rootUrl || 'https://healthcare.googleapis.com/'; const parameters = {options: Object.assign({url: (rootUrl + '/v1alpha2/{+name}:import').replace(/([^:]\/)\/+/g, '$1'), method: 'POST'}, options), params, requiredParams: ['name'], pathParams: ['name'], context: this.context}; if(callback) {
     createAPIRequest<Schema$Operation>(parameters, callback);
                                                                                                                                                                                                                                                                                                         } else {
     return createAPIRequest<Schema$Operation>(parameters);
@@ -7322,7 +7360,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Locations$Datasets$Fhirstores
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListFhirStoresResponse>(parameters, callback);
@@ -7393,7 +7431,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Locations$Datasets$Fhirstores
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$FhirStore>(parameters, callback);
@@ -7469,7 +7507,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Locations$Datasets$Fhirstores
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -7552,7 +7590,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Locations$Datasets$Fhirstores
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TestIamPermissionsResponse>(
@@ -7779,13 +7817,17 @@ import(paramsOrCallback?: Params$Resource$Projects$Locations$Datasets$Fhirstores
   }
 
   export class Resource$Projects$Locations$Datasets$Fhirstores$Fhir {
+    context: APIRequestContext;
     Patient: Resource$Projects$Locations$Datasets$Fhirstores$Fhir$Patient;
     _history: Resource$Projects$Locations$Datasets$Fhirstores$Fhir$_history;
-    constructor() {
+    constructor(context: APIRequestContext) {
+      this.context = context;
       this.Patient =
-          new Resource$Projects$Locations$Datasets$Fhirstores$Fhir$Patient();
+          new Resource$Projects$Locations$Datasets$Fhirstores$Fhir$Patient(
+              this.context);
       this._history =
-          new Resource$Projects$Locations$Datasets$Fhirstores$Fhir$_history();
+          new Resource$Projects$Locations$Datasets$Fhirstores$Fhir$_history(
+              this.context);
     }
 
 
@@ -7858,7 +7900,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Locations$Datasets$Fhirstores
         params,
         requiredParams: ['parent', 'type'],
         pathParams: ['parent', 'type'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -7934,7 +7976,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Locations$Datasets$Fhirstores
         params,
         requiredParams: ['parent', 'type'],
         pathParams: ['parent', 'type'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$HttpBody>(parameters, callback);
@@ -8010,7 +8052,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Locations$Datasets$Fhirstores
         params,
         requiredParams: ['parent', 'type'],
         pathParams: ['parent', 'type'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$HttpBody>(parameters, callback);
@@ -8084,7 +8126,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Locations$Datasets$Fhirstores
         params,
         requiredParams: ['parent', 'type'],
         pathParams: ['parent', 'type'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$HttpBody>(parameters, callback);
@@ -8159,7 +8201,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Locations$Datasets$Fhirstores
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$HttpBody>(parameters, callback);
@@ -8233,7 +8275,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Locations$Datasets$Fhirstores
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -8298,7 +8340,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Locations$Datasets$Fhirstores
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$HttpBody>(parameters, callback);
@@ -8370,7 +8412,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Locations$Datasets$Fhirstores
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$HttpBody>(parameters, callback);
@@ -8442,7 +8484,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Locations$Datasets$Fhirstores
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$HttpBody>(parameters, callback);
@@ -8522,7 +8564,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Locations$Datasets$Fhirstores
         params,
         requiredParams: ['parent', 'resourceType'],
         pathParams: ['parent', 'resourceType'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$HttpBody>(parameters, callback);
@@ -8596,7 +8638,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Locations$Datasets$Fhirstores
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$HttpBody>(parameters, callback);
@@ -8675,7 +8717,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Locations$Datasets$Fhirstores
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$HttpBody>(parameters, callback);
@@ -8881,7 +8923,10 @@ import(paramsOrCallback?: Params$Resource$Projects$Locations$Datasets$Fhirstores
   }
 
   export class Resource$Projects$Locations$Datasets$Fhirstores$Fhir$Patient {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -8948,7 +8993,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Locations$Datasets$Fhirstores
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$HttpBody>(parameters, callback);
@@ -8983,7 +9028,10 @@ import(paramsOrCallback?: Params$Resource$Projects$Locations$Datasets$Fhirstores
 
 
   export class Resource$Projects$Locations$Datasets$Fhirstores$Fhir$_history {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -9045,7 +9093,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Locations$Datasets$Fhirstores
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$HttpBody>(parameters, callback);
@@ -9122,7 +9170,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Locations$Datasets$Fhirstores
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$HttpBody>(parameters, callback);
@@ -9189,7 +9237,10 @@ import(paramsOrCallback?: Params$Resource$Projects$Locations$Datasets$Fhirstores
 
 
   export class Resource$Projects$Locations$Datasets$Fhirstores$Securitylabels {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -9259,7 +9310,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Locations$Datasets$Fhirstores
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -9336,7 +9387,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Locations$Datasets$Fhirstores
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -9381,10 +9432,13 @@ import(paramsOrCallback?: Params$Resource$Projects$Locations$Datasets$Fhirstores
 
 
   export class Resource$Projects$Locations$Datasets$Hl7v2stores {
+    context: APIRequestContext;
     messages: Resource$Projects$Locations$Datasets$Hl7v2stores$Messages;
-    constructor() {
+    constructor(context: APIRequestContext) {
+      this.context = context;
       this.messages =
-          new Resource$Projects$Locations$Datasets$Hl7v2stores$Messages();
+          new Resource$Projects$Locations$Datasets$Hl7v2stores$Messages(
+              this.context);
     }
 
 
@@ -9449,7 +9503,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Locations$Datasets$Fhirstores
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Hl7V2Store>(parameters, callback);
@@ -9518,7 +9572,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Locations$Datasets$Fhirstores
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -9583,7 +9637,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Locations$Datasets$Fhirstores
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Hl7V2Store>(parameters, callback);
@@ -9655,7 +9709,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Locations$Datasets$Fhirstores
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -9728,7 +9782,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Locations$Datasets$Fhirstores
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListHl7V2StoresResponse>(parameters, callback);
@@ -9799,7 +9853,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Locations$Datasets$Fhirstores
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Hl7V2Store>(parameters, callback);
@@ -9872,7 +9926,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Locations$Datasets$Fhirstores
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -9956,7 +10010,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Locations$Datasets$Fhirstores
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TestIamPermissionsResponse>(
@@ -10116,7 +10170,10 @@ import(paramsOrCallback?: Params$Resource$Projects$Locations$Datasets$Fhirstores
   }
 
   export class Resource$Projects$Locations$Datasets$Hl7v2stores$Messages {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -10186,7 +10243,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Locations$Datasets$Fhirstores
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Message>(parameters, callback);
@@ -10257,7 +10314,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Locations$Datasets$Fhirstores
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -10325,7 +10382,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Locations$Datasets$Fhirstores
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Message>(parameters, callback);
@@ -10403,7 +10460,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Locations$Datasets$Fhirstores
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$IngestMessageResponse>(parameters, callback);
@@ -10481,7 +10538,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Locations$Datasets$Fhirstores
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListMessagesResponse>(parameters, callback);
@@ -10554,7 +10611,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Locations$Datasets$Fhirstores
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Message>(parameters, callback);
@@ -10722,7 +10779,10 @@ import(paramsOrCallback?: Params$Resource$Projects$Locations$Datasets$Fhirstores
 
 
   export class Resource$Projects$Locations$Datasets$Operations {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -10782,7 +10842,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Locations$Datasets$Fhirstores
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -10863,7 +10923,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Locations$Datasets$Fhirstores
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListOperationsResponse>(parameters, callback);

--- a/src/apis/iam/v1.ts
+++ b/src/apis/iam/v1.ts
@@ -29,8 +29,6 @@ export namespace iam_v1 {
     version: 'v1';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * V1 error format.
@@ -100,6 +98,7 @@ export namespace iam_v1 {
    * @param {object=} options Options for Iam
    */
   export class Iam {
+    context: APIRequestContext;
     iamPolicies: Resource$Iampolicies;
     organizations: Resource$Organizations;
     permissions: Resource$Permissions;
@@ -107,13 +106,13 @@ export namespace iam_v1 {
     roles: Resource$Roles;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.iamPolicies = new Resource$Iampolicies();
-      this.organizations = new Resource$Organizations();
-      this.permissions = new Resource$Permissions();
-      this.projects = new Resource$Projects();
-      this.roles = new Resource$Roles();
+      this.iamPolicies = new Resource$Iampolicies(this.context);
+      this.organizations = new Resource$Organizations(this.context);
+      this.permissions = new Resource$Permissions(this.context);
+      this.projects = new Resource$Projects(this.context);
+      this.roles = new Resource$Roles(this.context);
     }
   }
 
@@ -933,7 +932,10 @@ export namespace iam_v1 {
 
 
   export class Resource$Iampolicies {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1009,7 +1011,7 @@ export namespace iam_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$LintPolicyResponse>(parameters, callback);
@@ -1083,7 +1085,7 @@ export namespace iam_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$QueryAuditableServicesResponse>(
@@ -1124,15 +1126,20 @@ export namespace iam_v1 {
 
 
   export class Resource$Organizations {
+    context: APIRequestContext;
     roles: Resource$Organizations$Roles;
-    constructor() {
-      this.roles = new Resource$Organizations$Roles();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.roles = new Resource$Organizations$Roles(this.context);
     }
   }
 
 
   export class Resource$Organizations$Roles {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1192,7 +1199,7 @@ export namespace iam_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Role>(parameters, callback);
@@ -1263,7 +1270,7 @@ export namespace iam_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Role>(parameters, callback);
@@ -1324,7 +1331,7 @@ export namespace iam_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Role>(parameters, callback);
@@ -1395,7 +1402,7 @@ export namespace iam_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListRolesResponse>(parameters, callback);
@@ -1462,7 +1469,7 @@ export namespace iam_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Role>(parameters, callback);
@@ -1529,7 +1536,7 @@ export namespace iam_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Role>(parameters, callback);
@@ -1668,7 +1675,10 @@ export namespace iam_v1 {
 
 
   export class Resource$Permissions {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1739,7 +1749,7 @@ export namespace iam_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$QueryTestablePermissionsResponse>(
@@ -1767,17 +1777,23 @@ export namespace iam_v1 {
 
 
   export class Resource$Projects {
+    context: APIRequestContext;
     roles: Resource$Projects$Roles;
     serviceAccounts: Resource$Projects$Serviceaccounts;
-    constructor() {
-      this.roles = new Resource$Projects$Roles();
-      this.serviceAccounts = new Resource$Projects$Serviceaccounts();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.roles = new Resource$Projects$Roles(this.context);
+      this.serviceAccounts =
+          new Resource$Projects$Serviceaccounts(this.context);
     }
   }
 
 
   export class Resource$Projects$Roles {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1837,7 +1853,7 @@ export namespace iam_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Role>(parameters, callback);
@@ -1908,7 +1924,7 @@ export namespace iam_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Role>(parameters, callback);
@@ -1969,7 +1985,7 @@ export namespace iam_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Role>(parameters, callback);
@@ -2039,7 +2055,7 @@ export namespace iam_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListRolesResponse>(parameters, callback);
@@ -2106,7 +2122,7 @@ export namespace iam_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Role>(parameters, callback);
@@ -2173,7 +2189,7 @@ export namespace iam_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Role>(parameters, callback);
@@ -2311,9 +2327,11 @@ export namespace iam_v1 {
 
 
   export class Resource$Projects$Serviceaccounts {
+    context: APIRequestContext;
     keys: Resource$Projects$Serviceaccounts$Keys;
-    constructor() {
-      this.keys = new Resource$Projects$Serviceaccounts$Keys();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.keys = new Resource$Projects$Serviceaccounts$Keys(this.context);
     }
 
 
@@ -2375,7 +2393,7 @@ export namespace iam_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ServiceAccount>(parameters, callback);
@@ -2440,7 +2458,7 @@ export namespace iam_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -2507,7 +2525,7 @@ export namespace iam_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -2574,7 +2592,7 @@ export namespace iam_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -2636,7 +2654,7 @@ export namespace iam_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ServiceAccount>(parameters, callback);
@@ -2713,7 +2731,7 @@ export namespace iam_v1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -2787,7 +2805,7 @@ export namespace iam_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListServiceAccountsResponse>(
@@ -2858,7 +2876,7 @@ export namespace iam_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ServiceAccount>(parameters, callback);
@@ -2937,7 +2955,7 @@ export namespace iam_v1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -3009,7 +3027,7 @@ export namespace iam_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$SignBlobResponse>(parameters, callback);
@@ -3084,7 +3102,7 @@ export namespace iam_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$SignJwtResponse>(parameters, callback);
@@ -3161,7 +3179,7 @@ export namespace iam_v1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TestIamPermissionsResponse>(
@@ -3237,7 +3255,7 @@ export namespace iam_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$UndeleteServiceAccountResponse>(
@@ -3309,7 +3327,7 @@ export namespace iam_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ServiceAccount>(parameters, callback);
@@ -3589,7 +3607,10 @@ export namespace iam_v1 {
   }
 
   export class Resource$Projects$Serviceaccounts$Keys {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -3649,7 +3670,7 @@ export namespace iam_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ServiceAccountKey>(parameters, callback);
@@ -3714,7 +3735,7 @@ export namespace iam_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -3777,7 +3798,7 @@ export namespace iam_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ServiceAccountKey>(parameters, callback);
@@ -3849,7 +3870,7 @@ export namespace iam_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListServiceAccountKeysResponse>(
@@ -3945,7 +3966,10 @@ export namespace iam_v1 {
 
 
   export class Resource$Roles {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -3998,7 +4022,7 @@ export namespace iam_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Role>(parameters, callback);
@@ -4066,7 +4090,7 @@ export namespace iam_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListRolesResponse>(parameters, callback);
@@ -4141,7 +4165,7 @@ export namespace iam_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$QueryGrantableRolesResponse>(

--- a/src/apis/iamcredentials/v1.ts
+++ b/src/apis/iamcredentials/v1.ts
@@ -29,8 +29,6 @@ export namespace iamcredentials_v1 {
     version: 'v1';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * V1 error format.
@@ -99,12 +97,13 @@ export namespace iamcredentials_v1 {
    * @param {object=} options Options for Iamcredentials
    */
   export class Iamcredentials {
+    context: APIRequestContext;
     projects: Resource$Projects;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.projects = new Resource$Projects();
+      this.projects = new Resource$Projects(this.context);
     }
   }
 
@@ -286,15 +285,21 @@ export namespace iamcredentials_v1 {
 
 
   export class Resource$Projects {
+    context: APIRequestContext;
     serviceAccounts: Resource$Projects$Serviceaccounts;
-    constructor() {
-      this.serviceAccounts = new Resource$Projects$Serviceaccounts();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.serviceAccounts =
+          new Resource$Projects$Serviceaccounts(this.context);
     }
   }
 
 
   export class Resource$Projects$Serviceaccounts {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -364,7 +369,7 @@ export namespace iamcredentials_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GenerateAccessTokenResponse>(
@@ -446,7 +451,7 @@ export namespace iamcredentials_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GenerateIdentityBindingAccessTokenResponse>(
@@ -520,7 +525,7 @@ export namespace iamcredentials_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GenerateIdTokenResponse>(parameters, callback);
@@ -589,7 +594,7 @@ export namespace iamcredentials_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$SignBlobResponse>(parameters, callback);
@@ -658,7 +663,7 @@ export namespace iamcredentials_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$SignJwtResponse>(parameters, callback);

--- a/src/apis/iap/v1.ts
+++ b/src/apis/iap/v1.ts
@@ -29,8 +29,6 @@ export namespace iap_v1 {
     version: 'v1';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * V1 error format.
@@ -98,12 +96,13 @@ export namespace iap_v1 {
    * @param {object=} options Options for Iap
    */
   export class Iap {
+    context: APIRequestContext;
     v1: Resource$V1;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.v1 = new Resource$V1();
+      this.v1 = new Resource$V1(this.context);
     }
   }
 
@@ -252,7 +251,10 @@ export namespace iap_v1 {
 
 
   export class Resource$V1 {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -314,7 +316,7 @@ export namespace iap_v1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -383,7 +385,7 @@ export namespace iap_v1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -460,7 +462,7 @@ export namespace iap_v1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TestIamPermissionsResponse>(

--- a/src/apis/iap/v1beta1.ts
+++ b/src/apis/iap/v1beta1.ts
@@ -29,8 +29,6 @@ export namespace iap_v1beta1 {
     version: 'v1beta1';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * V1 error format.
@@ -98,12 +96,13 @@ export namespace iap_v1beta1 {
    * @param {object=} options Options for Iap
    */
   export class Iap {
+    context: APIRequestContext;
     v1beta1: Resource$V1beta1;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.v1beta1 = new Resource$V1beta1();
+      this.v1beta1 = new Resource$V1beta1(this.context);
     }
   }
 
@@ -252,7 +251,10 @@ export namespace iap_v1beta1 {
 
 
   export class Resource$V1beta1 {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -315,7 +317,7 @@ export namespace iap_v1beta1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -385,7 +387,7 @@ export namespace iap_v1beta1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -464,7 +466,7 @@ export namespace iap_v1beta1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TestIamPermissionsResponse>(

--- a/src/apis/identitytoolkit/v3.ts
+++ b/src/apis/identitytoolkit/v3.ts
@@ -29,8 +29,6 @@ export namespace identitytoolkit_v3 {
     version: 'v3';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * Data format for the response.
@@ -81,12 +79,13 @@ export namespace identitytoolkit_v3 {
    * @param {object=} options Options for Identitytoolkit
    */
   export class Identitytoolkit {
+    context: APIRequestContext;
     relyingparty: Resource$Relyingparty;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.relyingparty = new Resource$Relyingparty();
+      this.relyingparty = new Resource$Relyingparty(this.context);
     }
   }
 
@@ -1591,7 +1590,10 @@ export namespace identitytoolkit_v3 {
 
 
   export class Resource$Relyingparty {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1653,7 +1655,7 @@ export namespace identitytoolkit_v3 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$CreateAuthUriResponse>(parameters, callback);
@@ -1722,7 +1724,7 @@ export namespace identitytoolkit_v3 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$DeleteAccountResponse>(parameters, callback);
@@ -1792,7 +1794,7 @@ export namespace identitytoolkit_v3 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$DownloadAccountResponse>(parameters, callback);
@@ -1862,7 +1864,7 @@ export namespace identitytoolkit_v3 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$EmailLinkSigninResponse>(parameters, callback);
@@ -1931,7 +1933,7 @@ export namespace identitytoolkit_v3 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GetAccountInfoResponse>(parameters, callback);
@@ -2005,7 +2007,7 @@ export namespace identitytoolkit_v3 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GetOobConfirmationCodeResponse>(
@@ -2086,7 +2088,7 @@ export namespace identitytoolkit_v3 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<
@@ -2164,7 +2166,7 @@ export namespace identitytoolkit_v3 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<
@@ -2238,7 +2240,7 @@ export namespace identitytoolkit_v3 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GetRecaptchaParamResponse>(
@@ -2308,7 +2310,7 @@ export namespace identitytoolkit_v3 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ResetPasswordResponse>(parameters, callback);
@@ -2389,7 +2391,7 @@ export namespace identitytoolkit_v3 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<
@@ -2462,7 +2464,7 @@ export namespace identitytoolkit_v3 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$SetAccountInfoResponse>(parameters, callback);
@@ -2540,7 +2542,7 @@ export namespace identitytoolkit_v3 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<
@@ -2618,7 +2620,7 @@ export namespace identitytoolkit_v3 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$IdentitytoolkitRelyingpartySignOutUserResponse>(
@@ -2689,7 +2691,7 @@ export namespace identitytoolkit_v3 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$SignupNewUserResponse>(parameters, callback);
@@ -2758,7 +2760,7 @@ export namespace identitytoolkit_v3 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$UploadAccountResponse>(parameters, callback);
@@ -2828,7 +2830,7 @@ export namespace identitytoolkit_v3 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$VerifyAssertionResponse>(parameters, callback);
@@ -2899,7 +2901,7 @@ export namespace identitytoolkit_v3 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$VerifyCustomTokenResponse>(
@@ -2969,7 +2971,7 @@ export namespace identitytoolkit_v3 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$VerifyPasswordResponse>(parameters, callback);
@@ -3048,7 +3050,7 @@ export namespace identitytoolkit_v3 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<

--- a/src/apis/indexing/v3.ts
+++ b/src/apis/indexing/v3.ts
@@ -29,8 +29,6 @@ export namespace indexing_v3 {
     version: 'v3';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * V1 error format.
@@ -98,12 +96,13 @@ export namespace indexing_v3 {
    * @param {object=} options Options for Indexing
    */
   export class Indexing {
+    context: APIRequestContext;
     urlNotifications: Resource$Urlnotifications;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.urlNotifications = new Resource$Urlnotifications();
+      this.urlNotifications = new Resource$Urlnotifications(this.context);
     }
   }
 
@@ -158,7 +157,10 @@ export namespace indexing_v3 {
 
 
   export class Resource$Urlnotifications {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -223,7 +225,7 @@ export namespace indexing_v3 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$UrlNotificationMetadata>(parameters, callback);
@@ -296,7 +298,7 @@ export namespace indexing_v3 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$PublishUrlNotificationResponse>(

--- a/src/apis/jobs/v2.ts
+++ b/src/apis/jobs/v2.ts
@@ -29,8 +29,6 @@ export namespace jobs_v2 {
     version: 'v2';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * V1 error format.
@@ -99,16 +97,17 @@ export namespace jobs_v2 {
    * @param {object=} options Options for Jobs
    */
   export class Jobs {
+    context: APIRequestContext;
     companies: Resource$Companies;
     jobs: Resource$Jobs;
     v2: Resource$V2;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.companies = new Resource$Companies();
-      this.jobs = new Resource$Jobs();
-      this.v2 = new Resource$V2();
+      this.companies = new Resource$Companies(this.context);
+      this.jobs = new Resource$Jobs(this.context);
+      this.v2 = new Resource$V2(this.context);
     }
   }
 
@@ -2210,9 +2209,11 @@ export namespace jobs_v2 {
 
 
   export class Resource$Companies {
+    context: APIRequestContext;
     jobs: Resource$Companies$Jobs;
-    constructor() {
-      this.jobs = new Resource$Companies$Jobs();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.jobs = new Resource$Companies$Jobs(this.context);
     }
 
 
@@ -2269,7 +2270,7 @@ export namespace jobs_v2 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Company>(parameters, callback);
@@ -2332,7 +2333,7 @@ export namespace jobs_v2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -2392,7 +2393,7 @@ export namespace jobs_v2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Company>(parameters, callback);
@@ -2460,7 +2461,7 @@ export namespace jobs_v2 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListCompaniesResponse>(parameters, callback);
@@ -2527,7 +2528,7 @@ export namespace jobs_v2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Company>(parameters, callback);
@@ -2626,7 +2627,10 @@ export namespace jobs_v2 {
   }
 
   export class Resource$Companies$Jobs {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -2692,7 +2696,7 @@ export namespace jobs_v2 {
         params,
         requiredParams: ['companyName'],
         pathParams: ['companyName'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListCompanyJobsResponse>(parameters, callback);
@@ -2747,7 +2751,10 @@ export namespace jobs_v2 {
 
 
   export class Resource$Jobs {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -2805,7 +2812,7 @@ export namespace jobs_v2 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -2869,7 +2876,7 @@ export namespace jobs_v2 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Job>(parameters, callback);
@@ -2934,7 +2941,7 @@ export namespace jobs_v2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -3003,7 +3010,7 @@ export namespace jobs_v2 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -3064,7 +3071,7 @@ export namespace jobs_v2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Job>(parameters, callback);
@@ -3138,7 +3145,7 @@ export namespace jobs_v2 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GetHistogramResponse>(parameters, callback);
@@ -3205,7 +3212,7 @@ export namespace jobs_v2 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListJobsResponse>(parameters, callback);
@@ -3270,7 +3277,7 @@ export namespace jobs_v2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Job>(parameters, callback);
@@ -3336,7 +3343,7 @@ export namespace jobs_v2 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$SearchJobsResponse>(parameters, callback);
@@ -3410,7 +3417,7 @@ export namespace jobs_v2 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$SearchJobsResponse>(parameters, callback);
@@ -3578,7 +3585,10 @@ export namespace jobs_v2 {
 
 
   export class Resource$V2 {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -3643,7 +3653,7 @@ export namespace jobs_v2 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$CompleteQueryResponse>(parameters, callback);

--- a/src/apis/jobs/v3.ts
+++ b/src/apis/jobs/v3.ts
@@ -29,8 +29,6 @@ export namespace jobs_v3 {
     version: 'v3';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * V1 error format.
@@ -99,12 +97,13 @@ export namespace jobs_v3 {
    * @param {object=} options Options for Jobs
    */
   export class Jobs {
+    context: APIRequestContext;
     projects: Resource$Projects;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.projects = new Resource$Projects();
+      this.projects = new Resource$Projects(this.context);
     }
   }
 
@@ -1759,13 +1758,15 @@ export namespace jobs_v3 {
 
 
   export class Resource$Projects {
+    context: APIRequestContext;
     clientEvents: Resource$Projects$Clientevents;
     companies: Resource$Projects$Companies;
     jobs: Resource$Projects$Jobs;
-    constructor() {
-      this.clientEvents = new Resource$Projects$Clientevents();
-      this.companies = new Resource$Projects$Companies();
-      this.jobs = new Resource$Projects$Jobs();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.clientEvents = new Resource$Projects$Clientevents(this.context);
+      this.companies = new Resource$Projects$Companies(this.context);
+      this.jobs = new Resource$Projects$Jobs(this.context);
     }
 
 
@@ -1836,7 +1837,7 @@ export namespace jobs_v3 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$CompleteQueryResponse>(parameters, callback);
@@ -1911,7 +1912,10 @@ export namespace jobs_v3 {
   }
 
   export class Resource$Projects$Clientevents {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1977,7 +1981,7 @@ export namespace jobs_v3 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ClientEvent>(parameters, callback);
@@ -2007,7 +2011,10 @@ export namespace jobs_v3 {
 
 
   export class Resource$Projects$Companies {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -2067,7 +2074,7 @@ export namespace jobs_v3 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Company>(parameters, callback);
@@ -2133,7 +2140,7 @@ export namespace jobs_v3 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -2194,7 +2201,7 @@ export namespace jobs_v3 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Company>(parameters, callback);
@@ -2265,7 +2272,7 @@ export namespace jobs_v3 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListCompaniesResponse>(parameters, callback);
@@ -2333,7 +2340,7 @@ export namespace jobs_v3 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Company>(parameters, callback);
@@ -2442,7 +2449,10 @@ export namespace jobs_v3 {
 
 
   export class Resource$Projects$Jobs {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -2502,7 +2512,7 @@ export namespace jobs_v3 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -2570,7 +2580,7 @@ export namespace jobs_v3 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Job>(parameters, callback);
@@ -2636,7 +2646,7 @@ export namespace jobs_v3 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -2698,7 +2708,7 @@ export namespace jobs_v3 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Job>(parameters, callback);
@@ -2768,7 +2778,7 @@ export namespace jobs_v3 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListJobsResponse>(parameters, callback);
@@ -2835,7 +2845,7 @@ export namespace jobs_v3 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Job>(parameters, callback);
@@ -2905,7 +2915,7 @@ export namespace jobs_v3 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$SearchJobsResponse>(parameters, callback);
@@ -2980,7 +2990,7 @@ export namespace jobs_v3 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$SearchJobsResponse>(parameters, callback);

--- a/src/apis/jobs/v3p1beta1.ts
+++ b/src/apis/jobs/v3p1beta1.ts
@@ -29,8 +29,6 @@ export namespace jobs_v3p1beta1 {
     version: 'v3p1beta1';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * V1 error format.
@@ -99,12 +97,13 @@ export namespace jobs_v3p1beta1 {
    * @param {object=} options Options for Jobs
    */
   export class Jobs {
+    context: APIRequestContext;
     projects: Resource$Projects;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.projects = new Resource$Projects();
+      this.projects = new Resource$Projects(this.context);
     }
   }
 
@@ -2005,15 +2004,17 @@ export namespace jobs_v3p1beta1 {
 
 
   export class Resource$Projects {
+    context: APIRequestContext;
     clientEvents: Resource$Projects$Clientevents;
     companies: Resource$Projects$Companies;
     jobs: Resource$Projects$Jobs;
     operations: Resource$Projects$Operations;
-    constructor() {
-      this.clientEvents = new Resource$Projects$Clientevents();
-      this.companies = new Resource$Projects$Companies();
-      this.jobs = new Resource$Projects$Jobs();
-      this.operations = new Resource$Projects$Operations();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.clientEvents = new Resource$Projects$Clientevents(this.context);
+      this.companies = new Resource$Projects$Companies(this.context);
+      this.jobs = new Resource$Projects$Jobs(this.context);
+      this.operations = new Resource$Projects$Operations(this.context);
     }
 
 
@@ -2084,7 +2085,7 @@ export namespace jobs_v3p1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$CompleteQueryResponse>(parameters, callback);
@@ -2159,7 +2160,10 @@ export namespace jobs_v3p1beta1 {
   }
 
   export class Resource$Projects$Clientevents {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -2225,7 +2229,7 @@ export namespace jobs_v3p1beta1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ClientEvent>(parameters, callback);
@@ -2255,7 +2259,10 @@ export namespace jobs_v3p1beta1 {
 
 
   export class Resource$Projects$Companies {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -2315,7 +2322,7 @@ export namespace jobs_v3p1beta1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Company>(parameters, callback);
@@ -2382,7 +2389,7 @@ export namespace jobs_v3p1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -2444,7 +2451,7 @@ export namespace jobs_v3p1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Company>(parameters, callback);
@@ -2515,7 +2522,7 @@ export namespace jobs_v3p1beta1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListCompaniesResponse>(parameters, callback);
@@ -2584,7 +2591,7 @@ export namespace jobs_v3p1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Company>(parameters, callback);
@@ -2693,7 +2700,10 @@ export namespace jobs_v3p1beta1 {
 
 
   export class Resource$Projects$Jobs {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -2753,7 +2763,7 @@ export namespace jobs_v3p1beta1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -2821,7 +2831,7 @@ export namespace jobs_v3p1beta1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Job>(parameters, callback);
@@ -2888,7 +2898,7 @@ export namespace jobs_v3p1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -2951,7 +2961,7 @@ export namespace jobs_v3p1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Job>(parameters, callback);
@@ -3021,7 +3031,7 @@ export namespace jobs_v3p1beta1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListJobsResponse>(parameters, callback);
@@ -3089,7 +3099,7 @@ export namespace jobs_v3p1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Job>(parameters, callback);
@@ -3159,7 +3169,7 @@ export namespace jobs_v3p1beta1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$SearchJobsResponse>(parameters, callback);
@@ -3234,7 +3244,7 @@ export namespace jobs_v3p1beta1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$SearchJobsResponse>(parameters, callback);
@@ -3409,7 +3419,10 @@ export namespace jobs_v3p1beta1 {
 
 
   export class Resource$Projects$Operations {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -3467,7 +3480,7 @@ export namespace jobs_v3p1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);

--- a/src/apis/kgsearch/v1.ts
+++ b/src/apis/kgsearch/v1.ts
@@ -29,8 +29,6 @@ export namespace kgsearch_v1 {
     version: 'v1';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * V1 error format.
@@ -98,12 +96,13 @@ export namespace kgsearch_v1 {
    * @param {object=} options Options for Kgsearch
    */
   export class Kgsearch {
+    context: APIRequestContext;
     entities: Resource$Entities;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.entities = new Resource$Entities();
+      this.entities = new Resource$Entities(this.context);
     }
   }
 
@@ -129,7 +128,10 @@ export namespace kgsearch_v1 {
 
 
   export class Resource$Entities {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -195,7 +197,7 @@ export namespace kgsearch_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$SearchResponse>(parameters, callback);

--- a/src/apis/language/v1.ts
+++ b/src/apis/language/v1.ts
@@ -29,8 +29,6 @@ export namespace language_v1 {
     version: 'v1';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * V1 error format.
@@ -100,12 +98,13 @@ export namespace language_v1 {
    * @param {object=} options Options for Language
    */
   export class Language {
+    context: APIRequestContext;
     documents: Resource$Documents;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.documents = new Resource$Documents();
+      this.documents = new Resource$Documents(this.context);
     }
   }
 
@@ -634,7 +633,10 @@ export namespace language_v1 {
 
 
   export class Resource$Documents {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -698,7 +700,7 @@ export namespace language_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AnalyzeEntitiesResponse>(parameters, callback);
@@ -772,7 +774,7 @@ export namespace language_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AnalyzeEntitySentimentResponse>(
@@ -844,7 +846,7 @@ export namespace language_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AnalyzeSentimentResponse>(parameters, callback);
@@ -915,7 +917,7 @@ export namespace language_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AnalyzeSyntaxResponse>(parameters, callback);
@@ -985,7 +987,7 @@ export namespace language_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AnnotateTextResponse>(parameters, callback);
@@ -1054,7 +1056,7 @@ export namespace language_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ClassifyTextResponse>(parameters, callback);

--- a/src/apis/language/v1beta1.ts
+++ b/src/apis/language/v1beta1.ts
@@ -29,8 +29,6 @@ export namespace language_v1beta1 {
     version: 'v1beta1';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * V1 error format.
@@ -100,12 +98,13 @@ export namespace language_v1beta1 {
    * @param {object=} options Options for Language
    */
   export class Language {
+    context: APIRequestContext;
     documents: Resource$Documents;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.documents = new Resource$Documents();
+      this.documents = new Resource$Documents(this.context);
     }
   }
 
@@ -551,7 +550,10 @@ export namespace language_v1beta1 {
 
 
   export class Resource$Documents {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -615,7 +617,7 @@ export namespace language_v1beta1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AnalyzeEntitiesResponse>(parameters, callback);
@@ -685,7 +687,7 @@ export namespace language_v1beta1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AnalyzeSentimentResponse>(parameters, callback);
@@ -756,7 +758,7 @@ export namespace language_v1beta1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AnalyzeSyntaxResponse>(parameters, callback);
@@ -826,7 +828,7 @@ export namespace language_v1beta1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AnnotateTextResponse>(parameters, callback);

--- a/src/apis/language/v1beta2.ts
+++ b/src/apis/language/v1beta2.ts
@@ -29,8 +29,6 @@ export namespace language_v1beta2 {
     version: 'v1beta2';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * V1 error format.
@@ -100,12 +98,13 @@ export namespace language_v1beta2 {
    * @param {object=} options Options for Language
    */
   export class Language {
+    context: APIRequestContext;
     documents: Resource$Documents;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.documents = new Resource$Documents();
+      this.documents = new Resource$Documents(this.context);
     }
   }
 
@@ -635,7 +634,10 @@ export namespace language_v1beta2 {
 
 
   export class Resource$Documents {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -699,7 +701,7 @@ export namespace language_v1beta2 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AnalyzeEntitiesResponse>(parameters, callback);
@@ -773,7 +775,7 @@ export namespace language_v1beta2 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AnalyzeEntitySentimentResponse>(
@@ -845,7 +847,7 @@ export namespace language_v1beta2 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AnalyzeSentimentResponse>(parameters, callback);
@@ -916,7 +918,7 @@ export namespace language_v1beta2 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AnalyzeSyntaxResponse>(parameters, callback);
@@ -986,7 +988,7 @@ export namespace language_v1beta2 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AnnotateTextResponse>(parameters, callback);
@@ -1055,7 +1057,7 @@ export namespace language_v1beta2 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ClassifyTextResponse>(parameters, callback);

--- a/src/apis/libraryagent/v1.ts
+++ b/src/apis/libraryagent/v1.ts
@@ -29,8 +29,6 @@ export namespace libraryagent_v1 {
     version: 'v1';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * V1 error format.
@@ -98,12 +96,13 @@ export namespace libraryagent_v1 {
    * @param {object=} options Options for Libraryagent
    */
   export class Libraryagent {
+    context: APIRequestContext;
     shelves: Resource$Shelves;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.shelves = new Resource$Shelves();
+      this.shelves = new Resource$Shelves(this.context);
     }
   }
 
@@ -177,9 +176,11 @@ export namespace libraryagent_v1 {
 
 
   export class Resource$Shelves {
+    context: APIRequestContext;
     books: Resource$Shelves$Books;
-    constructor() {
-      this.books = new Resource$Shelves$Books();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.books = new Resource$Shelves$Books(this.context);
     }
 
 
@@ -242,7 +243,7 @@ export namespace libraryagent_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleExampleLibraryagentV1Shelf>(
@@ -315,7 +316,7 @@ export namespace libraryagent_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleExampleLibraryagentV1ListShelvesResponse>(
@@ -358,7 +359,10 @@ export namespace libraryagent_v1 {
   }
 
   export class Resource$Shelves$Books {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -427,7 +431,7 @@ export namespace libraryagent_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleExampleLibraryagentV1Book>(
@@ -496,7 +500,7 @@ export namespace libraryagent_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleExampleLibraryagentV1Book>(
@@ -574,7 +578,7 @@ export namespace libraryagent_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleExampleLibraryagentV1ListBooksResponse>(
@@ -651,7 +655,7 @@ export namespace libraryagent_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleExampleLibraryagentV1Book>(

--- a/src/apis/licensing/v1.ts
+++ b/src/apis/licensing/v1.ts
@@ -29,8 +29,6 @@ export namespace licensing_v1 {
     version: 'v1';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * Data format for the response.
@@ -81,12 +79,13 @@ export namespace licensing_v1 {
    * @param {object=} options Options for Licensing
    */
   export class Licensing {
+    context: APIRequestContext;
     licenseAssignments: Resource$Licenseassignments;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.licenseAssignments = new Resource$Licenseassignments();
+      this.licenseAssignments = new Resource$Licenseassignments(this.context);
     }
   }
 
@@ -161,7 +160,10 @@ export namespace licensing_v1 {
 
 
   export class Resource$Licenseassignments {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -223,7 +225,7 @@ export namespace licensing_v1 {
         params,
         requiredParams: ['productId', 'skuId', 'userId'],
         pathParams: ['productId', 'skuId', 'userId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -290,7 +292,7 @@ export namespace licensing_v1 {
         params,
         requiredParams: ['productId', 'skuId', 'userId'],
         pathParams: ['productId', 'skuId', 'userId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$LicenseAssignment>(parameters, callback);
@@ -360,7 +362,7 @@ export namespace licensing_v1 {
         params,
         requiredParams: ['productId', 'skuId'],
         pathParams: ['productId', 'skuId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$LicenseAssignment>(parameters, callback);
@@ -432,7 +434,7 @@ export namespace licensing_v1 {
         params,
         requiredParams: ['productId', 'customerId'],
         pathParams: ['productId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$LicenseAssignmentList>(parameters, callback);
@@ -507,7 +509,7 @@ export namespace licensing_v1 {
         params,
         requiredParams: ['productId', 'skuId', 'customerId'],
         pathParams: ['productId', 'skuId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$LicenseAssignmentList>(parameters, callback);
@@ -579,7 +581,7 @@ export namespace licensing_v1 {
         params,
         requiredParams: ['productId', 'skuId', 'userId'],
         pathParams: ['productId', 'skuId', 'userId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$LicenseAssignment>(parameters, callback);
@@ -651,7 +653,7 @@ export namespace licensing_v1 {
         params,
         requiredParams: ['productId', 'skuId', 'userId'],
         pathParams: ['productId', 'skuId', 'userId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$LicenseAssignment>(parameters, callback);

--- a/src/apis/logging/v2.ts
+++ b/src/apis/logging/v2.ts
@@ -29,8 +29,6 @@ export namespace logging_v2 {
     version: 'v2';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * V1 error format.
@@ -98,6 +96,7 @@ export namespace logging_v2 {
    * @param {object=} options Options for Logging
    */
   export class Logging {
+    context: APIRequestContext;
     billingAccounts: Resource$Billingaccounts;
     entries: Resource$Entries;
     exclusions: Resource$Exclusions;
@@ -109,18 +108,18 @@ export namespace logging_v2 {
     sinks: Resource$Sinks;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.billingAccounts = new Resource$Billingaccounts();
-      this.entries = new Resource$Entries();
-      this.exclusions = new Resource$Exclusions();
-      this.folders = new Resource$Folders();
-      this.logs = new Resource$Logs();
+      this.billingAccounts = new Resource$Billingaccounts(this.context);
+      this.entries = new Resource$Entries(this.context);
+      this.exclusions = new Resource$Exclusions(this.context);
+      this.folders = new Resource$Folders(this.context);
+      this.logs = new Resource$Logs(this.context);
       this.monitoredResourceDescriptors =
-          new Resource$Monitoredresourcedescriptors();
-      this.organizations = new Resource$Organizations();
-      this.projects = new Resource$Projects();
-      this.sinks = new Resource$Sinks();
+          new Resource$Monitoredresourcedescriptors(this.context);
+      this.organizations = new Resource$Organizations(this.context);
+      this.projects = new Resource$Projects(this.context);
+      this.sinks = new Resource$Sinks(this.context);
     }
   }
 
@@ -1375,19 +1374,24 @@ export namespace logging_v2 {
 
 
   export class Resource$Billingaccounts {
+    context: APIRequestContext;
     exclusions: Resource$Billingaccounts$Exclusions;
     logs: Resource$Billingaccounts$Logs;
     sinks: Resource$Billingaccounts$Sinks;
-    constructor() {
-      this.exclusions = new Resource$Billingaccounts$Exclusions();
-      this.logs = new Resource$Billingaccounts$Logs();
-      this.sinks = new Resource$Billingaccounts$Sinks();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.exclusions = new Resource$Billingaccounts$Exclusions(this.context);
+      this.logs = new Resource$Billingaccounts$Logs(this.context);
+      this.sinks = new Resource$Billingaccounts$Sinks(this.context);
     }
   }
 
 
   export class Resource$Billingaccounts$Exclusions {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1450,7 +1454,7 @@ export namespace logging_v2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$LogExclusion>(parameters, callback);
@@ -1515,7 +1519,7 @@ export namespace logging_v2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -1577,7 +1581,7 @@ export namespace logging_v2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$LogExclusion>(parameters, callback);
@@ -1647,7 +1651,7 @@ export namespace logging_v2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListExclusionsResponse>(parameters, callback);
@@ -1715,7 +1719,7 @@ export namespace logging_v2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$LogExclusion>(parameters, callback);
@@ -1840,7 +1844,10 @@ export namespace logging_v2 {
 
 
   export class Resource$Billingaccounts$Logs {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1900,7 +1907,7 @@ export namespace logging_v2 {
         params,
         requiredParams: ['logName'],
         pathParams: ['logName'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -1970,7 +1977,7 @@ export namespace logging_v2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListLogsResponse>(parameters, callback);
@@ -2029,7 +2036,10 @@ export namespace logging_v2 {
 
 
   export class Resource$Billingaccounts$Sinks {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -2093,7 +2103,7 @@ export namespace logging_v2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$LogSink>(parameters, callback);
@@ -2159,7 +2169,7 @@ export namespace logging_v2 {
         params,
         requiredParams: ['sinkName'],
         pathParams: ['sinkName'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -2220,7 +2230,7 @@ export namespace logging_v2 {
         params,
         requiredParams: ['sinkName'],
         pathParams: ['sinkName'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$LogSink>(parameters, callback);
@@ -2289,7 +2299,7 @@ export namespace logging_v2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListSinksResponse>(parameters, callback);
@@ -2360,7 +2370,7 @@ export namespace logging_v2 {
         params,
         requiredParams: ['sinkName'],
         pathParams: ['sinkName'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$LogSink>(parameters, callback);
@@ -2431,7 +2441,7 @@ export namespace logging_v2 {
         params,
         requiredParams: ['sinkName'],
         pathParams: ['sinkName'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$LogSink>(parameters, callback);
@@ -2634,7 +2644,10 @@ export namespace logging_v2 {
 
 
   export class Resource$Entries {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -2694,7 +2707,7 @@ export namespace logging_v2 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListLogEntriesResponse>(parameters, callback);
@@ -2765,7 +2778,7 @@ export namespace logging_v2 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$WriteLogEntriesResponse>(parameters, callback);
@@ -2802,7 +2815,10 @@ export namespace logging_v2 {
 
 
   export class Resource$Exclusions {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -2864,7 +2880,7 @@ export namespace logging_v2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$LogExclusion>(parameters, callback);
@@ -2928,7 +2944,7 @@ export namespace logging_v2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -2989,7 +3005,7 @@ export namespace logging_v2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$LogExclusion>(parameters, callback);
@@ -3057,7 +3073,7 @@ export namespace logging_v2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListExclusionsResponse>(parameters, callback);
@@ -3123,7 +3139,7 @@ export namespace logging_v2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$LogExclusion>(parameters, callback);
@@ -3245,19 +3261,24 @@ export namespace logging_v2 {
 
 
   export class Resource$Folders {
+    context: APIRequestContext;
     exclusions: Resource$Folders$Exclusions;
     logs: Resource$Folders$Logs;
     sinks: Resource$Folders$Sinks;
-    constructor() {
-      this.exclusions = new Resource$Folders$Exclusions();
-      this.logs = new Resource$Folders$Logs();
-      this.sinks = new Resource$Folders$Sinks();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.exclusions = new Resource$Folders$Exclusions(this.context);
+      this.logs = new Resource$Folders$Logs(this.context);
+      this.sinks = new Resource$Folders$Sinks(this.context);
     }
   }
 
 
   export class Resource$Folders$Exclusions {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -3320,7 +3341,7 @@ export namespace logging_v2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$LogExclusion>(parameters, callback);
@@ -3385,7 +3406,7 @@ export namespace logging_v2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -3447,7 +3468,7 @@ export namespace logging_v2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$LogExclusion>(parameters, callback);
@@ -3517,7 +3538,7 @@ export namespace logging_v2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListExclusionsResponse>(parameters, callback);
@@ -3585,7 +3606,7 @@ export namespace logging_v2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$LogExclusion>(parameters, callback);
@@ -3710,7 +3731,10 @@ export namespace logging_v2 {
 
 
   export class Resource$Folders$Logs {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -3770,7 +3794,7 @@ export namespace logging_v2 {
         params,
         requiredParams: ['logName'],
         pathParams: ['logName'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -3839,7 +3863,7 @@ export namespace logging_v2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListLogsResponse>(parameters, callback);
@@ -3898,7 +3922,10 @@ export namespace logging_v2 {
 
 
   export class Resource$Folders$Sinks {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -3962,7 +3989,7 @@ export namespace logging_v2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$LogSink>(parameters, callback);
@@ -4028,7 +4055,7 @@ export namespace logging_v2 {
         params,
         requiredParams: ['sinkName'],
         pathParams: ['sinkName'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -4089,7 +4116,7 @@ export namespace logging_v2 {
         params,
         requiredParams: ['sinkName'],
         pathParams: ['sinkName'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$LogSink>(parameters, callback);
@@ -4157,7 +4184,7 @@ export namespace logging_v2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListSinksResponse>(parameters, callback);
@@ -4228,7 +4255,7 @@ export namespace logging_v2 {
         params,
         requiredParams: ['sinkName'],
         pathParams: ['sinkName'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$LogSink>(parameters, callback);
@@ -4299,7 +4326,7 @@ export namespace logging_v2 {
         params,
         requiredParams: ['sinkName'],
         pathParams: ['sinkName'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$LogSink>(parameters, callback);
@@ -4502,7 +4529,10 @@ export namespace logging_v2 {
 
 
   export class Resource$Logs {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -4560,7 +4590,7 @@ export namespace logging_v2 {
         params,
         requiredParams: ['logName'],
         pathParams: ['logName'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -4628,7 +4658,7 @@ export namespace logging_v2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListLogsResponse>(parameters, callback);
@@ -4685,7 +4715,10 @@ export namespace logging_v2 {
 
 
   export class Resource$Monitoredresourcedescriptors {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -4752,7 +4785,7 @@ export namespace logging_v2 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListMonitoredResourceDescriptorsResponse>(
@@ -4788,19 +4821,24 @@ export namespace logging_v2 {
 
 
   export class Resource$Organizations {
+    context: APIRequestContext;
     exclusions: Resource$Organizations$Exclusions;
     logs: Resource$Organizations$Logs;
     sinks: Resource$Organizations$Sinks;
-    constructor() {
-      this.exclusions = new Resource$Organizations$Exclusions();
-      this.logs = new Resource$Organizations$Logs();
-      this.sinks = new Resource$Organizations$Sinks();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.exclusions = new Resource$Organizations$Exclusions(this.context);
+      this.logs = new Resource$Organizations$Logs(this.context);
+      this.sinks = new Resource$Organizations$Sinks(this.context);
     }
   }
 
 
   export class Resource$Organizations$Exclusions {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -4863,7 +4901,7 @@ export namespace logging_v2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$LogExclusion>(parameters, callback);
@@ -4928,7 +4966,7 @@ export namespace logging_v2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -4990,7 +5028,7 @@ export namespace logging_v2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$LogExclusion>(parameters, callback);
@@ -5060,7 +5098,7 @@ export namespace logging_v2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListExclusionsResponse>(parameters, callback);
@@ -5128,7 +5166,7 @@ export namespace logging_v2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$LogExclusion>(parameters, callback);
@@ -5253,7 +5291,10 @@ export namespace logging_v2 {
 
 
   export class Resource$Organizations$Logs {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -5313,7 +5354,7 @@ export namespace logging_v2 {
         params,
         requiredParams: ['logName'],
         pathParams: ['logName'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -5383,7 +5424,7 @@ export namespace logging_v2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListLogsResponse>(parameters, callback);
@@ -5442,7 +5483,10 @@ export namespace logging_v2 {
 
 
   export class Resource$Organizations$Sinks {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -5506,7 +5550,7 @@ export namespace logging_v2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$LogSink>(parameters, callback);
@@ -5572,7 +5616,7 @@ export namespace logging_v2 {
         params,
         requiredParams: ['sinkName'],
         pathParams: ['sinkName'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -5633,7 +5677,7 @@ export namespace logging_v2 {
         params,
         requiredParams: ['sinkName'],
         pathParams: ['sinkName'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$LogSink>(parameters, callback);
@@ -5702,7 +5746,7 @@ export namespace logging_v2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListSinksResponse>(parameters, callback);
@@ -5773,7 +5817,7 @@ export namespace logging_v2 {
         params,
         requiredParams: ['sinkName'],
         pathParams: ['sinkName'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$LogSink>(parameters, callback);
@@ -5844,7 +5888,7 @@ export namespace logging_v2 {
         params,
         requiredParams: ['sinkName'],
         pathParams: ['sinkName'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$LogSink>(parameters, callback);
@@ -6047,21 +6091,26 @@ export namespace logging_v2 {
 
 
   export class Resource$Projects {
+    context: APIRequestContext;
     exclusions: Resource$Projects$Exclusions;
     logs: Resource$Projects$Logs;
     metrics: Resource$Projects$Metrics;
     sinks: Resource$Projects$Sinks;
-    constructor() {
-      this.exclusions = new Resource$Projects$Exclusions();
-      this.logs = new Resource$Projects$Logs();
-      this.metrics = new Resource$Projects$Metrics();
-      this.sinks = new Resource$Projects$Sinks();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.exclusions = new Resource$Projects$Exclusions(this.context);
+      this.logs = new Resource$Projects$Logs(this.context);
+      this.metrics = new Resource$Projects$Metrics(this.context);
+      this.sinks = new Resource$Projects$Sinks(this.context);
     }
   }
 
 
   export class Resource$Projects$Exclusions {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -6124,7 +6173,7 @@ export namespace logging_v2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$LogExclusion>(parameters, callback);
@@ -6189,7 +6238,7 @@ export namespace logging_v2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -6251,7 +6300,7 @@ export namespace logging_v2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$LogExclusion>(parameters, callback);
@@ -6321,7 +6370,7 @@ export namespace logging_v2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListExclusionsResponse>(parameters, callback);
@@ -6389,7 +6438,7 @@ export namespace logging_v2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$LogExclusion>(parameters, callback);
@@ -6514,7 +6563,10 @@ export namespace logging_v2 {
 
 
   export class Resource$Projects$Logs {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -6574,7 +6626,7 @@ export namespace logging_v2 {
         params,
         requiredParams: ['logName'],
         pathParams: ['logName'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -6643,7 +6695,7 @@ export namespace logging_v2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListLogsResponse>(parameters, callback);
@@ -6702,7 +6754,10 @@ export namespace logging_v2 {
 
 
   export class Resource$Projects$Metrics {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -6763,7 +6818,7 @@ export namespace logging_v2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$LogMetric>(parameters, callback);
@@ -6829,7 +6884,7 @@ export namespace logging_v2 {
         params,
         requiredParams: ['metricName'],
         pathParams: ['metricName'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -6892,7 +6947,7 @@ export namespace logging_v2 {
         params,
         requiredParams: ['metricName'],
         pathParams: ['metricName'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$LogMetric>(parameters, callback);
@@ -6962,7 +7017,7 @@ export namespace logging_v2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListLogMetricsResponse>(parameters, callback);
@@ -7030,7 +7085,7 @@ export namespace logging_v2 {
         params,
         requiredParams: ['metricName'],
         pathParams: ['metricName'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$LogMetric>(parameters, callback);
@@ -7134,7 +7189,10 @@ export namespace logging_v2 {
 
 
   export class Resource$Projects$Sinks {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -7198,7 +7256,7 @@ export namespace logging_v2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$LogSink>(parameters, callback);
@@ -7264,7 +7322,7 @@ export namespace logging_v2 {
         params,
         requiredParams: ['sinkName'],
         pathParams: ['sinkName'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -7325,7 +7383,7 @@ export namespace logging_v2 {
         params,
         requiredParams: ['sinkName'],
         pathParams: ['sinkName'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$LogSink>(parameters, callback);
@@ -7393,7 +7451,7 @@ export namespace logging_v2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListSinksResponse>(parameters, callback);
@@ -7464,7 +7522,7 @@ export namespace logging_v2 {
         params,
         requiredParams: ['sinkName'],
         pathParams: ['sinkName'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$LogSink>(parameters, callback);
@@ -7535,7 +7593,7 @@ export namespace logging_v2 {
         params,
         requiredParams: ['sinkName'],
         pathParams: ['sinkName'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$LogSink>(parameters, callback);
@@ -7738,7 +7796,10 @@ export namespace logging_v2 {
 
 
   export class Resource$Sinks {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -7800,7 +7861,7 @@ export namespace logging_v2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$LogSink>(parameters, callback);
@@ -7864,7 +7925,7 @@ export namespace logging_v2 {
         params,
         requiredParams: ['sinkName'],
         pathParams: ['sinkName'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -7924,7 +7985,7 @@ export namespace logging_v2 {
         params,
         requiredParams: ['sinkName'],
         pathParams: ['sinkName'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$LogSink>(parameters, callback);
@@ -7991,7 +8052,7 @@ export namespace logging_v2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListSinksResponse>(parameters, callback);
@@ -8060,7 +8121,7 @@ export namespace logging_v2 {
         params,
         requiredParams: ['sinkName'],
         pathParams: ['sinkName'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$LogSink>(parameters, callback);

--- a/src/apis/logging/v2beta1.ts
+++ b/src/apis/logging/v2beta1.ts
@@ -29,8 +29,6 @@ export namespace logging_v2beta1 {
     version: 'v2beta1';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * V1 error format.
@@ -98,17 +96,18 @@ export namespace logging_v2beta1 {
    * @param {object=} options Options for Logging
    */
   export class Logging {
+    context: APIRequestContext;
     entries: Resource$Entries;
     monitoredResourceDescriptors: Resource$Monitoredresourcedescriptors;
     projects: Resource$Projects;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.entries = new Resource$Entries();
+      this.entries = new Resource$Entries(this.context);
       this.monitoredResourceDescriptors =
-          new Resource$Monitoredresourcedescriptors();
-      this.projects = new Resource$Projects();
+          new Resource$Monitoredresourcedescriptors(this.context);
+      this.projects = new Resource$Projects(this.context);
     }
   }
 
@@ -1286,7 +1285,10 @@ export namespace logging_v2beta1 {
 
 
   export class Resource$Entries {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1414,7 +1416,7 @@ export namespace logging_v2beta1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListLogEntriesResponse>(parameters, callback);
@@ -1539,7 +1541,7 @@ export namespace logging_v2beta1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$WriteLogEntriesResponse>(parameters, callback);
@@ -1576,7 +1578,10 @@ export namespace logging_v2beta1 {
 
 
   export class Resource$Monitoredresourcedescriptors {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1707,7 +1712,7 @@ export namespace logging_v2beta1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListMonitoredResourceDescriptorsResponse>(
@@ -1743,17 +1748,22 @@ export namespace logging_v2beta1 {
 
 
   export class Resource$Projects {
+    context: APIRequestContext;
     metrics: Resource$Projects$Metrics;
     sinks: Resource$Projects$Sinks;
-    constructor() {
-      this.metrics = new Resource$Projects$Metrics();
-      this.sinks = new Resource$Projects$Sinks();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.metrics = new Resource$Projects$Metrics(this.context);
+      this.sinks = new Resource$Projects$Sinks(this.context);
     }
   }
 
 
   export class Resource$Projects$Metrics {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1873,7 +1883,7 @@ export namespace logging_v2beta1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$LogMetric>(parameters, callback);
@@ -1991,7 +2001,7 @@ export namespace logging_v2beta1 {
         params,
         requiredParams: ['metricName'],
         pathParams: ['metricName'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -2109,7 +2119,7 @@ export namespace logging_v2beta1 {
         params,
         requiredParams: ['metricName'],
         pathParams: ['metricName'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$LogMetric>(parameters, callback);
@@ -2246,7 +2256,7 @@ export namespace logging_v2beta1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListLogMetricsResponse>(parameters, callback);
@@ -2379,7 +2389,7 @@ export namespace logging_v2beta1 {
         params,
         requiredParams: ['metricName'],
         pathParams: ['metricName'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$LogMetric>(parameters, callback);
@@ -2483,7 +2493,10 @@ export namespace logging_v2beta1 {
 
 
   export class Resource$Projects$Sinks {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -2610,7 +2623,7 @@ export namespace logging_v2beta1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$LogSink>(parameters, callback);
@@ -2735,7 +2748,7 @@ export namespace logging_v2beta1 {
         params,
         requiredParams: ['sinkName'],
         pathParams: ['sinkName'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -2856,7 +2869,7 @@ export namespace logging_v2beta1 {
         params,
         requiredParams: ['sinkName'],
         pathParams: ['sinkName'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$LogSink>(parameters, callback);
@@ -2994,7 +3007,7 @@ export namespace logging_v2beta1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListSinksResponse>(parameters, callback);
@@ -3133,7 +3146,7 @@ export namespace logging_v2beta1 {
         params,
         requiredParams: ['sinkName'],
         pathParams: ['sinkName'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$LogSink>(parameters, callback);

--- a/src/apis/manufacturers/v1.ts
+++ b/src/apis/manufacturers/v1.ts
@@ -29,8 +29,6 @@ export namespace manufacturers_v1 {
     version: 'v1';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * V1 error format.
@@ -98,12 +96,13 @@ export namespace manufacturers_v1 {
    * @param {object=} options Options for Manufacturers
    */
   export class Manufacturers {
+    context: APIRequestContext;
     accounts: Resource$Accounts;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.accounts = new Resource$Accounts();
+      this.accounts = new Resource$Accounts(this.context);
     }
   }
 
@@ -505,15 +504,20 @@ export namespace manufacturers_v1 {
 
 
   export class Resource$Accounts {
+    context: APIRequestContext;
     products: Resource$Accounts$Products;
-    constructor() {
-      this.products = new Resource$Accounts$Products();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.products = new Resource$Accounts$Products(this.context);
     }
   }
 
 
   export class Resource$Accounts$Products {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -574,7 +578,7 @@ export namespace manufacturers_v1 {
         params,
         requiredParams: ['parent', 'name'],
         pathParams: ['name', 'parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -643,7 +647,7 @@ export namespace manufacturers_v1 {
         params,
         requiredParams: ['parent', 'name'],
         pathParams: ['name', 'parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Product>(parameters, callback);
@@ -715,7 +719,7 @@ export namespace manufacturers_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListProductsResponse>(parameters, callback);
@@ -795,7 +799,7 @@ export namespace manufacturers_v1 {
         params,
         requiredParams: ['parent', 'name'],
         pathParams: ['name', 'parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);

--- a/src/apis/mirror/v1.ts
+++ b/src/apis/mirror/v1.ts
@@ -29,8 +29,6 @@ export namespace mirror_v1 {
     version: 'v1';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * Data format for the response.
@@ -81,6 +79,7 @@ export namespace mirror_v1 {
    * @param {object=} options Options for Mirror
    */
   export class Mirror {
+    context: APIRequestContext;
     accounts: Resource$Accounts;
     contacts: Resource$Contacts;
     locations: Resource$Locations;
@@ -89,14 +88,14 @@ export namespace mirror_v1 {
     timeline: Resource$Timeline;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.accounts = new Resource$Accounts();
-      this.contacts = new Resource$Contacts();
-      this.locations = new Resource$Locations();
-      this.settings = new Resource$Settings();
-      this.subscriptions = new Resource$Subscriptions();
-      this.timeline = new Resource$Timeline();
+      this.accounts = new Resource$Accounts(this.context);
+      this.contacts = new Resource$Contacts(this.context);
+      this.locations = new Resource$Locations(this.context);
+      this.settings = new Resource$Settings(this.context);
+      this.subscriptions = new Resource$Subscriptions(this.context);
+      this.timeline = new Resource$Timeline(this.context);
     }
   }
 
@@ -744,7 +743,10 @@ export namespace mirror_v1 {
 
 
   export class Resource$Accounts {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -806,7 +808,7 @@ export namespace mirror_v1 {
         params,
         requiredParams: ['userToken', 'accountType', 'accountName'],
         pathParams: ['accountName', 'accountType', 'userToken'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Account>(parameters, callback);
@@ -843,7 +845,10 @@ export namespace mirror_v1 {
 
 
   export class Resource$Contacts {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -899,7 +904,7 @@ export namespace mirror_v1 {
         params,
         requiredParams: ['id'],
         pathParams: ['id'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -960,7 +965,7 @@ export namespace mirror_v1 {
         params,
         requiredParams: ['id'],
         pathParams: ['id'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Contact>(parameters, callback);
@@ -1024,7 +1029,7 @@ export namespace mirror_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Contact>(parameters, callback);
@@ -1089,7 +1094,7 @@ export namespace mirror_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ContactsListResponse>(parameters, callback);
@@ -1154,7 +1159,7 @@ export namespace mirror_v1 {
         params,
         requiredParams: ['id'],
         pathParams: ['id'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Contact>(parameters, callback);
@@ -1219,7 +1224,7 @@ export namespace mirror_v1 {
         params,
         requiredParams: ['id'],
         pathParams: ['id'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Contact>(parameters, callback);
@@ -1304,7 +1309,10 @@ export namespace mirror_v1 {
 
 
   export class Resource$Locations {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1358,7 +1366,7 @@ export namespace mirror_v1 {
         params,
         requiredParams: ['id'],
         pathParams: ['id'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Location>(parameters, callback);
@@ -1423,7 +1431,7 @@ export namespace mirror_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$LocationsListResponse>(parameters, callback);
@@ -1453,7 +1461,10 @@ export namespace mirror_v1 {
 
 
   export class Resource$Settings {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1507,7 +1518,7 @@ export namespace mirror_v1 {
         params,
         requiredParams: ['id'],
         pathParams: ['id'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Setting>(parameters, callback);
@@ -1535,7 +1546,10 @@ export namespace mirror_v1 {
 
 
   export class Resource$Subscriptions {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1593,7 +1607,7 @@ export namespace mirror_v1 {
         params,
         requiredParams: ['id'],
         pathParams: ['id'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -1660,7 +1674,7 @@ export namespace mirror_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Subscription>(parameters, callback);
@@ -1728,7 +1742,7 @@ export namespace mirror_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$SubscriptionsListResponse>(
@@ -1797,7 +1811,7 @@ export namespace mirror_v1 {
         params,
         requiredParams: ['id'],
         pathParams: ['id'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Subscription>(parameters, callback);
@@ -1859,9 +1873,11 @@ export namespace mirror_v1 {
 
 
   export class Resource$Timeline {
+    context: APIRequestContext;
     attachments: Resource$Timeline$Attachments;
-    constructor() {
-      this.attachments = new Resource$Timeline$Attachments();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.attachments = new Resource$Timeline$Attachments(this.context);
     }
 
 
@@ -1918,7 +1934,7 @@ export namespace mirror_v1 {
         params,
         requiredParams: ['id'],
         pathParams: ['id'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -1980,7 +1996,7 @@ export namespace mirror_v1 {
         params,
         requiredParams: ['id'],
         pathParams: ['id'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TimelineItem>(parameters, callback);
@@ -2050,7 +2066,7 @@ export namespace mirror_v1 {
                       .replace(/([^:]\/)\/+/g, '$1'),
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TimelineItem>(parameters, callback);
@@ -2122,7 +2138,7 @@ export namespace mirror_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TimelineListResponse>(parameters, callback);
@@ -2189,7 +2205,7 @@ export namespace mirror_v1 {
         params,
         requiredParams: ['id'],
         pathParams: ['id'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TimelineItem>(parameters, callback);
@@ -2260,7 +2276,7 @@ export namespace mirror_v1 {
                       .replace(/([^:]\/)\/+/g, '$1'),
         requiredParams: ['id'],
         pathParams: ['id'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TimelineItem>(parameters, callback);
@@ -2403,7 +2419,10 @@ export namespace mirror_v1 {
   }
 
   export class Resource$Timeline$Attachments {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -2463,7 +2482,7 @@ export namespace mirror_v1 {
         params,
         requiredParams: ['itemId', 'attachmentId'],
         pathParams: ['attachmentId', 'itemId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -2529,7 +2548,7 @@ export namespace mirror_v1 {
         params,
         requiredParams: ['itemId', 'attachmentId'],
         pathParams: ['attachmentId', 'itemId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Attachment>(parameters, callback);
@@ -2601,7 +2620,7 @@ export namespace mirror_v1 {
                       .replace(/([^:]\/)\/+/g, '$1'),
         requiredParams: ['itemId'],
         pathParams: ['itemId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Attachment>(parameters, callback);
@@ -2669,7 +2688,7 @@ export namespace mirror_v1 {
         params,
         requiredParams: ['itemId'],
         pathParams: ['itemId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AttachmentsListResponse>(parameters, callback);

--- a/src/apis/ml/v1.ts
+++ b/src/apis/ml/v1.ts
@@ -29,8 +29,6 @@ export namespace ml_v1 {
     version: 'v1';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * V1 error format.
@@ -98,14 +96,15 @@ export namespace ml_v1 {
    * @param {object=} options Options for Ml
    */
   export class Ml {
+    context: APIRequestContext;
     operations: Resource$Operations;
     projects: Resource$Projects;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.operations = new Resource$Operations();
-      this.projects = new Resource$Projects();
+      this.operations = new Resource$Operations(this.context);
+      this.projects = new Resource$Projects(this.context);
     }
   }
 
@@ -1452,7 +1451,10 @@ export namespace ml_v1 {
 
 
   export class Resource$Operations {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1514,7 +1516,7 @@ export namespace ml_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleProtobuf__Empty>(parameters, callback);
@@ -1539,15 +1541,17 @@ export namespace ml_v1 {
 
 
   export class Resource$Projects {
+    context: APIRequestContext;
     jobs: Resource$Projects$Jobs;
     locations: Resource$Projects$Locations;
     models: Resource$Projects$Models;
     operations: Resource$Projects$Operations;
-    constructor() {
-      this.jobs = new Resource$Projects$Jobs();
-      this.locations = new Resource$Projects$Locations();
-      this.models = new Resource$Projects$Models();
-      this.operations = new Resource$Projects$Operations();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.jobs = new Resource$Projects$Jobs(this.context);
+      this.locations = new Resource$Projects$Locations(this.context);
+      this.models = new Resource$Projects$Models(this.context);
+      this.operations = new Resource$Projects$Operations(this.context);
     }
 
 
@@ -1621,7 +1625,7 @@ export namespace ml_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleCloudMlV1__GetConfigResponse>(
@@ -1692,7 +1696,7 @@ export namespace ml_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleApi__HttpBody>(parameters, callback);
@@ -1733,7 +1737,10 @@ export namespace ml_v1 {
   }
 
   export class Resource$Projects$Jobs {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1795,7 +1802,7 @@ export namespace ml_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleProtobuf__Empty>(parameters, callback);
@@ -1864,7 +1871,7 @@ export namespace ml_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleCloudMlV1__Job>(parameters, callback);
@@ -1927,7 +1934,7 @@ export namespace ml_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleCloudMlV1__Job>(parameters, callback);
@@ -1996,7 +2003,7 @@ export namespace ml_v1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleIamV1__Policy>(parameters, callback);
@@ -2074,7 +2081,7 @@ export namespace ml_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleCloudMlV1__ListJobsResponse>(
@@ -2146,7 +2153,7 @@ export namespace ml_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleCloudMlV1__Job>(parameters, callback);
@@ -2216,7 +2223,7 @@ export namespace ml_v1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleIamV1__Policy>(parameters, callback);
@@ -2294,7 +2301,7 @@ export namespace ml_v1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleIamV1__TestIamPermissionsResponse>(
@@ -2471,7 +2478,10 @@ export namespace ml_v1 {
 
 
   export class Resource$Projects$Locations {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -2529,7 +2539,7 @@ export namespace ml_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleCloudMlV1__Location>(
@@ -2606,7 +2616,7 @@ export namespace ml_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleCloudMlV1__ListLocationsResponse>(
@@ -2659,9 +2669,11 @@ export namespace ml_v1 {
 
 
   export class Resource$Projects$Models {
+    context: APIRequestContext;
     versions: Resource$Projects$Models$Versions;
-    constructor() {
-      this.versions = new Resource$Projects$Models$Versions();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.versions = new Resource$Projects$Models$Versions(this.context);
     }
 
 
@@ -2727,7 +2739,7 @@ export namespace ml_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleCloudMlV1__Model>(parameters, callback);
@@ -2800,7 +2812,7 @@ export namespace ml_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleLongrunning__Operation>(
@@ -2867,7 +2879,7 @@ export namespace ml_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleCloudMlV1__Model>(parameters, callback);
@@ -2936,7 +2948,7 @@ export namespace ml_v1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleIamV1__Policy>(parameters, callback);
@@ -3017,7 +3029,7 @@ export namespace ml_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleCloudMlV1__ListModelsResponse>(
@@ -3093,7 +3105,7 @@ export namespace ml_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleLongrunning__Operation>(
@@ -3165,7 +3177,7 @@ export namespace ml_v1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleIamV1__Policy>(parameters, callback);
@@ -3243,7 +3255,7 @@ export namespace ml_v1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleIamV1__TestIamPermissionsResponse>(
@@ -3404,7 +3416,10 @@ export namespace ml_v1 {
   }
 
   export class Resource$Projects$Models$Versions {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -3476,7 +3491,7 @@ export namespace ml_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleLongrunning__Operation>(
@@ -3552,7 +3567,7 @@ export namespace ml_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleLongrunning__Operation>(
@@ -3622,7 +3637,7 @@ export namespace ml_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleCloudMlV1__Version>(parameters, callback);
@@ -3707,7 +3722,7 @@ export namespace ml_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleCloudMlV1__ListVersionsResponse>(
@@ -3783,7 +3798,7 @@ export namespace ml_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleLongrunning__Operation>(
@@ -3860,7 +3875,7 @@ export namespace ml_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleCloudMlV1__Version>(parameters, callback);
@@ -3992,7 +4007,10 @@ export namespace ml_v1 {
 
 
   export class Resource$Projects$Operations {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -4061,7 +4079,7 @@ export namespace ml_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleProtobuf__Empty>(parameters, callback);
@@ -4130,7 +4148,7 @@ export namespace ml_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleLongrunning__Operation>(
@@ -4216,7 +4234,7 @@ export namespace ml_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleLongrunning__ListOperationsResponse>(

--- a/src/apis/monitoring/v3.ts
+++ b/src/apis/monitoring/v3.ts
@@ -29,8 +29,6 @@ export namespace monitoring_v3 {
     version: 'v3';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * V1 error format.
@@ -100,14 +98,15 @@ export namespace monitoring_v3 {
    * @param {object=} options Options for Monitoring
    */
   export class Monitoring {
+    context: APIRequestContext;
     projects: Resource$Projects;
     uptimeCheckIps: Resource$Uptimecheckips;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.projects = new Resource$Projects();
-      this.uptimeCheckIps = new Resource$Uptimecheckips();
+      this.projects = new Resource$Projects(this.context);
+      this.uptimeCheckIps = new Resource$Uptimecheckips(this.context);
     }
   }
 
@@ -1992,6 +1991,7 @@ export namespace monitoring_v3 {
 
 
   export class Resource$Projects {
+    context: APIRequestContext;
     alertPolicies: Resource$Projects$Alertpolicies;
     collectdTimeSeries: Resource$Projects$Collectdtimeseries;
     groups: Resource$Projects$Groups;
@@ -2003,24 +2003,32 @@ export namespace monitoring_v3 {
     notificationChannels: Resource$Projects$Notificationchannels;
     timeSeries: Resource$Projects$Timeseries;
     uptimeCheckConfigs: Resource$Projects$Uptimecheckconfigs;
-    constructor() {
-      this.alertPolicies = new Resource$Projects$Alertpolicies();
-      this.collectdTimeSeries = new Resource$Projects$Collectdtimeseries();
-      this.groups = new Resource$Projects$Groups();
-      this.metricDescriptors = new Resource$Projects$Metricdescriptors();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.alertPolicies = new Resource$Projects$Alertpolicies(this.context);
+      this.collectdTimeSeries =
+          new Resource$Projects$Collectdtimeseries(this.context);
+      this.groups = new Resource$Projects$Groups(this.context);
+      this.metricDescriptors =
+          new Resource$Projects$Metricdescriptors(this.context);
       this.monitoredResourceDescriptors =
-          new Resource$Projects$Monitoredresourcedescriptors();
+          new Resource$Projects$Monitoredresourcedescriptors(this.context);
       this.notificationChannelDescriptors =
-          new Resource$Projects$Notificationchanneldescriptors();
-      this.notificationChannels = new Resource$Projects$Notificationchannels();
-      this.timeSeries = new Resource$Projects$Timeseries();
-      this.uptimeCheckConfigs = new Resource$Projects$Uptimecheckconfigs();
+          new Resource$Projects$Notificationchanneldescriptors(this.context);
+      this.notificationChannels =
+          new Resource$Projects$Notificationchannels(this.context);
+      this.timeSeries = new Resource$Projects$Timeseries(this.context);
+      this.uptimeCheckConfigs =
+          new Resource$Projects$Uptimecheckconfigs(this.context);
     }
   }
 
 
   export class Resource$Projects$Alertpolicies {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -2081,7 +2089,7 @@ export namespace monitoring_v3 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AlertPolicy>(parameters, callback);
@@ -2146,7 +2154,7 @@ export namespace monitoring_v3 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -2208,7 +2216,7 @@ export namespace monitoring_v3 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AlertPolicy>(parameters, callback);
@@ -2282,7 +2290,7 @@ export namespace monitoring_v3 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListAlertPoliciesResponse>(
@@ -2354,7 +2362,7 @@ export namespace monitoring_v3 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AlertPolicy>(parameters, callback);
@@ -2496,7 +2504,10 @@ export namespace monitoring_v3 {
 
 
   export class Resource$Projects$Collectdtimeseries {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -2612,7 +2623,7 @@ export namespace monitoring_v3 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$CreateCollectdTimeSeriesResponse>(
@@ -2645,9 +2656,11 @@ export namespace monitoring_v3 {
 
 
   export class Resource$Projects$Groups {
+    context: APIRequestContext;
     members: Resource$Projects$Groups$Members;
-    constructor() {
-      this.members = new Resource$Projects$Groups$Members();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.members = new Resource$Projects$Groups$Members(this.context);
     }
 
 
@@ -2756,7 +2769,7 @@ export namespace monitoring_v3 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Group>(parameters, callback);
@@ -2869,7 +2882,7 @@ export namespace monitoring_v3 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -2977,7 +2990,7 @@ export namespace monitoring_v3 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Group>(parameters, callback);
@@ -3102,7 +3115,7 @@ export namespace monitoring_v3 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListGroupsResponse>(parameters, callback);
@@ -3223,7 +3236,7 @@ export namespace monitoring_v3 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Group>(parameters, callback);
@@ -3358,7 +3371,10 @@ export namespace monitoring_v3 {
   }
 
   export class Resource$Projects$Groups$Members {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -3479,7 +3495,7 @@ export namespace monitoring_v3 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListGroupMembersResponse>(parameters, callback);
@@ -3534,7 +3550,10 @@ export namespace monitoring_v3 {
 
 
   export class Resource$Projects$Metricdescriptors {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -3640,7 +3659,7 @@ export namespace monitoring_v3 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$MetricDescriptor>(parameters, callback);
@@ -3753,7 +3772,7 @@ export namespace monitoring_v3 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -3863,7 +3882,7 @@ export namespace monitoring_v3 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$MetricDescriptor>(parameters, callback);
@@ -3992,7 +4011,7 @@ export namespace monitoring_v3 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListMetricDescriptorsResponse>(
@@ -4084,7 +4103,10 @@ export namespace monitoring_v3 {
 
 
   export class Resource$Projects$Monitoredresourcedescriptors {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -4196,7 +4218,7 @@ export namespace monitoring_v3 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$MonitoredResourceDescriptor>(
@@ -4330,7 +4352,7 @@ export namespace monitoring_v3 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListMonitoredResourceDescriptorsResponse>(
@@ -4389,7 +4411,10 @@ export namespace monitoring_v3 {
 
 
   export class Resource$Projects$Notificationchanneldescriptors {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -4453,7 +4478,7 @@ export namespace monitoring_v3 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$NotificationChannelDescriptor>(
@@ -4534,7 +4559,7 @@ export namespace monitoring_v3 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListNotificationChannelDescriptorsResponse>(
@@ -4589,7 +4614,10 @@ export namespace monitoring_v3 {
 
 
   export class Resource$Projects$Notificationchannels {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -4652,7 +4680,7 @@ export namespace monitoring_v3 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$NotificationChannel>(parameters, callback);
@@ -4718,7 +4746,7 @@ export namespace monitoring_v3 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -4784,7 +4812,7 @@ export namespace monitoring_v3 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$NotificationChannel>(parameters, callback);
@@ -4884,7 +4912,7 @@ export namespace monitoring_v3 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GetNotificationChannelVerificationCodeResponse>(
@@ -4967,7 +4995,7 @@ export namespace monitoring_v3 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListNotificationChannelsResponse>(
@@ -5038,7 +5066,7 @@ export namespace monitoring_v3 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$NotificationChannel>(parameters, callback);
@@ -5111,7 +5139,7 @@ export namespace monitoring_v3 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -5181,7 +5209,7 @@ export namespace monitoring_v3 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$NotificationChannel>(parameters, callback);
@@ -5365,7 +5393,10 @@ export namespace monitoring_v3 {
 
 
   export class Resource$Projects$Timeseries {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -5475,7 +5506,7 @@ export namespace monitoring_v3 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -5608,7 +5639,7 @@ export namespace monitoring_v3 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListTimeSeriesResponse>(parameters, callback);
@@ -5740,7 +5771,10 @@ export namespace monitoring_v3 {
 
 
   export class Resource$Projects$Uptimecheckconfigs {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -5801,7 +5835,7 @@ export namespace monitoring_v3 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$UptimeCheckConfig>(parameters, callback);
@@ -5869,7 +5903,7 @@ export namespace monitoring_v3 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -5931,7 +5965,7 @@ export namespace monitoring_v3 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$UptimeCheckConfig>(parameters, callback);
@@ -6006,7 +6040,7 @@ export namespace monitoring_v3 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListUptimeCheckConfigsResponse>(
@@ -6079,7 +6113,7 @@ export namespace monitoring_v3 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$UptimeCheckConfig>(parameters, callback);
@@ -6191,7 +6225,10 @@ export namespace monitoring_v3 {
 
 
   export class Resource$Uptimecheckips {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -6255,7 +6292,7 @@ export namespace monitoring_v3 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListUptimeCheckIpsResponse>(

--- a/src/apis/oauth2/v1.ts
+++ b/src/apis/oauth2/v1.ts
@@ -29,8 +29,6 @@ export namespace oauth2_v1 {
     version: 'v1';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * Data format for the response.
@@ -81,12 +79,13 @@ export namespace oauth2_v1 {
    * @param {object=} options Options for Oauth2
    */
   export class Oauth2 {
+    context: APIRequestContext;
     userinfo: Resource$Userinfo;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.userinfo = new Resource$Userinfo();
+      this.userinfo = new Resource$Userinfo(this.context);
     }
 
 
@@ -146,7 +145,7 @@ export namespace oauth2_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Tokeninfo>(parameters, callback);
@@ -275,9 +274,11 @@ export namespace oauth2_v1 {
   }
 
   export class Resource$Userinfo {
+    context: APIRequestContext;
     v2: Resource$Userinfo$V2;
-    constructor() {
-      this.v2 = new Resource$Userinfo$V2();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.v2 = new Resource$Userinfo$V2(this.context);
     }
 
 
@@ -332,7 +333,7 @@ export namespace oauth2_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Userinfoplus>(parameters, callback);
@@ -350,15 +351,20 @@ export namespace oauth2_v1 {
   }
 
   export class Resource$Userinfo$V2 {
+    context: APIRequestContext;
     me: Resource$Userinfo$V2$Me;
-    constructor() {
-      this.me = new Resource$Userinfo$V2$Me();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.me = new Resource$Userinfo$V2$Me(this.context);
     }
   }
 
 
   export class Resource$Userinfo$V2$Me {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -412,7 +418,7 @@ export namespace oauth2_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Userinfoplus>(parameters, callback);

--- a/src/apis/oauth2/v2.ts
+++ b/src/apis/oauth2/v2.ts
@@ -29,8 +29,6 @@ export namespace oauth2_v2 {
     version: 'v2';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * Data format for the response.
@@ -81,12 +79,13 @@ export namespace oauth2_v2 {
    * @param {object=} options Options for Oauth2
    */
   export class Oauth2 {
+    context: APIRequestContext;
     userinfo: Resource$Userinfo;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.userinfo = new Resource$Userinfo();
+      this.userinfo = new Resource$Userinfo(this.context);
     }
 
 
@@ -142,7 +141,7 @@ export namespace oauth2_v2 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Jwk>(parameters, callback);
@@ -208,7 +207,7 @@ export namespace oauth2_v2 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Tokeninfo>(parameters, callback);
@@ -344,9 +343,11 @@ export namespace oauth2_v2 {
   }
 
   export class Resource$Userinfo {
+    context: APIRequestContext;
     v2: Resource$Userinfo$V2;
-    constructor() {
-      this.v2 = new Resource$Userinfo$V2();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.v2 = new Resource$Userinfo$V2(this.context);
     }
 
 
@@ -400,7 +401,7 @@ export namespace oauth2_v2 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Userinfoplus>(parameters, callback);
@@ -418,15 +419,20 @@ export namespace oauth2_v2 {
   }
 
   export class Resource$Userinfo$V2 {
+    context: APIRequestContext;
     me: Resource$Userinfo$V2$Me;
-    constructor() {
-      this.me = new Resource$Userinfo$V2$Me();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.me = new Resource$Userinfo$V2$Me(this.context);
     }
   }
 
 
   export class Resource$Userinfo$V2$Me {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -479,7 +485,7 @@ export namespace oauth2_v2 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Userinfoplus>(parameters, callback);

--- a/src/apis/oslogin/v1.ts
+++ b/src/apis/oslogin/v1.ts
@@ -29,8 +29,6 @@ export namespace oslogin_v1 {
     version: 'v1';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * V1 error format.
@@ -98,12 +96,13 @@ export namespace oslogin_v1 {
    * @param {object=} options Options for Oslogin
    */
   export class Oslogin {
+    context: APIRequestContext;
     users: Resource$Users;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.users = new Resource$Users();
+      this.users = new Resource$Users(this.context);
     }
   }
 
@@ -210,11 +209,13 @@ export namespace oslogin_v1 {
 
 
   export class Resource$Users {
+    context: APIRequestContext;
     projects: Resource$Users$Projects;
     sshPublicKeys: Resource$Users$Sshpublickeys;
-    constructor() {
-      this.projects = new Resource$Users$Projects();
-      this.sshPublicKeys = new Resource$Users$Sshpublickeys();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.projects = new Resource$Users$Projects(this.context);
+      this.sshPublicKeys = new Resource$Users$Sshpublickeys(this.context);
     }
 
 
@@ -278,7 +279,7 @@ export namespace oslogin_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$LoginProfile>(parameters, callback);
@@ -355,7 +356,7 @@ export namespace oslogin_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ImportSshPublicKeyResponse>(
@@ -409,7 +410,10 @@ export namespace oslogin_v1 {
   }
 
   export class Resource$Users$Projects {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -467,7 +471,7 @@ export namespace oslogin_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -494,7 +498,10 @@ export namespace oslogin_v1 {
 
 
   export class Resource$Users$Sshpublickeys {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -552,7 +559,7 @@ export namespace oslogin_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -614,7 +621,7 @@ export namespace oslogin_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$SshPublicKey>(parameters, callback);
@@ -683,7 +690,7 @@ export namespace oslogin_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$SshPublicKey>(parameters, callback);

--- a/src/apis/oslogin/v1alpha.ts
+++ b/src/apis/oslogin/v1alpha.ts
@@ -29,8 +29,6 @@ export namespace oslogin_v1alpha {
     version: 'v1alpha';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * V1 error format.
@@ -98,12 +96,13 @@ export namespace oslogin_v1alpha {
    * @param {object=} options Options for Oslogin
    */
   export class Oslogin {
+    context: APIRequestContext;
     users: Resource$Users;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.users = new Resource$Users();
+      this.users = new Resource$Users(this.context);
     }
   }
 
@@ -210,11 +209,13 @@ export namespace oslogin_v1alpha {
 
 
   export class Resource$Users {
+    context: APIRequestContext;
     projects: Resource$Users$Projects;
     sshPublicKeys: Resource$Users$Sshpublickeys;
-    constructor() {
-      this.projects = new Resource$Users$Projects();
-      this.sshPublicKeys = new Resource$Users$Sshpublickeys();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.projects = new Resource$Users$Projects(this.context);
+      this.sshPublicKeys = new Resource$Users$Sshpublickeys(this.context);
     }
 
 
@@ -279,7 +280,7 @@ export namespace oslogin_v1alpha {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$LoginProfile>(parameters, callback);
@@ -356,7 +357,7 @@ export namespace oslogin_v1alpha {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ImportSshPublicKeyResponse>(
@@ -414,7 +415,10 @@ export namespace oslogin_v1alpha {
   }
 
   export class Resource$Users$Projects {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -473,7 +477,7 @@ export namespace oslogin_v1alpha {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -504,7 +508,10 @@ export namespace oslogin_v1alpha {
 
 
   export class Resource$Users$Sshpublickeys {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -562,7 +569,7 @@ export namespace oslogin_v1alpha {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -624,7 +631,7 @@ export namespace oslogin_v1alpha {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$SshPublicKey>(parameters, callback);
@@ -693,7 +700,7 @@ export namespace oslogin_v1alpha {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$SshPublicKey>(parameters, callback);

--- a/src/apis/oslogin/v1beta.ts
+++ b/src/apis/oslogin/v1beta.ts
@@ -29,8 +29,6 @@ export namespace oslogin_v1beta {
     version: 'v1beta';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * V1 error format.
@@ -98,12 +96,13 @@ export namespace oslogin_v1beta {
    * @param {object=} options Options for Oslogin
    */
   export class Oslogin {
+    context: APIRequestContext;
     users: Resource$Users;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.users = new Resource$Users();
+      this.users = new Resource$Users(this.context);
     }
   }
 
@@ -210,11 +209,13 @@ export namespace oslogin_v1beta {
 
 
   export class Resource$Users {
+    context: APIRequestContext;
     projects: Resource$Users$Projects;
     sshPublicKeys: Resource$Users$Sshpublickeys;
-    constructor() {
-      this.projects = new Resource$Users$Projects();
-      this.sshPublicKeys = new Resource$Users$Sshpublickeys();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.projects = new Resource$Users$Projects(this.context);
+      this.sshPublicKeys = new Resource$Users$Sshpublickeys(this.context);
     }
 
 
@@ -278,7 +279,7 @@ export namespace oslogin_v1beta {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$LoginProfile>(parameters, callback);
@@ -355,7 +356,7 @@ export namespace oslogin_v1beta {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ImportSshPublicKeyResponse>(
@@ -409,7 +410,10 @@ export namespace oslogin_v1beta {
   }
 
   export class Resource$Users$Projects {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -467,7 +471,7 @@ export namespace oslogin_v1beta {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -494,7 +498,10 @@ export namespace oslogin_v1beta {
 
 
   export class Resource$Users$Sshpublickeys {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -552,7 +559,7 @@ export namespace oslogin_v1beta {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -614,7 +621,7 @@ export namespace oslogin_v1beta {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$SshPublicKey>(parameters, callback);
@@ -683,7 +690,7 @@ export namespace oslogin_v1beta {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$SshPublicKey>(parameters, callback);

--- a/src/apis/pagespeedonline/v1.ts
+++ b/src/apis/pagespeedonline/v1.ts
@@ -29,8 +29,6 @@ export namespace pagespeedonline_v1 {
     version: 'v1';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * Data format for the response.
@@ -82,12 +80,13 @@ export namespace pagespeedonline_v1 {
    * @param {object=} options Options for Pagespeedonline
    */
   export class Pagespeedonline {
+    context: APIRequestContext;
     pagespeedapi: Resource$Pagespeedapi;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.pagespeedapi = new Resource$Pagespeedapi();
+      this.pagespeedapi = new Resource$Pagespeedapi(this.context);
     }
   }
 
@@ -186,7 +185,10 @@ export namespace pagespeedonline_v1 {
 
 
   export class Resource$Pagespeedapi {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -252,7 +254,7 @@ export namespace pagespeedonline_v1 {
         params,
         requiredParams: ['url'],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Result>(parameters, callback);

--- a/src/apis/pagespeedonline/v2.ts
+++ b/src/apis/pagespeedonline/v2.ts
@@ -29,8 +29,6 @@ export namespace pagespeedonline_v2 {
     version: 'v2';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * Data format for the response.
@@ -82,12 +80,13 @@ export namespace pagespeedonline_v2 {
    * @param {object=} options Options for Pagespeedonline
    */
   export class Pagespeedonline {
+    context: APIRequestContext;
     pagespeedapi: Resource$Pagespeedapi;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.pagespeedapi = new Resource$Pagespeedapi();
+      this.pagespeedapi = new Resource$Pagespeedapi(this.context);
     }
   }
 
@@ -224,7 +223,10 @@ export namespace pagespeedonline_v2 {
 
 
   export class Resource$Pagespeedapi {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -290,7 +292,7 @@ export namespace pagespeedonline_v2 {
         params,
         requiredParams: ['url'],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Result>(parameters, callback);

--- a/src/apis/pagespeedonline/v4.ts
+++ b/src/apis/pagespeedonline/v4.ts
@@ -29,8 +29,6 @@ export namespace pagespeedonline_v4 {
     version: 'v4';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * Data format for the response.
@@ -82,12 +80,13 @@ export namespace pagespeedonline_v4 {
    * @param {object=} options Options for Pagespeedonline
    */
   export class Pagespeedonline {
+    context: APIRequestContext;
     pagespeedapi: Resource$Pagespeedapi;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.pagespeedapi = new Resource$Pagespeedapi();
+      this.pagespeedapi = new Resource$Pagespeedapi(this.context);
     }
   }
 
@@ -250,7 +249,10 @@ export namespace pagespeedonline_v4 {
 
 
   export class Resource$Pagespeedapi {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -327,7 +329,7 @@ export namespace pagespeedonline_v4 {
         params,
         requiredParams: ['url'],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$PagespeedApiPagespeedResponseV4>(

--- a/src/apis/pagespeedonline/v5.ts
+++ b/src/apis/pagespeedonline/v5.ts
@@ -29,8 +29,6 @@ export namespace pagespeedonline_v5 {
     version: 'v5';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * Data format for the response.
@@ -82,12 +80,13 @@ export namespace pagespeedonline_v5 {
    * @param {object=} options Options for Pagespeedonline
    */
   export class Pagespeedonline {
+    context: APIRequestContext;
     pagespeedapi: Resource$Pagespeedapi;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.pagespeedapi = new Resource$Pagespeedapi();
+      this.pagespeedapi = new Resource$Pagespeedapi(this.context);
     }
   }
 
@@ -294,7 +293,10 @@ export namespace pagespeedonline_v5 {
 
 
   export class Resource$Pagespeedapi {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -368,7 +370,7 @@ export namespace pagespeedonline_v5 {
         params,
         requiredParams: ['url'],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$PagespeedApiPagespeedResponseV5>(

--- a/src/apis/people/v1.ts
+++ b/src/apis/people/v1.ts
@@ -29,8 +29,6 @@ export namespace people_v1 {
     version: 'v1';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * V1 error format.
@@ -98,14 +96,15 @@ export namespace people_v1 {
    * @param {object=} options Options for People
    */
   export class People {
+    context: APIRequestContext;
     contactGroups: Resource$Contactgroups;
     people: Resource$People;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.contactGroups = new Resource$Contactgroups();
-      this.people = new Resource$People();
+      this.contactGroups = new Resource$Contactgroups(this.context);
+      this.people = new Resource$People(this.context);
     }
   }
 
@@ -1347,9 +1346,11 @@ export namespace people_v1 {
 
 
   export class Resource$Contactgroups {
+    context: APIRequestContext;
     members: Resource$Contactgroups$Members;
-    constructor() {
-      this.members = new Resource$Contactgroups$Members();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.members = new Resource$Contactgroups$Members(this.context);
     }
 
 
@@ -1418,7 +1419,7 @@ export namespace people_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$BatchGetContactGroupsResponse>(
@@ -1487,7 +1488,7 @@ export namespace people_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ContactGroup>(parameters, callback);
@@ -1555,7 +1556,7 @@ export namespace people_v1 {
         params,
         requiredParams: ['resourceName'],
         pathParams: ['resourceName'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -1620,7 +1621,7 @@ export namespace people_v1 {
         params,
         requiredParams: ['resourceName'],
         pathParams: ['resourceName'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ContactGroup>(parameters, callback);
@@ -1691,7 +1692,7 @@ export namespace people_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListContactGroupsResponse>(
@@ -1761,7 +1762,7 @@ export namespace people_v1 {
         params,
         requiredParams: ['resourceName'],
         pathParams: ['resourceName'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ContactGroup>(parameters, callback);
@@ -1875,7 +1876,10 @@ export namespace people_v1 {
   }
 
   export class Resource$Contactgroups$Members {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1948,7 +1952,7 @@ export namespace people_v1 {
         params,
         requiredParams: ['resourceName'],
         pathParams: ['resourceName'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ModifyContactGroupMembersResponse>(
@@ -1981,9 +1985,11 @@ export namespace people_v1 {
 
 
   export class Resource$People {
+    context: APIRequestContext;
     connections: Resource$People$Connections;
-    constructor() {
-      this.connections = new Resource$People$Connections();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.connections = new Resource$People$Connections(this.context);
     }
 
 
@@ -2045,7 +2051,7 @@ export namespace people_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Person>(parameters, callback);
@@ -2111,7 +2117,7 @@ export namespace people_v1 {
         params,
         requiredParams: ['resourceName'],
         pathParams: ['resourceName'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -2176,7 +2182,7 @@ export namespace people_v1 {
         params,
         requiredParams: ['resourceName'],
         pathParams: ['resourceName'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Person>(parameters, callback);
@@ -2248,7 +2254,7 @@ export namespace people_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GetPeopleResponse>(parameters, callback);
@@ -2324,7 +2330,7 @@ export namespace people_v1 {
         params,
         requiredParams: ['resourceName'],
         pathParams: ['resourceName'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Person>(parameters, callback);
@@ -2461,7 +2467,10 @@ export namespace people_v1 {
   }
 
   export class Resource$People$Connections {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -2531,7 +2540,7 @@ export namespace people_v1 {
         params,
         requiredParams: ['resourceName'],
         pathParams: ['resourceName'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListConnectionsResponse>(parameters, callback);

--- a/src/apis/playcustomapp/v1.ts
+++ b/src/apis/playcustomapp/v1.ts
@@ -29,8 +29,6 @@ export namespace playcustomapp_v1 {
     version: 'v1';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * Data format for the response.
@@ -81,12 +79,13 @@ export namespace playcustomapp_v1 {
    * @param {object=} options Options for Playcustomapp
    */
   export class Playcustomapp {
+    context: APIRequestContext;
     accounts: Resource$Accounts;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.accounts = new Resource$Accounts();
+      this.accounts = new Resource$Accounts(this.context);
     }
   }
 
@@ -106,15 +105,20 @@ export namespace playcustomapp_v1 {
 
 
   export class Resource$Accounts {
+    context: APIRequestContext;
     customApps: Resource$Accounts$Customapps;
-    constructor() {
-      this.customApps = new Resource$Accounts$Customapps();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.customApps = new Resource$Accounts$Customapps(this.context);
     }
   }
 
 
   export class Resource$Accounts$Customapps {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -181,7 +185,7 @@ export namespace playcustomapp_v1 {
                 .replace(/([^:]\/)\/+/g, '$1'),
         requiredParams: ['account'],
         pathParams: ['account'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$CustomApp>(parameters, callback);

--- a/src/apis/plus/v1.ts
+++ b/src/apis/plus/v1.ts
@@ -29,8 +29,6 @@ export namespace plus_v1 {
     version: 'v1';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * Data format for the response.
@@ -81,16 +79,17 @@ export namespace plus_v1 {
    * @param {object=} options Options for Plus
    */
   export class Plus {
+    context: APIRequestContext;
     activities: Resource$Activities;
     comments: Resource$Comments;
     people: Resource$People;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.activities = new Resource$Activities();
-      this.comments = new Resource$Comments();
-      this.people = new Resource$People();
+      this.activities = new Resource$Activities(this.context);
+      this.comments = new Resource$Comments(this.context);
+      this.people = new Resource$People(this.context);
     }
   }
 
@@ -631,7 +630,10 @@ export namespace plus_v1 {
 
 
   export class Resource$Activities {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -685,7 +687,7 @@ export namespace plus_v1 {
         params,
         requiredParams: ['activityId'],
         pathParams: ['activityId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Activity>(parameters, callback);
@@ -755,7 +757,7 @@ export namespace plus_v1 {
         params,
         requiredParams: ['userId', 'collection'],
         pathParams: ['collection', 'userId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ActivityFeed>(parameters, callback);
@@ -825,7 +827,7 @@ export namespace plus_v1 {
         params,
         requiredParams: ['query'],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ActivityFeed>(parameters, callback);
@@ -911,7 +913,10 @@ export namespace plus_v1 {
 
 
   export class Resource$Comments {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -965,7 +970,7 @@ export namespace plus_v1 {
         params,
         requiredParams: ['commentId'],
         pathParams: ['commentId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Comment>(parameters, callback);
@@ -1033,7 +1038,7 @@ export namespace plus_v1 {
         params,
         requiredParams: ['activityId'],
         pathParams: ['activityId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$CommentFeed>(parameters, callback);
@@ -1084,7 +1089,10 @@ export namespace plus_v1 {
 
 
   export class Resource$People {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1140,7 +1148,7 @@ export namespace plus_v1 {
         params,
         requiredParams: ['userId'],
         pathParams: ['userId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Person>(parameters, callback);
@@ -1209,7 +1217,7 @@ export namespace plus_v1 {
         params,
         requiredParams: ['userId', 'collection'],
         pathParams: ['collection', 'userId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$PeopleFeed>(parameters, callback);
@@ -1281,7 +1289,7 @@ export namespace plus_v1 {
         params,
         requiredParams: ['activityId', 'collection'],
         pathParams: ['activityId', 'collection'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$PeopleFeed>(parameters, callback);
@@ -1348,7 +1356,7 @@ export namespace plus_v1 {
         params,
         requiredParams: ['query'],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$PeopleFeed>(parameters, callback);

--- a/src/apis/plusDomains/v1.ts
+++ b/src/apis/plusDomains/v1.ts
@@ -29,8 +29,6 @@ export namespace plusDomains_v1 {
     version: 'v1';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * Data format for the response.
@@ -81,6 +79,7 @@ export namespace plusDomains_v1 {
    * @param {object=} options Options for Plusdomains
    */
   export class Plusdomains {
+    context: APIRequestContext;
     activities: Resource$Activities;
     audiences: Resource$Audiences;
     circles: Resource$Circles;
@@ -89,14 +88,14 @@ export namespace plusDomains_v1 {
     people: Resource$People;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.activities = new Resource$Activities();
-      this.audiences = new Resource$Audiences();
-      this.circles = new Resource$Circles();
-      this.comments = new Resource$Comments();
-      this.media = new Resource$Media();
-      this.people = new Resource$People();
+      this.activities = new Resource$Activities(this.context);
+      this.audiences = new Resource$Audiences(this.context);
+      this.circles = new Resource$Circles(this.context);
+      this.comments = new Resource$Comments(this.context);
+      this.media = new Resource$Media(this.context);
+      this.people = new Resource$People(this.context);
     }
   }
 
@@ -868,7 +867,10 @@ export namespace plusDomains_v1 {
 
 
   export class Resource$Activities {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -922,7 +924,7 @@ export namespace plusDomains_v1 {
         params,
         requiredParams: ['activityId'],
         pathParams: ['activityId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Activity>(parameters, callback);
@@ -992,7 +994,7 @@ export namespace plusDomains_v1 {
         params,
         requiredParams: ['userId', 'collection'],
         pathParams: ['collection', 'userId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ActivityFeed>(parameters, callback);
@@ -1044,7 +1046,10 @@ export namespace plusDomains_v1 {
 
 
   export class Resource$Audiences {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1104,7 +1109,7 @@ export namespace plusDomains_v1 {
         params,
         requiredParams: ['userId'],
         pathParams: ['userId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AudiencesFeed>(parameters, callback);
@@ -1141,7 +1146,10 @@ export namespace plusDomains_v1 {
 
 
   export class Resource$Circles {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1201,7 +1209,7 @@ export namespace plusDomains_v1 {
         params,
         requiredParams: ['userId'],
         pathParams: ['userId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$CircleFeed>(parameters, callback);
@@ -1238,7 +1246,10 @@ export namespace plusDomains_v1 {
 
 
   export class Resource$Comments {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1292,7 +1303,7 @@ export namespace plusDomains_v1 {
         params,
         requiredParams: ['commentId'],
         pathParams: ['commentId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Comment>(parameters, callback);
@@ -1358,7 +1369,7 @@ export namespace plusDomains_v1 {
         params,
         requiredParams: ['activityId'],
         pathParams: ['activityId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Comment>(parameters, callback);
@@ -1427,7 +1438,7 @@ export namespace plusDomains_v1 {
         params,
         requiredParams: ['activityId'],
         pathParams: ['activityId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$CommentFeed>(parameters, callback);
@@ -1494,7 +1505,10 @@ export namespace plusDomains_v1 {
 
 
   export class Resource$Media {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1563,7 +1577,7 @@ export namespace plusDomains_v1 {
                       .replace(/([^:]\/)\/+/g, '$1'),
         requiredParams: ['userId', 'collection'],
         pathParams: ['collection', 'userId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Media>(parameters, callback);
@@ -1611,7 +1625,10 @@ export namespace plusDomains_v1 {
 
 
   export class Resource$People {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1665,7 +1682,7 @@ export namespace plusDomains_v1 {
         params,
         requiredParams: ['userId'],
         pathParams: ['userId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Person>(parameters, callback);
@@ -1735,7 +1752,7 @@ export namespace plusDomains_v1 {
         params,
         requiredParams: ['userId', 'collection'],
         pathParams: ['collection', 'userId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$PeopleFeed>(parameters, callback);
@@ -1808,7 +1825,7 @@ export namespace plusDomains_v1 {
         params,
         requiredParams: ['activityId', 'collection'],
         pathParams: ['activityId', 'collection'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$PeopleFeed>(parameters, callback);
@@ -1877,7 +1894,7 @@ export namespace plusDomains_v1 {
         params,
         requiredParams: ['circleId'],
         pathParams: ['circleId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$PeopleFeed>(parameters, callback);

--- a/src/apis/poly/v1.ts
+++ b/src/apis/poly/v1.ts
@@ -29,8 +29,6 @@ export namespace poly_v1 {
     version: 'v1';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * V1 error format.
@@ -102,14 +100,15 @@ export namespace poly_v1 {
    * @param {object=} options Options for Poly
    */
   export class Poly {
+    context: APIRequestContext;
     assets: Resource$Assets;
     users: Resource$Users;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.assets = new Resource$Assets();
-      this.users = new Resource$Users();
+      this.assets = new Resource$Assets(this.context);
+      this.users = new Resource$Users(this.context);
     }
   }
 
@@ -486,7 +485,10 @@ export namespace poly_v1 {
 
 
   export class Resource$Assets {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -541,7 +543,7 @@ export namespace poly_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Asset>(parameters, callback);
@@ -613,7 +615,7 @@ export namespace poly_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListAssetsResponse>(parameters, callback);
@@ -688,17 +690,22 @@ export namespace poly_v1 {
 
 
   export class Resource$Users {
+    context: APIRequestContext;
     assets: Resource$Users$Assets;
     likedassets: Resource$Users$Likedassets;
-    constructor() {
-      this.assets = new Resource$Users$Assets();
-      this.likedassets = new Resource$Users$Likedassets();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.assets = new Resource$Users$Assets(this.context);
+      this.likedassets = new Resource$Users$Likedassets(this.context);
     }
   }
 
 
   export class Resource$Users$Assets {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -766,7 +773,7 @@ export namespace poly_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListUserAssetsResponse>(parameters, callback);
@@ -820,7 +827,10 @@ export namespace poly_v1 {
 
 
   export class Resource$Users$Likedassets {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -887,7 +897,7 @@ export namespace poly_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListLikedAssetsResponse>(parameters, callback);

--- a/src/apis/proximitybeacon/v1beta1.ts
+++ b/src/apis/proximitybeacon/v1beta1.ts
@@ -29,8 +29,6 @@ export namespace proximitybeacon_v1beta1 {
     version: 'v1beta1';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * V1 error format.
@@ -98,18 +96,19 @@ export namespace proximitybeacon_v1beta1 {
    * @param {object=} options Options for Proximitybeacon
    */
   export class Proximitybeacon {
+    context: APIRequestContext;
     beaconinfo: Resource$Beaconinfo;
     beacons: Resource$Beacons;
     namespaces: Resource$Namespaces;
     v1beta1: Resource$V1beta1;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.beaconinfo = new Resource$Beaconinfo();
-      this.beacons = new Resource$Beacons();
-      this.namespaces = new Resource$Namespaces();
-      this.v1beta1 = new Resource$V1beta1();
+      this.beaconinfo = new Resource$Beaconinfo(this.context);
+      this.beacons = new Resource$Beacons(this.context);
+      this.namespaces = new Resource$Namespaces(this.context);
+      this.v1beta1 = new Resource$V1beta1(this.context);
     }
   }
 
@@ -613,7 +612,10 @@ export namespace proximitybeacon_v1beta1 {
 
 
   export class Resource$Beaconinfo {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -688,7 +690,7 @@ export namespace proximitybeacon_v1beta1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GetInfoForObservedBeaconsResponse>(
@@ -716,11 +718,13 @@ export namespace proximitybeacon_v1beta1 {
 
 
   export class Resource$Beacons {
+    context: APIRequestContext;
     attachments: Resource$Beacons$Attachments;
     diagnostics: Resource$Beacons$Diagnostics;
-    constructor() {
-      this.attachments = new Resource$Beacons$Attachments();
-      this.diagnostics = new Resource$Beacons$Diagnostics();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.attachments = new Resource$Beacons$Attachments(this.context);
+      this.diagnostics = new Resource$Beacons$Diagnostics(this.context);
     }
 
 
@@ -787,7 +791,7 @@ export namespace proximitybeacon_v1beta1 {
         params,
         requiredParams: ['beaconName'],
         pathParams: ['beaconName'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -862,7 +866,7 @@ export namespace proximitybeacon_v1beta1 {
         params,
         requiredParams: ['beaconName'],
         pathParams: ['beaconName'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -936,7 +940,7 @@ export namespace proximitybeacon_v1beta1 {
         params,
         requiredParams: ['beaconName'],
         pathParams: ['beaconName'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -1008,7 +1012,7 @@ export namespace proximitybeacon_v1beta1 {
         params,
         requiredParams: ['beaconName'],
         pathParams: ['beaconName'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -1080,7 +1084,7 @@ export namespace proximitybeacon_v1beta1 {
         params,
         requiredParams: ['beaconName'],
         pathParams: ['beaconName'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Beacon>(parameters, callback);
@@ -1153,7 +1157,7 @@ export namespace proximitybeacon_v1beta1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListBeaconsResponse>(parameters, callback);
@@ -1225,7 +1229,7 @@ export namespace proximitybeacon_v1beta1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Beacon>(parameters, callback);
@@ -1301,7 +1305,7 @@ export namespace proximitybeacon_v1beta1 {
         params,
         requiredParams: ['beaconName'],
         pathParams: ['beaconName'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Beacon>(parameters, callback);
@@ -1543,7 +1547,10 @@ export namespace proximitybeacon_v1beta1 {
   }
 
   export class Resource$Beacons$Attachments {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1617,7 +1624,7 @@ export namespace proximitybeacon_v1beta1 {
         params,
         requiredParams: ['beaconName'],
         pathParams: ['beaconName'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$DeleteAttachmentsResponse>(
@@ -1698,7 +1705,7 @@ export namespace proximitybeacon_v1beta1 {
         params,
         requiredParams: ['beaconName'],
         pathParams: ['beaconName'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$BeaconAttachment>(parameters, callback);
@@ -1773,7 +1780,7 @@ export namespace proximitybeacon_v1beta1 {
         params,
         requiredParams: ['attachmentName'],
         pathParams: ['attachmentName'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -1856,7 +1863,7 @@ export namespace proximitybeacon_v1beta1 {
         params,
         requiredParams: ['beaconName'],
         pathParams: ['beaconName'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListBeaconAttachmentsResponse>(
@@ -1982,7 +1989,10 @@ export namespace proximitybeacon_v1beta1 {
 
 
   export class Resource$Beacons$Diagnostics {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -2054,7 +2064,7 @@ export namespace proximitybeacon_v1beta1 {
         params,
         requiredParams: ['beaconName'],
         pathParams: ['beaconName'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListDiagnosticsResponse>(parameters, callback);
@@ -2101,7 +2111,10 @@ export namespace proximitybeacon_v1beta1 {
 
 
   export class Resource$Namespaces {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -2167,7 +2180,7 @@ export namespace proximitybeacon_v1beta1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListNamespacesResponse>(parameters, callback);
@@ -2237,7 +2250,7 @@ export namespace proximitybeacon_v1beta1 {
         params,
         requiredParams: ['namespaceName'],
         pathParams: ['namespaceName'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Namespace>(parameters, callback);
@@ -2285,7 +2298,10 @@ export namespace proximitybeacon_v1beta1 {
 
 
   export class Resource$V1beta1 {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -2356,7 +2372,7 @@ export namespace proximitybeacon_v1beta1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$EphemeralIdRegistrationParams>(

--- a/src/apis/pubsub/v1.ts
+++ b/src/apis/pubsub/v1.ts
@@ -29,8 +29,6 @@ export namespace pubsub_v1 {
     version: 'v1';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * V1 error format.
@@ -99,12 +97,13 @@ export namespace pubsub_v1 {
    * @param {object=} options Options for Pubsub
    */
   export class Pubsub {
+    context: APIRequestContext;
     projects: Resource$Projects;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.projects = new Resource$Projects();
+      this.projects = new Resource$Projects(this.context);
     }
   }
 
@@ -775,19 +774,24 @@ export namespace pubsub_v1 {
 
 
   export class Resource$Projects {
+    context: APIRequestContext;
     snapshots: Resource$Projects$Snapshots;
     subscriptions: Resource$Projects$Subscriptions;
     topics: Resource$Projects$Topics;
-    constructor() {
-      this.snapshots = new Resource$Projects$Snapshots();
-      this.subscriptions = new Resource$Projects$Subscriptions();
-      this.topics = new Resource$Projects$Topics();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.snapshots = new Resource$Projects$Snapshots(this.context);
+      this.subscriptions = new Resource$Projects$Subscriptions(this.context);
+      this.topics = new Resource$Projects$Topics(this.context);
     }
   }
 
 
   export class Resource$Projects$Snapshots {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -861,7 +865,7 @@ export namespace pubsub_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Snapshot>(parameters, callback);
@@ -935,7 +939,7 @@ export namespace pubsub_v1 {
         params,
         requiredParams: ['snapshot'],
         pathParams: ['snapshot'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -1000,7 +1004,7 @@ export namespace pubsub_v1 {
         params,
         requiredParams: ['snapshot'],
         pathParams: ['snapshot'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Snapshot>(parameters, callback);
@@ -1120,7 +1124,7 @@ export namespace pubsub_v1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -1194,7 +1198,7 @@ export namespace pubsub_v1 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListSnapshotsResponse>(parameters, callback);
@@ -1264,7 +1268,7 @@ export namespace pubsub_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Snapshot>(parameters, callback);
@@ -1389,7 +1393,7 @@ export namespace pubsub_v1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -1526,7 +1530,7 @@ export namespace pubsub_v1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TestIamPermissionsResponse>(
@@ -1677,7 +1681,10 @@ export namespace pubsub_v1 {
 
 
   export class Resource$Projects$Subscriptions {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1797,7 +1804,7 @@ export namespace pubsub_v1 {
         params,
         requiredParams: ['subscription'],
         pathParams: ['subscription'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -1942,7 +1949,7 @@ export namespace pubsub_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Subscription>(parameters, callback);
@@ -2064,7 +2071,7 @@ export namespace pubsub_v1 {
         params,
         requiredParams: ['subscription'],
         pathParams: ['subscription'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -2182,7 +2189,7 @@ export namespace pubsub_v1 {
         params,
         requiredParams: ['subscription'],
         pathParams: ['subscription'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Subscription>(parameters, callback);
@@ -2302,7 +2309,7 @@ export namespace pubsub_v1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -2442,7 +2449,7 @@ export namespace pubsub_v1 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListSubscriptionsResponse>(
@@ -2569,7 +2576,7 @@ export namespace pubsub_v1 {
         params,
         requiredParams: ['subscription'],
         pathParams: ['subscription'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -2697,7 +2704,7 @@ export namespace pubsub_v1 {
         params,
         requiredParams: ['subscription'],
         pathParams: ['subscription'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -2765,7 +2772,7 @@ export namespace pubsub_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Subscription>(parameters, callback);
@@ -2894,7 +2901,7 @@ export namespace pubsub_v1 {
         params,
         requiredParams: ['subscription'],
         pathParams: ['subscription'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$PullResponse>(parameters, callback);
@@ -2968,7 +2975,7 @@ export namespace pubsub_v1 {
         params,
         requiredParams: ['subscription'],
         pathParams: ['subscription'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$SeekResponse>(parameters, callback);
@@ -3093,7 +3100,7 @@ export namespace pubsub_v1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -3231,7 +3238,7 @@ export namespace pubsub_v1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TestIamPermissionsResponse>(
@@ -3476,11 +3483,14 @@ export namespace pubsub_v1 {
 
 
   export class Resource$Projects$Topics {
+    context: APIRequestContext;
     snapshots: Resource$Projects$Topics$Snapshots;
     subscriptions: Resource$Projects$Topics$Subscriptions;
-    constructor() {
-      this.snapshots = new Resource$Projects$Topics$Snapshots();
-      this.subscriptions = new Resource$Projects$Topics$Subscriptions();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.snapshots = new Resource$Projects$Topics$Snapshots(this.context);
+      this.subscriptions =
+          new Resource$Projects$Topics$Subscriptions(this.context);
     }
 
 
@@ -3611,7 +3621,7 @@ export namespace pubsub_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Topic>(parameters, callback);
@@ -3733,7 +3743,7 @@ export namespace pubsub_v1 {
         params,
         requiredParams: ['topic'],
         pathParams: ['topic'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -3849,7 +3859,7 @@ export namespace pubsub_v1 {
         params,
         requiredParams: ['topic'],
         pathParams: ['topic'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Topic>(parameters, callback);
@@ -3971,7 +3981,7 @@ export namespace pubsub_v1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -4107,7 +4117,7 @@ export namespace pubsub_v1 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListTopicsResponse>(parameters, callback);
@@ -4174,7 +4184,7 @@ export namespace pubsub_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Topic>(parameters, callback);
@@ -4302,7 +4312,7 @@ export namespace pubsub_v1 {
         params,
         requiredParams: ['topic'],
         pathParams: ['topic'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$PublishResponse>(parameters, callback);
@@ -4429,7 +4439,7 @@ export namespace pubsub_v1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -4565,7 +4575,7 @@ export namespace pubsub_v1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TestIamPermissionsResponse>(
@@ -4738,7 +4748,10 @@ export namespace pubsub_v1 {
   }
 
   export class Resource$Projects$Topics$Snapshots {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -4810,7 +4823,7 @@ export namespace pubsub_v1 {
         params,
         requiredParams: ['topic'],
         pathParams: ['topic'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListTopicSnapshotsResponse>(
@@ -4847,7 +4860,10 @@ export namespace pubsub_v1 {
 
 
   export class Resource$Projects$Topics$Subscriptions {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -4983,7 +4999,7 @@ export namespace pubsub_v1 {
         params,
         requiredParams: ['topic'],
         pathParams: ['topic'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListTopicSubscriptionsResponse>(

--- a/src/apis/pubsub/v1beta1a.ts
+++ b/src/apis/pubsub/v1beta1a.ts
@@ -29,8 +29,6 @@ export namespace pubsub_v1beta1a {
     version: 'v1beta1a';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * V1 error format.
@@ -99,14 +97,15 @@ export namespace pubsub_v1beta1a {
    * @param {object=} options Options for Pubsub
    */
   export class Pubsub {
+    context: APIRequestContext;
     subscriptions: Resource$Subscriptions;
     topics: Resource$Topics;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.subscriptions = new Resource$Subscriptions();
-      this.topics = new Resource$Topics();
+      this.subscriptions = new Resource$Subscriptions(this.context);
+      this.topics = new Resource$Topics(this.context);
     }
   }
 
@@ -446,7 +445,10 @@ export namespace pubsub_v1beta1a {
 
 
   export class Resource$Subscriptions {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -509,7 +511,7 @@ export namespace pubsub_v1beta1a {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -580,7 +582,7 @@ export namespace pubsub_v1beta1a {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Subscription>(parameters, callback);
@@ -648,7 +650,7 @@ export namespace pubsub_v1beta1a {
         params,
         requiredParams: ['subscription'],
         pathParams: ['subscription'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -711,7 +713,7 @@ export namespace pubsub_v1beta1a {
         params,
         requiredParams: ['subscription'],
         pathParams: ['subscription'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Subscription>(parameters, callback);
@@ -781,7 +783,7 @@ export namespace pubsub_v1beta1a {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListSubscriptionsResponse>(
@@ -849,7 +851,7 @@ export namespace pubsub_v1beta1a {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -919,7 +921,7 @@ export namespace pubsub_v1beta1a {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -989,7 +991,7 @@ export namespace pubsub_v1beta1a {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$PullResponse>(parameters, callback);
@@ -1059,7 +1061,7 @@ export namespace pubsub_v1beta1a {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$PullBatchResponse>(parameters, callback);
@@ -1195,7 +1197,10 @@ export namespace pubsub_v1beta1a {
 
 
   export class Resource$Topics {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1251,7 +1256,7 @@ export namespace pubsub_v1beta1a {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Topic>(parameters, callback);
@@ -1317,7 +1322,7 @@ export namespace pubsub_v1beta1a {
         params,
         requiredParams: ['topic'],
         pathParams: ['topic'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -1381,7 +1386,7 @@ export namespace pubsub_v1beta1a {
         params,
         requiredParams: ['topic'],
         pathParams: ['topic'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Topic>(parameters, callback);
@@ -1447,7 +1452,7 @@ export namespace pubsub_v1beta1a {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListTopicsResponse>(parameters, callback);
@@ -1512,7 +1517,7 @@ export namespace pubsub_v1beta1a {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -1582,7 +1587,7 @@ export namespace pubsub_v1beta1a {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$PublishBatchResponse>(parameters, callback);

--- a/src/apis/pubsub/v1beta2.ts
+++ b/src/apis/pubsub/v1beta2.ts
@@ -29,8 +29,6 @@ export namespace pubsub_v1beta2 {
     version: 'v1beta2';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * V1 error format.
@@ -99,12 +97,13 @@ export namespace pubsub_v1beta2 {
    * @param {object=} options Options for Pubsub
    */
   export class Pubsub {
+    context: APIRequestContext;
     projects: Resource$Projects;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.projects = new Resource$Projects();
+      this.projects = new Resource$Projects(this.context);
     }
   }
 
@@ -551,17 +550,22 @@ export namespace pubsub_v1beta2 {
 
 
   export class Resource$Projects {
+    context: APIRequestContext;
     subscriptions: Resource$Projects$Subscriptions;
     topics: Resource$Projects$Topics;
-    constructor() {
-      this.subscriptions = new Resource$Projects$Subscriptions();
-      this.topics = new Resource$Projects$Topics();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.subscriptions = new Resource$Projects$Subscriptions(this.context);
+      this.topics = new Resource$Projects$Topics(this.context);
     }
   }
 
 
   export class Resource$Projects$Subscriptions {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -625,7 +629,7 @@ export namespace pubsub_v1beta2 {
         params,
         requiredParams: ['subscription'],
         pathParams: ['subscription'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -697,7 +701,7 @@ export namespace pubsub_v1beta2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Subscription>(parameters, callback);
@@ -767,7 +771,7 @@ export namespace pubsub_v1beta2 {
         params,
         requiredParams: ['subscription'],
         pathParams: ['subscription'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -830,7 +834,7 @@ export namespace pubsub_v1beta2 {
         params,
         requiredParams: ['subscription'],
         pathParams: ['subscription'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Subscription>(parameters, callback);
@@ -897,7 +901,7 @@ export namespace pubsub_v1beta2 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -969,7 +973,7 @@ export namespace pubsub_v1beta2 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListSubscriptionsResponse>(
@@ -1042,7 +1046,7 @@ export namespace pubsub_v1beta2 {
         params,
         requiredParams: ['subscription'],
         pathParams: ['subscription'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -1114,7 +1118,7 @@ export namespace pubsub_v1beta2 {
         params,
         requiredParams: ['subscription'],
         pathParams: ['subscription'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -1185,7 +1189,7 @@ export namespace pubsub_v1beta2 {
         params,
         requiredParams: ['subscription'],
         pathParams: ['subscription'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$PullResponse>(parameters, callback);
@@ -1253,7 +1257,7 @@ export namespace pubsub_v1beta2 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -1333,7 +1337,7 @@ export namespace pubsub_v1beta2 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TestIamPermissionsResponse>(
@@ -1532,9 +1536,12 @@ export namespace pubsub_v1beta2 {
 
 
   export class Resource$Projects$Topics {
+    context: APIRequestContext;
     subscriptions: Resource$Projects$Topics$Subscriptions;
-    constructor() {
-      this.subscriptions = new Resource$Projects$Topics$Subscriptions();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.subscriptions =
+          new Resource$Projects$Topics$Subscriptions(this.context);
     }
 
 
@@ -1594,7 +1601,7 @@ export namespace pubsub_v1beta2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Topic>(parameters, callback);
@@ -1665,7 +1672,7 @@ export namespace pubsub_v1beta2 {
         params,
         requiredParams: ['topic'],
         pathParams: ['topic'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -1727,7 +1734,7 @@ export namespace pubsub_v1beta2 {
         params,
         requiredParams: ['topic'],
         pathParams: ['topic'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Topic>(parameters, callback);
@@ -1794,7 +1801,7 @@ export namespace pubsub_v1beta2 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -1863,7 +1870,7 @@ export namespace pubsub_v1beta2 {
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListTopicsResponse>(parameters, callback);
@@ -1933,7 +1940,7 @@ export namespace pubsub_v1beta2 {
         params,
         requiredParams: ['topic'],
         pathParams: ['topic'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$PublishResponse>(parameters, callback);
@@ -2001,7 +2008,7 @@ export namespace pubsub_v1beta2 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -2079,7 +2086,7 @@ export namespace pubsub_v1beta2 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TestIamPermissionsResponse>(
@@ -2226,7 +2233,10 @@ export namespace pubsub_v1beta2 {
   }
 
   export class Resource$Projects$Topics$Subscriptions {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -2293,7 +2303,7 @@ export namespace pubsub_v1beta2 {
         params,
         requiredParams: ['topic'],
         pathParams: ['topic'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListTopicSubscriptionsResponse>(

--- a/src/apis/redis/v1.ts
+++ b/src/apis/redis/v1.ts
@@ -29,8 +29,6 @@ export namespace redis_v1 {
     version: 'v1';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * V1 error format.
@@ -98,12 +96,13 @@ export namespace redis_v1 {
    * @param {object=} options Options for Redis
    */
   export class Redis {
+    context: APIRequestContext;
     projects: Resource$Projects;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.projects = new Resource$Projects();
+      this.projects = new Resource$Projects(this.context);
     }
   }
 
@@ -465,19 +464,24 @@ export namespace redis_v1 {
 
 
   export class Resource$Projects {
+    context: APIRequestContext;
     locations: Resource$Projects$Locations;
-    constructor() {
-      this.locations = new Resource$Projects$Locations();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.locations = new Resource$Projects$Locations(this.context);
     }
   }
 
 
   export class Resource$Projects$Locations {
+    context: APIRequestContext;
     instances: Resource$Projects$Locations$Instances;
     operations: Resource$Projects$Locations$Operations;
-    constructor() {
-      this.instances = new Resource$Projects$Locations$Instances();
-      this.operations = new Resource$Projects$Locations$Operations();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.instances = new Resource$Projects$Locations$Instances(this.context);
+      this.operations =
+          new Resource$Projects$Locations$Operations(this.context);
     }
 
 
@@ -532,7 +536,7 @@ export namespace redis_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Location>(parameters, callback);
@@ -603,7 +607,7 @@ export namespace redis_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListLocationsResponse>(parameters, callback);
@@ -651,7 +655,10 @@ export namespace redis_v1 {
   }
 
   export class Resource$Projects$Locations$Instances {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -721,7 +728,7 @@ export namespace redis_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -788,7 +795,7 @@ export namespace redis_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -858,7 +865,7 @@ export namespace redis_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -919,7 +926,7 @@ export namespace redis_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Instance>(parameters, callback);
@@ -993,7 +1000,7 @@ export namespace redis_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListInstancesResponse>(parameters, callback);
@@ -1064,7 +1071,7 @@ export namespace redis_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -1208,7 +1215,10 @@ export namespace redis_v1 {
 
 
   export class Resource$Projects$Locations$Operations {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1275,7 +1285,7 @@ export namespace redis_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -1343,7 +1353,7 @@ export namespace redis_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -1407,7 +1417,7 @@ export namespace redis_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -1486,7 +1496,7 @@ export namespace redis_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListOperationsResponse>(parameters, callback);

--- a/src/apis/redis/v1beta1.ts
+++ b/src/apis/redis/v1beta1.ts
@@ -29,8 +29,6 @@ export namespace redis_v1beta1 {
     version: 'v1beta1';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * V1 error format.
@@ -98,12 +96,13 @@ export namespace redis_v1beta1 {
    * @param {object=} options Options for Redis
    */
   export class Redis {
+    context: APIRequestContext;
     projects: Resource$Projects;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.projects = new Resource$Projects();
+      this.projects = new Resource$Projects(this.context);
     }
   }
 
@@ -462,19 +461,24 @@ export namespace redis_v1beta1 {
 
 
   export class Resource$Projects {
+    context: APIRequestContext;
     locations: Resource$Projects$Locations;
-    constructor() {
-      this.locations = new Resource$Projects$Locations();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.locations = new Resource$Projects$Locations(this.context);
     }
   }
 
 
   export class Resource$Projects$Locations {
+    context: APIRequestContext;
     instances: Resource$Projects$Locations$Instances;
     operations: Resource$Projects$Locations$Operations;
-    constructor() {
-      this.instances = new Resource$Projects$Locations$Instances();
-      this.operations = new Resource$Projects$Locations$Operations();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.instances = new Resource$Projects$Locations$Instances(this.context);
+      this.operations =
+          new Resource$Projects$Locations$Operations(this.context);
     }
 
 
@@ -529,7 +533,7 @@ export namespace redis_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Location>(parameters, callback);
@@ -600,7 +604,7 @@ export namespace redis_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListLocationsResponse>(parameters, callback);
@@ -648,7 +652,10 @@ export namespace redis_v1beta1 {
   }
 
   export class Resource$Projects$Locations$Instances {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -718,7 +725,7 @@ export namespace redis_v1beta1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -785,7 +792,7 @@ export namespace redis_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -846,7 +853,7 @@ export namespace redis_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Instance>(parameters, callback);
@@ -920,7 +927,7 @@ export namespace redis_v1beta1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListInstancesResponse>(parameters, callback);
@@ -991,7 +998,7 @@ export namespace redis_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -1116,7 +1123,10 @@ export namespace redis_v1beta1 {
 
 
   export class Resource$Projects$Locations$Operations {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1183,7 +1193,7 @@ export namespace redis_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -1251,7 +1261,7 @@ export namespace redis_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -1315,7 +1325,7 @@ export namespace redis_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -1394,7 +1404,7 @@ export namespace redis_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListOperationsResponse>(parameters, callback);

--- a/src/apis/remotebuildexecution/v1.ts
+++ b/src/apis/remotebuildexecution/v1.ts
@@ -29,8 +29,6 @@ export namespace remotebuildexecution_v1 {
     version: 'v1';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * V1 error format.
@@ -98,18 +96,19 @@ export namespace remotebuildexecution_v1 {
    * @param {object=} options Options for Remotebuildexecution
    */
   export class Remotebuildexecution {
+    context: APIRequestContext;
     media: Resource$Media;
     operations: Resource$Operations;
     projects: Resource$Projects;
     v1: Resource$V1;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.media = new Resource$Media();
-      this.operations = new Resource$Operations();
-      this.projects = new Resource$Projects();
-      this.v1 = new Resource$V1();
+      this.media = new Resource$Media(this.context);
+      this.operations = new Resource$Operations(this.context);
+      this.projects = new Resource$Projects(this.context);
+      this.v1 = new Resource$V1(this.context);
     }
   }
 
@@ -1980,7 +1979,10 @@ export namespace remotebuildexecution_v1 {
 
 
   export class Resource$Media {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -2042,7 +2044,7 @@ export namespace remotebuildexecution_v1 {
         params,
         requiredParams: ['resourceName'],
         pathParams: ['resourceName'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleBytestreamMedia>(parameters, callback);
@@ -2116,7 +2118,7 @@ export namespace remotebuildexecution_v1 {
                       .replace(/([^:]\/)\/+/g, '$1'),
         requiredParams: ['resourceName'],
         pathParams: ['resourceName'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleBytestreamMedia>(parameters, callback);
@@ -2173,7 +2175,10 @@ export namespace remotebuildexecution_v1 {
 
 
   export class Resource$Operations {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -2242,7 +2247,7 @@ export namespace remotebuildexecution_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleProtobufEmpty>(parameters, callback);
@@ -2311,7 +2316,7 @@ export namespace remotebuildexecution_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleProtobufEmpty>(parameters, callback);
@@ -2392,7 +2397,7 @@ export namespace remotebuildexecution_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleLongrunningListOperationsResponse>(
@@ -2459,15 +2464,20 @@ export namespace remotebuildexecution_v1 {
 
 
   export class Resource$Projects {
+    context: APIRequestContext;
     operations: Resource$Projects$Operations;
-    constructor() {
-      this.operations = new Resource$Projects$Operations();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.operations = new Resource$Projects$Operations(this.context);
     }
   }
 
 
   export class Resource$Projects$Operations {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -2530,7 +2540,7 @@ export namespace remotebuildexecution_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleLongrunningOperation>(
@@ -2557,7 +2567,10 @@ export namespace remotebuildexecution_v1 {
 
 
   export class Resource$V1 {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -2620,7 +2633,7 @@ export namespace remotebuildexecution_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleWatcherV1ChangeBatch>(

--- a/src/apis/remotebuildexecution/v1alpha.ts
+++ b/src/apis/remotebuildexecution/v1alpha.ts
@@ -29,8 +29,6 @@ export namespace remotebuildexecution_v1alpha {
     version: 'v1alpha';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * V1 error format.
@@ -98,12 +96,13 @@ export namespace remotebuildexecution_v1alpha {
    * @param {object=} options Options for Remotebuildexecution
    */
   export class Remotebuildexecution {
+    context: APIRequestContext;
     projects: Resource$Projects;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.projects = new Resource$Projects();
+      this.projects = new Resource$Projects(this.context);
     }
   }
 
@@ -1897,19 +1896,24 @@ export namespace remotebuildexecution_v1alpha {
 
 
   export class Resource$Projects {
+    context: APIRequestContext;
     instances: Resource$Projects$Instances;
     operations: Resource$Projects$Operations;
-    constructor() {
-      this.instances = new Resource$Projects$Instances();
-      this.operations = new Resource$Projects$Operations();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.instances = new Resource$Projects$Instances(this.context);
+      this.operations = new Resource$Projects$Operations(this.context);
     }
   }
 
 
   export class Resource$Projects$Instances {
+    context: APIRequestContext;
     workerpools: Resource$Projects$Instances$Workerpools;
-    constructor() {
-      this.workerpools = new Resource$Projects$Instances$Workerpools();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.workerpools =
+          new Resource$Projects$Instances$Workerpools(this.context);
     }
 
 
@@ -1980,7 +1984,7 @@ export namespace remotebuildexecution_v1alpha {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleLongrunningOperation>(
@@ -2055,7 +2059,7 @@ export namespace remotebuildexecution_v1alpha {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleLongrunningOperation>(
@@ -2130,7 +2134,7 @@ export namespace remotebuildexecution_v1alpha {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<
@@ -2214,7 +2218,7 @@ export namespace remotebuildexecution_v1alpha {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<
@@ -2287,7 +2291,10 @@ export namespace remotebuildexecution_v1alpha {
   }
 
   export class Resource$Projects$Instances$Workerpools {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -2358,7 +2365,7 @@ export namespace remotebuildexecution_v1alpha {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleLongrunningOperation>(
@@ -2435,7 +2442,7 @@ export namespace remotebuildexecution_v1alpha {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleLongrunningOperation>(
@@ -2510,7 +2517,7 @@ export namespace remotebuildexecution_v1alpha {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<
@@ -2594,7 +2601,7 @@ export namespace remotebuildexecution_v1alpha {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<
@@ -2674,7 +2681,7 @@ export namespace remotebuildexecution_v1alpha {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleLongrunningOperation>(
@@ -2768,7 +2775,10 @@ export namespace remotebuildexecution_v1alpha {
 
 
   export class Resource$Projects$Operations {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -2831,7 +2841,7 @@ export namespace remotebuildexecution_v1alpha {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleLongrunningOperation>(

--- a/src/apis/remotebuildexecution/v2.ts
+++ b/src/apis/remotebuildexecution/v2.ts
@@ -29,8 +29,6 @@ export namespace remotebuildexecution_v2 {
     version: 'v2';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * V1 error format.
@@ -98,6 +96,7 @@ export namespace remotebuildexecution_v2 {
    * @param {object=} options Options for Remotebuildexecution
    */
   export class Remotebuildexecution {
+    context: APIRequestContext;
     actionResults: Resource$Actionresults;
     actions: Resource$Actions;
     blobs: Resource$Blobs;
@@ -105,13 +104,13 @@ export namespace remotebuildexecution_v2 {
     v2: Resource$V2;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.actionResults = new Resource$Actionresults();
-      this.actions = new Resource$Actions();
-      this.blobs = new Resource$Blobs();
-      this.operations = new Resource$Operations();
-      this.v2 = new Resource$V2();
+      this.actionResults = new Resource$Actionresults(this.context);
+      this.actions = new Resource$Actions(this.context);
+      this.blobs = new Resource$Blobs(this.context);
+      this.operations = new Resource$Operations(this.context);
+      this.v2 = new Resource$V2(this.context);
     }
   }
 
@@ -2202,7 +2201,10 @@ export namespace remotebuildexecution_v2 {
 
 
   export class Resource$Actionresults {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -2268,7 +2270,7 @@ export namespace remotebuildexecution_v2 {
         params,
         requiredParams: ['instanceName', 'hash', 'sizeBytes'],
         pathParams: ['hash', 'instanceName', 'sizeBytes'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$BuildBazelRemoteExecutionV2ActionResult>(
@@ -2355,7 +2357,7 @@ export namespace remotebuildexecution_v2 {
         params,
         requiredParams: ['instanceName', 'hash', 'sizeBytes'],
         pathParams: ['hash', 'instanceName', 'sizeBytes'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$BuildBazelRemoteExecutionV2ActionResult>(
@@ -2435,7 +2437,10 @@ export namespace remotebuildexecution_v2 {
 
 
   export class Resource$Actions {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -2540,7 +2545,7 @@ export namespace remotebuildexecution_v2 {
         params,
         requiredParams: ['instanceName'],
         pathParams: ['instanceName'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleLongrunningOperation>(
@@ -2574,7 +2579,10 @@ export namespace remotebuildexecution_v2 {
 
 
   export class Resource$Blobs {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -2650,7 +2658,7 @@ export namespace remotebuildexecution_v2 {
         params,
         requiredParams: ['instanceName'],
         pathParams: ['instanceName'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<
@@ -2743,7 +2751,7 @@ export namespace remotebuildexecution_v2 {
         params,
         requiredParams: ['instanceName'],
         pathParams: ['instanceName'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<
@@ -2828,7 +2836,7 @@ export namespace remotebuildexecution_v2 {
         params,
         requiredParams: ['instanceName'],
         pathParams: ['instanceName'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<
@@ -2920,7 +2928,7 @@ export namespace remotebuildexecution_v2 {
         params,
         requiredParams: ['instanceName', 'hash', 'sizeBytes'],
         pathParams: ['hash', 'instanceName', 'sizeBytes'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$BuildBazelRemoteExecutionV2GetTreeResponse>(
@@ -3035,7 +3043,10 @@ export namespace remotebuildexecution_v2 {
 
 
   export class Resource$Operations {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -3109,7 +3120,7 @@ export namespace remotebuildexecution_v2 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleLongrunningOperation>(
@@ -3140,7 +3151,10 @@ export namespace remotebuildexecution_v2 {
 
 
   export class Resource$V2 {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -3208,7 +3222,7 @@ export namespace remotebuildexecution_v2 {
         params,
         requiredParams: ['instanceName'],
         pathParams: ['instanceName'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$BuildBazelRemoteExecutionV2ServerCapabilities>(

--- a/src/apis/replicapool/v1beta1.ts
+++ b/src/apis/replicapool/v1beta1.ts
@@ -29,8 +29,6 @@ export namespace replicapool_v1beta1 {
     version: 'v1beta1';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * Data format for the response.
@@ -82,14 +80,15 @@ export namespace replicapool_v1beta1 {
    * @param {object=} options Options for Replicapool
    */
   export class Replicapool {
+    context: APIRequestContext;
     pools: Resource$Pools;
     replicas: Resource$Replicas;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.pools = new Resource$Pools();
-      this.replicas = new Resource$Replicas();
+      this.pools = new Resource$Pools(this.context);
+      this.replicas = new Resource$Replicas(this.context);
     }
   }
 
@@ -605,7 +604,10 @@ export namespace replicapool_v1beta1 {
 
 
   export class Resource$Pools {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -666,7 +668,7 @@ export namespace replicapool_v1beta1 {
         params,
         requiredParams: ['projectName', 'zone', 'poolName'],
         pathParams: ['poolName', 'projectName', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -731,7 +733,7 @@ export namespace replicapool_v1beta1 {
         params,
         requiredParams: ['projectName', 'zone', 'poolName'],
         pathParams: ['poolName', 'projectName', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Pool>(parameters, callback);
@@ -799,7 +801,7 @@ export namespace replicapool_v1beta1 {
         params,
         requiredParams: ['projectName', 'zone'],
         pathParams: ['projectName', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Pool>(parameters, callback);
@@ -869,7 +871,7 @@ export namespace replicapool_v1beta1 {
         params,
         requiredParams: ['projectName', 'zone'],
         pathParams: ['projectName', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$PoolsListResponse>(parameters, callback);
@@ -940,7 +942,7 @@ export namespace replicapool_v1beta1 {
         params,
         requiredParams: ['projectName', 'zone', 'poolName'],
         pathParams: ['poolName', 'projectName', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Pool>(parameters, callback);
@@ -1010,7 +1012,7 @@ export namespace replicapool_v1beta1 {
         params,
         requiredParams: ['projectName', 'zone', 'poolName'],
         pathParams: ['poolName', 'projectName', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -1161,7 +1163,10 @@ export namespace replicapool_v1beta1 {
 
 
   export class Resource$Replicas {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1224,7 +1229,7 @@ export namespace replicapool_v1beta1 {
         params,
         requiredParams: ['projectName', 'zone', 'poolName', 'replicaName'],
         pathParams: ['poolName', 'projectName', 'replicaName', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Replica>(parameters, callback);
@@ -1290,7 +1295,7 @@ export namespace replicapool_v1beta1 {
         params,
         requiredParams: ['projectName', 'zone', 'poolName', 'replicaName'],
         pathParams: ['poolName', 'projectName', 'replicaName', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Replica>(parameters, callback);
@@ -1362,7 +1367,7 @@ export namespace replicapool_v1beta1 {
         params,
         requiredParams: ['projectName', 'zone', 'poolName'],
         pathParams: ['poolName', 'projectName', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ReplicasListResponse>(parameters, callback);
@@ -1431,7 +1436,7 @@ export namespace replicapool_v1beta1 {
         params,
         requiredParams: ['projectName', 'zone', 'poolName', 'replicaName'],
         pathParams: ['poolName', 'projectName', 'replicaName', 'zone'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Replica>(parameters, callback);

--- a/src/apis/reseller/v1.ts
+++ b/src/apis/reseller/v1.ts
@@ -29,8 +29,6 @@ export namespace reseller_v1 {
     version: 'v1';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * Data format for the response.
@@ -81,16 +79,17 @@ export namespace reseller_v1 {
    * @param {object=} options Options for Reseller
    */
   export class Reseller {
+    context: APIRequestContext;
     customers: Resource$Customers;
     resellernotify: Resource$Resellernotify;
     subscriptions: Resource$Subscriptions;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.customers = new Resource$Customers();
-      this.resellernotify = new Resource$Resellernotify();
-      this.subscriptions = new Resource$Subscriptions();
+      this.customers = new Resource$Customers(this.context);
+      this.resellernotify = new Resource$Resellernotify(this.context);
+      this.subscriptions = new Resource$Subscriptions(this.context);
     }
   }
 
@@ -461,7 +460,10 @@ export namespace reseller_v1 {
 
 
   export class Resource$Customers {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -515,7 +517,7 @@ export namespace reseller_v1 {
         params,
         requiredParams: ['customerId'],
         pathParams: ['customerId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Customer>(parameters, callback);
@@ -580,7 +582,7 @@ export namespace reseller_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Customer>(parameters, callback);
@@ -646,7 +648,7 @@ export namespace reseller_v1 {
         params,
         requiredParams: ['customerId'],
         pathParams: ['customerId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Customer>(parameters, callback);
@@ -711,7 +713,7 @@ export namespace reseller_v1 {
         params,
         requiredParams: ['customerId'],
         pathParams: ['customerId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Customer>(parameters, callback);
@@ -797,7 +799,10 @@ export namespace reseller_v1 {
 
 
   export class Resource$Resellernotify {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -867,7 +872,7 @@ export namespace reseller_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ResellernotifyGetwatchdetailsResponse>(
@@ -938,7 +943,7 @@ export namespace reseller_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ResellernotifyResource>(parameters, callback);
@@ -1007,7 +1012,7 @@ export namespace reseller_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ResellernotifyResource>(parameters, callback);
@@ -1051,7 +1056,10 @@ export namespace reseller_v1 {
 
 
   export class Resource$Subscriptions {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1114,7 +1122,7 @@ export namespace reseller_v1 {
         params,
         requiredParams: ['customerId', 'subscriptionId'],
         pathParams: ['customerId', 'subscriptionId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Subscription>(parameters, callback);
@@ -1187,7 +1195,7 @@ export namespace reseller_v1 {
         params,
         requiredParams: ['customerId', 'subscriptionId'],
         pathParams: ['customerId', 'subscriptionId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Subscription>(parameters, callback);
@@ -1260,7 +1268,7 @@ export namespace reseller_v1 {
         params,
         requiredParams: ['customerId', 'subscriptionId'],
         pathParams: ['customerId', 'subscriptionId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Subscription>(parameters, callback);
@@ -1331,7 +1339,7 @@ export namespace reseller_v1 {
         params,
         requiredParams: ['customerId', 'subscriptionId'],
         pathParams: ['customerId', 'subscriptionId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Subscription>(parameters, callback);
@@ -1400,7 +1408,7 @@ export namespace reseller_v1 {
         params,
         requiredParams: ['customerId', 'subscriptionId', 'deletionType'],
         pathParams: ['customerId', 'subscriptionId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -1466,7 +1474,7 @@ export namespace reseller_v1 {
         params,
         requiredParams: ['customerId', 'subscriptionId'],
         pathParams: ['customerId', 'subscriptionId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Subscription>(parameters, callback);
@@ -1536,7 +1544,7 @@ export namespace reseller_v1 {
         params,
         requiredParams: ['customerId'],
         pathParams: ['customerId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Subscription>(parameters, callback);
@@ -1608,7 +1616,7 @@ export namespace reseller_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Subscriptions>(parameters, callback);
@@ -1679,7 +1687,7 @@ export namespace reseller_v1 {
         params,
         requiredParams: ['customerId', 'subscriptionId'],
         pathParams: ['customerId', 'subscriptionId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Subscription>(parameters, callback);
@@ -1749,7 +1757,7 @@ export namespace reseller_v1 {
         params,
         requiredParams: ['customerId', 'subscriptionId'],
         pathParams: ['customerId', 'subscriptionId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Subscription>(parameters, callback);

--- a/src/apis/runtimeconfig/v1.ts
+++ b/src/apis/runtimeconfig/v1.ts
@@ -29,8 +29,6 @@ export namespace runtimeconfig_v1 {
     version: 'v1';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * V1 error format.
@@ -101,12 +99,13 @@ export namespace runtimeconfig_v1 {
    * @param {object=} options Options for Runtimeconfig
    */
   export class Runtimeconfig {
+    context: APIRequestContext;
     operations: Resource$Operations;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.operations = new Resource$Operations();
+      this.operations = new Resource$Operations(this.context);
     }
   }
 
@@ -230,7 +229,10 @@ export namespace runtimeconfig_v1 {
 
 
   export class Resource$Operations {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -298,7 +300,7 @@ export namespace runtimeconfig_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -366,7 +368,7 @@ export namespace runtimeconfig_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -443,7 +445,7 @@ export namespace runtimeconfig_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListOperationsResponse>(parameters, callback);

--- a/src/apis/runtimeconfig/v1beta1.ts
+++ b/src/apis/runtimeconfig/v1beta1.ts
@@ -29,8 +29,6 @@ export namespace runtimeconfig_v1beta1 {
     version: 'v1beta1';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * V1 error format.
@@ -101,12 +99,13 @@ export namespace runtimeconfig_v1beta1 {
    * @param {object=} options Options for Runtimeconfig
    */
   export class Runtimeconfig {
+    context: APIRequestContext;
     projects: Resource$Projects;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.projects = new Resource$Projects();
+      this.projects = new Resource$Projects(this.context);
     }
   }
 
@@ -588,21 +587,25 @@ export namespace runtimeconfig_v1beta1 {
 
 
   export class Resource$Projects {
+    context: APIRequestContext;
     configs: Resource$Projects$Configs;
-    constructor() {
-      this.configs = new Resource$Projects$Configs();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.configs = new Resource$Projects$Configs(this.context);
     }
   }
 
 
   export class Resource$Projects$Configs {
+    context: APIRequestContext;
     operations: Resource$Projects$Configs$Operations;
     variables: Resource$Projects$Configs$Variables;
     waiters: Resource$Projects$Configs$Waiters;
-    constructor() {
-      this.operations = new Resource$Projects$Configs$Operations();
-      this.variables = new Resource$Projects$Configs$Variables();
-      this.waiters = new Resource$Projects$Configs$Waiters();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.operations = new Resource$Projects$Configs$Operations(this.context);
+      this.variables = new Resource$Projects$Configs$Variables(this.context);
+      this.waiters = new Resource$Projects$Configs$Waiters(this.context);
     }
 
 
@@ -667,7 +670,7 @@ export namespace runtimeconfig_v1beta1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$RuntimeConfig>(parameters, callback);
@@ -733,7 +736,7 @@ export namespace runtimeconfig_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -796,7 +799,7 @@ export namespace runtimeconfig_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$RuntimeConfig>(parameters, callback);
@@ -864,7 +867,7 @@ export namespace runtimeconfig_v1beta1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -934,7 +937,7 @@ export namespace runtimeconfig_v1beta1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListConfigsResponse>(parameters, callback);
@@ -1003,7 +1006,7 @@ export namespace runtimeconfig_v1beta1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -1082,7 +1085,7 @@ export namespace runtimeconfig_v1beta1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TestIamPermissionsResponse>(
@@ -1152,7 +1155,7 @@ export namespace runtimeconfig_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$RuntimeConfig>(parameters, callback);
@@ -1309,7 +1312,10 @@ export namespace runtimeconfig_v1beta1 {
   }
 
   export class Resource$Projects$Configs$Operations {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1367,7 +1373,7 @@ export namespace runtimeconfig_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -1448,7 +1454,7 @@ export namespace runtimeconfig_v1beta1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TestIamPermissionsResponse>(
@@ -1492,7 +1498,10 @@ export namespace runtimeconfig_v1beta1 {
 
 
   export class Resource$Projects$Configs$Variables {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1559,7 +1568,7 @@ export namespace runtimeconfig_v1beta1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Variable>(parameters, callback);
@@ -1629,7 +1638,7 @@ export namespace runtimeconfig_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -1691,7 +1700,7 @@ export namespace runtimeconfig_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Variable>(parameters, callback);
@@ -1767,7 +1776,7 @@ export namespace runtimeconfig_v1beta1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListVariablesResponse>(parameters, callback);
@@ -1848,7 +1857,7 @@ export namespace runtimeconfig_v1beta1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TestIamPermissionsResponse>(
@@ -1916,7 +1925,7 @@ export namespace runtimeconfig_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Variable>(parameters, callback);
@@ -1993,7 +2002,7 @@ export namespace runtimeconfig_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Variable>(parameters, callback);
@@ -2154,7 +2163,10 @@ export namespace runtimeconfig_v1beta1 {
 
 
   export class Resource$Projects$Configs$Waiters {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -2222,7 +2234,7 @@ export namespace runtimeconfig_v1beta1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -2288,7 +2300,7 @@ export namespace runtimeconfig_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -2350,7 +2362,7 @@ export namespace runtimeconfig_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Waiter>(parameters, callback);
@@ -2420,7 +2432,7 @@ export namespace runtimeconfig_v1beta1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListWaitersResponse>(parameters, callback);
@@ -2501,7 +2513,7 @@ export namespace runtimeconfig_v1beta1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TestIamPermissionsResponse>(

--- a/src/apis/safebrowsing/v4.ts
+++ b/src/apis/safebrowsing/v4.ts
@@ -29,8 +29,6 @@ export namespace safebrowsing_v4 {
     version: 'v4';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * V1 error format.
@@ -99,6 +97,7 @@ export namespace safebrowsing_v4 {
    * @param {object=} options Options for Safebrowsing
    */
   export class Safebrowsing {
+    context: APIRequestContext;
     encodedFullHashes: Resource$Encodedfullhashes;
     encodedUpdates: Resource$Encodedupdates;
     fullHashes: Resource$Fullhashes;
@@ -108,15 +107,15 @@ export namespace safebrowsing_v4 {
     threatMatches: Resource$Threatmatches;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.encodedFullHashes = new Resource$Encodedfullhashes();
-      this.encodedUpdates = new Resource$Encodedupdates();
-      this.fullHashes = new Resource$Fullhashes();
-      this.threatHits = new Resource$Threathits();
-      this.threatLists = new Resource$Threatlists();
-      this.threatListUpdates = new Resource$Threatlistupdates();
-      this.threatMatches = new Resource$Threatmatches();
+      this.encodedFullHashes = new Resource$Encodedfullhashes(this.context);
+      this.encodedUpdates = new Resource$Encodedupdates(this.context);
+      this.fullHashes = new Resource$Fullhashes(this.context);
+      this.threatHits = new Resource$Threathits(this.context);
+      this.threatLists = new Resource$Threatlists(this.context);
+      this.threatListUpdates = new Resource$Threatlistupdates(this.context);
+      this.threatMatches = new Resource$Threatmatches(this.context);
     }
   }
 
@@ -619,7 +618,10 @@ export namespace safebrowsing_v4 {
 
 
   export class Resource$Encodedfullhashes {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -677,7 +679,7 @@ export namespace safebrowsing_v4 {
         params,
         requiredParams: ['encodedRequest'],
         pathParams: ['encodedRequest'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$FindFullHashesResponse>(parameters, callback);
@@ -711,7 +713,10 @@ export namespace safebrowsing_v4 {
 
 
   export class Resource$Encodedupdates {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -772,7 +777,7 @@ export namespace safebrowsing_v4 {
         params,
         requiredParams: ['encodedRequest'],
         pathParams: ['encodedRequest'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$FetchThreatListUpdatesResponse>(
@@ -808,7 +813,10 @@ export namespace safebrowsing_v4 {
 
 
   export class Resource$Fullhashes {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -867,7 +875,7 @@ export namespace safebrowsing_v4 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$FindFullHashesResponse>(parameters, callback);
@@ -892,7 +900,10 @@ export namespace safebrowsing_v4 {
 
 
   export class Resource$Threathits {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -950,7 +961,7 @@ export namespace safebrowsing_v4 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -976,7 +987,10 @@ export namespace safebrowsing_v4 {
 
 
   export class Resource$Threatlists {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1033,7 +1047,7 @@ export namespace safebrowsing_v4 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListThreatListsResponse>(parameters, callback);
@@ -1052,7 +1066,10 @@ export namespace safebrowsing_v4 {
 
 
   export class Resource$Threatlistupdates {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1119,7 +1136,7 @@ export namespace safebrowsing_v4 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$FetchThreatListUpdatesResponse>(
@@ -1147,7 +1164,10 @@ export namespace safebrowsing_v4 {
 
 
   export class Resource$Threatmatches {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1208,7 +1228,7 @@ export namespace safebrowsing_v4 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$FindThreatMatchesResponse>(

--- a/src/apis/script/v1.ts
+++ b/src/apis/script/v1.ts
@@ -29,8 +29,6 @@ export namespace script_v1 {
     version: 'v1';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * V1 error format.
@@ -98,16 +96,17 @@ export namespace script_v1 {
    * @param {object=} options Options for Script
    */
   export class Script {
+    context: APIRequestContext;
     processes: Resource$Processes;
     projects: Resource$Projects;
     scripts: Resource$Scripts;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.processes = new Resource$Processes();
-      this.projects = new Resource$Projects();
-      this.scripts = new Resource$Scripts();
+      this.processes = new Resource$Processes(this.context);
+      this.projects = new Resource$Projects(this.context);
+      this.scripts = new Resource$Scripts(this.context);
     }
   }
 
@@ -726,7 +725,10 @@ export namespace script_v1 {
 
 
   export class Resource$Processes {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -796,7 +798,7 @@ export namespace script_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListUserProcessesResponse>(
@@ -880,7 +882,7 @@ export namespace script_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListScriptProcessesResponse>(
@@ -1013,11 +1015,13 @@ export namespace script_v1 {
 
 
   export class Resource$Projects {
+    context: APIRequestContext;
     deployments: Resource$Projects$Deployments;
     versions: Resource$Projects$Versions;
-    constructor() {
-      this.deployments = new Resource$Projects$Deployments();
-      this.versions = new Resource$Projects$Versions();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.deployments = new Resource$Projects$Deployments(this.context);
+      this.versions = new Resource$Projects$Versions(this.context);
     }
 
 
@@ -1075,7 +1079,7 @@ export namespace script_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Project>(parameters, callback);
@@ -1136,7 +1140,7 @@ export namespace script_v1 {
         params,
         requiredParams: ['scriptId'],
         pathParams: ['scriptId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Project>(parameters, callback);
@@ -1204,7 +1208,7 @@ export namespace script_v1 {
         params,
         requiredParams: ['scriptId'],
         pathParams: ['scriptId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Content>(parameters, callback);
@@ -1273,7 +1277,7 @@ export namespace script_v1 {
         params,
         requiredParams: ['scriptId'],
         pathParams: ['scriptId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Metrics>(parameters, callback);
@@ -1344,7 +1348,7 @@ export namespace script_v1 {
         params,
         requiredParams: ['scriptId'],
         pathParams: ['scriptId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Content>(parameters, callback);
@@ -1433,7 +1437,10 @@ export namespace script_v1 {
   }
 
   export class Resource$Projects$Deployments {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1494,7 +1501,7 @@ export namespace script_v1 {
         params,
         requiredParams: ['scriptId'],
         pathParams: ['scriptId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Deployment>(parameters, callback);
@@ -1562,7 +1569,7 @@ export namespace script_v1 {
         params,
         requiredParams: ['scriptId', 'deploymentId'],
         pathParams: ['deploymentId', 'scriptId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -1627,7 +1634,7 @@ export namespace script_v1 {
         params,
         requiredParams: ['scriptId', 'deploymentId'],
         pathParams: ['deploymentId', 'scriptId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Deployment>(parameters, callback);
@@ -1697,7 +1704,7 @@ export namespace script_v1 {
         params,
         requiredParams: ['scriptId'],
         pathParams: ['scriptId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListDeploymentsResponse>(parameters, callback);
@@ -1767,7 +1774,7 @@ export namespace script_v1 {
         params,
         requiredParams: ['scriptId', 'deploymentId'],
         pathParams: ['deploymentId', 'scriptId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Deployment>(parameters, callback);
@@ -1871,7 +1878,10 @@ export namespace script_v1 {
 
 
   export class Resource$Projects$Versions {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1932,7 +1942,7 @@ export namespace script_v1 {
         params,
         requiredParams: ['scriptId'],
         pathParams: ['scriptId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Version>(parameters, callback);
@@ -1996,7 +2006,7 @@ export namespace script_v1 {
         params,
         requiredParams: ['scriptId', 'versionNumber'],
         pathParams: ['scriptId', 'versionNumber'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Version>(parameters, callback);
@@ -2066,7 +2076,7 @@ export namespace script_v1 {
         params,
         requiredParams: ['scriptId'],
         pathParams: ['scriptId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListVersionsResponse>(parameters, callback);
@@ -2134,7 +2144,10 @@ export namespace script_v1 {
 
 
   export class Resource$Scripts {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -2201,7 +2214,7 @@ export namespace script_v1 {
         params,
         requiredParams: ['scriptId'],
         pathParams: ['scriptId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);

--- a/src/apis/searchconsole/v1.ts
+++ b/src/apis/searchconsole/v1.ts
@@ -29,8 +29,6 @@ export namespace searchconsole_v1 {
     version: 'v1';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * V1 error format.
@@ -98,12 +96,13 @@ export namespace searchconsole_v1 {
    * @param {object=} options Options for Searchconsole
    */
   export class Searchconsole {
+    context: APIRequestContext;
     urlTestingTools: Resource$Urltestingtools;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.urlTestingTools = new Resource$Urltestingtools();
+      this.urlTestingTools = new Resource$Urltestingtools(this.context);
     }
   }
 
@@ -204,16 +203,21 @@ export namespace searchconsole_v1 {
 
 
   export class Resource$Urltestingtools {
+    context: APIRequestContext;
     mobileFriendlyTest: Resource$Urltestingtools$Mobilefriendlytest;
-    constructor() {
+    constructor(context: APIRequestContext) {
+      this.context = context;
       this.mobileFriendlyTest =
-          new Resource$Urltestingtools$Mobilefriendlytest();
+          new Resource$Urltestingtools$Mobilefriendlytest(this.context);
     }
   }
 
 
   export class Resource$Urltestingtools$Mobilefriendlytest {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -276,7 +280,7 @@ export namespace searchconsole_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$RunMobileFriendlyTestResponse>(

--- a/src/apis/servicebroker/v1.ts
+++ b/src/apis/servicebroker/v1.ts
@@ -29,8 +29,6 @@ export namespace servicebroker_v1 {
     version: 'v1';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * V1 error format.
@@ -100,12 +98,13 @@ export namespace servicebroker_v1 {
    * @param {object=} options Options for Servicebroker
    */
   export class Servicebroker {
+    context: APIRequestContext;
     v1: Resource$V1;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.v1 = new Resource$V1();
+      this.v1 = new Resource$V1(this.context);
     }
   }
 
@@ -250,7 +249,10 @@ export namespace servicebroker_v1 {
 
 
   export class Resource$V1 {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -312,7 +314,7 @@ export namespace servicebroker_v1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleIamV1__Policy>(parameters, callback);
@@ -382,7 +384,7 @@ export namespace servicebroker_v1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleIamV1__Policy>(parameters, callback);
@@ -461,7 +463,7 @@ export namespace servicebroker_v1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleIamV1__TestIamPermissionsResponse>(

--- a/src/apis/servicebroker/v1alpha1.ts
+++ b/src/apis/servicebroker/v1alpha1.ts
@@ -29,8 +29,6 @@ export namespace servicebroker_v1alpha1 {
     version: 'v1alpha1';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * V1 error format.
@@ -100,14 +98,15 @@ export namespace servicebroker_v1alpha1 {
    * @param {object=} options Options for Servicebroker
    */
   export class Servicebroker {
+    context: APIRequestContext;
     projects: Resource$Projects;
     v1alpha1: Resource$V1alpha1;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.projects = new Resource$Projects();
-      this.v1alpha1 = new Resource$V1alpha1();
+      this.projects = new Resource$Projects(this.context);
+      this.v1alpha1 = new Resource$V1alpha1(this.context);
     }
   }
 
@@ -674,31 +673,38 @@ export namespace servicebroker_v1alpha1 {
 
 
   export class Resource$Projects {
+    context: APIRequestContext;
     brokers: Resource$Projects$Brokers;
-    constructor() {
-      this.brokers = new Resource$Projects$Brokers();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.brokers = new Resource$Projects$Brokers(this.context);
     }
   }
 
 
   export class Resource$Projects$Brokers {
+    context: APIRequestContext;
     instances: Resource$Projects$Brokers$Instances;
     service_instances: Resource$Projects$Brokers$Service_instances;
     v2: Resource$Projects$Brokers$V2;
-    constructor() {
-      this.instances = new Resource$Projects$Brokers$Instances();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.instances = new Resource$Projects$Brokers$Instances(this.context);
       this.service_instances =
-          new Resource$Projects$Brokers$Service_instances();
-      this.v2 = new Resource$Projects$Brokers$V2();
+          new Resource$Projects$Brokers$Service_instances(this.context);
+      this.v2 = new Resource$Projects$Brokers$V2(this.context);
     }
   }
 
 
   export class Resource$Projects$Brokers$Instances {
+    context: APIRequestContext;
     service_bindings: Resource$Projects$Brokers$Instances$Service_bindings;
-    constructor() {
+    constructor(context: APIRequestContext) {
+      this.context = context;
       this.service_bindings =
-          new Resource$Projects$Brokers$Instances$Service_bindings();
+          new Resource$Projects$Brokers$Instances$Service_bindings(
+              this.context);
     }
 
 
@@ -766,7 +772,7 @@ export namespace servicebroker_v1alpha1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<
@@ -794,7 +800,10 @@ export namespace servicebroker_v1alpha1 {
   }
 
   export class Resource$Projects$Brokers$Instances$Service_bindings {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -873,7 +882,7 @@ export namespace servicebroker_v1alpha1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<
@@ -915,7 +924,10 @@ export namespace servicebroker_v1alpha1 {
 
 
   export class Resource$Projects$Brokers$Service_instances {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -992,7 +1004,7 @@ export namespace servicebroker_v1alpha1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<
@@ -1032,18 +1044,23 @@ export namespace servicebroker_v1alpha1 {
 
 
   export class Resource$Projects$Brokers$V2 {
+    context: APIRequestContext;
     catalog: Resource$Projects$Brokers$V2$Catalog;
     service_instances: Resource$Projects$Brokers$V2$Service_instances;
-    constructor() {
-      this.catalog = new Resource$Projects$Brokers$V2$Catalog();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.catalog = new Resource$Projects$Brokers$V2$Catalog(this.context);
       this.service_instances =
-          new Resource$Projects$Brokers$V2$Service_instances();
+          new Resource$Projects$Brokers$V2$Service_instances(this.context);
     }
   }
 
 
   export class Resource$Projects$Brokers$V2$Catalog {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1119,7 +1136,7 @@ export namespace servicebroker_v1alpha1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<
@@ -1159,11 +1176,14 @@ export namespace servicebroker_v1alpha1 {
 
 
   export class Resource$Projects$Brokers$V2$Service_instances {
+    context: APIRequestContext;
     service_bindings:
         Resource$Projects$Brokers$V2$Service_instances$Service_bindings;
-    constructor() {
+    constructor(context: APIRequestContext) {
+      this.context = context;
       this.service_bindings =
-          new Resource$Projects$Brokers$V2$Service_instances$Service_bindings();
+          new Resource$Projects$Brokers$V2$Service_instances$Service_bindings(
+              this.context);
     }
 
 
@@ -1252,7 +1272,7 @@ export namespace servicebroker_v1alpha1 {
         params,
         requiredParams: ['parent', 'instance_id'],
         pathParams: ['instance_id', 'parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<
@@ -1345,7 +1365,7 @@ export namespace servicebroker_v1alpha1 {
         params,
         requiredParams: ['parent', 'instanceId'],
         pathParams: ['instanceId', 'parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<
@@ -1425,7 +1445,7 @@ export namespace servicebroker_v1alpha1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<
@@ -1518,7 +1538,7 @@ export namespace servicebroker_v1alpha1 {
         params,
         requiredParams: ['parent', 'instanceId'],
         pathParams: ['instanceId', 'parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleCloudServicebrokerV1alpha1__Operation>(
@@ -1607,7 +1627,7 @@ export namespace servicebroker_v1alpha1 {
         params,
         requiredParams: ['parent', 'instance_id'],
         pathParams: ['instance_id', 'parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<
@@ -1749,7 +1769,10 @@ export namespace servicebroker_v1alpha1 {
   }
 
   export class Resource$Projects$Brokers$V2$Service_instances$Service_bindings {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1835,7 +1858,7 @@ export namespace servicebroker_v1alpha1 {
         params,
         requiredParams: ['parent', 'instanceId', 'binding_id'],
         pathParams: ['binding_id', 'instanceId', 'parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<
@@ -1934,7 +1957,7 @@ export namespace servicebroker_v1alpha1 {
         params,
         requiredParams: ['parent', 'instanceId', 'bindingId'],
         pathParams: ['bindingId', 'instanceId', 'parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<
@@ -2023,7 +2046,7 @@ export namespace servicebroker_v1alpha1 {
         params,
         requiredParams: ['parent', 'instanceId', 'bindingId'],
         pathParams: ['bindingId', 'instanceId', 'parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<
@@ -2117,7 +2140,7 @@ export namespace servicebroker_v1alpha1 {
         params,
         requiredParams: ['parent', 'instanceId', 'bindingId'],
         pathParams: ['bindingId', 'instanceId', 'parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleCloudServicebrokerV1alpha1__Operation>(
@@ -2257,7 +2280,10 @@ export namespace servicebroker_v1alpha1 {
 
 
   export class Resource$V1alpha1 {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -2320,7 +2346,7 @@ export namespace servicebroker_v1alpha1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleIamV1__Policy>(parameters, callback);
@@ -2391,7 +2417,7 @@ export namespace servicebroker_v1alpha1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleIamV1__Policy>(parameters, callback);
@@ -2470,7 +2496,7 @@ export namespace servicebroker_v1alpha1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleIamV1__TestIamPermissionsResponse>(

--- a/src/apis/servicebroker/v1beta1.ts
+++ b/src/apis/servicebroker/v1beta1.ts
@@ -29,8 +29,6 @@ export namespace servicebroker_v1beta1 {
     version: 'v1beta1';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * V1 error format.
@@ -100,14 +98,15 @@ export namespace servicebroker_v1beta1 {
    * @param {object=} options Options for Servicebroker
    */
   export class Servicebroker {
+    context: APIRequestContext;
     projects: Resource$Projects;
     v1beta1: Resource$V1beta1;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.projects = new Resource$Projects();
-      this.v1beta1 = new Resource$V1beta1();
+      this.projects = new Resource$Projects(this.context);
+      this.v1beta1 = new Resource$V1beta1(this.context);
     }
   }
 
@@ -755,19 +754,23 @@ export namespace servicebroker_v1beta1 {
 
 
   export class Resource$Projects {
+    context: APIRequestContext;
     brokers: Resource$Projects$Brokers;
-    constructor() {
-      this.brokers = new Resource$Projects$Brokers();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.brokers = new Resource$Projects$Brokers(this.context);
     }
   }
 
 
   export class Resource$Projects$Brokers {
+    context: APIRequestContext;
     instances: Resource$Projects$Brokers$Instances;
     v2: Resource$Projects$Brokers$V2;
-    constructor() {
-      this.instances = new Resource$Projects$Brokers$Instances();
-      this.v2 = new Resource$Projects$Brokers$V2();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.instances = new Resource$Projects$Brokers$Instances(this.context);
+      this.v2 = new Resource$Projects$Brokers$V2(this.context);
     }
 
 
@@ -836,7 +839,7 @@ export namespace servicebroker_v1beta1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleCloudServicebrokerV1beta1__Broker>(
@@ -906,7 +909,7 @@ export namespace servicebroker_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleProtobuf__Empty>(parameters, callback);
@@ -985,7 +988,7 @@ export namespace servicebroker_v1beta1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<
@@ -1053,9 +1056,12 @@ export namespace servicebroker_v1beta1 {
   }
 
   export class Resource$Projects$Brokers$Instances {
+    context: APIRequestContext;
     bindings: Resource$Projects$Brokers$Instances$Bindings;
-    constructor() {
-      this.bindings = new Resource$Projects$Brokers$Instances$Bindings();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.bindings =
+          new Resource$Projects$Brokers$Instances$Bindings(this.context);
     }
 
 
@@ -1122,7 +1128,7 @@ export namespace servicebroker_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<
@@ -1206,7 +1212,7 @@ export namespace servicebroker_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleCloudServicebrokerV1beta1__Operation>(
@@ -1291,7 +1297,7 @@ export namespace servicebroker_v1beta1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<
@@ -1371,7 +1377,10 @@ export namespace servicebroker_v1beta1 {
   }
 
   export class Resource$Projects$Brokers$Instances$Bindings {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1448,7 +1457,7 @@ export namespace servicebroker_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleCloudServicebrokerV1beta1__Operation>(
@@ -1532,7 +1541,7 @@ export namespace servicebroker_v1beta1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<
@@ -1601,18 +1610,23 @@ export namespace servicebroker_v1beta1 {
 
 
   export class Resource$Projects$Brokers$V2 {
+    context: APIRequestContext;
     catalog: Resource$Projects$Brokers$V2$Catalog;
     service_instances: Resource$Projects$Brokers$V2$Service_instances;
-    constructor() {
-      this.catalog = new Resource$Projects$Brokers$V2$Catalog();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.catalog = new Resource$Projects$Brokers$V2$Catalog(this.context);
       this.service_instances =
-          new Resource$Projects$Brokers$V2$Service_instances();
+          new Resource$Projects$Brokers$V2$Service_instances(this.context);
     }
   }
 
 
   export class Resource$Projects$Brokers$V2$Catalog {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1686,7 +1700,7 @@ export namespace servicebroker_v1beta1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<
@@ -1726,11 +1740,14 @@ export namespace servicebroker_v1beta1 {
 
 
   export class Resource$Projects$Brokers$V2$Service_instances {
+    context: APIRequestContext;
     service_bindings:
         Resource$Projects$Brokers$V2$Service_instances$Service_bindings;
-    constructor() {
+    constructor(context: APIRequestContext) {
+      this.context = context;
       this.service_bindings =
-          new Resource$Projects$Brokers$V2$Service_instances$Service_bindings();
+          new Resource$Projects$Brokers$V2$Service_instances$Service_bindings(
+              this.context);
     }
 
 
@@ -1819,7 +1836,7 @@ export namespace servicebroker_v1beta1 {
         params,
         requiredParams: ['parent', 'instance_id'],
         pathParams: ['instance_id', 'parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<
@@ -1909,7 +1926,7 @@ export namespace servicebroker_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<
@@ -1988,7 +2005,7 @@ export namespace servicebroker_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<
@@ -2076,7 +2093,7 @@ export namespace servicebroker_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleCloudServicebrokerV1beta1__Operation>(
@@ -2162,7 +2179,7 @@ export namespace servicebroker_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<
@@ -2298,7 +2315,10 @@ export namespace servicebroker_v1beta1 {
   }
 
   export class Resource$Projects$Brokers$V2$Service_instances$Service_bindings {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -2382,7 +2402,7 @@ export namespace servicebroker_v1beta1 {
         params,
         requiredParams: ['parent', 'binding_id'],
         pathParams: ['binding_id', 'parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<
@@ -2476,7 +2496,7 @@ export namespace servicebroker_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<
@@ -2560,7 +2580,7 @@ export namespace servicebroker_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<
@@ -2648,7 +2668,7 @@ export namespace servicebroker_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleCloudServicebrokerV1beta1__Operation>(
@@ -2765,7 +2785,10 @@ export namespace servicebroker_v1beta1 {
 
 
   export class Resource$V1beta1 {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -2828,7 +2851,7 @@ export namespace servicebroker_v1beta1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleIamV1__Policy>(parameters, callback);
@@ -2899,7 +2922,7 @@ export namespace servicebroker_v1beta1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleIamV1__Policy>(parameters, callback);
@@ -2978,7 +3001,7 @@ export namespace servicebroker_v1beta1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleIamV1__TestIamPermissionsResponse>(

--- a/src/apis/serviceconsumermanagement/v1.ts
+++ b/src/apis/serviceconsumermanagement/v1.ts
@@ -29,8 +29,6 @@ export namespace serviceconsumermanagement_v1 {
     version: 'v1';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * V1 error format.
@@ -98,14 +96,15 @@ export namespace serviceconsumermanagement_v1 {
    * @param {object=} options Options for Serviceconsumermanagement
    */
   export class Serviceconsumermanagement {
+    context: APIRequestContext;
     operations: Resource$Operations;
     services: Resource$Services;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.operations = new Resource$Operations();
-      this.services = new Resource$Services();
+      this.operations = new Resource$Operations(this.context);
+      this.services = new Resource$Services(this.context);
     }
   }
 
@@ -2238,7 +2237,10 @@ export namespace serviceconsumermanagement_v1 {
 
 
   export class Resource$Operations {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -2306,7 +2308,7 @@ export namespace serviceconsumermanagement_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -2374,7 +2376,7 @@ export namespace serviceconsumermanagement_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -2438,7 +2440,7 @@ export namespace serviceconsumermanagement_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -2515,7 +2517,7 @@ export namespace serviceconsumermanagement_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListOperationsResponse>(parameters, callback);
@@ -2591,9 +2593,11 @@ export namespace serviceconsumermanagement_v1 {
 
 
   export class Resource$Services {
+    context: APIRequestContext;
     tenancyUnits: Resource$Services$Tenancyunits;
-    constructor() {
-      this.tenancyUnits = new Resource$Services$Tenancyunits();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.tenancyUnits = new Resource$Services$Tenancyunits(this.context);
     }
 
 
@@ -2660,7 +2664,7 @@ export namespace serviceconsumermanagement_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$SearchTenancyUnitsResponse>(
@@ -2713,7 +2717,10 @@ export namespace serviceconsumermanagement_v1 {
   }
 
   export class Resource$Services$Tenancyunits {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -2779,7 +2786,7 @@ export namespace serviceconsumermanagement_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -2861,7 +2868,7 @@ export namespace serviceconsumermanagement_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -2939,7 +2946,7 @@ export namespace serviceconsumermanagement_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -3008,7 +3015,7 @@ export namespace serviceconsumermanagement_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TenancyUnit>(parameters, callback);
@@ -3077,7 +3084,7 @@ export namespace serviceconsumermanagement_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -3154,7 +3161,7 @@ export namespace serviceconsumermanagement_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListTenancyUnitsResponse>(parameters, callback);
@@ -3229,7 +3236,7 @@ export namespace serviceconsumermanagement_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);

--- a/src/apis/servicecontrol/v1.ts
+++ b/src/apis/servicecontrol/v1.ts
@@ -29,8 +29,6 @@ export namespace servicecontrol_v1 {
     version: 'v1';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * V1 error format.
@@ -99,12 +97,13 @@ export namespace servicecontrol_v1 {
    * @param {object=} options Options for Servicecontrol
    */
   export class Servicecontrol {
+    context: APIRequestContext;
     services: Resource$Services;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.services = new Resource$Services();
+      this.services = new Resource$Services(this.context);
     }
   }
 
@@ -1491,7 +1490,10 @@ export namespace servicecontrol_v1 {
 
 
   export class Resource$Services {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1562,7 +1564,7 @@ export namespace servicecontrol_v1 {
         params,
         requiredParams: ['serviceName'],
         pathParams: ['serviceName'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AllocateQuotaResponse>(parameters, callback);
@@ -1639,7 +1641,7 @@ export namespace servicecontrol_v1 {
         params,
         requiredParams: ['serviceName'],
         pathParams: ['serviceName'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$CheckResponse>(parameters, callback);
@@ -1716,7 +1718,7 @@ export namespace servicecontrol_v1 {
         params,
         requiredParams: ['serviceName'],
         pathParams: ['serviceName'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ReportResponse>(parameters, callback);

--- a/src/apis/servicemanagement/v1.ts
+++ b/src/apis/servicemanagement/v1.ts
@@ -29,8 +29,6 @@ export namespace servicemanagement_v1 {
     version: 'v1';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * V1 error format.
@@ -100,14 +98,15 @@ export namespace servicemanagement_v1 {
    * @param {object=} options Options for Servicemanagement
    */
   export class Servicemanagement {
+    context: APIRequestContext;
     operations: Resource$Operations;
     services: Resource$Services;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.operations = new Resource$Operations();
-      this.services = new Resource$Services();
+      this.operations = new Resource$Operations(this.context);
+      this.services = new Resource$Services(this.context);
     }
   }
 
@@ -2573,7 +2572,10 @@ export namespace servicemanagement_v1 {
 
 
   export class Resource$Operations {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -2630,7 +2632,7 @@ export namespace servicemanagement_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -2700,7 +2702,7 @@ export namespace servicemanagement_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListOperationsResponse>(parameters, callback);
@@ -2761,13 +2763,15 @@ export namespace servicemanagement_v1 {
 
 
   export class Resource$Services {
+    context: APIRequestContext;
     configs: Resource$Services$Configs;
     consumers: Resource$Services$Consumers;
     rollouts: Resource$Services$Rollouts;
-    constructor() {
-      this.configs = new Resource$Services$Configs();
-      this.consumers = new Resource$Services$Consumers();
-      this.rollouts = new Resource$Services$Rollouts();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.configs = new Resource$Services$Configs(this.context);
+      this.consumers = new Resource$Services$Consumers(this.context);
+      this.rollouts = new Resource$Services$Rollouts(this.context);
     }
 
 
@@ -2827,7 +2831,7 @@ export namespace servicemanagement_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -2897,7 +2901,7 @@ export namespace servicemanagement_v1 {
         params,
         requiredParams: ['serviceName'],
         pathParams: ['serviceName'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -2967,7 +2971,7 @@ export namespace servicemanagement_v1 {
         params,
         requiredParams: ['serviceName'],
         pathParams: ['serviceName'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -3036,7 +3040,7 @@ export namespace servicemanagement_v1 {
         params,
         requiredParams: ['serviceName'],
         pathParams: ['serviceName'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -3119,7 +3123,7 @@ export namespace servicemanagement_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GenerateConfigReportResponse>(
@@ -3185,7 +3189,7 @@ export namespace servicemanagement_v1 {
         params,
         requiredParams: ['serviceName'],
         pathParams: ['serviceName'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ManagedService>(parameters, callback);
@@ -3254,7 +3258,7 @@ export namespace servicemanagement_v1 {
         params,
         requiredParams: ['serviceName'],
         pathParams: ['serviceName'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Service>(parameters, callback);
@@ -3323,7 +3327,7 @@ export namespace servicemanagement_v1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -3397,7 +3401,7 @@ export namespace servicemanagement_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListServicesResponse>(parameters, callback);
@@ -3466,7 +3470,7 @@ export namespace servicemanagement_v1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -3545,7 +3549,7 @@ export namespace servicemanagement_v1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TestIamPermissionsResponse>(
@@ -3617,7 +3621,7 @@ export namespace servicemanagement_v1 {
         params,
         requiredParams: ['serviceName'],
         pathParams: ['serviceName'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -3831,7 +3835,10 @@ export namespace servicemanagement_v1 {
   }
 
   export class Resource$Services$Configs {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -3897,7 +3904,7 @@ export namespace servicemanagement_v1 {
         params,
         requiredParams: ['serviceName'],
         pathParams: ['serviceName'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Service>(parameters, callback);
@@ -3962,7 +3969,7 @@ export namespace servicemanagement_v1 {
         params,
         requiredParams: ['serviceName', 'configId'],
         pathParams: ['configId', 'serviceName'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Service>(parameters, callback);
@@ -4038,7 +4045,7 @@ export namespace servicemanagement_v1 {
         params,
         requiredParams: ['serviceName'],
         pathParams: ['serviceName'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListServiceConfigsResponse>(
@@ -4115,7 +4122,7 @@ export namespace servicemanagement_v1 {
         params,
         requiredParams: ['serviceName'],
         pathParams: ['serviceName'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -4213,7 +4220,10 @@ export namespace servicemanagement_v1 {
 
 
   export class Resource$Services$Consumers {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -4275,7 +4285,7 @@ export namespace servicemanagement_v1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -4344,7 +4354,7 @@ export namespace servicemanagement_v1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -4424,7 +4434,7 @@ export namespace servicemanagement_v1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TestIamPermissionsResponse>(
@@ -4492,7 +4502,10 @@ export namespace servicemanagement_v1 {
 
 
   export class Resource$Services$Rollouts {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -4563,7 +4576,7 @@ export namespace servicemanagement_v1 {
         params,
         requiredParams: ['serviceName'],
         pathParams: ['serviceName'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -4627,7 +4640,7 @@ export namespace servicemanagement_v1 {
         params,
         requiredParams: ['serviceName', 'rolloutId'],
         pathParams: ['rolloutId', 'serviceName'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Rollout>(parameters, callback);
@@ -4704,7 +4717,7 @@ export namespace servicemanagement_v1 {
         params,
         requiredParams: ['serviceName'],
         pathParams: ['serviceName'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListServiceRolloutsResponse>(

--- a/src/apis/servicenetworking/v1.ts
+++ b/src/apis/servicenetworking/v1.ts
@@ -29,8 +29,6 @@ export namespace servicenetworking_v1 {
     version: 'v1';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * V1 error format.
@@ -99,14 +97,15 @@ export namespace servicenetworking_v1 {
    * @param {object=} options Options for Servicenetworking
    */
   export class Servicenetworking {
+    context: APIRequestContext;
     operations: Resource$Operations;
     services: Resource$Services;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.operations = new Resource$Operations();
-      this.services = new Resource$Services();
+      this.operations = new Resource$Operations(this.context);
+      this.services = new Resource$Services(this.context);
     }
   }
 
@@ -2179,7 +2178,10 @@ export namespace servicenetworking_v1 {
 
 
   export class Resource$Operations {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -2247,7 +2249,7 @@ export namespace servicenetworking_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -2315,7 +2317,7 @@ export namespace servicenetworking_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -2379,7 +2381,7 @@ export namespace servicenetworking_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -2456,7 +2458,7 @@ export namespace servicenetworking_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListOperationsResponse>(parameters, callback);
@@ -2532,9 +2534,11 @@ export namespace servicenetworking_v1 {
 
 
   export class Resource$Services {
+    context: APIRequestContext;
     connections: Resource$Services$Connections;
-    constructor() {
-      this.connections = new Resource$Services$Connections();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.connections = new Resource$Services$Connections(this.context);
     }
 
 
@@ -2606,7 +2610,7 @@ export namespace servicenetworking_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -2680,7 +2684,7 @@ export namespace servicenetworking_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -2734,7 +2738,10 @@ export namespace servicenetworking_v1 {
   }
 
   export class Resource$Services$Connections {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -2804,7 +2811,7 @@ export namespace servicenetworking_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -2875,7 +2882,7 @@ export namespace servicenetworking_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListConnectionsResponse>(parameters, callback);
@@ -2947,7 +2954,7 @@ export namespace servicenetworking_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);

--- a/src/apis/servicenetworking/v1beta.ts
+++ b/src/apis/servicenetworking/v1beta.ts
@@ -29,8 +29,6 @@ export namespace servicenetworking_v1beta {
     version: 'v1beta';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * V1 error format.
@@ -99,14 +97,15 @@ export namespace servicenetworking_v1beta {
    * @param {object=} options Options for Servicenetworking
    */
   export class Servicenetworking {
+    context: APIRequestContext;
     operations: Resource$Operations;
     services: Resource$Services;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.operations = new Resource$Operations();
-      this.services = new Resource$Services();
+      this.operations = new Resource$Operations(this.context);
+      this.services = new Resource$Services(this.context);
     }
   }
 
@@ -2151,7 +2150,10 @@ export namespace servicenetworking_v1beta {
 
 
   export class Resource$Operations {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -2208,7 +2210,7 @@ export namespace servicenetworking_v1beta {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -2232,9 +2234,11 @@ export namespace servicenetworking_v1beta {
 
 
   export class Resource$Services {
+    context: APIRequestContext;
     connections: Resource$Services$Connections;
-    constructor() {
-      this.connections = new Resource$Services$Connections();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.connections = new Resource$Services$Connections(this.context);
     }
 
 
@@ -2306,7 +2310,7 @@ export namespace servicenetworking_v1beta {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -2380,7 +2384,7 @@ export namespace servicenetworking_v1beta {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -2453,7 +2457,7 @@ export namespace servicenetworking_v1beta {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -2537,7 +2541,10 @@ export namespace servicenetworking_v1beta {
   }
 
   export class Resource$Services$Connections {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -2607,7 +2614,7 @@ export namespace servicenetworking_v1beta {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -2678,7 +2685,7 @@ export namespace servicenetworking_v1beta {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListConnectionsResponse>(parameters, callback);

--- a/src/apis/serviceusage/v1.ts
+++ b/src/apis/serviceusage/v1.ts
@@ -29,8 +29,6 @@ export namespace serviceusage_v1 {
     version: 'v1';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * V1 error format.
@@ -100,14 +98,15 @@ export namespace serviceusage_v1 {
    * @param {object=} options Options for Serviceusage
    */
   export class Serviceusage {
+    context: APIRequestContext;
     operations: Resource$Operations;
     services: Resource$Services;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.operations = new Resource$Operations();
-      this.services = new Resource$Services();
+      this.operations = new Resource$Operations(this.context);
+      this.services = new Resource$Services(this.context);
     }
   }
 
@@ -2172,7 +2171,10 @@ export namespace serviceusage_v1 {
 
 
   export class Resource$Operations {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -2239,7 +2241,7 @@ export namespace serviceusage_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -2306,7 +2308,7 @@ export namespace serviceusage_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -2369,7 +2371,7 @@ export namespace serviceusage_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -2445,7 +2447,7 @@ export namespace serviceusage_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListOperationsResponse>(parameters, callback);
@@ -2521,7 +2523,10 @@ export namespace serviceusage_v1 {
 
 
   export class Resource$Services {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -2584,7 +2589,7 @@ export namespace serviceusage_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -2655,7 +2660,7 @@ export namespace serviceusage_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -2721,7 +2726,7 @@ export namespace serviceusage_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -2787,7 +2792,7 @@ export namespace serviceusage_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleApiServiceusageV1Service>(
@@ -2864,7 +2869,7 @@ export namespace serviceusage_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListServicesResponse>(parameters, callback);

--- a/src/apis/serviceusage/v1beta1.ts
+++ b/src/apis/serviceusage/v1beta1.ts
@@ -29,8 +29,6 @@ export namespace serviceusage_v1beta1 {
     version: 'v1beta1';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * V1 error format.
@@ -100,14 +98,15 @@ export namespace serviceusage_v1beta1 {
    * @param {object=} options Options for Serviceusage
    */
   export class Serviceusage {
+    context: APIRequestContext;
     operations: Resource$Operations;
     services: Resource$Services;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.operations = new Resource$Operations();
-      this.services = new Resource$Services();
+      this.operations = new Resource$Operations(this.context);
+      this.services = new Resource$Services(this.context);
     }
   }
 
@@ -2225,7 +2224,10 @@ export namespace serviceusage_v1beta1 {
 
 
   export class Resource$Operations {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -2281,7 +2283,7 @@ export namespace serviceusage_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -2358,7 +2360,7 @@ export namespace serviceusage_v1beta1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListOperationsResponse>(parameters, callback);
@@ -2405,7 +2407,10 @@ export namespace serviceusage_v1beta1 {
 
 
   export class Resource$Services {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -2468,7 +2473,7 @@ export namespace serviceusage_v1beta1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -2539,7 +2544,7 @@ export namespace serviceusage_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -2606,7 +2611,7 @@ export namespace serviceusage_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -2667,7 +2672,7 @@ export namespace serviceusage_v1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Service>(parameters, callback);
@@ -2742,7 +2747,7 @@ export namespace serviceusage_v1beta1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListServicesResponse>(parameters, callback);

--- a/src/apis/sheets/v4.ts
+++ b/src/apis/sheets/v4.ts
@@ -29,8 +29,6 @@ export namespace sheets_v4 {
     version: 'v4';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * V1 error format.
@@ -98,12 +96,13 @@ export namespace sheets_v4 {
    * @param {object=} options Options for Sheets
    */
   export class Sheets {
+    context: APIRequestContext;
     spreadsheets: Resource$Spreadsheets;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.spreadsheets = new Resource$Spreadsheets();
+      this.spreadsheets = new Resource$Spreadsheets(this.context);
     }
   }
 
@@ -4427,13 +4426,16 @@ export namespace sheets_v4 {
 
 
   export class Resource$Spreadsheets {
+    context: APIRequestContext;
     developerMetadata: Resource$Spreadsheets$Developermetadata;
     sheets: Resource$Spreadsheets$Sheets;
     values: Resource$Spreadsheets$Values;
-    constructor() {
-      this.developerMetadata = new Resource$Spreadsheets$Developermetadata();
-      this.sheets = new Resource$Spreadsheets$Sheets();
-      this.values = new Resource$Spreadsheets$Values();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.developerMetadata =
+          new Resource$Spreadsheets$Developermetadata(this.context);
+      this.sheets = new Resource$Spreadsheets$Sheets(this.context);
+      this.values = new Resource$Spreadsheets$Values(this.context);
     }
 
 
@@ -4572,7 +4574,7 @@ export namespace sheets_v4 {
         params,
         requiredParams: ['spreadsheetId'],
         pathParams: ['spreadsheetId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$BatchUpdateSpreadsheetResponse>(
@@ -4690,7 +4692,7 @@ export namespace sheets_v4 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Spreadsheet>(parameters, callback);
@@ -4823,7 +4825,7 @@ export namespace sheets_v4 {
         params,
         requiredParams: ['spreadsheetId'],
         pathParams: ['spreadsheetId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Spreadsheet>(parameters, callback);
@@ -4965,7 +4967,7 @@ export namespace sheets_v4 {
         params,
         requiredParams: ['spreadsheetId'],
         pathParams: ['spreadsheetId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Spreadsheet>(parameters, callback);
@@ -5044,7 +5046,10 @@ export namespace sheets_v4 {
   }
 
   export class Resource$Spreadsheets$Developermetadata {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -5156,7 +5161,7 @@ export namespace sheets_v4 {
         params,
         requiredParams: ['spreadsheetId', 'metadataId'],
         pathParams: ['metadataId', 'spreadsheetId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$DeveloperMetadata>(parameters, callback);
@@ -5289,7 +5294,7 @@ export namespace sheets_v4 {
         params,
         requiredParams: ['spreadsheetId'],
         pathParams: ['spreadsheetId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$SearchDeveloperMetadataResponse>(
@@ -5337,7 +5342,10 @@ export namespace sheets_v4 {
 
 
   export class Resource$Spreadsheets$Sheets {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -5461,7 +5469,7 @@ export namespace sheets_v4 {
         params,
         requiredParams: ['spreadsheetId', 'sheetId'],
         pathParams: ['sheetId', 'spreadsheetId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$SheetProperties>(parameters, callback);
@@ -5495,7 +5503,10 @@ export namespace sheets_v4 {
 
 
   export class Resource$Spreadsheets$Values {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -5637,7 +5648,7 @@ export namespace sheets_v4 {
         params,
         requiredParams: ['spreadsheetId', 'range'],
         pathParams: ['range', 'spreadsheetId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AppendValuesResponse>(parameters, callback);
@@ -5767,7 +5778,7 @@ export namespace sheets_v4 {
         params,
         requiredParams: ['spreadsheetId'],
         pathParams: ['spreadsheetId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$BatchClearValuesResponse>(parameters, callback);
@@ -5908,7 +5919,7 @@ export namespace sheets_v4 {
         params,
         requiredParams: ['spreadsheetId'],
         pathParams: ['spreadsheetId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$BatchClearValuesByDataFilterResponse>(
@@ -6052,7 +6063,7 @@ export namespace sheets_v4 {
         params,
         requiredParams: ['spreadsheetId'],
         pathParams: ['spreadsheetId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$BatchGetValuesResponse>(parameters, callback);
@@ -6207,7 +6218,7 @@ export namespace sheets_v4 {
         params,
         requiredParams: ['spreadsheetId'],
         pathParams: ['spreadsheetId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$BatchGetValuesByDataFilterResponse>(
@@ -6341,7 +6352,7 @@ export namespace sheets_v4 {
         params,
         requiredParams: ['spreadsheetId'],
         pathParams: ['spreadsheetId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$BatchUpdateValuesResponse>(
@@ -6487,7 +6498,7 @@ export namespace sheets_v4 {
         params,
         requiredParams: ['spreadsheetId'],
         pathParams: ['spreadsheetId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$BatchUpdateValuesByDataFilterResponse>(
@@ -6618,7 +6629,7 @@ export namespace sheets_v4 {
         params,
         requiredParams: ['spreadsheetId', 'range'],
         pathParams: ['range', 'spreadsheetId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ClearValuesResponse>(parameters, callback);
@@ -6753,7 +6764,7 @@ export namespace sheets_v4 {
         params,
         requiredParams: ['spreadsheetId', 'range'],
         pathParams: ['range', 'spreadsheetId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ValueRange>(parameters, callback);
@@ -6890,7 +6901,7 @@ export namespace sheets_v4 {
         params,
         requiredParams: ['spreadsheetId', 'range'],
         pathParams: ['range', 'spreadsheetId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$UpdateValuesResponse>(parameters, callback);

--- a/src/apis/siteVerification/v1.ts
+++ b/src/apis/siteVerification/v1.ts
@@ -29,8 +29,6 @@ export namespace siteVerification_v1 {
     version: 'v1';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * Data format for the response.
@@ -81,12 +79,13 @@ export namespace siteVerification_v1 {
    * @param {object=} options Options for Siteverification
    */
   export class Siteverification {
+    context: APIRequestContext;
     webResource: Resource$Webresource;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.webResource = new Resource$Webresource();
+      this.webResource = new Resource$Webresource(this.context);
     }
   }
 
@@ -142,7 +141,10 @@ export namespace siteVerification_v1 {
 
 
   export class Resource$Webresource {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -200,7 +202,7 @@ export namespace siteVerification_v1 {
         params,
         requiredParams: ['id'],
         pathParams: ['id'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -270,7 +272,7 @@ export namespace siteVerification_v1 {
         params,
         requiredParams: ['id'],
         pathParams: ['id'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$SiteVerificationWebResourceResource>(
@@ -345,7 +347,7 @@ export namespace siteVerification_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$SiteVerificationWebResourceGettokenResponse>(
@@ -424,7 +426,7 @@ export namespace siteVerification_v1 {
         params,
         requiredParams: ['verificationMethod'],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$SiteVerificationWebResourceResource>(
@@ -495,7 +497,7 @@ export namespace siteVerification_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$SiteVerificationWebResourceListResponse>(
@@ -573,7 +575,7 @@ export namespace siteVerification_v1 {
         params,
         requiredParams: ['id'],
         pathParams: ['id'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$SiteVerificationWebResourceResource>(
@@ -652,7 +654,7 @@ export namespace siteVerification_v1 {
         params,
         requiredParams: ['id'],
         pathParams: ['id'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$SiteVerificationWebResourceResource>(

--- a/src/apis/slides/v1.ts
+++ b/src/apis/slides/v1.ts
@@ -29,8 +29,6 @@ export namespace slides_v1 {
     version: 'v1';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * V1 error format.
@@ -98,12 +96,13 @@ export namespace slides_v1 {
    * @param {object=} options Options for Slides
    */
   export class Slides {
+    context: APIRequestContext;
     presentations: Resource$Presentations;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.presentations = new Resource$Presentations();
+      this.presentations = new Resource$Presentations(this.context);
     }
   }
 
@@ -3302,9 +3301,11 @@ export namespace slides_v1 {
 
 
   export class Resource$Presentations {
+    context: APIRequestContext;
     pages: Resource$Presentations$Pages;
-    constructor() {
-      this.pages = new Resource$Presentations$Pages();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.pages = new Resource$Presentations$Pages(this.context);
     }
 
 
@@ -3386,7 +3387,7 @@ export namespace slides_v1 {
         params,
         requiredParams: ['presentationId'],
         pathParams: ['presentationId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$BatchUpdatePresentationResponse>(
@@ -3459,7 +3460,7 @@ export namespace slides_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Presentation>(parameters, callback);
@@ -3522,7 +3523,7 @@ export namespace slides_v1 {
         params,
         requiredParams: ['presentationId'],
         pathParams: ['presentationId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Presentation>(parameters, callback);
@@ -3576,7 +3577,10 @@ export namespace slides_v1 {
   }
 
   export class Resource$Presentations$Pages {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -3633,7 +3637,7 @@ export namespace slides_v1 {
         params,
         requiredParams: ['presentationId', 'pageObjectId'],
         pathParams: ['pageObjectId', 'presentationId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Page>(parameters, callback);
@@ -3708,7 +3712,7 @@ export namespace slides_v1 {
         params,
         requiredParams: ['presentationId', 'pageObjectId'],
         pathParams: ['pageObjectId', 'presentationId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Thumbnail>(parameters, callback);

--- a/src/apis/sourcerepo/v1.ts
+++ b/src/apis/sourcerepo/v1.ts
@@ -29,8 +29,6 @@ export namespace sourcerepo_v1 {
     version: 'v1';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * V1 error format.
@@ -98,12 +96,13 @@ export namespace sourcerepo_v1 {
    * @param {object=} options Options for Sourcerepo
    */
   export class Sourcerepo {
+    context: APIRequestContext;
     projects: Resource$Projects;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.projects = new Resource$Projects();
+      this.projects = new Resource$Projects(this.context);
     }
   }
 
@@ -465,9 +464,11 @@ export namespace sourcerepo_v1 {
 
 
   export class Resource$Projects {
+    context: APIRequestContext;
     repos: Resource$Projects$Repos;
-    constructor() {
-      this.repos = new Resource$Projects$Repos();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.repos = new Resource$Projects$Repos(this.context);
     }
 
 
@@ -528,7 +529,7 @@ export namespace sourcerepo_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ProjectConfig>(parameters, callback);
@@ -596,7 +597,7 @@ export namespace sourcerepo_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ProjectConfig>(parameters, callback);
@@ -639,7 +640,10 @@ export namespace sourcerepo_v1 {
   }
 
   export class Resource$Projects$Repos {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -700,7 +704,7 @@ export namespace sourcerepo_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Repo>(parameters, callback);
@@ -765,7 +769,7 @@ export namespace sourcerepo_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -826,7 +830,7 @@ export namespace sourcerepo_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Repo>(parameters, callback);
@@ -893,7 +897,7 @@ export namespace sourcerepo_v1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -962,7 +966,7 @@ export namespace sourcerepo_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListReposResponse>(parameters, callback);
@@ -1028,7 +1032,7 @@ export namespace sourcerepo_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Repo>(parameters, callback);
@@ -1096,7 +1100,7 @@ export namespace sourcerepo_v1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -1172,7 +1176,7 @@ export namespace sourcerepo_v1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TestIamPermissionsResponse>(

--- a/src/apis/spanner/v1.ts
+++ b/src/apis/spanner/v1.ts
@@ -29,8 +29,6 @@ export namespace spanner_v1 {
     version: 'v1';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * V1 error format.
@@ -99,12 +97,13 @@ export namespace spanner_v1 {
    * @param {object=} options Options for Spanner
    */
   export class Spanner {
+    context: APIRequestContext;
     projects: Resource$Projects;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.projects = new Resource$Projects();
+      this.projects = new Resource$Projects(this.context);
     }
   }
 
@@ -1892,17 +1891,23 @@ export namespace spanner_v1 {
 
 
   export class Resource$Projects {
+    context: APIRequestContext;
     instanceConfigs: Resource$Projects$Instanceconfigs;
     instances: Resource$Projects$Instances;
-    constructor() {
-      this.instanceConfigs = new Resource$Projects$Instanceconfigs();
-      this.instances = new Resource$Projects$Instances();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.instanceConfigs =
+          new Resource$Projects$Instanceconfigs(this.context);
+      this.instances = new Resource$Projects$Instances(this.context);
     }
   }
 
 
   export class Resource$Projects$Instanceconfigs {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1957,7 +1962,7 @@ export namespace spanner_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$InstanceConfig>(parameters, callback);
@@ -2031,7 +2036,7 @@ export namespace spanner_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListInstanceConfigsResponse>(
@@ -2081,11 +2086,14 @@ export namespace spanner_v1 {
 
 
   export class Resource$Projects$Instances {
+    context: APIRequestContext;
     databases: Resource$Projects$Instances$Databases;
     operations: Resource$Projects$Instances$Operations;
-    constructor() {
-      this.databases = new Resource$Projects$Instances$Databases();
-      this.operations = new Resource$Projects$Instances$Operations();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.databases = new Resource$Projects$Instances$Databases(this.context);
+      this.operations =
+          new Resource$Projects$Instances$Operations(this.context);
     }
 
 
@@ -2166,7 +2174,7 @@ export namespace spanner_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -2235,7 +2243,7 @@ export namespace spanner_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -2296,7 +2304,7 @@ export namespace spanner_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Instance>(parameters, callback);
@@ -2365,7 +2373,7 @@ export namespace spanner_v1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -2436,7 +2444,7 @@ export namespace spanner_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListInstancesResponse>(parameters, callback);
@@ -2525,7 +2533,7 @@ export namespace spanner_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -2594,7 +2602,7 @@ export namespace spanner_v1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -2673,7 +2681,7 @@ export namespace spanner_v1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TestIamPermissionsResponse>(
@@ -2847,11 +2855,15 @@ export namespace spanner_v1 {
   }
 
   export class Resource$Projects$Instances$Databases {
+    context: APIRequestContext;
     operations: Resource$Projects$Instances$Databases$Operations;
     sessions: Resource$Projects$Instances$Databases$Sessions;
-    constructor() {
-      this.operations = new Resource$Projects$Instances$Databases$Operations();
-      this.sessions = new Resource$Projects$Instances$Databases$Sessions();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.operations =
+          new Resource$Projects$Instances$Databases$Operations(this.context);
+      this.sessions =
+          new Resource$Projects$Instances$Databases$Sessions(this.context);
     }
 
 
@@ -2918,7 +2930,7 @@ export namespace spanner_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -2985,7 +2997,7 @@ export namespace spanner_v1 {
         params,
         requiredParams: ['database'],
         pathParams: ['database'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -3046,7 +3058,7 @@ export namespace spanner_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Database>(parameters, callback);
@@ -3116,7 +3128,7 @@ export namespace spanner_v1 {
         params,
         requiredParams: ['database'],
         pathParams: ['database'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GetDatabaseDdlResponse>(parameters, callback);
@@ -3188,7 +3200,7 @@ export namespace spanner_v1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -3258,7 +3270,7 @@ export namespace spanner_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListDatabasesResponse>(parameters, callback);
@@ -3329,7 +3341,7 @@ export namespace spanner_v1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -3410,7 +3422,7 @@ export namespace spanner_v1 {
         params,
         requiredParams: ['resource'],
         pathParams: ['resource'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TestIamPermissionsResponse>(
@@ -3485,7 +3497,7 @@ export namespace spanner_v1 {
         params,
         requiredParams: ['database'],
         pathParams: ['database'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -3652,7 +3664,10 @@ export namespace spanner_v1 {
   }
 
   export class Resource$Projects$Instances$Databases$Operations {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -3721,7 +3736,7 @@ export namespace spanner_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -3791,7 +3806,7 @@ export namespace spanner_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -3857,7 +3872,7 @@ export namespace spanner_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -3937,7 +3952,7 @@ export namespace spanner_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListOperationsResponse>(parameters, callback);
@@ -4010,7 +4025,10 @@ export namespace spanner_v1 {
 
 
   export class Resource$Projects$Instances$Databases$Sessions {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -4077,7 +4095,7 @@ export namespace spanner_v1 {
         params,
         requiredParams: ['session'],
         pathParams: ['session'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Transaction>(parameters, callback);
@@ -4152,7 +4170,7 @@ export namespace spanner_v1 {
         params,
         requiredParams: ['session'],
         pathParams: ['session'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$CommitResponse>(parameters, callback);
@@ -4233,7 +4251,7 @@ export namespace spanner_v1 {
         params,
         requiredParams: ['database'],
         pathParams: ['database'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Session>(parameters, callback);
@@ -4302,7 +4320,7 @@ export namespace spanner_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -4388,7 +4406,7 @@ export namespace spanner_v1 {
         params,
         requiredParams: ['session'],
         pathParams: ['session'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ExecuteBatchDmlResponse>(parameters, callback);
@@ -4468,7 +4486,7 @@ export namespace spanner_v1 {
         params,
         requiredParams: ['session'],
         pathParams: ['session'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ResultSet>(parameters, callback);
@@ -4545,7 +4563,7 @@ export namespace spanner_v1 {
         params,
         requiredParams: ['session'],
         pathParams: ['session'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$PartialResultSet>(parameters, callback);
@@ -4609,7 +4627,7 @@ export namespace spanner_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Session>(parameters, callback);
@@ -4682,7 +4700,7 @@ export namespace spanner_v1 {
         params,
         requiredParams: ['database'],
         pathParams: ['database'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListSessionsResponse>(parameters, callback);
@@ -4765,7 +4783,7 @@ export namespace spanner_v1 {
         params,
         requiredParams: ['session'],
         pathParams: ['session'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$PartitionResponse>(parameters, callback);
@@ -4850,7 +4868,7 @@ export namespace spanner_v1 {
         params,
         requiredParams: ['session'],
         pathParams: ['session'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$PartitionResponse>(parameters, callback);
@@ -4927,7 +4945,7 @@ export namespace spanner_v1 {
         params,
         requiredParams: ['session'],
         pathParams: ['session'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ResultSet>(parameters, callback);
@@ -5001,7 +5019,7 @@ export namespace spanner_v1 {
         params,
         requiredParams: ['session'],
         pathParams: ['session'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -5078,7 +5096,7 @@ export namespace spanner_v1 {
         params,
         requiredParams: ['session'],
         pathParams: ['session'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$PartialResultSet>(parameters, callback);
@@ -5335,7 +5353,10 @@ export namespace spanner_v1 {
 
 
   export class Resource$Projects$Instances$Operations {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -5402,7 +5423,7 @@ export namespace spanner_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -5470,7 +5491,7 @@ export namespace spanner_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -5534,7 +5555,7 @@ export namespace spanner_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -5612,7 +5633,7 @@ export namespace spanner_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListOperationsResponse>(parameters, callback);

--- a/src/apis/speech/v1.ts
+++ b/src/apis/speech/v1.ts
@@ -29,8 +29,6 @@ export namespace speech_v1 {
     version: 'v1';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * V1 error format.
@@ -98,16 +96,17 @@ export namespace speech_v1 {
    * @param {object=} options Options for Speech
    */
   export class Speech {
+    context: APIRequestContext;
     operations: Resource$Operations;
     projects: Resource$Projects;
     speech: Resource$Speech;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.operations = new Resource$Operations();
-      this.projects = new Resource$Projects();
-      this.speech = new Resource$Speech();
+      this.operations = new Resource$Operations(this.context);
+      this.projects = new Resource$Projects(this.context);
+      this.speech = new Resource$Speech(this.context);
     }
   }
 
@@ -582,7 +581,10 @@ export namespace speech_v1 {
 
 
   export class Resource$Operations {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -639,7 +641,7 @@ export namespace speech_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -715,7 +717,7 @@ export namespace speech_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListOperationsResponse>(parameters, callback);
@@ -762,25 +764,33 @@ export namespace speech_v1 {
 
 
   export class Resource$Projects {
+    context: APIRequestContext;
     locations: Resource$Projects$Locations;
     operations: Resource$Projects$Operations;
-    constructor() {
-      this.locations = new Resource$Projects$Locations();
-      this.operations = new Resource$Projects$Operations();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.locations = new Resource$Projects$Locations(this.context);
+      this.operations = new Resource$Projects$Operations(this.context);
     }
   }
 
 
   export class Resource$Projects$Locations {
+    context: APIRequestContext;
     operations: Resource$Projects$Locations$Operations;
-    constructor() {
-      this.operations = new Resource$Projects$Locations$Operations();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.operations =
+          new Resource$Projects$Locations$Operations(this.context);
     }
   }
 
 
   export class Resource$Projects$Locations$Operations {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -837,7 +847,7 @@ export namespace speech_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -916,7 +926,7 @@ export namespace speech_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListOperationsResponse>(parameters, callback);
@@ -966,16 +976,21 @@ export namespace speech_v1 {
 
 
   export class Resource$Projects$Operations {
+    context: APIRequestContext;
     manualRecognitionTasks: Resource$Projects$Operations$Manualrecognitiontasks;
-    constructor() {
+    constructor(context: APIRequestContext) {
+      this.context = context;
       this.manualRecognitionTasks =
-          new Resource$Projects$Operations$Manualrecognitiontasks();
+          new Resource$Projects$Operations$Manualrecognitiontasks(this.context);
     }
   }
 
 
   export class Resource$Projects$Operations$Manualrecognitiontasks {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1034,7 +1049,7 @@ export namespace speech_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -1060,7 +1075,10 @@ export namespace speech_v1 {
 
 
   export class Resource$Speech {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1126,7 +1144,7 @@ export namespace speech_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -1193,7 +1211,7 @@ export namespace speech_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$RecognizeResponse>(parameters, callback);

--- a/src/apis/speech/v1p1beta1.ts
+++ b/src/apis/speech/v1p1beta1.ts
@@ -29,8 +29,6 @@ export namespace speech_v1p1beta1 {
     version: 'v1p1beta1';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * V1 error format.
@@ -98,16 +96,17 @@ export namespace speech_v1p1beta1 {
    * @param {object=} options Options for Speech
    */
   export class Speech {
+    context: APIRequestContext;
     operations: Resource$Operations;
     projects: Resource$Projects;
     speech: Resource$Speech;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.operations = new Resource$Operations();
-      this.projects = new Resource$Projects();
-      this.speech = new Resource$Speech();
+      this.operations = new Resource$Operations(this.context);
+      this.projects = new Resource$Projects(this.context);
+      this.speech = new Resource$Speech(this.context);
     }
   }
 
@@ -678,7 +677,10 @@ export namespace speech_v1p1beta1 {
 
 
   export class Resource$Operations {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -735,7 +737,7 @@ export namespace speech_v1p1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -812,7 +814,7 @@ export namespace speech_v1p1beta1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListOperationsResponse>(parameters, callback);
@@ -859,25 +861,33 @@ export namespace speech_v1p1beta1 {
 
 
   export class Resource$Projects {
+    context: APIRequestContext;
     locations: Resource$Projects$Locations;
     operations: Resource$Projects$Operations;
-    constructor() {
-      this.locations = new Resource$Projects$Locations();
-      this.operations = new Resource$Projects$Operations();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.locations = new Resource$Projects$Locations(this.context);
+      this.operations = new Resource$Projects$Operations(this.context);
     }
   }
 
 
   export class Resource$Projects$Locations {
+    context: APIRequestContext;
     operations: Resource$Projects$Locations$Operations;
-    constructor() {
-      this.operations = new Resource$Projects$Locations$Operations();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.operations =
+          new Resource$Projects$Locations$Operations(this.context);
     }
   }
 
 
   export class Resource$Projects$Locations$Operations {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -935,7 +945,7 @@ export namespace speech_v1p1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -1014,7 +1024,7 @@ export namespace speech_v1p1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListOperationsResponse>(parameters, callback);
@@ -1064,16 +1074,21 @@ export namespace speech_v1p1beta1 {
 
 
   export class Resource$Projects$Operations {
+    context: APIRequestContext;
     manualRecognitionTasks: Resource$Projects$Operations$Manualrecognitiontasks;
-    constructor() {
+    constructor(context: APIRequestContext) {
+      this.context = context;
       this.manualRecognitionTasks =
-          new Resource$Projects$Operations$Manualrecognitiontasks();
+          new Resource$Projects$Operations$Manualrecognitiontasks(this.context);
     }
   }
 
 
   export class Resource$Projects$Operations$Manualrecognitiontasks {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1133,7 +1148,7 @@ export namespace speech_v1p1beta1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -1159,7 +1174,10 @@ export namespace speech_v1p1beta1 {
 
 
   export class Resource$Speech {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1225,7 +1243,7 @@ export namespace speech_v1p1beta1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -1292,7 +1310,7 @@ export namespace speech_v1p1beta1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$RecognizeResponse>(parameters, callback);

--- a/src/apis/sqladmin/v1beta4.ts
+++ b/src/apis/sqladmin/v1beta4.ts
@@ -29,8 +29,6 @@ export namespace sqladmin_v1beta4 {
     version: 'v1beta4';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * Data format for the response.
@@ -82,6 +80,7 @@ export namespace sqladmin_v1beta4 {
    * @param {object=} options Options for Sqladmin
    */
   export class Sqladmin {
+    context: APIRequestContext;
     backupRuns: Resource$Backupruns;
     databases: Resource$Databases;
     flags: Resource$Flags;
@@ -92,16 +91,16 @@ export namespace sqladmin_v1beta4 {
     users: Resource$Users;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.backupRuns = new Resource$Backupruns();
-      this.databases = new Resource$Databases();
-      this.flags = new Resource$Flags();
-      this.instances = new Resource$Instances();
-      this.operations = new Resource$Operations();
-      this.sslCerts = new Resource$Sslcerts();
-      this.tiers = new Resource$Tiers();
-      this.users = new Resource$Users();
+      this.backupRuns = new Resource$Backupruns(this.context);
+      this.databases = new Resource$Databases(this.context);
+      this.flags = new Resource$Flags(this.context);
+      this.instances = new Resource$Instances(this.context);
+      this.operations = new Resource$Operations(this.context);
+      this.sslCerts = new Resource$Sslcerts(this.context);
+      this.tiers = new Resource$Tiers(this.context);
+      this.users = new Resource$Users(this.context);
     }
   }
 
@@ -1566,7 +1565,10 @@ export namespace sqladmin_v1beta4 {
 
 
   export class Resource$Backupruns {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1629,7 +1631,7 @@ export namespace sqladmin_v1beta4 {
         params,
         requiredParams: ['project', 'instance', 'id'],
         pathParams: ['id', 'instance', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -1695,7 +1697,7 @@ export namespace sqladmin_v1beta4 {
         params,
         requiredParams: ['project', 'instance', 'id'],
         pathParams: ['id', 'instance', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$BackupRun>(parameters, callback);
@@ -1766,7 +1768,7 @@ export namespace sqladmin_v1beta4 {
         params,
         requiredParams: ['project', 'instance'],
         pathParams: ['instance', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -1839,7 +1841,7 @@ export namespace sqladmin_v1beta4 {
         params,
         requiredParams: ['project', 'instance'],
         pathParams: ['instance', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$BackupRunsListResponse>(parameters, callback);
@@ -1937,7 +1939,10 @@ export namespace sqladmin_v1beta4 {
 
 
   export class Resource$Databases {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1999,7 +2004,7 @@ export namespace sqladmin_v1beta4 {
         params,
         requiredParams: ['project', 'instance', 'database'],
         pathParams: ['database', 'instance', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -2065,7 +2070,7 @@ export namespace sqladmin_v1beta4 {
         params,
         requiredParams: ['project', 'instance', 'database'],
         pathParams: ['database', 'instance', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Database>(parameters, callback);
@@ -2135,7 +2140,7 @@ export namespace sqladmin_v1beta4 {
         params,
         requiredParams: ['project', 'instance'],
         pathParams: ['instance', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -2204,7 +2209,7 @@ export namespace sqladmin_v1beta4 {
         params,
         requiredParams: ['project', 'instance'],
         pathParams: ['instance', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$DatabasesListResponse>(parameters, callback);
@@ -2275,7 +2280,7 @@ export namespace sqladmin_v1beta4 {
         params,
         requiredParams: ['project', 'instance', 'database'],
         pathParams: ['database', 'instance', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -2346,7 +2351,7 @@ export namespace sqladmin_v1beta4 {
         params,
         requiredParams: ['project', 'instance', 'database'],
         pathParams: ['database', 'instance', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -2480,7 +2485,10 @@ export namespace sqladmin_v1beta4 {
 
 
   export class Resource$Flags {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -2538,7 +2546,7 @@ export namespace sqladmin_v1beta4 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$FlagsListResponse>(parameters, callback);
@@ -2563,7 +2571,10 @@ export namespace sqladmin_v1beta4 {
 
 
   export class Resource$Instances {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -2630,7 +2641,7 @@ export namespace sqladmin_v1beta4 {
         params,
         requiredParams: ['project', 'instance'],
         pathParams: ['instance', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -2699,7 +2710,7 @@ export namespace sqladmin_v1beta4 {
         params,
         requiredParams: ['project', 'instance'],
         pathParams: ['instance', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -2766,7 +2777,7 @@ export namespace sqladmin_v1beta4 {
         params,
         requiredParams: ['project', 'instance'],
         pathParams: ['instance', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -2838,7 +2849,7 @@ export namespace sqladmin_v1beta4 {
         params,
         requiredParams: ['project', 'instance'],
         pathParams: ['instance', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -2908,7 +2919,7 @@ export namespace sqladmin_v1beta4 {
         params,
         requiredParams: ['project', 'instance'],
         pathParams: ['instance', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -2979,7 +2990,7 @@ export namespace sqladmin_v1beta4 {
         params,
         requiredParams: ['project', 'instance'],
         pathParams: ['instance', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -3044,7 +3055,7 @@ export namespace sqladmin_v1beta4 {
         params,
         requiredParams: ['project', 'instance'],
         pathParams: ['instance', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$DatabaseInstance>(parameters, callback);
@@ -3086,7 +3097,7 @@ import(paramsOrCallback?: Params$Resource$Instances$Import|BodyResponseCallback<
     options = {};
                                                                                                                                                                                                                                                                            }
 
-                                                                                                                                                                                                                                                                           const rootUrl = options.rootUrl || 'https://www.googleapis.com/'; const parameters = {options: Object.assign({url: (rootUrl + '/sql/v1beta4/projects/{project}/instances/{instance}/import').replace(/([^:]\/)\/+/g, '$1'), method: 'POST'}, options), params, requiredParams: ['project', 'instance'], pathParams: ['instance', 'project'], context}; if(callback) {
+                                                                                                                                                                                                                                                                           const rootUrl = options.rootUrl || 'https://www.googleapis.com/'; const parameters = {options: Object.assign({url: (rootUrl + '/sql/v1beta4/projects/{project}/instances/{instance}/import').replace(/([^:]\/)\/+/g, '$1'), method: 'POST'}, options), params, requiredParams: ['project', 'instance'], pathParams: ['instance', 'project'], context: this.context}; if(callback) {
     createAPIRequest<Schema$Operation>(parameters, callback);
                                                                                                                                                                                                                                                                            } else {
     return createAPIRequest<Schema$Operation>(parameters);
@@ -3148,7 +3159,7 @@ import(paramsOrCallback?: Params$Resource$Instances$Import|BodyResponseCallback<
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -3218,7 +3229,7 @@ import(paramsOrCallback?: Params$Resource$Instances$Import|BodyResponseCallback<
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$InstancesListResponse>(parameters, callback);
@@ -3298,7 +3309,7 @@ import(paramsOrCallback?: Params$Resource$Instances$Import|BodyResponseCallback<
         params,
         requiredParams: ['project', 'instance'],
         pathParams: ['instance', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$InstancesListServerCasResponse>(
@@ -3371,7 +3382,7 @@ import(paramsOrCallback?: Params$Resource$Instances$Import|BodyResponseCallback<
         params,
         requiredParams: ['project', 'instance'],
         pathParams: ['instance', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -3442,7 +3453,7 @@ import(paramsOrCallback?: Params$Resource$Instances$Import|BodyResponseCallback<
         params,
         requiredParams: ['project', 'instance'],
         pathParams: ['instance', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -3513,7 +3524,7 @@ import(paramsOrCallback?: Params$Resource$Instances$Import|BodyResponseCallback<
         params,
         requiredParams: ['project', 'instance'],
         pathParams: ['instance', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -3583,7 +3594,7 @@ import(paramsOrCallback?: Params$Resource$Instances$Import|BodyResponseCallback<
         params,
         requiredParams: ['project', 'instance'],
         pathParams: ['instance', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -3654,7 +3665,7 @@ import(paramsOrCallback?: Params$Resource$Instances$Import|BodyResponseCallback<
         params,
         requiredParams: ['project', 'instance'],
         pathParams: ['instance', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -3726,7 +3737,7 @@ import(paramsOrCallback?: Params$Resource$Instances$Import|BodyResponseCallback<
         params,
         requiredParams: ['project', 'instance'],
         pathParams: ['instance', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -3796,7 +3807,7 @@ import(paramsOrCallback?: Params$Resource$Instances$Import|BodyResponseCallback<
         params,
         requiredParams: ['project', 'instance'],
         pathParams: ['instance', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -3866,7 +3877,7 @@ import(paramsOrCallback?: Params$Resource$Instances$Import|BodyResponseCallback<
         params,
         requiredParams: ['project', 'instance'],
         pathParams: ['instance', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -3937,7 +3948,7 @@ import(paramsOrCallback?: Params$Resource$Instances$Import|BodyResponseCallback<
         params,
         requiredParams: ['project', 'instance'],
         pathParams: ['instance', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -4007,7 +4018,7 @@ import(paramsOrCallback?: Params$Resource$Instances$Import|BodyResponseCallback<
         params,
         requiredParams: ['project', 'instance'],
         pathParams: ['instance', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -4410,7 +4421,10 @@ import(paramsOrCallback?: Params$Resource$Instances$Import|BodyResponseCallback<
 
 
   export class Resource$Operations {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -4468,7 +4482,7 @@ import(paramsOrCallback?: Params$Resource$Instances$Import|BodyResponseCallback<
         params,
         requiredParams: ['project', 'operation'],
         pathParams: ['operation', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -4538,7 +4552,7 @@ import(paramsOrCallback?: Params$Resource$Instances$Import|BodyResponseCallback<
         params,
         requiredParams: ['project', 'instance'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$OperationsListResponse>(parameters, callback);
@@ -4590,7 +4604,10 @@ import(paramsOrCallback?: Params$Resource$Instances$Import|BodyResponseCallback<
 
 
   export class Resource$Sslcerts {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -4656,7 +4673,7 @@ import(paramsOrCallback?: Params$Resource$Instances$Import|BodyResponseCallback<
         params,
         requiredParams: ['project', 'instance'],
         pathParams: ['instance', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$SslCert>(parameters, callback);
@@ -4726,7 +4743,7 @@ import(paramsOrCallback?: Params$Resource$Instances$Import|BodyResponseCallback<
         params,
         requiredParams: ['project', 'instance', 'sha1Fingerprint'],
         pathParams: ['instance', 'project', 'sha1Fingerprint'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -4793,7 +4810,7 @@ import(paramsOrCallback?: Params$Resource$Instances$Import|BodyResponseCallback<
         params,
         requiredParams: ['project', 'instance', 'sha1Fingerprint'],
         pathParams: ['instance', 'project', 'sha1Fingerprint'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$SslCert>(parameters, callback);
@@ -4865,7 +4882,7 @@ import(paramsOrCallback?: Params$Resource$Instances$Import|BodyResponseCallback<
         params,
         requiredParams: ['project', 'instance'],
         pathParams: ['instance', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$SslCertsInsertResponse>(parameters, callback);
@@ -4934,7 +4951,7 @@ import(paramsOrCallback?: Params$Resource$Instances$Import|BodyResponseCallback<
         params,
         requiredParams: ['project', 'instance'],
         pathParams: ['instance', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$SslCertsListResponse>(parameters, callback);
@@ -5041,7 +5058,10 @@ import(paramsOrCallback?: Params$Resource$Instances$Import|BodyResponseCallback<
 
 
   export class Resource$Tiers {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -5100,7 +5120,7 @@ import(paramsOrCallback?: Params$Resource$Instances$Import|BodyResponseCallback<
         params,
         requiredParams: ['project'],
         pathParams: ['project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TiersListResponse>(parameters, callback);
@@ -5124,7 +5144,10 @@ import(paramsOrCallback?: Params$Resource$Instances$Import|BodyResponseCallback<
 
 
   export class Resource$Users {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -5187,7 +5210,7 @@ import(paramsOrCallback?: Params$Resource$Instances$Import|BodyResponseCallback<
         params,
         requiredParams: ['project', 'instance', 'host', 'name'],
         pathParams: ['instance', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -5256,7 +5279,7 @@ import(paramsOrCallback?: Params$Resource$Instances$Import|BodyResponseCallback<
         params,
         requiredParams: ['project', 'instance'],
         pathParams: ['instance', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -5324,7 +5347,7 @@ import(paramsOrCallback?: Params$Resource$Instances$Import|BodyResponseCallback<
         params,
         requiredParams: ['project', 'instance'],
         pathParams: ['instance', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$UsersListResponse>(parameters, callback);
@@ -5395,7 +5418,7 @@ import(paramsOrCallback?: Params$Resource$Instances$Import|BodyResponseCallback<
         params,
         requiredParams: ['project', 'instance', 'name'],
         pathParams: ['instance', 'project'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);

--- a/src/apis/storage/v1.ts
+++ b/src/apis/storage/v1.ts
@@ -29,8 +29,6 @@ export namespace storage_v1 {
     version: 'v1';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * Data format for the response.
@@ -81,6 +79,7 @@ export namespace storage_v1 {
    * @param {object=} options Options for Storage
    */
   export class Storage {
+    context: APIRequestContext;
     bucketAccessControls: Resource$Bucketaccesscontrols;
     buckets: Resource$Buckets;
     channels: Resource$Channels;
@@ -91,17 +90,19 @@ export namespace storage_v1 {
     projects: Resource$Projects;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.bucketAccessControls = new Resource$Bucketaccesscontrols();
-      this.buckets = new Resource$Buckets();
-      this.channels = new Resource$Channels();
+      this.bucketAccessControls =
+          new Resource$Bucketaccesscontrols(this.context);
+      this.buckets = new Resource$Buckets(this.context);
+      this.channels = new Resource$Channels(this.context);
       this.defaultObjectAccessControls =
-          new Resource$Defaultobjectaccesscontrols();
-      this.notifications = new Resource$Notifications();
-      this.objectAccessControls = new Resource$Objectaccesscontrols();
-      this.objects = new Resource$Objects();
-      this.projects = new Resource$Projects();
+          new Resource$Defaultobjectaccesscontrols(this.context);
+      this.notifications = new Resource$Notifications(this.context);
+      this.objectAccessControls =
+          new Resource$Objectaccesscontrols(this.context);
+      this.objects = new Resource$Objects(this.context);
+      this.projects = new Resource$Projects(this.context);
     }
   }
 
@@ -896,7 +897,10 @@ export namespace storage_v1 {
 
 
   export class Resource$Bucketaccesscontrols {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1012,7 +1016,7 @@ export namespace storage_v1 {
         params,
         requiredParams: ['bucket', 'entity'],
         pathParams: ['bucket', 'entity'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -1136,7 +1140,7 @@ export namespace storage_v1 {
         params,
         requiredParams: ['bucket', 'entity'],
         pathParams: ['bucket', 'entity'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$BucketAccessControl>(parameters, callback);
@@ -1262,7 +1266,7 @@ export namespace storage_v1 {
         params,
         requiredParams: ['bucket'],
         pathParams: ['bucket'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$BucketAccessControl>(parameters, callback);
@@ -1384,7 +1388,7 @@ export namespace storage_v1 {
         params,
         requiredParams: ['bucket'],
         pathParams: ['bucket'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$BucketAccessControls>(parameters, callback);
@@ -1518,7 +1522,7 @@ export namespace storage_v1 {
         params,
         requiredParams: ['bucket', 'entity'],
         pathParams: ['bucket', 'entity'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$BucketAccessControl>(parameters, callback);
@@ -1652,7 +1656,7 @@ export namespace storage_v1 {
         params,
         requiredParams: ['bucket', 'entity'],
         pathParams: ['bucket', 'entity'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$BucketAccessControl>(parameters, callback);
@@ -1802,7 +1806,10 @@ export namespace storage_v1 {
 
 
   export class Resource$Buckets {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1911,7 +1918,7 @@ export namespace storage_v1 {
         params,
         requiredParams: ['bucket'],
         pathParams: ['bucket'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -2029,7 +2036,7 @@ export namespace storage_v1 {
         params,
         requiredParams: ['bucket'],
         pathParams: ['bucket'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Bucket>(parameters, callback);
@@ -2149,7 +2156,7 @@ export namespace storage_v1 {
         params,
         requiredParams: ['bucket'],
         pathParams: ['bucket'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -2274,7 +2281,7 @@ export namespace storage_v1 {
         params,
         requiredParams: ['project'],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Bucket>(parameters, callback);
@@ -2408,7 +2415,7 @@ export namespace storage_v1 {
         params,
         requiredParams: ['project'],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Buckets>(parameters, callback);
@@ -2476,7 +2483,7 @@ export namespace storage_v1 {
         params,
         requiredParams: ['bucket', 'ifMetagenerationMatch'],
         pathParams: ['bucket'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Bucket>(parameters, callback);
@@ -2608,7 +2615,7 @@ export namespace storage_v1 {
         params,
         requiredParams: ['bucket'],
         pathParams: ['bucket'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Bucket>(parameters, callback);
@@ -2735,7 +2742,7 @@ export namespace storage_v1 {
         params,
         requiredParams: ['bucket'],
         pathParams: ['bucket'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -2867,7 +2874,7 @@ export namespace storage_v1 {
         params,
         requiredParams: ['bucket', 'permissions'],
         pathParams: ['bucket'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TestIamPermissionsResponse>(
@@ -3000,7 +3007,7 @@ export namespace storage_v1 {
         params,
         requiredParams: ['bucket'],
         pathParams: ['bucket'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Bucket>(parameters, callback);
@@ -3303,7 +3310,10 @@ export namespace storage_v1 {
 
 
   export class Resource$Channels {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -3410,7 +3420,7 @@ export namespace storage_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -3435,7 +3445,10 @@ export namespace storage_v1 {
 
 
   export class Resource$Defaultobjectaccesscontrols {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -3552,7 +3565,7 @@ export namespace storage_v1 {
         params,
         requiredParams: ['bucket', 'entity'],
         pathParams: ['bucket', 'entity'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -3675,7 +3688,7 @@ export namespace storage_v1 {
         params,
         requiredParams: ['bucket', 'entity'],
         pathParams: ['bucket', 'entity'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ObjectAccessControl>(parameters, callback);
@@ -3799,7 +3812,7 @@ export namespace storage_v1 {
         params,
         requiredParams: ['bucket'],
         pathParams: ['bucket'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ObjectAccessControl>(parameters, callback);
@@ -3921,7 +3934,7 @@ export namespace storage_v1 {
         params,
         requiredParams: ['bucket'],
         pathParams: ['bucket'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ObjectAccessControls>(parameters, callback);
@@ -4054,7 +4067,7 @@ export namespace storage_v1 {
         params,
         requiredParams: ['bucket', 'entity'],
         pathParams: ['bucket', 'entity'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ObjectAccessControl>(parameters, callback);
@@ -4187,7 +4200,7 @@ export namespace storage_v1 {
         params,
         requiredParams: ['bucket', 'entity'],
         pathParams: ['bucket', 'entity'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ObjectAccessControl>(parameters, callback);
@@ -4347,7 +4360,10 @@ export namespace storage_v1 {
 
 
   export class Resource$Notifications {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -4461,7 +4477,7 @@ export namespace storage_v1 {
         params,
         requiredParams: ['bucket', 'notification'],
         pathParams: ['bucket', 'notification'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -4583,7 +4599,7 @@ export namespace storage_v1 {
         params,
         requiredParams: ['bucket', 'notification'],
         pathParams: ['bucket', 'notification'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Notification>(parameters, callback);
@@ -4709,7 +4725,7 @@ export namespace storage_v1 {
         params,
         requiredParams: ['bucket'],
         pathParams: ['bucket'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Notification>(parameters, callback);
@@ -4829,7 +4845,7 @@ export namespace storage_v1 {
         params,
         requiredParams: ['bucket'],
         pathParams: ['bucket'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Notifications>(parameters, callback);
@@ -4923,7 +4939,10 @@ export namespace storage_v1 {
 
 
   export class Resource$Objectaccesscontrols {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -5046,7 +5065,7 @@ export namespace storage_v1 {
         params,
         requiredParams: ['bucket', 'object', 'entity'],
         pathParams: ['bucket', 'entity', 'object'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -5177,7 +5196,7 @@ export namespace storage_v1 {
         params,
         requiredParams: ['bucket', 'object', 'entity'],
         pathParams: ['bucket', 'entity', 'object'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ObjectAccessControl>(parameters, callback);
@@ -5310,7 +5329,7 @@ export namespace storage_v1 {
         params,
         requiredParams: ['bucket', 'object'],
         pathParams: ['bucket', 'object'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ObjectAccessControl>(parameters, callback);
@@ -5439,7 +5458,7 @@ export namespace storage_v1 {
         params,
         requiredParams: ['bucket', 'object'],
         pathParams: ['bucket', 'object'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ObjectAccessControls>(parameters, callback);
@@ -5580,7 +5599,7 @@ export namespace storage_v1 {
         params,
         requiredParams: ['bucket', 'object', 'entity'],
         pathParams: ['bucket', 'entity', 'object'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ObjectAccessControl>(parameters, callback);
@@ -5721,7 +5740,7 @@ export namespace storage_v1 {
         params,
         requiredParams: ['bucket', 'object', 'entity'],
         pathParams: ['bucket', 'entity', 'object'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ObjectAccessControl>(parameters, callback);
@@ -5931,7 +5950,10 @@ export namespace storage_v1 {
 
 
   export class Resource$Objects {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -6062,7 +6084,7 @@ export namespace storage_v1 {
         params,
         requiredParams: ['destinationBucket', 'destinationObject'],
         pathParams: ['destinationBucket', 'destinationObject'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Object>(parameters, callback);
@@ -6227,7 +6249,7 @@ export namespace storage_v1 {
           'destinationBucket', 'destinationObject', 'sourceBucket',
           'sourceObject'
         ],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Object>(parameters, callback);
@@ -6354,7 +6376,7 @@ export namespace storage_v1 {
         params,
         requiredParams: ['bucket', 'object'],
         pathParams: ['bucket', 'object'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -6485,7 +6507,7 @@ export namespace storage_v1 {
         params,
         requiredParams: ['bucket', 'object'],
         pathParams: ['bucket', 'object'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Object>(parameters, callback);
@@ -6612,7 +6634,7 @@ export namespace storage_v1 {
         params,
         requiredParams: ['bucket', 'object'],
         pathParams: ['bucket', 'object'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -6758,7 +6780,7 @@ export namespace storage_v1 {
                       .replace(/([^:]\/)\/+/g, '$1'),
         requiredParams: ['bucket'],
         pathParams: ['bucket'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Object>(parameters, callback);
@@ -6896,7 +6918,7 @@ export namespace storage_v1 {
         params,
         requiredParams: ['bucket'],
         pathParams: ['bucket'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Objects>(parameters, callback);
@@ -7034,7 +7056,7 @@ export namespace storage_v1 {
         params,
         requiredParams: ['bucket', 'object'],
         pathParams: ['bucket', 'object'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Object>(parameters, callback);
@@ -7203,7 +7225,7 @@ export namespace storage_v1 {
           'destinationBucket', 'destinationObject', 'sourceBucket',
           'sourceObject'
         ],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$RewriteResponse>(parameters, callback);
@@ -7337,7 +7359,7 @@ export namespace storage_v1 {
         params,
         requiredParams: ['bucket', 'object'],
         pathParams: ['bucket', 'object'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Policy>(parameters, callback);
@@ -7477,7 +7499,7 @@ export namespace storage_v1 {
         params,
         requiredParams: ['bucket', 'object', 'permissions'],
         pathParams: ['bucket', 'object'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TestIamPermissionsResponse>(
@@ -7616,7 +7638,7 @@ export namespace storage_v1 {
         params,
         requiredParams: ['bucket', 'object'],
         pathParams: ['bucket', 'object'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Object>(parameters, callback);
@@ -7747,7 +7769,7 @@ export namespace storage_v1 {
         params,
         requiredParams: ['bucket'],
         pathParams: ['bucket'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Channel>(parameters, callback);
@@ -8542,15 +8564,20 @@ export namespace storage_v1 {
 
 
   export class Resource$Projects {
+    context: APIRequestContext;
     serviceAccount: Resource$Projects$Serviceaccount;
-    constructor() {
-      this.serviceAccount = new Resource$Projects$Serviceaccount();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.serviceAccount = new Resource$Projects$Serviceaccount(this.context);
     }
   }
 
 
   export class Resource$Projects$Serviceaccount {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -8661,7 +8688,7 @@ export namespace storage_v1 {
         params,
         requiredParams: ['projectId'],
         pathParams: ['projectId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ServiceAccount>(parameters, callback);

--- a/src/apis/storage/v1beta1.ts
+++ b/src/apis/storage/v1beta1.ts
@@ -29,8 +29,6 @@ export namespace storage_v1beta1 {
     version: 'v1beta1';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * Data format for the response.
@@ -81,18 +79,21 @@ export namespace storage_v1beta1 {
    * @param {object=} options Options for Storage
    */
   export class Storage {
+    context: APIRequestContext;
     bucketAccessControls: Resource$Bucketaccesscontrols;
     buckets: Resource$Buckets;
     objectAccessControls: Resource$Objectaccesscontrols;
     objects: Resource$Objects;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.bucketAccessControls = new Resource$Bucketaccesscontrols();
-      this.buckets = new Resource$Buckets();
-      this.objectAccessControls = new Resource$Objectaccesscontrols();
-      this.objects = new Resource$Objects();
+      this.bucketAccessControls =
+          new Resource$Bucketaccesscontrols(this.context);
+      this.buckets = new Resource$Buckets(this.context);
+      this.objectAccessControls =
+          new Resource$Objectaccesscontrols(this.context);
+      this.objects = new Resource$Objects(this.context);
     }
   }
 
@@ -383,7 +384,10 @@ export namespace storage_v1beta1 {
 
 
   export class Resource$Bucketaccesscontrols {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -443,7 +447,7 @@ export namespace storage_v1beta1 {
         params,
         requiredParams: ['bucket', 'entity'],
         pathParams: ['bucket', 'entity'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -508,7 +512,7 @@ export namespace storage_v1beta1 {
         params,
         requiredParams: ['bucket', 'entity'],
         pathParams: ['bucket', 'entity'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$BucketAccessControl>(parameters, callback);
@@ -576,7 +580,7 @@ export namespace storage_v1beta1 {
         params,
         requiredParams: ['bucket'],
         pathParams: ['bucket'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$BucketAccessControl>(parameters, callback);
@@ -644,7 +648,7 @@ export namespace storage_v1beta1 {
         params,
         requiredParams: ['bucket'],
         pathParams: ['bucket'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$BucketAccessControls>(parameters, callback);
@@ -714,7 +718,7 @@ export namespace storage_v1beta1 {
         params,
         requiredParams: ['bucket', 'entity'],
         pathParams: ['bucket', 'entity'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$BucketAccessControl>(parameters, callback);
@@ -783,7 +787,7 @@ export namespace storage_v1beta1 {
         params,
         requiredParams: ['bucket', 'entity'],
         pathParams: ['bucket', 'entity'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$BucketAccessControl>(parameters, callback);
@@ -903,7 +907,10 @@ export namespace storage_v1beta1 {
 
 
   export class Resource$Buckets {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -959,7 +966,7 @@ export namespace storage_v1beta1 {
         params,
         requiredParams: ['bucket'],
         pathParams: ['bucket'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -1021,7 +1028,7 @@ export namespace storage_v1beta1 {
         params,
         requiredParams: ['bucket'],
         pathParams: ['bucket'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Bucket>(parameters, callback);
@@ -1086,7 +1093,7 @@ export namespace storage_v1beta1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Bucket>(parameters, callback);
@@ -1153,7 +1160,7 @@ export namespace storage_v1beta1 {
         params,
         requiredParams: ['projectId'],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Buckets>(parameters, callback);
@@ -1219,7 +1226,7 @@ export namespace storage_v1beta1 {
         params,
         requiredParams: ['bucket'],
         pathParams: ['bucket'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Bucket>(parameters, callback);
@@ -1285,7 +1292,7 @@ export namespace storage_v1beta1 {
         params,
         requiredParams: ['bucket'],
         pathParams: ['bucket'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Bucket>(parameters, callback);
@@ -1406,7 +1413,10 @@ export namespace storage_v1beta1 {
 
 
   export class Resource$Objectaccesscontrols {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1468,7 +1478,7 @@ export namespace storage_v1beta1 {
         params,
         requiredParams: ['bucket', 'object', 'entity'],
         pathParams: ['bucket', 'entity', 'object'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -1535,7 +1545,7 @@ export namespace storage_v1beta1 {
         params,
         requiredParams: ['bucket', 'object', 'entity'],
         pathParams: ['bucket', 'entity', 'object'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ObjectAccessControl>(parameters, callback);
@@ -1604,7 +1614,7 @@ export namespace storage_v1beta1 {
         params,
         requiredParams: ['bucket', 'object'],
         pathParams: ['bucket', 'object'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ObjectAccessControl>(parameters, callback);
@@ -1673,7 +1683,7 @@ export namespace storage_v1beta1 {
         params,
         requiredParams: ['bucket', 'object'],
         pathParams: ['bucket', 'object'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ObjectAccessControls>(parameters, callback);
@@ -1745,7 +1755,7 @@ export namespace storage_v1beta1 {
         params,
         requiredParams: ['bucket', 'object', 'entity'],
         pathParams: ['bucket', 'entity', 'object'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ObjectAccessControl>(parameters, callback);
@@ -1816,7 +1826,7 @@ export namespace storage_v1beta1 {
         params,
         requiredParams: ['bucket', 'object', 'entity'],
         pathParams: ['bucket', 'entity', 'object'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ObjectAccessControl>(parameters, callback);
@@ -1960,7 +1970,10 @@ export namespace storage_v1beta1 {
 
 
   export class Resource$Objects {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -2017,7 +2030,7 @@ export namespace storage_v1beta1 {
         params,
         requiredParams: ['bucket', 'object'],
         pathParams: ['bucket', 'object'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -2080,7 +2093,7 @@ export namespace storage_v1beta1 {
         params,
         requiredParams: ['bucket', 'object'],
         pathParams: ['bucket', 'object'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Object>(parameters, callback);
@@ -2152,7 +2165,7 @@ export namespace storage_v1beta1 {
                       .replace(/([^:]\/)\/+/g, '$1'),
         requiredParams: ['bucket'],
         pathParams: ['bucket'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Object>(parameters, callback);
@@ -2221,7 +2234,7 @@ export namespace storage_v1beta1 {
         params,
         requiredParams: ['bucket'],
         pathParams: ['bucket'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Objects>(parameters, callback);
@@ -2289,7 +2302,7 @@ export namespace storage_v1beta1 {
         params,
         requiredParams: ['bucket', 'object'],
         pathParams: ['bucket', 'object'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Object>(parameters, callback);
@@ -2356,7 +2369,7 @@ export namespace storage_v1beta1 {
         params,
         requiredParams: ['bucket', 'object'],
         pathParams: ['bucket', 'object'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Object>(parameters, callback);

--- a/src/apis/storage/v1beta2.ts
+++ b/src/apis/storage/v1beta2.ts
@@ -29,8 +29,6 @@ export namespace storage_v1beta2 {
     version: 'v1beta2';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * Data format for the response.
@@ -81,6 +79,7 @@ export namespace storage_v1beta2 {
    * @param {object=} options Options for Storage
    */
   export class Storage {
+    context: APIRequestContext;
     bucketAccessControls: Resource$Bucketaccesscontrols;
     buckets: Resource$Buckets;
     channels: Resource$Channels;
@@ -89,15 +88,17 @@ export namespace storage_v1beta2 {
     objects: Resource$Objects;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.bucketAccessControls = new Resource$Bucketaccesscontrols();
-      this.buckets = new Resource$Buckets();
-      this.channels = new Resource$Channels();
+      this.bucketAccessControls =
+          new Resource$Bucketaccesscontrols(this.context);
+      this.buckets = new Resource$Buckets(this.context);
+      this.channels = new Resource$Channels(this.context);
       this.defaultObjectAccessControls =
-          new Resource$Defaultobjectaccesscontrols();
-      this.objectAccessControls = new Resource$Objectaccesscontrols();
-      this.objects = new Resource$Objects();
+          new Resource$Defaultobjectaccesscontrols(this.context);
+      this.objectAccessControls =
+          new Resource$Objectaccesscontrols(this.context);
+      this.objects = new Resource$Objects(this.context);
     }
   }
 
@@ -560,7 +561,10 @@ export namespace storage_v1beta2 {
 
 
   export class Resource$Bucketaccesscontrols {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -620,7 +624,7 @@ export namespace storage_v1beta2 {
         params,
         requiredParams: ['bucket', 'entity'],
         pathParams: ['bucket', 'entity'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -685,7 +689,7 @@ export namespace storage_v1beta2 {
         params,
         requiredParams: ['bucket', 'entity'],
         pathParams: ['bucket', 'entity'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$BucketAccessControl>(parameters, callback);
@@ -753,7 +757,7 @@ export namespace storage_v1beta2 {
         params,
         requiredParams: ['bucket'],
         pathParams: ['bucket'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$BucketAccessControl>(parameters, callback);
@@ -821,7 +825,7 @@ export namespace storage_v1beta2 {
         params,
         requiredParams: ['bucket'],
         pathParams: ['bucket'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$BucketAccessControls>(parameters, callback);
@@ -891,7 +895,7 @@ export namespace storage_v1beta2 {
         params,
         requiredParams: ['bucket', 'entity'],
         pathParams: ['bucket', 'entity'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$BucketAccessControl>(parameters, callback);
@@ -960,7 +964,7 @@ export namespace storage_v1beta2 {
         params,
         requiredParams: ['bucket', 'entity'],
         pathParams: ['bucket', 'entity'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$BucketAccessControl>(parameters, callback);
@@ -1080,7 +1084,10 @@ export namespace storage_v1beta2 {
 
 
   export class Resource$Buckets {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1138,7 +1145,7 @@ export namespace storage_v1beta2 {
         params,
         requiredParams: ['bucket'],
         pathParams: ['bucket'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -1202,7 +1209,7 @@ export namespace storage_v1beta2 {
         params,
         requiredParams: ['bucket'],
         pathParams: ['bucket'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Bucket>(parameters, callback);
@@ -1268,7 +1275,7 @@ export namespace storage_v1beta2 {
         params,
         requiredParams: ['project'],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Bucket>(parameters, callback);
@@ -1335,7 +1342,7 @@ export namespace storage_v1beta2 {
         params,
         requiredParams: ['project'],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Buckets>(parameters, callback);
@@ -1403,7 +1410,7 @@ export namespace storage_v1beta2 {
         params,
         requiredParams: ['bucket'],
         pathParams: ['bucket'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Bucket>(parameters, callback);
@@ -1471,7 +1478,7 @@ export namespace storage_v1beta2 {
         params,
         requiredParams: ['bucket'],
         pathParams: ['bucket'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Bucket>(parameters, callback);
@@ -1636,7 +1643,10 @@ export namespace storage_v1beta2 {
 
 
   export class Resource$Channels {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1692,7 +1702,7 @@ export namespace storage_v1beta2 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -1717,7 +1727,10 @@ export namespace storage_v1beta2 {
 
 
   export class Resource$Defaultobjectaccesscontrols {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1778,7 +1791,7 @@ export namespace storage_v1beta2 {
         params,
         requiredParams: ['bucket', 'entity'],
         pathParams: ['bucket', 'entity'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -1844,7 +1857,7 @@ export namespace storage_v1beta2 {
         params,
         requiredParams: ['bucket', 'entity'],
         pathParams: ['bucket', 'entity'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ObjectAccessControl>(parameters, callback);
@@ -1912,7 +1925,7 @@ export namespace storage_v1beta2 {
         params,
         requiredParams: ['bucket'],
         pathParams: ['bucket'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ObjectAccessControl>(parameters, callback);
@@ -1982,7 +1995,7 @@ export namespace storage_v1beta2 {
         params,
         requiredParams: ['bucket'],
         pathParams: ['bucket'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ObjectAccessControls>(parameters, callback);
@@ -2053,7 +2066,7 @@ export namespace storage_v1beta2 {
         params,
         requiredParams: ['bucket', 'entity'],
         pathParams: ['bucket', 'entity'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ObjectAccessControl>(parameters, callback);
@@ -2123,7 +2136,7 @@ export namespace storage_v1beta2 {
         params,
         requiredParams: ['bucket', 'entity'],
         pathParams: ['bucket', 'entity'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ObjectAccessControl>(parameters, callback);
@@ -2253,7 +2266,10 @@ export namespace storage_v1beta2 {
 
 
   export class Resource$Objectaccesscontrols {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -2316,7 +2332,7 @@ export namespace storage_v1beta2 {
         params,
         requiredParams: ['bucket', 'object', 'entity'],
         pathParams: ['bucket', 'entity', 'object'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -2384,7 +2400,7 @@ export namespace storage_v1beta2 {
         params,
         requiredParams: ['bucket', 'object', 'entity'],
         pathParams: ['bucket', 'entity', 'object'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ObjectAccessControl>(parameters, callback);
@@ -2454,7 +2470,7 @@ export namespace storage_v1beta2 {
         params,
         requiredParams: ['bucket', 'object'],
         pathParams: ['bucket', 'object'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ObjectAccessControl>(parameters, callback);
@@ -2524,7 +2540,7 @@ export namespace storage_v1beta2 {
         params,
         requiredParams: ['bucket', 'object'],
         pathParams: ['bucket', 'object'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ObjectAccessControls>(parameters, callback);
@@ -2597,7 +2613,7 @@ export namespace storage_v1beta2 {
         params,
         requiredParams: ['bucket', 'object', 'entity'],
         pathParams: ['bucket', 'entity', 'object'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ObjectAccessControl>(parameters, callback);
@@ -2669,7 +2685,7 @@ export namespace storage_v1beta2 {
         params,
         requiredParams: ['bucket', 'object', 'entity'],
         pathParams: ['bucket', 'entity', 'object'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ObjectAccessControl>(parameters, callback);
@@ -2843,7 +2859,10 @@ export namespace storage_v1beta2 {
 
 
   export class Resource$Objects {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -2907,7 +2926,7 @@ export namespace storage_v1beta2 {
         params,
         requiredParams: ['destinationBucket', 'destinationObject'],
         pathParams: ['destinationBucket', 'destinationObject'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Object>(parameters, callback);
@@ -2994,7 +3013,7 @@ export namespace storage_v1beta2 {
           'destinationBucket', 'destinationObject', 'sourceBucket',
           'sourceObject'
         ],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Object>(parameters, callback);
@@ -3065,7 +3084,7 @@ export namespace storage_v1beta2 {
         params,
         requiredParams: ['bucket', 'object'],
         pathParams: ['bucket', 'object'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -3133,7 +3152,7 @@ export namespace storage_v1beta2 {
         params,
         requiredParams: ['bucket', 'object'],
         pathParams: ['bucket', 'object'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Object>(parameters, callback);
@@ -3209,7 +3228,7 @@ export namespace storage_v1beta2 {
                       .replace(/([^:]\/)\/+/g, '$1'),
         requiredParams: ['bucket'],
         pathParams: ['bucket'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Object>(parameters, callback);
@@ -3279,7 +3298,7 @@ export namespace storage_v1beta2 {
         params,
         requiredParams: ['bucket'],
         pathParams: ['bucket'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Objects>(parameters, callback);
@@ -3352,7 +3371,7 @@ export namespace storage_v1beta2 {
         params,
         requiredParams: ['bucket', 'object'],
         pathParams: ['bucket', 'object'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Object>(parameters, callback);
@@ -3424,7 +3443,7 @@ export namespace storage_v1beta2 {
         params,
         requiredParams: ['bucket', 'object'],
         pathParams: ['bucket', 'object'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Object>(parameters, callback);
@@ -3496,7 +3515,7 @@ export namespace storage_v1beta2 {
         params,
         requiredParams: ['bucket'],
         pathParams: ['bucket'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Channel>(parameters, callback);

--- a/src/apis/storagetransfer/v1.ts
+++ b/src/apis/storagetransfer/v1.ts
@@ -29,8 +29,6 @@ export namespace storagetransfer_v1 {
     version: 'v1';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * V1 error format.
@@ -99,16 +97,18 @@ export namespace storagetransfer_v1 {
    * @param {object=} options Options for Storagetransfer
    */
   export class Storagetransfer {
+    context: APIRequestContext;
     googleServiceAccounts: Resource$Googleserviceaccounts;
     transferJobs: Resource$Transferjobs;
     transferOperations: Resource$Transferoperations;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.googleServiceAccounts = new Resource$Googleserviceaccounts();
-      this.transferJobs = new Resource$Transferjobs();
-      this.transferOperations = new Resource$Transferoperations();
+      this.googleServiceAccounts =
+          new Resource$Googleserviceaccounts(this.context);
+      this.transferJobs = new Resource$Transferjobs(this.context);
+      this.transferOperations = new Resource$Transferoperations(this.context);
     }
   }
 
@@ -760,7 +760,10 @@ export namespace storagetransfer_v1 {
 
 
   export class Resource$Googleserviceaccounts {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -878,7 +881,7 @@ export namespace storagetransfer_v1 {
         params,
         requiredParams: ['projectId'],
         pathParams: ['projectId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleServiceAccount>(parameters, callback);
@@ -904,7 +907,10 @@ export namespace storagetransfer_v1 {
 
 
   export class Resource$Transferjobs {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1018,7 +1024,7 @@ export namespace storagetransfer_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TransferJob>(parameters, callback);
@@ -1136,7 +1142,7 @@ export namespace storagetransfer_v1 {
         params,
         requiredParams: ['jobName'],
         pathParams: ['jobName'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TransferJob>(parameters, callback);
@@ -1269,7 +1275,7 @@ export namespace storagetransfer_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListTransferJobsResponse>(parameters, callback);
@@ -1399,7 +1405,7 @@ export namespace storagetransfer_v1 {
         params,
         requiredParams: ['jobName'],
         pathParams: ['jobName'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TransferJob>(parameters, callback);
@@ -1484,7 +1490,10 @@ export namespace storagetransfer_v1 {
 
 
   export class Resource$Transferoperations {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1597,7 +1606,7 @@ export namespace storagetransfer_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -1715,7 +1724,7 @@ export namespace storagetransfer_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -1832,7 +1841,7 @@ export namespace storagetransfer_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -1978,7 +1987,7 @@ export namespace storagetransfer_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListOperationsResponse>(parameters, callback);
@@ -2102,7 +2111,7 @@ export namespace storagetransfer_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -2226,7 +2235,7 @@ export namespace storagetransfer_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);

--- a/src/apis/streetviewpublish/v1.ts
+++ b/src/apis/streetviewpublish/v1.ts
@@ -29,8 +29,6 @@ export namespace streetviewpublish_v1 {
     version: 'v1';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * V1 error format.
@@ -100,14 +98,15 @@ export namespace streetviewpublish_v1 {
    * @param {object=} options Options for Streetviewpublish
    */
   export class Streetviewpublish {
+    context: APIRequestContext;
     photo: Resource$Photo;
     photos: Resource$Photos;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.photo = new Resource$Photo();
-      this.photos = new Resource$Photos();
+      this.photo = new Resource$Photo(this.context);
+      this.photos = new Resource$Photos(this.context);
     }
   }
 
@@ -513,7 +512,10 @@ export namespace streetviewpublish_v1 {
 
 
   export class Resource$Photo {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -581,7 +583,7 @@ export namespace streetviewpublish_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Photo>(parameters, callback);
@@ -649,7 +651,7 @@ export namespace streetviewpublish_v1 {
         params,
         requiredParams: ['photoId'],
         pathParams: ['photoId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -718,7 +720,7 @@ export namespace streetviewpublish_v1 {
         params,
         requiredParams: ['photoId'],
         pathParams: ['photoId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Photo>(parameters, callback);
@@ -798,7 +800,7 @@ export namespace streetviewpublish_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$UploadRef>(parameters, callback);
@@ -873,7 +875,7 @@ export namespace streetviewpublish_v1 {
         params,
         requiredParams: ['id'],
         pathParams: ['id'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Photo>(parameters, callback);
@@ -976,7 +978,10 @@ export namespace streetviewpublish_v1 {
 
 
   export class Resource$Photos {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1044,7 +1049,7 @@ export namespace streetviewpublish_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$BatchDeletePhotosResponse>(
@@ -1120,7 +1125,7 @@ export namespace streetviewpublish_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$BatchGetPhotosResponse>(parameters, callback);
@@ -1202,7 +1207,7 @@ export namespace streetviewpublish_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$BatchUpdatePhotosResponse>(
@@ -1274,7 +1279,7 @@ export namespace streetviewpublish_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListPhotosResponse>(parameters, callback);

--- a/src/apis/surveys/v2.ts
+++ b/src/apis/surveys/v2.ts
@@ -29,8 +29,6 @@ export namespace surveys_v2 {
     version: 'v2';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * Data format for the response.
@@ -82,14 +80,15 @@ export namespace surveys_v2 {
    * @param {object=} options Options for Surveys
    */
   export class Surveys {
+    context: APIRequestContext;
     results: Resource$Results;
     surveys: Resource$Surveys;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.results = new Resource$Results();
-      this.surveys = new Resource$Surveys();
+      this.results = new Resource$Results(this.context);
+      this.surveys = new Resource$Surveys(this.context);
     }
   }
 
@@ -429,7 +428,10 @@ export namespace surveys_v2 {
 
 
   export class Resource$Results {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -487,7 +489,7 @@ export namespace surveys_v2 {
         params,
         requiredParams: ['surveyUrlId'],
         pathParams: ['surveyUrlId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$SurveyResults>(parameters, callback);
@@ -516,7 +518,10 @@ export namespace surveys_v2 {
 
 
   export class Resource$Surveys {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -575,7 +580,7 @@ export namespace surveys_v2 {
         params,
         requiredParams: ['surveyUrlId'],
         pathParams: ['surveyUrlId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$SurveysDeleteResponse>(parameters, callback);
@@ -636,7 +641,7 @@ export namespace surveys_v2 {
         params,
         requiredParams: ['surveyUrlId'],
         pathParams: ['surveyUrlId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Survey>(parameters, callback);
@@ -700,7 +705,7 @@ export namespace surveys_v2 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Survey>(parameters, callback);
@@ -767,7 +772,7 @@ export namespace surveys_v2 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$SurveysListResponse>(parameters, callback);
@@ -834,7 +839,7 @@ export namespace surveys_v2 {
         params,
         requiredParams: ['resourceId'],
         pathParams: ['resourceId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$SurveysStartResponse>(parameters, callback);
@@ -899,7 +904,7 @@ export namespace surveys_v2 {
         params,
         requiredParams: ['resourceId'],
         pathParams: ['resourceId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$SurveysStopResponse>(parameters, callback);
@@ -965,7 +970,7 @@ export namespace surveys_v2 {
         params,
         requiredParams: ['surveyUrlId'],
         pathParams: ['surveyUrlId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Survey>(parameters, callback);

--- a/src/apis/tagmanager/v1.ts
+++ b/src/apis/tagmanager/v1.ts
@@ -29,8 +29,6 @@ export namespace tagmanager_v1 {
     version: 'v1';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * Data format for the response.
@@ -81,12 +79,13 @@ export namespace tagmanager_v1 {
    * @param {object=} options Options for Tagmanager
    */
   export class Tagmanager {
+    context: APIRequestContext;
     accounts: Resource$Accounts;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.accounts = new Resource$Accounts();
+      this.accounts = new Resource$Accounts(this.context);
     }
   }
 
@@ -1038,11 +1037,13 @@ export namespace tagmanager_v1 {
 
 
   export class Resource$Accounts {
+    context: APIRequestContext;
     containers: Resource$Accounts$Containers;
     permissions: Resource$Accounts$Permissions;
-    constructor() {
-      this.containers = new Resource$Accounts$Containers();
-      this.permissions = new Resource$Accounts$Permissions();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.containers = new Resource$Accounts$Containers(this.context);
+      this.permissions = new Resource$Accounts$Permissions(this.context);
     }
 
 
@@ -1097,7 +1098,7 @@ export namespace tagmanager_v1 {
         params,
         requiredParams: ['accountId'],
         pathParams: ['accountId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Account>(parameters, callback);
@@ -1162,7 +1163,7 @@ export namespace tagmanager_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListAccountsResponse>(parameters, callback);
@@ -1228,7 +1229,7 @@ export namespace tagmanager_v1 {
         params,
         requiredParams: ['accountId'],
         pathParams: ['accountId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Account>(parameters, callback);
@@ -1278,6 +1279,7 @@ export namespace tagmanager_v1 {
   }
 
   export class Resource$Accounts$Containers {
+    context: APIRequestContext;
     environments: Resource$Accounts$Containers$Environments;
     folders: Resource$Accounts$Containers$Folders;
     move_folders: Resource$Accounts$Containers$Move_folders;
@@ -1287,16 +1289,20 @@ export namespace tagmanager_v1 {
     triggers: Resource$Accounts$Containers$Triggers;
     variables: Resource$Accounts$Containers$Variables;
     versions: Resource$Accounts$Containers$Versions;
-    constructor() {
-      this.environments = new Resource$Accounts$Containers$Environments();
-      this.folders = new Resource$Accounts$Containers$Folders();
-      this.move_folders = new Resource$Accounts$Containers$Move_folders();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.environments =
+          new Resource$Accounts$Containers$Environments(this.context);
+      this.folders = new Resource$Accounts$Containers$Folders(this.context);
+      this.move_folders =
+          new Resource$Accounts$Containers$Move_folders(this.context);
       this.reauthorize_environments =
-          new Resource$Accounts$Containers$Reauthorize_environments();
-      this.tags = new Resource$Accounts$Containers$Tags();
-      this.triggers = new Resource$Accounts$Containers$Triggers();
-      this.variables = new Resource$Accounts$Containers$Variables();
-      this.versions = new Resource$Accounts$Containers$Versions();
+          new Resource$Accounts$Containers$Reauthorize_environments(
+              this.context);
+      this.tags = new Resource$Accounts$Containers$Tags(this.context);
+      this.triggers = new Resource$Accounts$Containers$Triggers(this.context);
+      this.variables = new Resource$Accounts$Containers$Variables(this.context);
+      this.versions = new Resource$Accounts$Containers$Versions(this.context);
     }
 
 
@@ -1358,7 +1364,7 @@ export namespace tagmanager_v1 {
         params,
         requiredParams: ['accountId'],
         pathParams: ['accountId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Container>(parameters, callback);
@@ -1426,7 +1432,7 @@ export namespace tagmanager_v1 {
         params,
         requiredParams: ['accountId', 'containerId'],
         pathParams: ['accountId', 'containerId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -1492,7 +1498,7 @@ export namespace tagmanager_v1 {
         params,
         requiredParams: ['accountId', 'containerId'],
         pathParams: ['accountId', 'containerId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Container>(parameters, callback);
@@ -1560,7 +1566,7 @@ export namespace tagmanager_v1 {
         params,
         requiredParams: ['accountId'],
         pathParams: ['accountId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListContainersResponse>(parameters, callback);
@@ -1632,7 +1638,7 @@ export namespace tagmanager_v1 {
         params,
         requiredParams: ['accountId', 'containerId'],
         pathParams: ['accountId', 'containerId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Container>(parameters, callback);
@@ -1731,7 +1737,10 @@ export namespace tagmanager_v1 {
   }
 
   export class Resource$Accounts$Containers$Environments {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1796,7 +1805,7 @@ export namespace tagmanager_v1 {
         params,
         requiredParams: ['accountId', 'containerId'],
         pathParams: ['accountId', 'containerId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Environment>(parameters, callback);
@@ -1866,7 +1875,7 @@ export namespace tagmanager_v1 {
         params,
         requiredParams: ['accountId', 'containerId', 'environmentId'],
         pathParams: ['accountId', 'containerId', 'environmentId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -1933,7 +1942,7 @@ export namespace tagmanager_v1 {
         params,
         requiredParams: ['accountId', 'containerId', 'environmentId'],
         pathParams: ['accountId', 'containerId', 'environmentId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Environment>(parameters, callback);
@@ -2006,7 +2015,7 @@ export namespace tagmanager_v1 {
         params,
         requiredParams: ['accountId', 'containerId'],
         pathParams: ['accountId', 'containerId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListEnvironmentsResponse>(parameters, callback);
@@ -2080,7 +2089,7 @@ export namespace tagmanager_v1 {
         params,
         requiredParams: ['accountId', 'containerId', 'environmentId'],
         pathParams: ['accountId', 'containerId', 'environmentId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Environment>(parameters, callback);
@@ -2200,9 +2209,12 @@ export namespace tagmanager_v1 {
 
 
   export class Resource$Accounts$Containers$Folders {
+    context: APIRequestContext;
     entities: Resource$Accounts$Containers$Folders$Entities;
-    constructor() {
-      this.entities = new Resource$Accounts$Containers$Folders$Entities();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.entities =
+          new Resource$Accounts$Containers$Folders$Entities(this.context);
     }
 
 
@@ -2266,7 +2278,7 @@ export namespace tagmanager_v1 {
         params,
         requiredParams: ['accountId', 'containerId'],
         pathParams: ['accountId', 'containerId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Folder>(parameters, callback);
@@ -2335,7 +2347,7 @@ export namespace tagmanager_v1 {
         params,
         requiredParams: ['accountId', 'containerId', 'folderId'],
         pathParams: ['accountId', 'containerId', 'folderId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -2401,7 +2413,7 @@ export namespace tagmanager_v1 {
         params,
         requiredParams: ['accountId', 'containerId', 'folderId'],
         pathParams: ['accountId', 'containerId', 'folderId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Folder>(parameters, callback);
@@ -2471,7 +2483,7 @@ export namespace tagmanager_v1 {
         params,
         requiredParams: ['accountId', 'containerId'],
         pathParams: ['accountId', 'containerId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListFoldersResponse>(parameters, callback);
@@ -2543,7 +2555,7 @@ export namespace tagmanager_v1 {
         params,
         requiredParams: ['accountId', 'containerId', 'folderId'],
         pathParams: ['accountId', 'containerId', 'folderId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Folder>(parameters, callback);
@@ -2662,7 +2674,10 @@ export namespace tagmanager_v1 {
   }
 
   export class Resource$Accounts$Containers$Folders$Entities {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -2728,7 +2743,7 @@ export namespace tagmanager_v1 {
         params,
         requiredParams: ['accountId', 'containerId', 'folderId'],
         pathParams: ['accountId', 'containerId', 'folderId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$FolderEntities>(parameters, callback);
@@ -2762,7 +2777,10 @@ export namespace tagmanager_v1 {
 
 
   export class Resource$Accounts$Containers$Move_folders {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -2829,7 +2847,7 @@ export namespace tagmanager_v1 {
         params,
         requiredParams: ['accountId', 'containerId', 'folderId'],
         pathParams: ['accountId', 'containerId', 'folderId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -2879,7 +2897,10 @@ export namespace tagmanager_v1 {
 
 
   export class Resource$Accounts$Containers$Reauthorize_environments {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -2949,7 +2970,7 @@ export namespace tagmanager_v1 {
         params,
         requiredParams: ['accountId', 'containerId', 'environmentId'],
         pathParams: ['accountId', 'containerId', 'environmentId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Environment>(parameters, callback);
@@ -2987,7 +3008,10 @@ export namespace tagmanager_v1 {
 
 
   export class Resource$Accounts$Containers$Tags {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -3050,7 +3074,7 @@ export namespace tagmanager_v1 {
         params,
         requiredParams: ['accountId', 'containerId'],
         pathParams: ['accountId', 'containerId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Tag>(parameters, callback);
@@ -3119,7 +3143,7 @@ export namespace tagmanager_v1 {
         params,
         requiredParams: ['accountId', 'containerId', 'tagId'],
         pathParams: ['accountId', 'containerId', 'tagId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -3185,7 +3209,7 @@ export namespace tagmanager_v1 {
         params,
         requiredParams: ['accountId', 'containerId', 'tagId'],
         pathParams: ['accountId', 'containerId', 'tagId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Tag>(parameters, callback);
@@ -3255,7 +3279,7 @@ export namespace tagmanager_v1 {
         params,
         requiredParams: ['accountId', 'containerId'],
         pathParams: ['accountId', 'containerId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListTagsResponse>(parameters, callback);
@@ -3327,7 +3351,7 @@ export namespace tagmanager_v1 {
         params,
         requiredParams: ['accountId', 'containerId', 'tagId'],
         pathParams: ['accountId', 'containerId', 'tagId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Tag>(parameters, callback);
@@ -3447,7 +3471,10 @@ export namespace tagmanager_v1 {
 
 
   export class Resource$Accounts$Containers$Triggers {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -3510,7 +3537,7 @@ export namespace tagmanager_v1 {
         params,
         requiredParams: ['accountId', 'containerId'],
         pathParams: ['accountId', 'containerId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Trigger>(parameters, callback);
@@ -3579,7 +3606,7 @@ export namespace tagmanager_v1 {
         params,
         requiredParams: ['accountId', 'containerId', 'triggerId'],
         pathParams: ['accountId', 'containerId', 'triggerId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -3645,7 +3672,7 @@ export namespace tagmanager_v1 {
         params,
         requiredParams: ['accountId', 'containerId', 'triggerId'],
         pathParams: ['accountId', 'containerId', 'triggerId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Trigger>(parameters, callback);
@@ -3716,7 +3743,7 @@ export namespace tagmanager_v1 {
         params,
         requiredParams: ['accountId', 'containerId'],
         pathParams: ['accountId', 'containerId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListTriggersResponse>(parameters, callback);
@@ -3788,7 +3815,7 @@ export namespace tagmanager_v1 {
         params,
         requiredParams: ['accountId', 'containerId', 'triggerId'],
         pathParams: ['accountId', 'containerId', 'triggerId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Trigger>(parameters, callback);
@@ -3908,7 +3935,10 @@ export namespace tagmanager_v1 {
 
 
   export class Resource$Accounts$Containers$Variables {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -3971,7 +4001,7 @@ export namespace tagmanager_v1 {
         params,
         requiredParams: ['accountId', 'containerId'],
         pathParams: ['accountId', 'containerId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Variable>(parameters, callback);
@@ -4040,7 +4070,7 @@ export namespace tagmanager_v1 {
         params,
         requiredParams: ['accountId', 'containerId', 'variableId'],
         pathParams: ['accountId', 'containerId', 'variableId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -4106,7 +4136,7 @@ export namespace tagmanager_v1 {
         params,
         requiredParams: ['accountId', 'containerId', 'variableId'],
         pathParams: ['accountId', 'containerId', 'variableId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Variable>(parameters, callback);
@@ -4177,7 +4207,7 @@ export namespace tagmanager_v1 {
         params,
         requiredParams: ['accountId', 'containerId'],
         pathParams: ['accountId', 'containerId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListVariablesResponse>(parameters, callback);
@@ -4249,7 +4279,7 @@ export namespace tagmanager_v1 {
         params,
         requiredParams: ['accountId', 'containerId', 'variableId'],
         pathParams: ['accountId', 'containerId', 'variableId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Variable>(parameters, callback);
@@ -4369,7 +4399,10 @@ export namespace tagmanager_v1 {
 
 
   export class Resource$Accounts$Containers$Versions {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -4439,7 +4472,7 @@ export namespace tagmanager_v1 {
         params,
         requiredParams: ['accountId', 'containerId'],
         pathParams: ['accountId', 'containerId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$CreateContainerVersionResponse>(
@@ -4510,7 +4543,7 @@ export namespace tagmanager_v1 {
         params,
         requiredParams: ['accountId', 'containerId', 'containerVersionId'],
         pathParams: ['accountId', 'containerId', 'containerVersionId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -4577,7 +4610,7 @@ export namespace tagmanager_v1 {
         params,
         requiredParams: ['accountId', 'containerId', 'containerVersionId'],
         pathParams: ['accountId', 'containerId', 'containerVersionId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ContainerVersion>(parameters, callback);
@@ -4654,7 +4687,7 @@ export namespace tagmanager_v1 {
         params,
         requiredParams: ['accountId', 'containerId'],
         pathParams: ['accountId', 'containerId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListContainerVersionsResponse>(
@@ -4735,7 +4768,7 @@ export namespace tagmanager_v1 {
         params,
         requiredParams: ['accountId', 'containerId', 'containerVersionId'],
         pathParams: ['accountId', 'containerId', 'containerVersionId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$PublishContainerVersionResponse>(
@@ -4811,7 +4844,7 @@ export namespace tagmanager_v1 {
         params,
         requiredParams: ['accountId', 'containerId', 'containerVersionId'],
         pathParams: ['accountId', 'containerId', 'containerVersionId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ContainerVersion>(parameters, callback);
@@ -4883,7 +4916,7 @@ export namespace tagmanager_v1 {
         params,
         requiredParams: ['accountId', 'containerId', 'containerVersionId'],
         pathParams: ['accountId', 'containerId', 'containerVersionId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ContainerVersion>(parameters, callback);
@@ -4956,7 +4989,7 @@ export namespace tagmanager_v1 {
         params,
         requiredParams: ['accountId', 'containerId', 'containerVersionId'],
         pathParams: ['accountId', 'containerId', 'containerVersionId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ContainerVersion>(parameters, callback);
@@ -5151,7 +5184,10 @@ export namespace tagmanager_v1 {
 
 
   export class Resource$Accounts$Permissions {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -5212,7 +5248,7 @@ export namespace tagmanager_v1 {
         params,
         requiredParams: ['accountId'],
         pathParams: ['accountId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$UserAccess>(parameters, callback);
@@ -5281,7 +5317,7 @@ export namespace tagmanager_v1 {
         params,
         requiredParams: ['accountId', 'permissionId'],
         pathParams: ['accountId', 'permissionId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -5347,7 +5383,7 @@ export namespace tagmanager_v1 {
         params,
         requiredParams: ['accountId', 'permissionId'],
         pathParams: ['accountId', 'permissionId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$UserAccess>(parameters, callback);
@@ -5417,7 +5453,7 @@ export namespace tagmanager_v1 {
         params,
         requiredParams: ['accountId'],
         pathParams: ['accountId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListAccountUsersResponse>(parameters, callback);
@@ -5488,7 +5524,7 @@ export namespace tagmanager_v1 {
         params,
         requiredParams: ['accountId', 'permissionId'],
         pathParams: ['accountId', 'permissionId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$UserAccess>(parameters, callback);

--- a/src/apis/tagmanager/v2.ts
+++ b/src/apis/tagmanager/v2.ts
@@ -29,8 +29,6 @@ export namespace tagmanager_v2 {
     version: 'v2';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * Data format for the response.
@@ -81,12 +79,13 @@ export namespace tagmanager_v2 {
    * @param {object=} options Options for Tagmanager
    */
   export class Tagmanager {
+    context: APIRequestContext;
     accounts: Resource$Accounts;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.accounts = new Resource$Accounts();
+      this.accounts = new Resource$Accounts(this.context);
     }
   }
 
@@ -1598,11 +1597,14 @@ export namespace tagmanager_v2 {
 
 
   export class Resource$Accounts {
+    context: APIRequestContext;
     containers: Resource$Accounts$Containers;
     user_permissions: Resource$Accounts$User_permissions;
-    constructor() {
-      this.containers = new Resource$Accounts$Containers();
-      this.user_permissions = new Resource$Accounts$User_permissions();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.containers = new Resource$Accounts$Containers(this.context);
+      this.user_permissions =
+          new Resource$Accounts$User_permissions(this.context);
     }
 
 
@@ -1657,7 +1659,7 @@ export namespace tagmanager_v2 {
         params,
         requiredParams: ['path'],
         pathParams: ['path'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Account>(parameters, callback);
@@ -1723,7 +1725,7 @@ export namespace tagmanager_v2 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListAccountsResponse>(parameters, callback);
@@ -1789,7 +1791,7 @@ export namespace tagmanager_v2 {
         params,
         requiredParams: ['path'],
         pathParams: ['path'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Account>(parameters, callback);
@@ -1844,15 +1846,20 @@ export namespace tagmanager_v2 {
   }
 
   export class Resource$Accounts$Containers {
+    context: APIRequestContext;
     environments: Resource$Accounts$Containers$Environments;
     versions: Resource$Accounts$Containers$Versions;
     version_headers: Resource$Accounts$Containers$Version_headers;
     workspaces: Resource$Accounts$Containers$Workspaces;
-    constructor() {
-      this.environments = new Resource$Accounts$Containers$Environments();
-      this.versions = new Resource$Accounts$Containers$Versions();
-      this.version_headers = new Resource$Accounts$Containers$Version_headers();
-      this.workspaces = new Resource$Accounts$Containers$Workspaces();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.environments =
+          new Resource$Accounts$Containers$Environments(this.context);
+      this.versions = new Resource$Accounts$Containers$Versions(this.context);
+      this.version_headers =
+          new Resource$Accounts$Containers$Version_headers(this.context);
+      this.workspaces =
+          new Resource$Accounts$Containers$Workspaces(this.context);
     }
 
 
@@ -1914,7 +1921,7 @@ export namespace tagmanager_v2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Container>(parameters, callback);
@@ -1979,7 +1986,7 @@ export namespace tagmanager_v2 {
         params,
         requiredParams: ['path'],
         pathParams: ['path'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -2042,7 +2049,7 @@ export namespace tagmanager_v2 {
         params,
         requiredParams: ['path'],
         pathParams: ['path'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Container>(parameters, callback);
@@ -2111,7 +2118,7 @@ export namespace tagmanager_v2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListContainersResponse>(parameters, callback);
@@ -2180,7 +2187,7 @@ export namespace tagmanager_v2 {
         params,
         requiredParams: ['path'],
         pathParams: ['path'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Container>(parameters, callback);
@@ -2274,7 +2281,10 @@ export namespace tagmanager_v2 {
   }
 
   export class Resource$Accounts$Containers$Environments {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -2336,7 +2346,7 @@ export namespace tagmanager_v2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Environment>(parameters, callback);
@@ -2402,7 +2412,7 @@ export namespace tagmanager_v2 {
         params,
         requiredParams: ['path'],
         pathParams: ['path'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -2465,7 +2475,7 @@ export namespace tagmanager_v2 {
         params,
         requiredParams: ['path'],
         pathParams: ['path'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Environment>(parameters, callback);
@@ -2536,7 +2546,7 @@ export namespace tagmanager_v2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListEnvironmentsResponse>(parameters, callback);
@@ -2606,7 +2616,7 @@ export namespace tagmanager_v2 {
         params,
         requiredParams: ['path'],
         pathParams: ['path'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Environment>(parameters, callback);
@@ -2676,7 +2686,7 @@ export namespace tagmanager_v2 {
         params,
         requiredParams: ['path'],
         pathParams: ['path'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Environment>(parameters, callback);
@@ -2791,7 +2801,10 @@ export namespace tagmanager_v2 {
 
 
   export class Resource$Accounts$Containers$Versions {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -2849,7 +2862,7 @@ export namespace tagmanager_v2 {
         params,
         requiredParams: ['path'],
         pathParams: ['path'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -2913,7 +2926,7 @@ export namespace tagmanager_v2 {
         params,
         requiredParams: ['path'],
         pathParams: ['path'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ContainerVersion>(parameters, callback);
@@ -2980,7 +2993,7 @@ export namespace tagmanager_v2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ContainerVersion>(parameters, callback);
@@ -3055,7 +3068,7 @@ export namespace tagmanager_v2 {
         params,
         requiredParams: ['path'],
         pathParams: ['path'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$PublishContainerVersionResponse>(
@@ -3126,7 +3139,7 @@ export namespace tagmanager_v2 {
         params,
         requiredParams: ['path'],
         pathParams: ['path'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ContainerVersion>(parameters, callback);
@@ -3194,7 +3207,7 @@ export namespace tagmanager_v2 {
         params,
         requiredParams: ['path'],
         pathParams: ['path'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ContainerVersion>(parameters, callback);
@@ -3263,7 +3276,7 @@ export namespace tagmanager_v2 {
         params,
         requiredParams: ['path'],
         pathParams: ['path'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ContainerVersion>(parameters, callback);
@@ -3387,7 +3400,10 @@ export namespace tagmanager_v2 {
 
 
   export class Resource$Accounts$Containers$Version_headers {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -3450,7 +3466,7 @@ export namespace tagmanager_v2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ContainerVersionHeader>(parameters, callback);
@@ -3525,7 +3541,7 @@ export namespace tagmanager_v2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListContainerVersionsResponse>(
@@ -3574,6 +3590,7 @@ export namespace tagmanager_v2 {
 
 
   export class Resource$Accounts$Containers$Workspaces {
+    context: APIRequestContext;
     built_in_variables:
         Resource$Accounts$Containers$Workspaces$Built_in_variables;
     folders: Resource$Accounts$Containers$Workspaces$Folders;
@@ -3581,14 +3598,21 @@ export namespace tagmanager_v2 {
     triggers: Resource$Accounts$Containers$Workspaces$Triggers;
     variables: Resource$Accounts$Containers$Workspaces$Variables;
     zones: Resource$Accounts$Containers$Workspaces$Zones;
-    constructor() {
+    constructor(context: APIRequestContext) {
+      this.context = context;
       this.built_in_variables =
-          new Resource$Accounts$Containers$Workspaces$Built_in_variables();
-      this.folders = new Resource$Accounts$Containers$Workspaces$Folders();
-      this.tags = new Resource$Accounts$Containers$Workspaces$Tags();
-      this.triggers = new Resource$Accounts$Containers$Workspaces$Triggers();
-      this.variables = new Resource$Accounts$Containers$Workspaces$Variables();
-      this.zones = new Resource$Accounts$Containers$Workspaces$Zones();
+          new Resource$Accounts$Containers$Workspaces$Built_in_variables(
+              this.context);
+      this.folders =
+          new Resource$Accounts$Containers$Workspaces$Folders(this.context);
+      this.tags =
+          new Resource$Accounts$Containers$Workspaces$Tags(this.context);
+      this.triggers =
+          new Resource$Accounts$Containers$Workspaces$Triggers(this.context);
+      this.variables =
+          new Resource$Accounts$Containers$Workspaces$Variables(this.context);
+      this.zones =
+          new Resource$Accounts$Containers$Workspaces$Zones(this.context);
     }
 
 
@@ -3651,7 +3675,7 @@ export namespace tagmanager_v2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Workspace>(parameters, callback);
@@ -3729,7 +3753,7 @@ export namespace tagmanager_v2 {
         params,
         requiredParams: ['path'],
         pathParams: ['path'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$CreateContainerVersionResponse>(
@@ -3797,7 +3821,7 @@ export namespace tagmanager_v2 {
         params,
         requiredParams: ['path'],
         pathParams: ['path'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -3860,7 +3884,7 @@ export namespace tagmanager_v2 {
         params,
         requiredParams: ['path'],
         pathParams: ['path'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Workspace>(parameters, callback);
@@ -3934,7 +3958,7 @@ export namespace tagmanager_v2 {
         params,
         requiredParams: ['path'],
         pathParams: ['path'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GetWorkspaceStatusResponse>(
@@ -4004,7 +4028,7 @@ export namespace tagmanager_v2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListWorkspacesResponse>(parameters, callback);
@@ -4076,7 +4100,7 @@ export namespace tagmanager_v2 {
         params,
         requiredParams: ['path'],
         pathParams: ['path'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$QuickPreviewResponse>(parameters, callback);
@@ -4147,7 +4171,7 @@ export namespace tagmanager_v2 {
         params,
         requiredParams: ['path'],
         pathParams: ['path'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -4217,7 +4241,7 @@ export namespace tagmanager_v2 {
         params,
         requiredParams: ['path'],
         pathParams: ['path'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$SyncWorkspaceResponse>(parameters, callback);
@@ -4287,7 +4311,7 @@ export namespace tagmanager_v2 {
         params,
         requiredParams: ['path'],
         pathParams: ['path'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Workspace>(parameters, callback);
@@ -4463,7 +4487,10 @@ export namespace tagmanager_v2 {
   }
 
   export class Resource$Accounts$Containers$Workspaces$Built_in_variables {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -4536,7 +4563,7 @@ export namespace tagmanager_v2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$CreateBuiltInVariableResponse>(
@@ -4610,7 +4637,7 @@ export namespace tagmanager_v2 {
         params,
         requiredParams: ['path'],
         pathParams: ['path'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -4692,7 +4719,7 @@ export namespace tagmanager_v2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListEnabledBuiltInVariablesResponse>(
@@ -4775,7 +4802,7 @@ export namespace tagmanager_v2 {
         params,
         requiredParams: ['path'],
         pathParams: ['path'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$RevertBuiltInVariableResponse>(
@@ -4858,7 +4885,10 @@ export namespace tagmanager_v2 {
 
 
   export class Resource$Accounts$Containers$Workspaces$Folders {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -4920,7 +4950,7 @@ export namespace tagmanager_v2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Folder>(parameters, callback);
@@ -4987,7 +5017,7 @@ export namespace tagmanager_v2 {
         params,
         requiredParams: ['path'],
         pathParams: ['path'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -5058,7 +5088,7 @@ export namespace tagmanager_v2 {
         params,
         requiredParams: ['path'],
         pathParams: ['path'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$FolderEntities>(parameters, callback);
@@ -5122,7 +5152,7 @@ export namespace tagmanager_v2 {
         params,
         requiredParams: ['path'],
         pathParams: ['path'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Folder>(parameters, callback);
@@ -5192,7 +5222,7 @@ export namespace tagmanager_v2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListFoldersResponse>(parameters, callback);
@@ -5267,7 +5297,7 @@ export namespace tagmanager_v2 {
         params,
         requiredParams: ['path'],
         pathParams: ['path'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -5338,7 +5368,7 @@ export namespace tagmanager_v2 {
         params,
         requiredParams: ['path'],
         pathParams: ['path'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$RevertFolderResponse>(parameters, callback);
@@ -5408,7 +5438,7 @@ export namespace tagmanager_v2 {
         params,
         requiredParams: ['path'],
         pathParams: ['path'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Folder>(parameters, callback);
@@ -5570,7 +5600,10 @@ export namespace tagmanager_v2 {
 
 
   export class Resource$Accounts$Containers$Workspaces$Tags {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -5632,7 +5665,7 @@ export namespace tagmanager_v2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Tag>(parameters, callback);
@@ -5699,7 +5732,7 @@ export namespace tagmanager_v2 {
         params,
         requiredParams: ['path'],
         pathParams: ['path'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -5762,7 +5795,7 @@ export namespace tagmanager_v2 {
         params,
         requiredParams: ['path'],
         pathParams: ['path'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Tag>(parameters, callback);
@@ -5831,7 +5864,7 @@ export namespace tagmanager_v2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListTagsResponse>(parameters, callback);
@@ -5901,7 +5934,7 @@ export namespace tagmanager_v2 {
         params,
         requiredParams: ['path'],
         pathParams: ['path'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$RevertTagResponse>(parameters, callback);
@@ -5971,7 +6004,7 @@ export namespace tagmanager_v2 {
         params,
         requiredParams: ['path'],
         pathParams: ['path'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Tag>(parameters, callback);
@@ -6086,7 +6119,10 @@ export namespace tagmanager_v2 {
 
 
   export class Resource$Accounts$Containers$Workspaces$Triggers {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -6148,7 +6184,7 @@ export namespace tagmanager_v2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Trigger>(parameters, callback);
@@ -6215,7 +6251,7 @@ export namespace tagmanager_v2 {
         params,
         requiredParams: ['path'],
         pathParams: ['path'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -6279,7 +6315,7 @@ export namespace tagmanager_v2 {
         params,
         requiredParams: ['path'],
         pathParams: ['path'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Trigger>(parameters, callback);
@@ -6350,7 +6386,7 @@ export namespace tagmanager_v2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListTriggersResponse>(parameters, callback);
@@ -6421,7 +6457,7 @@ export namespace tagmanager_v2 {
         params,
         requiredParams: ['path'],
         pathParams: ['path'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$RevertTriggerResponse>(parameters, callback);
@@ -6491,7 +6527,7 @@ export namespace tagmanager_v2 {
         params,
         requiredParams: ['path'],
         pathParams: ['path'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Trigger>(parameters, callback);
@@ -6606,7 +6642,10 @@ export namespace tagmanager_v2 {
 
 
   export class Resource$Accounts$Containers$Workspaces$Variables {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -6669,7 +6708,7 @@ export namespace tagmanager_v2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Variable>(parameters, callback);
@@ -6737,7 +6776,7 @@ export namespace tagmanager_v2 {
         params,
         requiredParams: ['path'],
         pathParams: ['path'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -6801,7 +6840,7 @@ export namespace tagmanager_v2 {
         params,
         requiredParams: ['path'],
         pathParams: ['path'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Variable>(parameters, callback);
@@ -6872,7 +6911,7 @@ export namespace tagmanager_v2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListVariablesResponse>(parameters, callback);
@@ -6944,7 +6983,7 @@ export namespace tagmanager_v2 {
         params,
         requiredParams: ['path'],
         pathParams: ['path'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$RevertVariableResponse>(parameters, callback);
@@ -7015,7 +7054,7 @@ export namespace tagmanager_v2 {
         params,
         requiredParams: ['path'],
         pathParams: ['path'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Variable>(parameters, callback);
@@ -7130,7 +7169,10 @@ export namespace tagmanager_v2 {
 
 
   export class Resource$Accounts$Containers$Workspaces$Zones {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -7192,7 +7234,7 @@ export namespace tagmanager_v2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Zone>(parameters, callback);
@@ -7259,7 +7301,7 @@ export namespace tagmanager_v2 {
         params,
         requiredParams: ['path'],
         pathParams: ['path'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -7322,7 +7364,7 @@ export namespace tagmanager_v2 {
         params,
         requiredParams: ['path'],
         pathParams: ['path'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Zone>(parameters, callback);
@@ -7392,7 +7434,7 @@ export namespace tagmanager_v2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListZonesResponse>(parameters, callback);
@@ -7462,7 +7504,7 @@ export namespace tagmanager_v2 {
         params,
         requiredParams: ['path'],
         pathParams: ['path'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$RevertZoneResponse>(parameters, callback);
@@ -7532,7 +7574,7 @@ export namespace tagmanager_v2 {
         params,
         requiredParams: ['path'],
         pathParams: ['path'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Zone>(parameters, callback);
@@ -7648,7 +7690,10 @@ export namespace tagmanager_v2 {
 
 
   export class Resource$Accounts$User_permissions {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -7709,7 +7754,7 @@ export namespace tagmanager_v2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$UserPermission>(parameters, callback);
@@ -7775,7 +7820,7 @@ export namespace tagmanager_v2 {
         params,
         requiredParams: ['path'],
         pathParams: ['path'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -7838,7 +7883,7 @@ export namespace tagmanager_v2 {
         params,
         requiredParams: ['path'],
         pathParams: ['path'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$UserPermission>(parameters, callback);
@@ -7912,7 +7957,7 @@ export namespace tagmanager_v2 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListUserPermissionsResponse>(
@@ -7981,7 +8026,7 @@ export namespace tagmanager_v2 {
         params,
         requiredParams: ['path'],
         pathParams: ['path'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$UserPermission>(parameters, callback);

--- a/src/apis/tasks/v1.ts
+++ b/src/apis/tasks/v1.ts
@@ -29,8 +29,6 @@ export namespace tasks_v1 {
     version: 'v1';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * Data format for the response.
@@ -81,14 +79,15 @@ export namespace tasks_v1 {
    * @param {object=} options Options for Tasks
    */
   export class Tasks {
+    context: APIRequestContext;
     tasklists: Resource$Tasklists;
     tasks: Resource$Tasks;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.tasklists = new Resource$Tasklists();
-      this.tasks = new Resource$Tasks();
+      this.tasklists = new Resource$Tasklists(this.context);
+      this.tasks = new Resource$Tasks(this.context);
     }
   }
 
@@ -232,7 +231,10 @@ export namespace tasks_v1 {
 
 
   export class Resource$Tasklists {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -288,7 +290,7 @@ export namespace tasks_v1 {
         params,
         requiredParams: ['tasklist'],
         pathParams: ['tasklist'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -349,7 +351,7 @@ export namespace tasks_v1 {
         params,
         requiredParams: ['tasklist'],
         pathParams: ['tasklist'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TaskList>(parameters, callback);
@@ -414,7 +416,7 @@ export namespace tasks_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TaskList>(parameters, callback);
@@ -480,7 +482,7 @@ export namespace tasks_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TaskLists>(parameters, callback);
@@ -546,7 +548,7 @@ export namespace tasks_v1 {
         params,
         requiredParams: ['tasklist'],
         pathParams: ['tasklist'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TaskList>(parameters, callback);
@@ -611,7 +613,7 @@ export namespace tasks_v1 {
         params,
         requiredParams: ['tasklist'],
         pathParams: ['tasklist'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TaskList>(parameters, callback);
@@ -706,7 +708,10 @@ export namespace tasks_v1 {
 
 
   export class Resource$Tasks {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -764,7 +769,7 @@ export namespace tasks_v1 {
         params,
         requiredParams: ['tasklist'],
         pathParams: ['tasklist'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -828,7 +833,7 @@ export namespace tasks_v1 {
         params,
         requiredParams: ['tasklist', 'task'],
         pathParams: ['task', 'tasklist'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -890,7 +895,7 @@ export namespace tasks_v1 {
         params,
         requiredParams: ['tasklist', 'task'],
         pathParams: ['task', 'tasklist'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Task>(parameters, callback);
@@ -957,7 +962,7 @@ export namespace tasks_v1 {
         params,
         requiredParams: ['tasklist'],
         pathParams: ['tasklist'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Task>(parameters, callback);
@@ -1031,7 +1036,7 @@ export namespace tasks_v1 {
         params,
         requiredParams: ['tasklist'],
         pathParams: ['tasklist'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Tasks>(parameters, callback);
@@ -1100,7 +1105,7 @@ export namespace tasks_v1 {
         params,
         requiredParams: ['tasklist', 'task'],
         pathParams: ['task', 'tasklist'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Task>(parameters, callback);
@@ -1166,7 +1171,7 @@ export namespace tasks_v1 {
         params,
         requiredParams: ['tasklist', 'task'],
         pathParams: ['task', 'tasklist'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Task>(parameters, callback);
@@ -1232,7 +1237,7 @@ export namespace tasks_v1 {
         params,
         requiredParams: ['tasklist', 'task'],
         pathParams: ['task', 'tasklist'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Task>(parameters, callback);

--- a/src/apis/testing/v1.ts
+++ b/src/apis/testing/v1.ts
@@ -29,8 +29,6 @@ export namespace testing_v1 {
     version: 'v1';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * V1 error format.
@@ -99,16 +97,19 @@ export namespace testing_v1 {
    * @param {object=} options Options for Testing
    */
   export class Testing {
+    context: APIRequestContext;
     applicationDetailService: Resource$Applicationdetailservice;
     projects: Resource$Projects;
     testEnvironmentCatalog: Resource$Testenvironmentcatalog;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.applicationDetailService = new Resource$Applicationdetailservice();
-      this.projects = new Resource$Projects();
-      this.testEnvironmentCatalog = new Resource$Testenvironmentcatalog();
+      this.applicationDetailService =
+          new Resource$Applicationdetailservice(this.context);
+      this.projects = new Resource$Projects(this.context);
+      this.testEnvironmentCatalog =
+          new Resource$Testenvironmentcatalog(this.context);
     }
   }
 
@@ -1395,7 +1396,10 @@ export namespace testing_v1 {
 
 
   export class Resource$Applicationdetailservice {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1458,7 +1462,7 @@ export namespace testing_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GetApkDetailsResponse>(parameters, callback);
@@ -1484,15 +1488,20 @@ export namespace testing_v1 {
 
 
   export class Resource$Projects {
+    context: APIRequestContext;
     testMatrices: Resource$Projects$Testmatrices;
-    constructor() {
-      this.testMatrices = new Resource$Projects$Testmatrices();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.testMatrices = new Resource$Projects$Testmatrices(this.context);
     }
   }
 
 
   export class Resource$Projects$Testmatrices {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1563,7 +1572,7 @@ export namespace testing_v1 {
         params,
         requiredParams: ['projectId', 'testMatrixId'],
         pathParams: ['projectId', 'testMatrixId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$CancelTestMatrixResponse>(parameters, callback);
@@ -1638,7 +1647,7 @@ export namespace testing_v1 {
         params,
         requiredParams: ['projectId'],
         pathParams: ['projectId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TestMatrix>(parameters, callback);
@@ -1706,7 +1715,7 @@ export namespace testing_v1 {
         params,
         requiredParams: ['projectId', 'testMatrixId'],
         pathParams: ['projectId', 'testMatrixId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TestMatrix>(parameters, callback);
@@ -1775,7 +1784,10 @@ export namespace testing_v1 {
 
 
   export class Resource$Testenvironmentcatalog {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1836,7 +1848,7 @@ export namespace testing_v1 {
         params,
         requiredParams: ['environmentType'],
         pathParams: ['environmentType'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TestEnvironmentCatalog>(parameters, callback);

--- a/src/apis/texttospeech/v1.ts
+++ b/src/apis/texttospeech/v1.ts
@@ -29,8 +29,6 @@ export namespace texttospeech_v1 {
     version: 'v1';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * V1 error format.
@@ -99,14 +97,15 @@ export namespace texttospeech_v1 {
    * @param {object=} options Options for Texttospeech
    */
   export class Texttospeech {
+    context: APIRequestContext;
     text: Resource$Text;
     voices: Resource$Voices;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.text = new Resource$Text();
-      this.voices = new Resource$Voices();
+      this.text = new Resource$Text(this.context);
+      this.voices = new Resource$Voices(this.context);
     }
   }
 
@@ -277,7 +276,10 @@ export namespace texttospeech_v1 {
 
 
   export class Resource$Text {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -339,7 +341,7 @@ export namespace texttospeech_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$SynthesizeSpeechResponse>(parameters, callback);
@@ -364,7 +366,10 @@ export namespace texttospeech_v1 {
 
 
   export class Resource$Voices {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -421,7 +426,7 @@ export namespace texttospeech_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListVoicesResponse>(parameters, callback);

--- a/src/apis/texttospeech/v1beta1.ts
+++ b/src/apis/texttospeech/v1beta1.ts
@@ -29,8 +29,6 @@ export namespace texttospeech_v1beta1 {
     version: 'v1beta1';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * V1 error format.
@@ -99,14 +97,15 @@ export namespace texttospeech_v1beta1 {
    * @param {object=} options Options for Texttospeech
    */
   export class Texttospeech {
+    context: APIRequestContext;
     text: Resource$Text;
     voices: Resource$Voices;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.text = new Resource$Text();
-      this.voices = new Resource$Voices();
+      this.text = new Resource$Text(this.context);
+      this.voices = new Resource$Voices(this.context);
     }
   }
 
@@ -277,7 +276,10 @@ export namespace texttospeech_v1beta1 {
 
 
   export class Resource$Text {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -339,7 +341,7 @@ export namespace texttospeech_v1beta1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$SynthesizeSpeechResponse>(parameters, callback);
@@ -364,7 +366,10 @@ export namespace texttospeech_v1beta1 {
 
 
   export class Resource$Voices {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -421,7 +426,7 @@ export namespace texttospeech_v1beta1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListVoicesResponse>(parameters, callback);

--- a/src/apis/toolresults/v1beta3.ts
+++ b/src/apis/toolresults/v1beta3.ts
@@ -29,8 +29,6 @@ export namespace toolresults_v1beta3 {
     version: 'v1beta3';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * Data format for the response.
@@ -81,12 +79,13 @@ export namespace toolresults_v1beta3 {
    * @param {object=} options Options for Toolresults
    */
   export class Toolresults {
+    context: APIRequestContext;
     projects: Resource$Projects;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.projects = new Resource$Projects();
+      this.projects = new Resource$Projects(this.context);
     }
   }
 
@@ -1448,9 +1447,11 @@ export namespace toolresults_v1beta3 {
 
 
   export class Resource$Projects {
+    context: APIRequestContext;
     histories: Resource$Projects$Histories;
-    constructor() {
-      this.histories = new Resource$Projects$Histories();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.histories = new Resource$Projects$Histories(this.context);
     }
 
 
@@ -1514,7 +1515,7 @@ export namespace toolresults_v1beta3 {
         params,
         requiredParams: ['projectId'],
         pathParams: ['projectId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ProjectSettings>(parameters, callback);
@@ -1603,7 +1604,7 @@ export namespace toolresults_v1beta3 {
         params,
         requiredParams: ['projectId'],
         pathParams: ['projectId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ProjectSettings>(parameters, callback);
@@ -1639,9 +1640,12 @@ export namespace toolresults_v1beta3 {
   }
 
   export class Resource$Projects$Histories {
+    context: APIRequestContext;
     executions: Resource$Projects$Histories$Executions;
-    constructor() {
-      this.executions = new Resource$Projects$Histories$Executions();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.executions =
+          new Resource$Projects$Histories$Executions(this.context);
     }
 
 
@@ -1708,7 +1712,7 @@ export namespace toolresults_v1beta3 {
         params,
         requiredParams: ['projectId'],
         pathParams: ['projectId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$History>(parameters, callback);
@@ -1776,7 +1780,7 @@ export namespace toolresults_v1beta3 {
         params,
         requiredParams: ['projectId', 'historyId'],
         pathParams: ['historyId', 'projectId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$History>(parameters, callback);
@@ -1853,7 +1857,7 @@ export namespace toolresults_v1beta3 {
         params,
         requiredParams: ['projectId'],
         pathParams: ['projectId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListHistoriesResponse>(parameters, callback);
@@ -1929,11 +1933,15 @@ export namespace toolresults_v1beta3 {
   }
 
   export class Resource$Projects$Histories$Executions {
+    context: APIRequestContext;
     clusters: Resource$Projects$Histories$Executions$Clusters;
     steps: Resource$Projects$Histories$Executions$Steps;
-    constructor() {
-      this.clusters = new Resource$Projects$Histories$Executions$Clusters();
-      this.steps = new Resource$Projects$Histories$Executions$Steps();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.clusters =
+          new Resource$Projects$Histories$Executions$Clusters(this.context);
+      this.steps =
+          new Resource$Projects$Histories$Executions$Steps(this.context);
     }
 
 
@@ -2003,7 +2011,7 @@ export namespace toolresults_v1beta3 {
         params,
         requiredParams: ['projectId', 'historyId'],
         pathParams: ['historyId', 'projectId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Execution>(parameters, callback);
@@ -2073,7 +2081,7 @@ export namespace toolresults_v1beta3 {
         params,
         requiredParams: ['projectId', 'historyId', 'executionId'],
         pathParams: ['executionId', 'historyId', 'projectId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Execution>(parameters, callback);
@@ -2151,7 +2159,7 @@ export namespace toolresults_v1beta3 {
         params,
         requiredParams: ['projectId', 'historyId'],
         pathParams: ['historyId', 'projectId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListExecutionsResponse>(parameters, callback);
@@ -2229,7 +2237,7 @@ export namespace toolresults_v1beta3 {
         params,
         requiredParams: ['projectId', 'historyId', 'executionId'],
         pathParams: ['executionId', 'historyId', 'projectId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Execution>(parameters, callback);
@@ -2343,7 +2351,10 @@ export namespace toolresults_v1beta3 {
   }
 
   export class Resource$Projects$Histories$Executions$Clusters {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -2406,7 +2417,7 @@ export namespace toolresults_v1beta3 {
         params,
         requiredParams: ['projectId', 'historyId', 'executionId', 'clusterId'],
         pathParams: ['clusterId', 'executionId', 'historyId', 'projectId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ScreenshotCluster>(parameters, callback);
@@ -2490,7 +2501,7 @@ export namespace toolresults_v1beta3 {
         params,
         requiredParams: ['projectId', 'historyId', 'executionId'],
         pathParams: ['executionId', 'historyId', 'projectId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListScreenshotClustersResponse>(
@@ -2549,18 +2560,23 @@ export namespace toolresults_v1beta3 {
 
 
   export class Resource$Projects$Histories$Executions$Steps {
+    context: APIRequestContext;
     perfMetricsSummary:
         Resource$Projects$Histories$Executions$Steps$Perfmetricssummary;
     perfSampleSeries:
         Resource$Projects$Histories$Executions$Steps$Perfsampleseries;
     thumbnails: Resource$Projects$Histories$Executions$Steps$Thumbnails;
-    constructor() {
+    constructor(context: APIRequestContext) {
+      this.context = context;
       this.perfMetricsSummary =
-          new Resource$Projects$Histories$Executions$Steps$Perfmetricssummary();
+          new Resource$Projects$Histories$Executions$Steps$Perfmetricssummary(
+              this.context);
       this.perfSampleSeries =
-          new Resource$Projects$Histories$Executions$Steps$Perfsampleseries();
+          new Resource$Projects$Histories$Executions$Steps$Perfsampleseries(
+              this.context);
       this.thumbnails =
-          new Resource$Projects$Histories$Executions$Steps$Thumbnails();
+          new Resource$Projects$Histories$Executions$Steps$Thumbnails(
+              this.context);
     }
 
 
@@ -2633,7 +2649,7 @@ export namespace toolresults_v1beta3 {
         params,
         requiredParams: ['projectId', 'historyId', 'executionId'],
         pathParams: ['executionId', 'historyId', 'projectId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Step>(parameters, callback);
@@ -2704,7 +2720,7 @@ export namespace toolresults_v1beta3 {
         params,
         requiredParams: ['projectId', 'historyId', 'executionId', 'stepId'],
         pathParams: ['executionId', 'historyId', 'projectId', 'stepId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Step>(parameters, callback);
@@ -2785,7 +2801,7 @@ export namespace toolresults_v1beta3 {
         params,
         requiredParams: ['projectId', 'historyId', 'executionId', 'stepId'],
         pathParams: ['executionId', 'historyId', 'projectId', 'stepId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$PerfMetricsSummary>(parameters, callback);
@@ -2866,7 +2882,7 @@ export namespace toolresults_v1beta3 {
         params,
         requiredParams: ['projectId', 'historyId', 'executionId'],
         pathParams: ['executionId', 'historyId', 'projectId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListStepsResponse>(parameters, callback);
@@ -2947,7 +2963,7 @@ export namespace toolresults_v1beta3 {
         params,
         requiredParams: ['projectId', 'historyId', 'executionId', 'stepId'],
         pathParams: ['executionId', 'historyId', 'projectId', 'stepId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Step>(parameters, callback);
@@ -3030,7 +3046,7 @@ export namespace toolresults_v1beta3 {
         params,
         requiredParams: ['projectId', 'historyId', 'executionId', 'stepId'],
         pathParams: ['executionId', 'historyId', 'projectId', 'stepId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Step>(parameters, callback);
@@ -3212,7 +3228,10 @@ export namespace toolresults_v1beta3 {
   }
 
   export class Resource$Projects$Histories$Executions$Steps$Perfmetricssummary {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -3286,7 +3305,7 @@ export namespace toolresults_v1beta3 {
         params,
         requiredParams: ['projectId', 'historyId', 'executionId', 'stepId'],
         pathParams: ['executionId', 'historyId', 'projectId', 'stepId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$PerfMetricsSummary>(parameters, callback);
@@ -3328,11 +3347,14 @@ export namespace toolresults_v1beta3 {
 
 
   export class Resource$Projects$Histories$Executions$Steps$Perfsampleseries {
+    context: APIRequestContext;
     samples:
         Resource$Projects$Histories$Executions$Steps$Perfsampleseries$Samples;
-    constructor() {
+    constructor(context: APIRequestContext) {
+      this.context = context;
       this.samples =
-          new Resource$Projects$Histories$Executions$Steps$Perfsampleseries$Samples();
+          new Resource$Projects$Histories$Executions$Steps$Perfsampleseries$Samples(
+              this.context);
     }
 
 
@@ -3407,7 +3429,7 @@ export namespace toolresults_v1beta3 {
         params,
         requiredParams: ['projectId', 'historyId', 'executionId', 'stepId'],
         pathParams: ['executionId', 'historyId', 'projectId', 'stepId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$PerfSampleSeries>(parameters, callback);
@@ -3487,7 +3509,7 @@ export namespace toolresults_v1beta3 {
         pathParams: [
           'executionId', 'historyId', 'projectId', 'sampleSeriesId', 'stepId'
         ],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$PerfSampleSeries>(parameters, callback);
@@ -3575,7 +3597,7 @@ export namespace toolresults_v1beta3 {
         params,
         requiredParams: ['projectId', 'historyId', 'executionId', 'stepId'],
         pathParams: ['executionId', 'historyId', 'projectId', 'stepId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListPerfSampleSeriesResponse>(
@@ -3676,7 +3698,10 @@ export namespace toolresults_v1beta3 {
 
   export class
       Resource$Projects$Histories$Executions$Steps$Perfsampleseries$Samples {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -3766,7 +3791,7 @@ export namespace toolresults_v1beta3 {
         pathParams: [
           'executionId', 'historyId', 'projectId', 'sampleSeriesId', 'stepId'
         ],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$BatchCreatePerfSamplesResponse>(
@@ -3862,7 +3887,7 @@ export namespace toolresults_v1beta3 {
         pathParams: [
           'executionId', 'historyId', 'projectId', 'sampleSeriesId', 'stepId'
         ],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListPerfSamplesResponse>(parameters, callback);
@@ -3946,7 +3971,10 @@ export namespace toolresults_v1beta3 {
 
 
   export class Resource$Projects$Histories$Executions$Steps$Thumbnails {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -4027,7 +4055,7 @@ export namespace toolresults_v1beta3 {
         params,
         requiredParams: ['projectId', 'historyId', 'executionId', 'stepId'],
         pathParams: ['executionId', 'historyId', 'projectId', 'stepId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListStepThumbnailsResponse>(

--- a/src/apis/tpu/v1.ts
+++ b/src/apis/tpu/v1.ts
@@ -29,8 +29,6 @@ export namespace tpu_v1 {
     version: 'v1';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * V1 error format.
@@ -98,12 +96,13 @@ export namespace tpu_v1 {
    * @param {object=} options Options for Tpu
    */
   export class Tpu {
+    context: APIRequestContext;
     projects: Resource$Projects;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.projects = new Resource$Projects();
+      this.projects = new Resource$Projects(this.context);
     }
   }
 
@@ -488,25 +487,30 @@ export namespace tpu_v1 {
 
 
   export class Resource$Projects {
+    context: APIRequestContext;
     locations: Resource$Projects$Locations;
-    constructor() {
-      this.locations = new Resource$Projects$Locations();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.locations = new Resource$Projects$Locations(this.context);
     }
   }
 
 
   export class Resource$Projects$Locations {
+    context: APIRequestContext;
     acceleratorTypes: Resource$Projects$Locations$Acceleratortypes;
     nodes: Resource$Projects$Locations$Nodes;
     operations: Resource$Projects$Locations$Operations;
     tensorflowVersions: Resource$Projects$Locations$Tensorflowversions;
-    constructor() {
+    constructor(context: APIRequestContext) {
+      this.context = context;
       this.acceleratorTypes =
-          new Resource$Projects$Locations$Acceleratortypes();
-      this.nodes = new Resource$Projects$Locations$Nodes();
-      this.operations = new Resource$Projects$Locations$Operations();
+          new Resource$Projects$Locations$Acceleratortypes(this.context);
+      this.nodes = new Resource$Projects$Locations$Nodes(this.context);
+      this.operations =
+          new Resource$Projects$Locations$Operations(this.context);
       this.tensorflowVersions =
-          new Resource$Projects$Locations$Tensorflowversions();
+          new Resource$Projects$Locations$Tensorflowversions(this.context);
     }
 
 
@@ -561,7 +565,7 @@ export namespace tpu_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Location>(parameters, callback);
@@ -632,7 +636,7 @@ export namespace tpu_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListLocationsResponse>(parameters, callback);
@@ -680,7 +684,10 @@ export namespace tpu_v1 {
   }
 
   export class Resource$Projects$Locations$Acceleratortypes {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -736,7 +743,7 @@ export namespace tpu_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AcceleratorType>(parameters, callback);
@@ -813,7 +820,7 @@ export namespace tpu_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListAcceleratorTypesResponse>(
@@ -868,7 +875,10 @@ export namespace tpu_v1 {
 
 
   export class Resource$Projects$Locations$Nodes {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -930,7 +940,7 @@ export namespace tpu_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -996,7 +1006,7 @@ export namespace tpu_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -1057,7 +1067,7 @@ export namespace tpu_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Node>(parameters, callback);
@@ -1126,7 +1136,7 @@ export namespace tpu_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListNodesResponse>(parameters, callback);
@@ -1194,7 +1204,7 @@ export namespace tpu_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -1262,7 +1272,7 @@ export namespace tpu_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -1329,7 +1339,7 @@ export namespace tpu_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -1458,7 +1468,10 @@ export namespace tpu_v1 {
 
 
   export class Resource$Projects$Locations$Operations {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1525,7 +1538,7 @@ export namespace tpu_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -1593,7 +1606,7 @@ export namespace tpu_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -1657,7 +1670,7 @@ export namespace tpu_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -1736,7 +1749,7 @@ export namespace tpu_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListOperationsResponse>(parameters, callback);
@@ -1809,7 +1822,10 @@ export namespace tpu_v1 {
 
 
   export class Resource$Projects$Locations$Tensorflowversions {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1866,7 +1882,7 @@ export namespace tpu_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TensorFlowVersion>(parameters, callback);
@@ -1944,7 +1960,7 @@ export namespace tpu_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListTensorFlowVersionsResponse>(

--- a/src/apis/tpu/v1alpha1.ts
+++ b/src/apis/tpu/v1alpha1.ts
@@ -29,8 +29,6 @@ export namespace tpu_v1alpha1 {
     version: 'v1alpha1';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * V1 error format.
@@ -98,12 +96,13 @@ export namespace tpu_v1alpha1 {
    * @param {object=} options Options for Tpu
    */
   export class Tpu {
+    context: APIRequestContext;
     projects: Resource$Projects;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.projects = new Resource$Projects();
+      this.projects = new Resource$Projects(this.context);
     }
   }
 
@@ -488,25 +487,30 @@ export namespace tpu_v1alpha1 {
 
 
   export class Resource$Projects {
+    context: APIRequestContext;
     locations: Resource$Projects$Locations;
-    constructor() {
-      this.locations = new Resource$Projects$Locations();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.locations = new Resource$Projects$Locations(this.context);
     }
   }
 
 
   export class Resource$Projects$Locations {
+    context: APIRequestContext;
     acceleratorTypes: Resource$Projects$Locations$Acceleratortypes;
     nodes: Resource$Projects$Locations$Nodes;
     operations: Resource$Projects$Locations$Operations;
     tensorflowVersions: Resource$Projects$Locations$Tensorflowversions;
-    constructor() {
+    constructor(context: APIRequestContext) {
+      this.context = context;
       this.acceleratorTypes =
-          new Resource$Projects$Locations$Acceleratortypes();
-      this.nodes = new Resource$Projects$Locations$Nodes();
-      this.operations = new Resource$Projects$Locations$Operations();
+          new Resource$Projects$Locations$Acceleratortypes(this.context);
+      this.nodes = new Resource$Projects$Locations$Nodes(this.context);
+      this.operations =
+          new Resource$Projects$Locations$Operations(this.context);
       this.tensorflowVersions =
-          new Resource$Projects$Locations$Tensorflowversions();
+          new Resource$Projects$Locations$Tensorflowversions(this.context);
     }
 
 
@@ -562,7 +566,7 @@ export namespace tpu_v1alpha1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Location>(parameters, callback);
@@ -633,7 +637,7 @@ export namespace tpu_v1alpha1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListLocationsResponse>(parameters, callback);
@@ -681,7 +685,10 @@ export namespace tpu_v1alpha1 {
   }
 
   export class Resource$Projects$Locations$Acceleratortypes {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -738,7 +745,7 @@ export namespace tpu_v1alpha1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AcceleratorType>(parameters, callback);
@@ -815,7 +822,7 @@ export namespace tpu_v1alpha1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListAcceleratorTypesResponse>(
@@ -870,7 +877,10 @@ export namespace tpu_v1alpha1 {
 
 
   export class Resource$Projects$Locations$Nodes {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -932,7 +942,7 @@ export namespace tpu_v1alpha1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -999,7 +1009,7 @@ export namespace tpu_v1alpha1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -1061,7 +1071,7 @@ export namespace tpu_v1alpha1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Node>(parameters, callback);
@@ -1130,7 +1140,7 @@ export namespace tpu_v1alpha1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListNodesResponse>(parameters, callback);
@@ -1198,7 +1208,7 @@ export namespace tpu_v1alpha1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -1266,7 +1276,7 @@ export namespace tpu_v1alpha1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -1334,7 +1344,7 @@ export namespace tpu_v1alpha1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -1463,7 +1473,10 @@ export namespace tpu_v1alpha1 {
 
 
   export class Resource$Projects$Locations$Operations {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1530,7 +1543,7 @@ export namespace tpu_v1alpha1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -1599,7 +1612,7 @@ export namespace tpu_v1alpha1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -1664,7 +1677,7 @@ export namespace tpu_v1alpha1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -1743,7 +1756,7 @@ export namespace tpu_v1alpha1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListOperationsResponse>(parameters, callback);
@@ -1816,7 +1829,10 @@ export namespace tpu_v1alpha1 {
 
 
   export class Resource$Projects$Locations$Tensorflowversions {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1874,7 +1890,7 @@ export namespace tpu_v1alpha1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TensorFlowVersion>(parameters, callback);
@@ -1952,7 +1968,7 @@ export namespace tpu_v1alpha1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListTensorFlowVersionsResponse>(

--- a/src/apis/translate/v2.ts
+++ b/src/apis/translate/v2.ts
@@ -29,8 +29,6 @@ export namespace translate_v2 {
     version: 'v2';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * V1 error format.
@@ -107,16 +105,17 @@ export namespace translate_v2 {
    * @param {object=} options Options for Translate
    */
   export class Translate {
+    context: APIRequestContext;
     detections: Resource$Detections;
     languages: Resource$Languages;
     translations: Resource$Translations;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.detections = new Resource$Detections();
-      this.languages = new Resource$Languages();
-      this.translations = new Resource$Translations();
+      this.detections = new Resource$Detections(this.context);
+      this.languages = new Resource$Languages(this.context);
+      this.translations = new Resource$Translations(this.context);
     }
   }
 
@@ -238,7 +237,10 @@ export namespace translate_v2 {
 
 
   export class Resource$Detections {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -298,7 +300,7 @@ export namespace translate_v2 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$DetectionsListResponse>(parameters, callback);
@@ -364,7 +366,7 @@ export namespace translate_v2 {
         params,
         requiredParams: ['q'],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$DetectionsListResponse>(parameters, callback);
@@ -402,7 +404,10 @@ export namespace translate_v2 {
 
 
   export class Resource$Languages {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -462,7 +467,7 @@ export namespace translate_v2 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$LanguagesListResponse>(parameters, callback);
@@ -491,7 +496,10 @@ export namespace translate_v2 {
 
 
   export class Resource$Translations {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -556,7 +564,7 @@ export namespace translate_v2 {
         params,
         requiredParams: ['q', 'target'],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TranslationsListResponse>(parameters, callback);
@@ -626,7 +634,7 @@ export namespace translate_v2 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$TranslationsListResponse>(parameters, callback);

--- a/src/apis/urlshortener/v1.ts
+++ b/src/apis/urlshortener/v1.ts
@@ -29,8 +29,6 @@ export namespace urlshortener_v1 {
     version: 'v1';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * Data format for the response.
@@ -81,12 +79,13 @@ export namespace urlshortener_v1 {
    * @param {object=} options Options for Urlshortener
    */
   export class Urlshortener {
+    context: APIRequestContext;
     url: Resource$Url;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.url = new Resource$Url();
+      this.url = new Resource$Url(this.context);
     }
   }
 
@@ -216,7 +215,10 @@ export namespace urlshortener_v1 {
 
 
   export class Resource$Url {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -271,7 +273,7 @@ export namespace urlshortener_v1 {
         params,
         requiredParams: ['shortUrl'],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Url>(parameters, callback);
@@ -335,7 +337,7 @@ export namespace urlshortener_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Url>(parameters, callback);
@@ -401,7 +403,7 @@ export namespace urlshortener_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$UrlHistory>(parameters, callback);

--- a/src/apis/vault/v1.ts
+++ b/src/apis/vault/v1.ts
@@ -29,8 +29,6 @@ export namespace vault_v1 {
     version: 'v1';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * V1 error format.
@@ -98,12 +96,13 @@ export namespace vault_v1 {
    * @param {object=} options Options for Vault
    */
   export class Vault {
+    context: APIRequestContext;
     matters: Resource$Matters;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.matters = new Resource$Matters();
+      this.matters = new Resource$Matters(this.context);
     }
   }
 
@@ -889,13 +888,15 @@ export namespace vault_v1 {
 
 
   export class Resource$Matters {
+    context: APIRequestContext;
     exports: Resource$Matters$Exports;
     holds: Resource$Matters$Holds;
     savedQueries: Resource$Matters$Savedqueries;
-    constructor() {
-      this.exports = new Resource$Matters$Exports();
-      this.holds = new Resource$Matters$Holds();
-      this.savedQueries = new Resource$Matters$Savedqueries();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.exports = new Resource$Matters$Exports(this.context);
+      this.holds = new Resource$Matters$Holds(this.context);
+      this.savedQueries = new Resource$Matters$Savedqueries(this.context);
     }
 
 
@@ -958,7 +959,7 @@ export namespace vault_v1 {
         params,
         requiredParams: ['matterId'],
         pathParams: ['matterId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$MatterPermission>(parameters, callback);
@@ -1024,7 +1025,7 @@ export namespace vault_v1 {
         params,
         requiredParams: ['matterId'],
         pathParams: ['matterId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$CloseMatterResponse>(parameters, callback);
@@ -1089,7 +1090,7 @@ export namespace vault_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Matter>(parameters, callback);
@@ -1153,7 +1154,7 @@ export namespace vault_v1 {
         params,
         requiredParams: ['matterId'],
         pathParams: ['matterId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Matter>(parameters, callback);
@@ -1215,7 +1216,7 @@ export namespace vault_v1 {
         params,
         requiredParams: ['matterId'],
         pathParams: ['matterId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Matter>(parameters, callback);
@@ -1282,7 +1283,7 @@ export namespace vault_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListMattersResponse>(parameters, callback);
@@ -1349,7 +1350,7 @@ export namespace vault_v1 {
         params,
         requiredParams: ['matterId'],
         pathParams: ['matterId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -1416,7 +1417,7 @@ export namespace vault_v1 {
         params,
         requiredParams: ['matterId'],
         pathParams: ['matterId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ReopenMatterResponse>(parameters, callback);
@@ -1482,7 +1483,7 @@ export namespace vault_v1 {
         params,
         requiredParams: ['matterId'],
         pathParams: ['matterId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Matter>(parameters, callback);
@@ -1549,7 +1550,7 @@ export namespace vault_v1 {
         params,
         requiredParams: ['matterId'],
         pathParams: ['matterId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Matter>(parameters, callback);
@@ -1722,7 +1723,10 @@ export namespace vault_v1 {
   }
 
   export class Resource$Matters$Exports {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1782,7 +1786,7 @@ export namespace vault_v1 {
         params,
         requiredParams: ['matterId'],
         pathParams: ['matterId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Export>(parameters, callback);
@@ -1849,7 +1853,7 @@ export namespace vault_v1 {
         params,
         requiredParams: ['matterId', 'exportId'],
         pathParams: ['exportId', 'matterId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -1912,7 +1916,7 @@ export namespace vault_v1 {
         params,
         requiredParams: ['matterId', 'exportId'],
         pathParams: ['exportId', 'matterId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Export>(parameters, callback);
@@ -1981,7 +1985,7 @@ export namespace vault_v1 {
         params,
         requiredParams: ['matterId'],
         pathParams: ['matterId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListExportsResponse>(parameters, callback);
@@ -2063,9 +2067,11 @@ export namespace vault_v1 {
 
 
   export class Resource$Matters$Holds {
+    context: APIRequestContext;
     accounts: Resource$Matters$Holds$Accounts;
-    constructor() {
-      this.accounts = new Resource$Matters$Holds$Accounts();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.accounts = new Resource$Matters$Holds$Accounts(this.context);
     }
 
 
@@ -2133,7 +2139,7 @@ export namespace vault_v1 {
         params,
         requiredParams: ['matterId', 'holdId'],
         pathParams: ['holdId', 'matterId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$AddHeldAccountsResponse>(parameters, callback);
@@ -2200,7 +2206,7 @@ export namespace vault_v1 {
         params,
         requiredParams: ['matterId'],
         pathParams: ['matterId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Hold>(parameters, callback);
@@ -2268,7 +2274,7 @@ export namespace vault_v1 {
         params,
         requiredParams: ['matterId', 'holdId'],
         pathParams: ['holdId', 'matterId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -2332,7 +2338,7 @@ export namespace vault_v1 {
         params,
         requiredParams: ['matterId', 'holdId'],
         pathParams: ['holdId', 'matterId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Hold>(parameters, callback);
@@ -2402,7 +2408,7 @@ export namespace vault_v1 {
         params,
         requiredParams: ['matterId'],
         pathParams: ['matterId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListHoldsResponse>(parameters, callback);
@@ -2480,7 +2486,7 @@ export namespace vault_v1 {
         params,
         requiredParams: ['matterId', 'holdId'],
         pathParams: ['holdId', 'matterId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$RemoveHeldAccountsResponse>(
@@ -2551,7 +2557,7 @@ export namespace vault_v1 {
         params,
         requiredParams: ['matterId', 'holdId'],
         pathParams: ['holdId', 'matterId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Hold>(parameters, callback);
@@ -2705,7 +2711,10 @@ export namespace vault_v1 {
   }
 
   export class Resource$Matters$Holds$Accounts {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -2769,7 +2778,7 @@ export namespace vault_v1 {
         params,
         requiredParams: ['matterId', 'holdId'],
         pathParams: ['holdId', 'matterId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$HeldAccount>(parameters, callback);
@@ -2840,7 +2849,7 @@ export namespace vault_v1 {
         params,
         requiredParams: ['matterId', 'holdId', 'accountId'],
         pathParams: ['accountId', 'holdId', 'matterId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -2913,7 +2922,7 @@ export namespace vault_v1 {
         params,
         requiredParams: ['matterId', 'holdId'],
         pathParams: ['holdId', 'matterId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListHeldAccountsResponse>(parameters, callback);
@@ -2984,7 +2993,10 @@ export namespace vault_v1 {
 
 
   export class Resource$Matters$Savedqueries {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -3045,7 +3057,7 @@ export namespace vault_v1 {
         params,
         requiredParams: ['matterId'],
         pathParams: ['matterId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$SavedQuery>(parameters, callback);
@@ -3113,7 +3125,7 @@ export namespace vault_v1 {
         params,
         requiredParams: ['matterId', 'savedQueryId'],
         pathParams: ['matterId', 'savedQueryId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -3178,7 +3190,7 @@ export namespace vault_v1 {
         params,
         requiredParams: ['matterId', 'savedQueryId'],
         pathParams: ['matterId', 'savedQueryId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$SavedQuery>(parameters, callback);
@@ -3250,7 +3262,7 @@ export namespace vault_v1 {
         params,
         requiredParams: ['matterId'],
         pathParams: ['matterId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListSavedQueriesResponse>(parameters, callback);

--- a/src/apis/videointelligence/v1.ts
+++ b/src/apis/videointelligence/v1.ts
@@ -29,8 +29,6 @@ export namespace videointelligence_v1 {
     version: 'v1';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * V1 error format.
@@ -100,14 +98,15 @@ export namespace videointelligence_v1 {
    * @param {object=} options Options for Videointelligence
    */
   export class Videointelligence {
+    context: APIRequestContext;
     operations: Resource$Operations;
     videos: Resource$Videos;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.operations = new Resource$Operations();
-      this.videos = new Resource$Videos();
+      this.operations = new Resource$Operations(this.context);
+      this.videos = new Resource$Videos(this.context);
     }
   }
 
@@ -2753,7 +2752,10 @@ export namespace videointelligence_v1 {
 
 
   export class Resource$Operations {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -2823,7 +2825,7 @@ export namespace videointelligence_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleProtobuf_Empty>(parameters, callback);
@@ -2894,7 +2896,7 @@ export namespace videointelligence_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleProtobuf_Empty>(parameters, callback);
@@ -2963,7 +2965,7 @@ export namespace videointelligence_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleLongrunning_Operation>(
@@ -3045,7 +3047,7 @@ export namespace videointelligence_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleLongrunning_ListOperationsResponse>(
@@ -3123,7 +3125,10 @@ export namespace videointelligence_v1 {
 
 
   export class Resource$Videos {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -3190,7 +3195,7 @@ export namespace videointelligence_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleLongrunning_Operation>(

--- a/src/apis/videointelligence/v1beta2.ts
+++ b/src/apis/videointelligence/v1beta2.ts
@@ -29,8 +29,6 @@ export namespace videointelligence_v1beta2 {
     version: 'v1beta2';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * V1 error format.
@@ -100,12 +98,13 @@ export namespace videointelligence_v1beta2 {
    * @param {object=} options Options for Videointelligence
    */
   export class Videointelligence {
+    context: APIRequestContext;
     videos: Resource$Videos;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.videos = new Resource$Videos();
+      this.videos = new Resource$Videos(this.context);
     }
   }
 
@@ -2726,7 +2725,10 @@ export namespace videointelligence_v1beta2 {
 
 
   export class Resource$Videos {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -2793,7 +2795,7 @@ export namespace videointelligence_v1beta2 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleLongrunning_Operation>(

--- a/src/apis/videointelligence/v1p1beta1.ts
+++ b/src/apis/videointelligence/v1p1beta1.ts
@@ -29,8 +29,6 @@ export namespace videointelligence_v1p1beta1 {
     version: 'v1p1beta1';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * V1 error format.
@@ -100,12 +98,13 @@ export namespace videointelligence_v1p1beta1 {
    * @param {object=} options Options for Videointelligence
    */
   export class Videointelligence {
+    context: APIRequestContext;
     videos: Resource$Videos;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.videos = new Resource$Videos();
+      this.videos = new Resource$Videos(this.context);
     }
   }
 
@@ -2727,7 +2726,10 @@ export namespace videointelligence_v1p1beta1 {
 
 
   export class Resource$Videos {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -2794,7 +2796,7 @@ export namespace videointelligence_v1p1beta1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleLongrunning_Operation>(

--- a/src/apis/videointelligence/v1p2beta1.ts
+++ b/src/apis/videointelligence/v1p2beta1.ts
@@ -29,8 +29,6 @@ export namespace videointelligence_v1p2beta1 {
     version: 'v1p2beta1';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * V1 error format.
@@ -100,12 +98,13 @@ export namespace videointelligence_v1p2beta1 {
    * @param {object=} options Options for Videointelligence
    */
   export class Videointelligence {
+    context: APIRequestContext;
     videos: Resource$Videos;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.videos = new Resource$Videos();
+      this.videos = new Resource$Videos(this.context);
     }
   }
 
@@ -2727,7 +2726,10 @@ export namespace videointelligence_v1p2beta1 {
 
 
   export class Resource$Videos {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -2794,7 +2796,7 @@ export namespace videointelligence_v1p2beta1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleLongrunning_Operation>(

--- a/src/apis/videointelligence/v1p3beta1.ts
+++ b/src/apis/videointelligence/v1p3beta1.ts
@@ -29,8 +29,6 @@ export namespace videointelligence_v1p3beta1 {
     version: 'v1p3beta1';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * V1 error format.
@@ -100,12 +98,13 @@ export namespace videointelligence_v1p3beta1 {
    * @param {object=} options Options for Videointelligence
    */
   export class Videointelligence {
+    context: APIRequestContext;
     videos: Resource$Videos;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.videos = new Resource$Videos();
+      this.videos = new Resource$Videos(this.context);
     }
   }
 
@@ -2727,7 +2726,10 @@ export namespace videointelligence_v1p3beta1 {
 
 
   export class Resource$Videos {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -2794,7 +2796,7 @@ export namespace videointelligence_v1p3beta1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GoogleLongrunning_Operation>(

--- a/src/apis/vision/v1.ts
+++ b/src/apis/vision/v1.ts
@@ -29,8 +29,6 @@ export namespace vision_v1 {
     version: 'v1';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * V1 error format.
@@ -100,6 +98,7 @@ export namespace vision_v1 {
    * @param {object=} options Options for Vision
    */
   export class Vision {
+    context: APIRequestContext;
     files: Resource$Files;
     images: Resource$Images;
     locations: Resource$Locations;
@@ -107,13 +106,13 @@ export namespace vision_v1 {
     projects: Resource$Projects;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.files = new Resource$Files();
-      this.images = new Resource$Images();
-      this.locations = new Resource$Locations();
-      this.operations = new Resource$Operations();
-      this.projects = new Resource$Projects();
+      this.files = new Resource$Files(this.context);
+      this.images = new Resource$Images(this.context);
+      this.locations = new Resource$Locations(this.context);
+      this.operations = new Resource$Operations(this.context);
+      this.projects = new Resource$Projects(this.context);
     }
   }
 
@@ -5876,7 +5875,10 @@ export namespace vision_v1 {
 
 
   export class Resource$Files {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -5941,7 +5943,7 @@ export namespace vision_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -5967,7 +5969,10 @@ export namespace vision_v1 {
 
 
   export class Resource$Images {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -6084,7 +6089,7 @@ export namespace vision_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$BatchAnnotateImagesResponse>(
@@ -6110,15 +6115,20 @@ export namespace vision_v1 {
 
 
   export class Resource$Locations {
+    context: APIRequestContext;
     operations: Resource$Locations$Operations;
-    constructor() {
-      this.operations = new Resource$Locations$Operations();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.operations = new Resource$Locations$Operations(this.context);
     }
   }
 
 
   export class Resource$Locations$Operations {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -6175,7 +6185,7 @@ export namespace vision_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -6201,7 +6211,10 @@ export namespace vision_v1 {
 
 
   export class Resource$Operations {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -6268,7 +6281,7 @@ export namespace vision_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -6335,7 +6348,7 @@ export namespace vision_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -6398,7 +6411,7 @@ export namespace vision_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -6474,7 +6487,7 @@ export namespace vision_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListOperationsResponse>(parameters, callback);
@@ -6550,28 +6563,36 @@ export namespace vision_v1 {
 
 
   export class Resource$Projects {
+    context: APIRequestContext;
     locations: Resource$Projects$Locations;
-    constructor() {
-      this.locations = new Resource$Projects$Locations();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.locations = new Resource$Projects$Locations(this.context);
     }
   }
 
 
   export class Resource$Projects$Locations {
+    context: APIRequestContext;
     products: Resource$Projects$Locations$Products;
     productSets: Resource$Projects$Locations$Productsets;
-    constructor() {
-      this.products = new Resource$Projects$Locations$Products();
-      this.productSets = new Resource$Projects$Locations$Productsets();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.products = new Resource$Projects$Locations$Products(this.context);
+      this.productSets =
+          new Resource$Projects$Locations$Productsets(this.context);
     }
   }
 
 
   export class Resource$Projects$Locations$Products {
+    context: APIRequestContext;
     referenceImages: Resource$Projects$Locations$Products$Referenceimages;
-    constructor() {
+    constructor(context: APIRequestContext) {
+      this.context = context;
       this.referenceImages =
-          new Resource$Projects$Locations$Products$Referenceimages();
+          new Resource$Projects$Locations$Products$Referenceimages(
+              this.context);
     }
 
 
@@ -6637,7 +6658,7 @@ export namespace vision_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Product>(parameters, callback);
@@ -6706,7 +6727,7 @@ export namespace vision_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -6768,7 +6789,7 @@ export namespace vision_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Product>(parameters, callback);
@@ -6839,7 +6860,7 @@ export namespace vision_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListProductsResponse>(parameters, callback);
@@ -6914,7 +6935,7 @@ export namespace vision_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Product>(parameters, callback);
@@ -7023,7 +7044,10 @@ export namespace vision_v1 {
   }
 
   export class Resource$Projects$Locations$Products$Referenceimages {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -7102,7 +7126,7 @@ export namespace vision_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ReferenceImage>(parameters, callback);
@@ -7176,7 +7200,7 @@ export namespace vision_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -7242,7 +7266,7 @@ export namespace vision_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ReferenceImage>(parameters, callback);
@@ -7323,7 +7347,7 @@ export namespace vision_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListReferenceImagesResponse>(
@@ -7412,9 +7436,12 @@ export namespace vision_v1 {
 
 
   export class Resource$Projects$Locations$Productsets {
+    context: APIRequestContext;
     products: Resource$Projects$Locations$Productsets$Products;
-    constructor() {
-      this.products = new Resource$Projects$Locations$Productsets$Products();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.products =
+          new Resource$Projects$Locations$Productsets$Products(this.context);
     }
 
 
@@ -7480,7 +7507,7 @@ export namespace vision_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -7552,7 +7579,7 @@ export namespace vision_v1 {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ProductSet>(parameters, callback);
@@ -7621,7 +7648,7 @@ export namespace vision_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -7684,7 +7711,7 @@ export namespace vision_v1 {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ProductSet>(parameters, callback);
@@ -7731,7 +7758,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Locations$Productsets$Import|
     options = {};
                                                                                                                                                                                                                                                                                                 }
 
-                                                                                                                                                                                                                                                                                                const rootUrl = options.rootUrl || 'https://vision.googleapis.com/'; const parameters = {options: Object.assign({url: (rootUrl + '/v1/{+parent}/productSets:import').replace(/([^:]\/)\/+/g, '$1'), method: 'POST'}, options), params, requiredParams: ['parent'], pathParams: ['parent'], context}; if(callback) {
+                                                                                                                                                                                                                                                                                                const rootUrl = options.rootUrl || 'https://vision.googleapis.com/'; const parameters = {options: Object.assign({url: (rootUrl + '/v1/{+parent}/productSets:import').replace(/([^:]\/)\/+/g, '$1'), method: 'POST'}, options), params, requiredParams: ['parent'], pathParams: ['parent'], context: this.context}; if(callback) {
     createAPIRequest<Schema$Operation>(parameters, callback);
                                                                                                                                                                                                                                                                                                 } else {
     return createAPIRequest<Schema$Operation>(parameters);
@@ -7796,7 +7823,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Locations$Productsets$Import|
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListProductSetsResponse>(parameters, callback);
@@ -7868,7 +7895,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Locations$Productsets$Import|
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ProductSet>(parameters, callback);
@@ -7938,7 +7965,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Locations$Productsets$Import|
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -8101,7 +8128,10 @@ import(paramsOrCallback?: Params$Resource$Projects$Locations$Productsets$Import|
   }
 
   export class Resource$Projects$Locations$Productsets$Products {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -8177,7 +8207,7 @@ import(paramsOrCallback?: Params$Resource$Projects$Locations$Productsets$Import|
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListProductsInProductSetResponse>(

--- a/src/apis/vision/v1p1beta1.ts
+++ b/src/apis/vision/v1p1beta1.ts
@@ -29,8 +29,6 @@ export namespace vision_v1p1beta1 {
     version: 'v1p1beta1';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * V1 error format.
@@ -100,14 +98,15 @@ export namespace vision_v1p1beta1 {
    * @param {object=} options Options for Vision
    */
   export class Vision {
+    context: APIRequestContext;
     files: Resource$Files;
     images: Resource$Images;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.files = new Resource$Files();
-      this.images = new Resource$Images();
+      this.files = new Resource$Files(this.context);
+      this.images = new Resource$Images(this.context);
     }
   }
 
@@ -5673,7 +5672,10 @@ export namespace vision_v1p1beta1 {
 
 
   export class Resource$Files {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -5738,7 +5740,7 @@ export namespace vision_v1p1beta1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -5765,7 +5767,10 @@ export namespace vision_v1p1beta1 {
 
 
   export class Resource$Images {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -5833,7 +5838,7 @@ export namespace vision_v1p1beta1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<

--- a/src/apis/vision/v1p2beta1.ts
+++ b/src/apis/vision/v1p2beta1.ts
@@ -29,8 +29,6 @@ export namespace vision_v1p2beta1 {
     version: 'v1p2beta1';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * V1 error format.
@@ -100,14 +98,15 @@ export namespace vision_v1p2beta1 {
    * @param {object=} options Options for Vision
    */
   export class Vision {
+    context: APIRequestContext;
     files: Resource$Files;
     images: Resource$Images;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.files = new Resource$Files();
-      this.images = new Resource$Images();
+      this.files = new Resource$Files(this.context);
+      this.images = new Resource$Images(this.context);
     }
   }
 
@@ -5673,7 +5672,10 @@ export namespace vision_v1p2beta1 {
 
 
   export class Resource$Files {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -5738,7 +5740,7 @@ export namespace vision_v1p2beta1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Operation>(parameters, callback);
@@ -5765,7 +5767,10 @@ export namespace vision_v1p2beta1 {
 
 
   export class Resource$Images {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -5833,7 +5838,7 @@ export namespace vision_v1p2beta1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<

--- a/src/apis/webfonts/v1.ts
+++ b/src/apis/webfonts/v1.ts
@@ -29,8 +29,6 @@ export namespace webfonts_v1 {
     version: 'v1';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * Data format for the response.
@@ -83,12 +81,13 @@ export namespace webfonts_v1 {
    * @param {object=} options Options for Webfonts
    */
   export class Webfonts {
+    context: APIRequestContext;
     webfonts: Resource$Webfonts;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.webfonts = new Resource$Webfonts();
+      this.webfonts = new Resource$Webfonts(this.context);
     }
   }
 
@@ -141,7 +140,10 @@ export namespace webfonts_v1 {
 
 
   export class Resource$Webfonts {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -200,7 +202,7 @@ export namespace webfonts_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$WebfontList>(parameters, callback);

--- a/src/apis/webmasters/v3.ts
+++ b/src/apis/webmasters/v3.ts
@@ -29,8 +29,6 @@ export namespace webmasters_v3 {
     version: 'v3';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * Data format for the response.
@@ -81,6 +79,7 @@ export namespace webmasters_v3 {
    * @param {object=} options Options for Webmasters
    */
   export class Webmasters {
+    context: APIRequestContext;
     searchanalytics: Resource$Searchanalytics;
     sitemaps: Resource$Sitemaps;
     sites: Resource$Sites;
@@ -88,13 +87,15 @@ export namespace webmasters_v3 {
     urlcrawlerrorssamples: Resource$Urlcrawlerrorssamples;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.searchanalytics = new Resource$Searchanalytics();
-      this.sitemaps = new Resource$Sitemaps();
-      this.sites = new Resource$Sites();
-      this.urlcrawlerrorscounts = new Resource$Urlcrawlerrorscounts();
-      this.urlcrawlerrorssamples = new Resource$Urlcrawlerrorssamples();
+      this.searchanalytics = new Resource$Searchanalytics(this.context);
+      this.sitemaps = new Resource$Sitemaps(this.context);
+      this.sites = new Resource$Sites(this.context);
+      this.urlcrawlerrorscounts =
+          new Resource$Urlcrawlerrorscounts(this.context);
+      this.urlcrawlerrorssamples =
+          new Resource$Urlcrawlerrorssamples(this.context);
     }
   }
 
@@ -375,7 +376,10 @@ export namespace webmasters_v3 {
 
 
   export class Resource$Searchanalytics {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -447,7 +451,7 @@ export namespace webmasters_v3 {
         params,
         requiredParams: ['siteUrl'],
         pathParams: ['siteUrl'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$SearchAnalyticsQueryResponse>(
@@ -479,7 +483,10 @@ export namespace webmasters_v3 {
 
 
   export class Resource$Sitemaps {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -537,7 +544,7 @@ export namespace webmasters_v3 {
         params,
         requiredParams: ['siteUrl', 'feedpath'],
         pathParams: ['feedpath', 'siteUrl'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -601,7 +608,7 @@ export namespace webmasters_v3 {
         params,
         requiredParams: ['siteUrl', 'feedpath'],
         pathParams: ['feedpath', 'siteUrl'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$WmxSitemap>(parameters, callback);
@@ -669,7 +676,7 @@ export namespace webmasters_v3 {
         params,
         requiredParams: ['siteUrl'],
         pathParams: ['siteUrl'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$SitemapsListResponse>(parameters, callback);
@@ -734,7 +741,7 @@ export namespace webmasters_v3 {
         params,
         requiredParams: ['siteUrl', 'feedpath'],
         pathParams: ['feedpath', 'siteUrl'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -811,7 +818,10 @@ export namespace webmasters_v3 {
 
 
   export class Resource$Sites {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -863,7 +873,7 @@ export namespace webmasters_v3 {
         params,
         requiredParams: ['siteUrl'],
         pathParams: ['siteUrl'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -926,7 +936,7 @@ export namespace webmasters_v3 {
         params,
         requiredParams: ['siteUrl'],
         pathParams: ['siteUrl'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -987,7 +997,7 @@ export namespace webmasters_v3 {
         params,
         requiredParams: ['siteUrl'],
         pathParams: ['siteUrl'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$WmxSite>(parameters, callback);
@@ -1051,7 +1061,7 @@ export namespace webmasters_v3 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$SitesListResponse>(parameters, callback);
@@ -1109,7 +1119,10 @@ export namespace webmasters_v3 {
 
 
   export class Resource$Urlcrawlerrorscounts {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1183,7 +1196,7 @@ export namespace webmasters_v3 {
         params,
         requiredParams: ['siteUrl'],
         pathParams: ['siteUrl'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$UrlCrawlErrorsCountsQueryResponse>(
@@ -1224,7 +1237,10 @@ export namespace webmasters_v3 {
 
 
   export class Resource$Urlcrawlerrorssamples {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1286,7 +1302,7 @@ export namespace webmasters_v3 {
         params,
         requiredParams: ['siteUrl', 'url', 'category', 'platform'],
         pathParams: ['siteUrl', 'url'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$UrlCrawlErrorsSample>(parameters, callback);
@@ -1366,7 +1382,7 @@ export namespace webmasters_v3 {
         params,
         requiredParams: ['siteUrl', 'category', 'platform'],
         pathParams: ['siteUrl'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$UrlCrawlErrorsSamplesListResponse>(
@@ -1439,7 +1455,7 @@ export namespace webmasters_v3 {
         params,
         requiredParams: ['siteUrl', 'url', 'category', 'platform'],
         pathParams: ['siteUrl', 'url'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);

--- a/src/apis/websecurityscanner/v1alpha.ts
+++ b/src/apis/websecurityscanner/v1alpha.ts
@@ -29,8 +29,6 @@ export namespace websecurityscanner_v1alpha {
     version: 'v1alpha';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * V1 error format.
@@ -98,12 +96,13 @@ export namespace websecurityscanner_v1alpha {
    * @param {object=} options Options for Websecurityscanner
    */
   export class Websecurityscanner {
+    context: APIRequestContext;
     projects: Resource$Projects;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.projects = new Resource$Projects();
+      this.projects = new Resource$Projects(this.context);
     }
   }
 
@@ -553,17 +552,21 @@ export namespace websecurityscanner_v1alpha {
 
 
   export class Resource$Projects {
+    context: APIRequestContext;
     scanConfigs: Resource$Projects$Scanconfigs;
-    constructor() {
-      this.scanConfigs = new Resource$Projects$Scanconfigs();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.scanConfigs = new Resource$Projects$Scanconfigs(this.context);
     }
   }
 
 
   export class Resource$Projects$Scanconfigs {
+    context: APIRequestContext;
     scanRuns: Resource$Projects$Scanconfigs$Scanruns;
-    constructor() {
-      this.scanRuns = new Resource$Projects$Scanconfigs$Scanruns();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.scanRuns = new Resource$Projects$Scanconfigs$Scanruns(this.context);
     }
 
 
@@ -626,7 +629,7 @@ export namespace websecurityscanner_v1alpha {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ScanConfig>(parameters, callback);
@@ -692,7 +695,7 @@ export namespace websecurityscanner_v1alpha {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -755,7 +758,7 @@ export namespace websecurityscanner_v1alpha {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ScanConfig>(parameters, callback);
@@ -826,7 +829,7 @@ export namespace websecurityscanner_v1alpha {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListScanConfigsResponse>(parameters, callback);
@@ -896,7 +899,7 @@ export namespace websecurityscanner_v1alpha {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ScanConfig>(parameters, callback);
@@ -964,7 +967,7 @@ export namespace websecurityscanner_v1alpha {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ScanRun>(parameters, callback);
@@ -1088,15 +1091,19 @@ export namespace websecurityscanner_v1alpha {
   }
 
   export class Resource$Projects$Scanconfigs$Scanruns {
+    context: APIRequestContext;
     crawledUrls: Resource$Projects$Scanconfigs$Scanruns$Crawledurls;
     findings: Resource$Projects$Scanconfigs$Scanruns$Findings;
     findingTypeStats: Resource$Projects$Scanconfigs$Scanruns$Findingtypestats;
-    constructor() {
+    constructor(context: APIRequestContext) {
+      this.context = context;
       this.crawledUrls =
-          new Resource$Projects$Scanconfigs$Scanruns$Crawledurls();
-      this.findings = new Resource$Projects$Scanconfigs$Scanruns$Findings();
+          new Resource$Projects$Scanconfigs$Scanruns$Crawledurls(this.context);
+      this.findings =
+          new Resource$Projects$Scanconfigs$Scanruns$Findings(this.context);
       this.findingTypeStats =
-          new Resource$Projects$Scanconfigs$Scanruns$Findingtypestats();
+          new Resource$Projects$Scanconfigs$Scanruns$Findingtypestats(
+              this.context);
     }
 
 
@@ -1152,7 +1159,7 @@ export namespace websecurityscanner_v1alpha {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ScanRun>(parameters, callback);
@@ -1224,7 +1231,7 @@ export namespace websecurityscanner_v1alpha {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListScanRunsResponse>(parameters, callback);
@@ -1292,7 +1299,7 @@ export namespace websecurityscanner_v1alpha {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ScanRun>(parameters, callback);
@@ -1362,7 +1369,10 @@ export namespace websecurityscanner_v1alpha {
   }
 
   export class Resource$Projects$Scanconfigs$Scanruns$Crawledurls {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1428,7 +1438,7 @@ export namespace websecurityscanner_v1alpha {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListCrawledUrlsResponse>(parameters, callback);
@@ -1467,7 +1477,10 @@ export namespace websecurityscanner_v1alpha {
 
 
   export class Resource$Projects$Scanconfigs$Scanruns$Findings {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1524,7 +1537,7 @@ export namespace websecurityscanner_v1alpha {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Finding>(parameters, callback);
@@ -1598,7 +1611,7 @@ export namespace websecurityscanner_v1alpha {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListFindingsResponse>(parameters, callback);
@@ -1657,7 +1670,10 @@ export namespace websecurityscanner_v1alpha {
 
 
   export class Resource$Projects$Scanconfigs$Scanruns$Findingtypestats {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1729,7 +1745,7 @@ export namespace websecurityscanner_v1alpha {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListFindingTypeStatsResponse>(

--- a/src/apis/websecurityscanner/v1beta.ts
+++ b/src/apis/websecurityscanner/v1beta.ts
@@ -29,8 +29,6 @@ export namespace websecurityscanner_v1beta {
     version: 'v1beta';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * V1 error format.
@@ -98,12 +96,13 @@ export namespace websecurityscanner_v1beta {
    * @param {object=} options Options for Websecurityscanner
    */
   export class Websecurityscanner {
+    context: APIRequestContext;
     projects: Resource$Projects;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.projects = new Resource$Projects();
+      this.projects = new Resource$Projects(this.context);
     }
   }
 
@@ -642,17 +641,21 @@ export namespace websecurityscanner_v1beta {
 
 
   export class Resource$Projects {
+    context: APIRequestContext;
     scanConfigs: Resource$Projects$Scanconfigs;
-    constructor() {
-      this.scanConfigs = new Resource$Projects$Scanconfigs();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.scanConfigs = new Resource$Projects$Scanconfigs(this.context);
     }
   }
 
 
   export class Resource$Projects$Scanconfigs {
+    context: APIRequestContext;
     scanRuns: Resource$Projects$Scanconfigs$Scanruns;
-    constructor() {
-      this.scanRuns = new Resource$Projects$Scanconfigs$Scanruns();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.scanRuns = new Resource$Projects$Scanconfigs$Scanruns(this.context);
     }
 
 
@@ -715,7 +718,7 @@ export namespace websecurityscanner_v1beta {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ScanConfig>(parameters, callback);
@@ -781,7 +784,7 @@ export namespace websecurityscanner_v1beta {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -844,7 +847,7 @@ export namespace websecurityscanner_v1beta {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ScanConfig>(parameters, callback);
@@ -915,7 +918,7 @@ export namespace websecurityscanner_v1beta {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListScanConfigsResponse>(parameters, callback);
@@ -985,7 +988,7 @@ export namespace websecurityscanner_v1beta {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ScanConfig>(parameters, callback);
@@ -1053,7 +1056,7 @@ export namespace websecurityscanner_v1beta {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ScanRun>(parameters, callback);
@@ -1177,15 +1180,19 @@ export namespace websecurityscanner_v1beta {
   }
 
   export class Resource$Projects$Scanconfigs$Scanruns {
+    context: APIRequestContext;
     crawledUrls: Resource$Projects$Scanconfigs$Scanruns$Crawledurls;
     findings: Resource$Projects$Scanconfigs$Scanruns$Findings;
     findingTypeStats: Resource$Projects$Scanconfigs$Scanruns$Findingtypestats;
-    constructor() {
+    constructor(context: APIRequestContext) {
+      this.context = context;
       this.crawledUrls =
-          new Resource$Projects$Scanconfigs$Scanruns$Crawledurls();
-      this.findings = new Resource$Projects$Scanconfigs$Scanruns$Findings();
+          new Resource$Projects$Scanconfigs$Scanruns$Crawledurls(this.context);
+      this.findings =
+          new Resource$Projects$Scanconfigs$Scanruns$Findings(this.context);
       this.findingTypeStats =
-          new Resource$Projects$Scanconfigs$Scanruns$Findingtypestats();
+          new Resource$Projects$Scanconfigs$Scanruns$Findingtypestats(
+              this.context);
     }
 
 
@@ -1241,7 +1248,7 @@ export namespace websecurityscanner_v1beta {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ScanRun>(parameters, callback);
@@ -1313,7 +1320,7 @@ export namespace websecurityscanner_v1beta {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListScanRunsResponse>(parameters, callback);
@@ -1381,7 +1388,7 @@ export namespace websecurityscanner_v1beta {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ScanRun>(parameters, callback);
@@ -1451,7 +1458,10 @@ export namespace websecurityscanner_v1beta {
   }
 
   export class Resource$Projects$Scanconfigs$Scanruns$Crawledurls {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1517,7 +1527,7 @@ export namespace websecurityscanner_v1beta {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListCrawledUrlsResponse>(parameters, callback);
@@ -1556,7 +1566,10 @@ export namespace websecurityscanner_v1beta {
 
 
   export class Resource$Projects$Scanconfigs$Scanruns$Findings {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1613,7 +1626,7 @@ export namespace websecurityscanner_v1beta {
         params,
         requiredParams: ['name'],
         pathParams: ['name'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Finding>(parameters, callback);
@@ -1687,7 +1700,7 @@ export namespace websecurityscanner_v1beta {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListFindingsResponse>(parameters, callback);
@@ -1746,7 +1759,10 @@ export namespace websecurityscanner_v1beta {
 
 
   export class Resource$Projects$Scanconfigs$Scanruns$Findingtypestats {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1818,7 +1834,7 @@ export namespace websecurityscanner_v1beta {
         params,
         requiredParams: ['parent'],
         pathParams: ['parent'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListFindingTypeStatsResponse>(

--- a/src/apis/youtube/v3.ts
+++ b/src/apis/youtube/v3.ts
@@ -29,8 +29,6 @@ export namespace youtube_v3 {
     version: 'v3';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * Data format for the response.
@@ -82,6 +80,7 @@ export namespace youtube_v3 {
    * @param {object=} options Options for Youtube
    */
   export class Youtube {
+    context: APIRequestContext;
     activities: Resource$Activities;
     captions: Resource$Captions;
     channelBanners: Resource$Channelbanners;
@@ -110,34 +109,35 @@ export namespace youtube_v3 {
     watermarks: Resource$Watermarks;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.activities = new Resource$Activities();
-      this.captions = new Resource$Captions();
-      this.channelBanners = new Resource$Channelbanners();
-      this.channels = new Resource$Channels();
-      this.channelSections = new Resource$Channelsections();
-      this.comments = new Resource$Comments();
-      this.commentThreads = new Resource$Commentthreads();
-      this.guideCategories = new Resource$Guidecategories();
-      this.i18nLanguages = new Resource$I18nlanguages();
-      this.i18nRegions = new Resource$I18nregions();
-      this.liveBroadcasts = new Resource$Livebroadcasts();
-      this.liveChatBans = new Resource$Livechatbans();
-      this.liveChatMessages = new Resource$Livechatmessages();
-      this.liveChatModerators = new Resource$Livechatmoderators();
-      this.liveStreams = new Resource$Livestreams();
-      this.playlistItems = new Resource$Playlistitems();
-      this.playlists = new Resource$Playlists();
-      this.search = new Resource$Search();
-      this.sponsors = new Resource$Sponsors();
-      this.subscriptions = new Resource$Subscriptions();
-      this.superChatEvents = new Resource$Superchatevents();
-      this.thumbnails = new Resource$Thumbnails();
-      this.videoAbuseReportReasons = new Resource$Videoabusereportreasons();
-      this.videoCategories = new Resource$Videocategories();
-      this.videos = new Resource$Videos();
-      this.watermarks = new Resource$Watermarks();
+      this.activities = new Resource$Activities(this.context);
+      this.captions = new Resource$Captions(this.context);
+      this.channelBanners = new Resource$Channelbanners(this.context);
+      this.channels = new Resource$Channels(this.context);
+      this.channelSections = new Resource$Channelsections(this.context);
+      this.comments = new Resource$Comments(this.context);
+      this.commentThreads = new Resource$Commentthreads(this.context);
+      this.guideCategories = new Resource$Guidecategories(this.context);
+      this.i18nLanguages = new Resource$I18nlanguages(this.context);
+      this.i18nRegions = new Resource$I18nregions(this.context);
+      this.liveBroadcasts = new Resource$Livebroadcasts(this.context);
+      this.liveChatBans = new Resource$Livechatbans(this.context);
+      this.liveChatMessages = new Resource$Livechatmessages(this.context);
+      this.liveChatModerators = new Resource$Livechatmoderators(this.context);
+      this.liveStreams = new Resource$Livestreams(this.context);
+      this.playlistItems = new Resource$Playlistitems(this.context);
+      this.playlists = new Resource$Playlists(this.context);
+      this.search = new Resource$Search(this.context);
+      this.sponsors = new Resource$Sponsors(this.context);
+      this.subscriptions = new Resource$Subscriptions(this.context);
+      this.superChatEvents = new Resource$Superchatevents(this.context);
+      this.thumbnails = new Resource$Thumbnails(this.context);
+      this.videoAbuseReportReasons =
+          new Resource$Videoabusereportreasons(this.context);
+      this.videoCategories = new Resource$Videocategories(this.context);
+      this.videos = new Resource$Videos(this.context);
+      this.watermarks = new Resource$Watermarks(this.context);
     }
   }
 
@@ -5033,7 +5033,10 @@ export namespace youtube_v3 {
 
 
   export class Resource$Activities {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -5098,7 +5101,7 @@ export namespace youtube_v3 {
         params,
         requiredParams: ['part'],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Activity>(parameters, callback);
@@ -5176,7 +5179,7 @@ export namespace youtube_v3 {
         params,
         requiredParams: ['part'],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ActivityListResponse>(parameters, callback);
@@ -5276,7 +5279,10 @@ export namespace youtube_v3 {
 
 
   export class Resource$Captions {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -5334,7 +5340,7 @@ export namespace youtube_v3 {
         params,
         requiredParams: ['id'],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -5406,7 +5412,7 @@ export namespace youtube_v3 {
         params,
         requiredParams: ['id'],
         pathParams: ['id'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -5479,7 +5485,7 @@ export namespace youtube_v3 {
                       .replace(/([^:]\/)\/+/g, '$1'),
         requiredParams: ['part'],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Caption>(parameters, callback);
@@ -5551,7 +5557,7 @@ export namespace youtube_v3 {
         params,
         requiredParams: ['part', 'videoId'],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$CaptionListResponse>(parameters, callback);
@@ -5626,7 +5632,7 @@ export namespace youtube_v3 {
                       .replace(/([^:]\/)\/+/g, '$1'),
         requiredParams: ['part'],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Caption>(parameters, callback);
@@ -5878,7 +5884,10 @@ export namespace youtube_v3 {
 
 
   export class Resource$Channelbanners {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -5954,7 +5963,7 @@ export namespace youtube_v3 {
                       .replace(/([^:]\/)\/+/g, '$1'),
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ChannelBannerResource>(parameters, callback);
@@ -6019,7 +6028,10 @@ export namespace youtube_v3 {
 
 
   export class Resource$Channels {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -6088,7 +6100,7 @@ export namespace youtube_v3 {
         params,
         requiredParams: ['part'],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ChannelListResponse>(parameters, callback);
@@ -6156,7 +6168,7 @@ export namespace youtube_v3 {
         params,
         requiredParams: ['part'],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Channel>(parameters, callback);
@@ -6284,7 +6296,10 @@ export namespace youtube_v3 {
 
 
   export class Resource$Channelsections {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -6343,7 +6358,7 @@ export namespace youtube_v3 {
         params,
         requiredParams: ['id'],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -6413,7 +6428,7 @@ export namespace youtube_v3 {
         params,
         requiredParams: ['part'],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ChannelSection>(parameters, callback);
@@ -6490,7 +6505,7 @@ export namespace youtube_v3 {
         params,
         requiredParams: ['part'],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ChannelSectionListResponse>(
@@ -6560,7 +6575,7 @@ export namespace youtube_v3 {
         params,
         requiredParams: ['part'],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ChannelSection>(parameters, callback);
@@ -6745,7 +6760,10 @@ export namespace youtube_v3 {
 
 
   export class Resource$Comments {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -6801,7 +6819,7 @@ export namespace youtube_v3 {
         params,
         requiredParams: ['id'],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -6867,7 +6885,7 @@ export namespace youtube_v3 {
         params,
         requiredParams: ['part'],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Comment>(parameters, callback);
@@ -6937,7 +6955,7 @@ export namespace youtube_v3 {
         params,
         requiredParams: ['part'],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$CommentListResponse>(parameters, callback);
@@ -7003,7 +7021,7 @@ export namespace youtube_v3 {
         params,
         requiredParams: ['id'],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -7072,7 +7090,7 @@ export namespace youtube_v3 {
         params,
         requiredParams: ['id', 'moderationStatus'],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -7137,7 +7155,7 @@ export namespace youtube_v3 {
         params,
         requiredParams: ['part'],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Comment>(parameters, callback);
@@ -7279,7 +7297,10 @@ export namespace youtube_v3 {
 
 
   export class Resource$Commentthreads {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -7341,7 +7362,7 @@ export namespace youtube_v3 {
         params,
         requiredParams: ['part'],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$CommentThread>(parameters, callback);
@@ -7420,7 +7441,7 @@ export namespace youtube_v3 {
         params,
         requiredParams: ['part'],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$CommentThreadListResponse>(
@@ -7489,7 +7510,7 @@ export namespace youtube_v3 {
         params,
         requiredParams: ['part'],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$CommentThread>(parameters, callback);
@@ -7615,7 +7636,10 @@ export namespace youtube_v3 {
 
 
   export class Resource$Guidecategories {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -7681,7 +7705,7 @@ export namespace youtube_v3 {
         params,
         requiredParams: ['part'],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GuideCategoryListResponse>(
@@ -7726,7 +7750,10 @@ export namespace youtube_v3 {
 
 
   export class Resource$I18nlanguages {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -7788,7 +7815,7 @@ export namespace youtube_v3 {
         params,
         requiredParams: ['part'],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$I18nLanguageListResponse>(parameters, callback);
@@ -7819,7 +7846,10 @@ export namespace youtube_v3 {
 
 
   export class Resource$I18nregions {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -7880,7 +7910,7 @@ export namespace youtube_v3 {
         params,
         requiredParams: ['part'],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$I18nRegionListResponse>(parameters, callback);
@@ -7910,7 +7940,10 @@ export namespace youtube_v3 {
 
 
   export class Resource$Livebroadcasts {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -7976,7 +8009,7 @@ export namespace youtube_v3 {
         params,
         requiredParams: ['id', 'part'],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$LiveBroadcast>(parameters, callback);
@@ -8050,7 +8083,7 @@ export namespace youtube_v3 {
         params,
         requiredParams: ['id', 'part'],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$LiveBroadcast>(parameters, callback);
@@ -8117,7 +8150,7 @@ export namespace youtube_v3 {
         params,
         requiredParams: ['id'],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -8187,7 +8220,7 @@ export namespace youtube_v3 {
         params,
         requiredParams: ['part'],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$LiveBroadcast>(parameters, callback);
@@ -8264,7 +8297,7 @@ export namespace youtube_v3 {
         params,
         requiredParams: ['part'],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$LiveBroadcastListResponse>(
@@ -8341,7 +8374,7 @@ export namespace youtube_v3 {
         params,
         requiredParams: ['broadcastStatus', 'id', 'part'],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$LiveBroadcast>(parameters, callback);
@@ -8412,7 +8445,7 @@ export namespace youtube_v3 {
         params,
         requiredParams: ['part'],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$LiveBroadcast>(parameters, callback);
@@ -8858,7 +8891,10 @@ export namespace youtube_v3 {
 
 
   export class Resource$Livechatbans {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -8916,7 +8952,7 @@ export namespace youtube_v3 {
         params,
         requiredParams: ['id'],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -8984,7 +9020,7 @@ export namespace youtube_v3 {
         params,
         requiredParams: ['part'],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$LiveChatBan>(parameters, callback);
@@ -9030,7 +9066,10 @@ export namespace youtube_v3 {
 
 
   export class Resource$Livechatmessages {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -9088,7 +9127,7 @@ export namespace youtube_v3 {
         params,
         requiredParams: ['id'],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -9156,7 +9195,7 @@ export namespace youtube_v3 {
         params,
         requiredParams: ['part'],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$LiveChatMessage>(parameters, callback);
@@ -9233,7 +9272,7 @@ export namespace youtube_v3 {
         params,
         requiredParams: ['liveChatId', 'part'],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$LiveChatMessageListResponse>(
@@ -9324,7 +9363,10 @@ export namespace youtube_v3 {
 
 
   export class Resource$Livechatmoderators {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -9382,7 +9424,7 @@ export namespace youtube_v3 {
         params,
         requiredParams: ['id'],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -9450,7 +9492,7 @@ export namespace youtube_v3 {
         params,
         requiredParams: ['part'],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$LiveChatModerator>(parameters, callback);
@@ -9525,7 +9567,7 @@ export namespace youtube_v3 {
         params,
         requiredParams: ['liveChatId', 'part'],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$LiveChatModeratorListResponse>(
@@ -9602,7 +9644,10 @@ export namespace youtube_v3 {
 
 
   export class Resource$Livestreams {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -9662,7 +9707,7 @@ export namespace youtube_v3 {
         params,
         requiredParams: ['id'],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -9733,7 +9778,7 @@ export namespace youtube_v3 {
         params,
         requiredParams: ['part'],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$LiveStream>(parameters, callback);
@@ -9806,7 +9851,7 @@ export namespace youtube_v3 {
         params,
         requiredParams: ['part'],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$LiveStreamListResponse>(parameters, callback);
@@ -9878,7 +9923,7 @@ export namespace youtube_v3 {
         params,
         requiredParams: ['part'],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$LiveStream>(parameters, callback);
@@ -10113,7 +10158,10 @@ export namespace youtube_v3 {
 
 
   export class Resource$Playlistitems {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -10172,7 +10220,7 @@ export namespace youtube_v3 {
         params,
         requiredParams: ['id'],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -10241,7 +10289,7 @@ export namespace youtube_v3 {
         params,
         requiredParams: ['part'],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$PlaylistItem>(parameters, callback);
@@ -10316,7 +10364,7 @@ export namespace youtube_v3 {
         params,
         requiredParams: ['part'],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$PlaylistItemListResponse>(parameters, callback);
@@ -10386,7 +10434,7 @@ export namespace youtube_v3 {
         params,
         requiredParams: ['part'],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$PlaylistItem>(parameters, callback);
@@ -10560,7 +10608,10 @@ export namespace youtube_v3 {
 
 
   export class Resource$Playlists {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -10617,7 +10668,7 @@ export namespace youtube_v3 {
         params,
         requiredParams: ['id'],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -10684,7 +10735,7 @@ export namespace youtube_v3 {
         params,
         requiredParams: ['part'],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Playlist>(parameters, callback);
@@ -10761,7 +10812,7 @@ export namespace youtube_v3 {
         params,
         requiredParams: ['part'],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$PlaylistListResponse>(parameters, callback);
@@ -10828,7 +10879,7 @@ export namespace youtube_v3 {
         params,
         requiredParams: ['part'],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Playlist>(parameters, callback);
@@ -11035,7 +11086,10 @@ export namespace youtube_v3 {
 
 
   export class Resource$Search {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -11126,7 +11180,7 @@ export namespace youtube_v3 {
         params,
         requiredParams: ['part'],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$SearchListResponse>(parameters, callback);
@@ -11366,7 +11420,10 @@ export namespace youtube_v3 {
 
 
   export class Resource$Sponsors {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -11427,7 +11484,7 @@ export namespace youtube_v3 {
         params,
         requiredParams: ['part'],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$SponsorListResponse>(parameters, callback);
@@ -11467,7 +11524,10 @@ export namespace youtube_v3 {
 
 
   export class Resource$Subscriptions {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -11525,7 +11585,7 @@ export namespace youtube_v3 {
         params,
         requiredParams: ['id'],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -11593,7 +11653,7 @@ export namespace youtube_v3 {
         params,
         requiredParams: ['part'],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Subscription>(parameters, callback);
@@ -11671,7 +11731,7 @@ export namespace youtube_v3 {
         params,
         requiredParams: ['part'],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$SubscriptionListResponse>(parameters, callback);
@@ -11816,7 +11876,10 @@ export namespace youtube_v3 {
 
 
   export class Resource$Superchatevents {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -11883,7 +11946,7 @@ export namespace youtube_v3 {
         params,
         requiredParams: ['part'],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$SuperChatEventListResponse>(
@@ -11932,7 +11995,10 @@ export namespace youtube_v3 {
 
 
   export class Resource$Thumbnails {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -11995,7 +12061,7 @@ export namespace youtube_v3 {
                       .replace(/([^:]\/)\/+/g, '$1'),
         requiredParams: ['videoId'],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ThumbnailSetResponse>(parameters, callback);
@@ -12049,7 +12115,10 @@ export namespace youtube_v3 {
 
 
   export class Resource$Videoabusereportreasons {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -12120,7 +12189,7 @@ export namespace youtube_v3 {
         params,
         requiredParams: ['part'],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$VideoAbuseReportReasonListResponse>(
@@ -12153,7 +12222,10 @@ export namespace youtube_v3 {
 
 
   export class Resource$Videocategories {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -12219,7 +12291,7 @@ export namespace youtube_v3 {
         params,
         requiredParams: ['part'],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$VideoCategoryListResponse>(
@@ -12262,7 +12334,10 @@ export namespace youtube_v3 {
 
 
   export class Resource$Videos {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -12319,7 +12394,7 @@ export namespace youtube_v3 {
         params,
         requiredParams: ['id'],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -12389,7 +12464,7 @@ export namespace youtube_v3 {
         params,
         requiredParams: ['id'],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$VideoGetRatingResponse>(parameters, callback);
@@ -12465,7 +12540,7 @@ export namespace youtube_v3 {
                       .replace(/([^:]\/)\/+/g, '$1'),
         requiredParams: ['part'],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Video>(parameters, callback);
@@ -12542,7 +12617,7 @@ export namespace youtube_v3 {
         params,
         requiredParams: ['part'],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$VideoListResponse>(parameters, callback);
@@ -12607,7 +12682,7 @@ export namespace youtube_v3 {
         params,
         requiredParams: ['id', 'rating'],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -12673,7 +12748,7 @@ export namespace youtube_v3 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -12739,7 +12814,7 @@ export namespace youtube_v3 {
         params,
         requiredParams: ['part'],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Video>(parameters, callback);
@@ -13082,7 +13157,10 @@ export namespace youtube_v3 {
 
 
   export class Resource$Watermarks {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -13142,7 +13220,7 @@ export namespace youtube_v3 {
                       .replace(/([^:]\/)\/+/g, '$1'),
         requiredParams: ['channelId'],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -13206,7 +13284,7 @@ export namespace youtube_v3 {
         params,
         requiredParams: ['channelId'],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);

--- a/src/apis/youtubeAnalytics/v1.ts
+++ b/src/apis/youtubeAnalytics/v1.ts
@@ -29,8 +29,6 @@ export namespace youtubeAnalytics_v1 {
     version: 'v1';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * Data format for the response.
@@ -81,16 +79,17 @@ export namespace youtubeAnalytics_v1 {
    * @param {object=} options Options for Youtubeanalytics
    */
   export class Youtubeanalytics {
+    context: APIRequestContext;
     groupItems: Resource$Groupitems;
     groups: Resource$Groups;
     reports: Resource$Reports;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.groupItems = new Resource$Groupitems();
-      this.groups = new Resource$Groups();
-      this.reports = new Resource$Reports();
+      this.groupItems = new Resource$Groupitems(this.context);
+      this.groups = new Resource$Groups(this.context);
+      this.reports = new Resource$Reports(this.context);
     }
   }
 
@@ -168,7 +167,10 @@ export namespace youtubeAnalytics_v1 {
 
 
   export class Resource$Groupitems {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -226,7 +228,7 @@ export namespace youtubeAnalytics_v1 {
         params,
         requiredParams: ['id'],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -293,7 +295,7 @@ export namespace youtubeAnalytics_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GroupItem>(parameters, callback);
@@ -361,7 +363,7 @@ export namespace youtubeAnalytics_v1 {
         params,
         requiredParams: ['groupId'],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GroupItemListResponse>(parameters, callback);
@@ -451,7 +453,10 @@ export namespace youtubeAnalytics_v1 {
 
 
   export class Resource$Groups {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -508,7 +513,7 @@ export namespace youtubeAnalytics_v1 {
         params,
         requiredParams: ['id'],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -573,7 +578,7 @@ export namespace youtubeAnalytics_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Group>(parameters, callback);
@@ -644,7 +649,7 @@ export namespace youtubeAnalytics_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GroupListResponse>(parameters, callback);
@@ -709,7 +714,7 @@ export namespace youtubeAnalytics_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Group>(parameters, callback);
@@ -834,7 +839,10 @@ export namespace youtubeAnalytics_v1 {
 
 
   export class Resource$Reports {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -902,7 +910,7 @@ export namespace youtubeAnalytics_v1 {
         params,
         requiredParams: ['ids', 'start-date', 'end-date', 'metrics'],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ResultTable>(parameters, callback);

--- a/src/apis/youtubeAnalytics/v1beta1.ts
+++ b/src/apis/youtubeAnalytics/v1beta1.ts
@@ -29,8 +29,6 @@ export namespace youtubeAnalytics_v1beta1 {
     version: 'v1beta1';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * Data format for the response.
@@ -81,16 +79,17 @@ export namespace youtubeAnalytics_v1beta1 {
    * @param {object=} options Options for Youtubeanalytics
    */
   export class Youtubeanalytics {
+    context: APIRequestContext;
     groupItems: Resource$Groupitems;
     groups: Resource$Groups;
     reports: Resource$Reports;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.groupItems = new Resource$Groupitems();
-      this.groups = new Resource$Groups();
-      this.reports = new Resource$Reports();
+      this.groupItems = new Resource$Groupitems(this.context);
+      this.groups = new Resource$Groups(this.context);
+      this.reports = new Resource$Reports(this.context);
     }
   }
 
@@ -168,7 +167,10 @@ export namespace youtubeAnalytics_v1beta1 {
 
 
   export class Resource$Groupitems {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -226,7 +228,7 @@ export namespace youtubeAnalytics_v1beta1 {
         params,
         requiredParams: ['id'],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -293,7 +295,7 @@ export namespace youtubeAnalytics_v1beta1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GroupItem>(parameters, callback);
@@ -361,7 +363,7 @@ export namespace youtubeAnalytics_v1beta1 {
         params,
         requiredParams: ['groupId'],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GroupItemListResponse>(parameters, callback);
@@ -451,7 +453,10 @@ export namespace youtubeAnalytics_v1beta1 {
 
 
   export class Resource$Groups {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -508,7 +513,7 @@ export namespace youtubeAnalytics_v1beta1 {
         params,
         requiredParams: ['id'],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<void>(parameters, callback);
@@ -573,7 +578,7 @@ export namespace youtubeAnalytics_v1beta1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Group>(parameters, callback);
@@ -644,7 +649,7 @@ export namespace youtubeAnalytics_v1beta1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GroupListResponse>(parameters, callback);
@@ -709,7 +714,7 @@ export namespace youtubeAnalytics_v1beta1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Group>(parameters, callback);
@@ -834,7 +839,10 @@ export namespace youtubeAnalytics_v1beta1 {
 
 
   export class Resource$Reports {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -902,7 +910,7 @@ export namespace youtubeAnalytics_v1beta1 {
         params,
         requiredParams: ['ids', 'start-date', 'end-date', 'metrics'],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ResultTable>(parameters, callback);

--- a/src/apis/youtubeAnalytics/v2.ts
+++ b/src/apis/youtubeAnalytics/v2.ts
@@ -29,8 +29,6 @@ export namespace youtubeAnalytics_v2 {
     version: 'v2';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * V1 error format.
@@ -98,16 +96,17 @@ export namespace youtubeAnalytics_v2 {
    * @param {object=} options Options for Youtubeanalytics
    */
   export class Youtubeanalytics {
+    context: APIRequestContext;
     groupItems: Resource$Groupitems;
     groups: Resource$Groups;
     reports: Resource$Reports;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.groupItems = new Resource$Groupitems();
-      this.groups = new Resource$Groups();
-      this.reports = new Resource$Reports();
+      this.groupItems = new Resource$Groupitems(this.context);
+      this.groups = new Resource$Groups(this.context);
+      this.reports = new Resource$Reports(this.context);
     }
   }
 
@@ -407,7 +406,10 @@ export namespace youtubeAnalytics_v2 {
 
 
   export class Resource$Groupitems {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -467,7 +469,7 @@ export namespace youtubeAnalytics_v2 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$EmptyResponse>(parameters, callback);
@@ -534,7 +536,7 @@ export namespace youtubeAnalytics_v2 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GroupItem>(parameters, callback);
@@ -602,7 +604,7 @@ export namespace youtubeAnalytics_v2 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListGroupItemsResponse>(parameters, callback);
@@ -692,7 +694,10 @@ export namespace youtubeAnalytics_v2 {
 
 
   export class Resource$Groups {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -751,7 +756,7 @@ export namespace youtubeAnalytics_v2 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$EmptyResponse>(parameters, callback);
@@ -816,7 +821,7 @@ export namespace youtubeAnalytics_v2 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Group>(parameters, callback);
@@ -887,7 +892,7 @@ export namespace youtubeAnalytics_v2 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListGroupsResponse>(parameters, callback);
@@ -952,7 +957,7 @@ export namespace youtubeAnalytics_v2 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Group>(parameters, callback);
@@ -1081,7 +1086,10 @@ export namespace youtubeAnalytics_v2 {
 
 
   export class Resource$Reports {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1149,7 +1157,7 @@ export namespace youtubeAnalytics_v2 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$QueryResponse>(parameters, callback);

--- a/src/apis/youtubereporting/v1.ts
+++ b/src/apis/youtubereporting/v1.ts
@@ -29,8 +29,6 @@ export namespace youtubereporting_v1 {
     version: 'v1';
   }
 
-  let context: APIRequestContext;
-
   interface StandardParameters {
     /**
      * V1 error format.
@@ -99,16 +97,17 @@ export namespace youtubereporting_v1 {
    * @param {object=} options Options for Youtubereporting
    */
   export class Youtubereporting {
+    context: APIRequestContext;
     jobs: Resource$Jobs;
     media: Resource$Media;
     reportTypes: Resource$Reporttypes;
 
     constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-      context = {_options: options || {}, google};
+      this.context = {_options: options || {}, google};
 
-      this.jobs = new Resource$Jobs();
-      this.media = new Resource$Media();
-      this.reportTypes = new Resource$Reporttypes();
+      this.jobs = new Resource$Jobs(this.context);
+      this.media = new Resource$Media(this.context);
+      this.reportTypes = new Resource$Reporttypes(this.context);
     }
   }
 
@@ -590,9 +589,11 @@ export namespace youtubereporting_v1 {
 
 
   export class Resource$Jobs {
+    context: APIRequestContext;
     reports: Resource$Jobs$Reports;
-    constructor() {
-      this.reports = new Resource$Jobs$Reports();
+    constructor(context: APIRequestContext) {
+      this.context = context;
+      this.reports = new Resource$Jobs$Reports(this.context);
     }
 
 
@@ -651,7 +652,7 @@ export namespace youtubereporting_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Job>(parameters, callback);
@@ -716,7 +717,7 @@ export namespace youtubereporting_v1 {
         params,
         requiredParams: ['jobId'],
         pathParams: ['jobId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Empty>(parameters, callback);
@@ -778,7 +779,7 @@ export namespace youtubereporting_v1 {
         params,
         requiredParams: ['jobId'],
         pathParams: ['jobId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Job>(parameters, callback);
@@ -846,7 +847,7 @@ export namespace youtubereporting_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListJobsResponse>(parameters, callback);
@@ -936,7 +937,10 @@ export namespace youtubereporting_v1 {
   }
 
   export class Resource$Jobs$Reports {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -993,7 +997,7 @@ export namespace youtubereporting_v1 {
         params,
         requiredParams: ['jobId', 'reportId'],
         pathParams: ['jobId', 'reportId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$Report>(parameters, callback);
@@ -1067,7 +1071,7 @@ export namespace youtubereporting_v1 {
         params,
         requiredParams: ['jobId'],
         pathParams: ['jobId'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListReportsResponse>(parameters, callback);
@@ -1143,7 +1147,10 @@ export namespace youtubereporting_v1 {
 
 
   export class Resource$Media {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1203,7 +1210,7 @@ export namespace youtubereporting_v1 {
         params,
         requiredParams: ['resourceName'],
         pathParams: ['resourceName'],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$GdataMedia>(parameters, callback);
@@ -1227,7 +1234,10 @@ export namespace youtubereporting_v1 {
 
 
   export class Resource$Reporttypes {
-    constructor() {}
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
 
 
     /**
@@ -1289,7 +1299,7 @@ export namespace youtubereporting_v1 {
         params,
         requiredParams: [],
         pathParams: [],
-        context
+        context: this.context
       };
       if (callback) {
         createAPIRequest<Schema$ListReportTypesResponse>(parameters, callback);

--- a/src/generator/templates/api-endpoint.njk
+++ b/src/generator/templates/api-endpoint.njk
@@ -40,8 +40,6 @@ export interface Options extends GlobalOptions {
   version: '{{api.version|replace('\.', '_')}}';
 }
 
-let context: APIRequestContext;
-
 interface StandardParameters {
   {% for pname, p in api.parameters|dictsort %}
   /**
@@ -67,7 +65,7 @@ interface StandardParameters {
  * @param {object=} options Options for {{ Name }}
  */
 export class {{ Name }} {
-
+  context: APIRequestContext;
   {% if api.resources %}
     {% for rname, r in api.resources|dictsort %}
       {{ rname }}: Resource${{ rname|capitalize }};
@@ -75,14 +73,14 @@ export class {{ Name }} {
   {% endif %}
 
   constructor(options: GlobalOptions, google?: GoogleConfigurable) {
-    context = {
+    this.context = {
       _options: options || {},
       google
     };
 
     {% if api.resources %}
       {% for rname, r in api.resources|dictsort %}
-        this.{{ rname }} = new Resource${{ rname|capitalize }}();
+        this.{{ rname }} = new Resource${{ rname|capitalize }}(this.context);
       {% endfor %}
     {% endif %}
   }

--- a/src/generator/templates/method-partial.njk
+++ b/src/generator/templates/method-partial.njk
@@ -68,7 +68,7 @@
     {% if m.mediaUpload.protocols.simple.path %}mediaUrl: (rootUrl + {{ ('/' + m.mediaUpload.protocols.simple.path)|buildurl|safe }}).replace(/([^:]\/)\/+/g, '$1'),{% endif %}
     requiredParams: [{% if m.parameterOrder.length %}'{{ m.parameterOrder|join("', '")|safe }}'{% endif %}],
     pathParams: [{% if pathParams.length %}'{{ pathParams|join("', '")|safe }}'{% endif %}],
-    context
+    context: this.context
   };
   {% set responseType = "Schema$" + m.response.$ref|default() %}
   if (callback) {

--- a/src/generator/templates/resource-partial.njk
+++ b/src/generator/templates/resource-partial.njk
@@ -4,17 +4,19 @@
   {% for rname, r in api.resources|dictsort %}
     {% set ClassName = classPath + rname|capitalize|camelify %}
     export class {{ ClassName }} {
+      context: APIRequestContext;
       {% if r.resources %}
         {% for rname, r2 in r.resources|dictsort %}
           {% set innerClassName = ClassName + "$" + rname|capitalize|camelify %}
           {{ rname|camelify }}: {{ innerClassName }};
         {% endfor %}
       {% endif %}
-      constructor() {
+      constructor(context: APIRequestContext) {
+        this.context = context;
         {% if r.resources %}
           {% for rname, r2 in r.resources|dictsort %}
             {% set innerClassName = ClassName + "$" + rname|capitalize|camelify %}
-            this.{{ rname|camelify }} = new {{ innerClassName }}();
+            this.{{ rname|camelify }} = new {{ innerClassName }}(this.context);
           {% endfor %}
         {% endif %}
       }


### PR DESCRIPTION
Fixes #1594.  The `context` object was moved from the outer namespace of the template inside of the class.  This ensures that differently scoped objects get their own context, which can have their own authentication provider.  

This was broken in https://github.com/googleapis/google-api-nodejs-client/pull/1476.  The affected versions are 36 => 39.  

The fix should be in 40 when it is released.