### PR TITLE
docs: document export as alternative to get

### DIFF
--- a/samples/drive/download.js
+++ b/samples/drive/download.js
@@ -31,6 +31,9 @@ async function runSample(fileId) {
     console.log(`writing to ${filePath}`);
     const dest = fs.createWriteStream(filePath);
     let progress = 0;
+    // For converting document formats, and for downloading template
+    // documents, see the method drive.files.export():
+    // https://developers.google.com/drive/api/v3/manage-downloads
     const res = await drive.files.get(
       {fileId, alt: 'media'},
       {responseType: 'stream'}


### PR DESCRIPTION
Refs #1651 just a thought, based on the conversation in `1651` it might be worth adding this point of clarification in our sample.

- [x] Tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
