### PR TITLE
refactor: drop usage of assert.rejects

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,6 @@
     "@types/source-map-support": "^0.5.0",
     "@types/tmp": "^0.1.0",
     "@types/url-template": "^2.0.28",
-    "assert-rejects": "^1.0.0",
     "chai": "^4.2.0",
     "codecov": "^3.0.2",
     "eslint": "^5.6.0",

--- a/test/test.auth.ts
+++ b/test/test.auth.ts
@@ -17,10 +17,7 @@ import {APIEndpoint} from 'googleapis-common';
 import * as nock from 'nock';
 
 import {GoogleApis} from '../src';
-
 import {Utils} from './utils';
-
-const assertRejects = require('assert-rejects');
 
 const googleapis = new GoogleApis();
 
@@ -51,7 +48,7 @@ describe('Compute client', () => {
 });
 
 async function testNoTokens(urlshortener: APIEndpoint, client: OAuth2Client) {
-  await assertRejects(
+  await assert.rejects(
     urlshortener.url.get({shortUrl: '123', auth: client}),
     /No access, refresh token or API key is set./
   );
@@ -307,7 +304,7 @@ describe('OAuth2 client', () => {
         REDIRECT_URI
       );
       oauth2client.credentials = {refresh_token: 'abc'};
-      await assertRejects(
+      await assert.rejects(
         oauth2client.revokeCredentials(),
         /Error: No access token to revoke./
       );


### PR DESCRIPTION
This shouldn't be required on nodejs 8 and up