### PR TITLE
fix: make webpack work on Windows

### DIFF
--- a/src/generator/templates/webpack.config.js.njk
+++ b/src/generator/templates/webpack.config.js.njk
@@ -36,27 +36,27 @@ module.exports = {
   module: {
     rules: [
       {
-        test: /node_modules\/google-auth-library\/src\/crypto\/node\/crypto/,
+        test: /node_modules[\\\/]google-auth-library[\\\/]src[\\\/]crypto[\\\/]node[\\\/]crypto/,
         use: 'null-loader',
       },
       {
-        test: /node_modules\/https-proxy-agent\//,
+        test: /node_modules[\\\/]https-proxy-agent[\\\/]/,
         use: 'null-loader',
       },
       {
-        test: /node_modules\/gcp-metadata\//,
+        test: /node_modules[\\\/]gcp-metadata[\\\/]/,
         use: 'null-loader',
       },
       {
-        test: /node_modules\/gtoken\//,
+        test: /node_modules[\\\/]gtoken[\\\/]/,
         use: 'null-loader',
       },
       {
-        test: /node_modules\/pkginfo\//,
+        test: /node_modules[\\\/]pkginfo[\\\/]/,
         use: 'null-loader',
       },
       {
-        test: /node_modules\/semver\//,
+        test: /node_modules[\\\/]semver[\\\/]/,
         use: 'null-loader',
       },
       {


### PR DESCRIPTION
Turns out `webpack` rules break on Windows because of different path separator used. This PR fixes #1732 by fixing the regular expression in the `null-module` rules in `webpack.config.js` to accept both `/` and `\` as a possible path separators.

- [x] Tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
