### PR TITLE
fix(deps): pull in version of gts that does not OOM error

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,7 +89,6 @@
     "server-destroy": "^1.0.1",
     "source-map-support": "^0.5.12",
     "tmp": "^0.1.0",
-    "typedoc": "^0.15.0",
     "typescript": "~3.5.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -65,12 +65,13 @@
     "c8": "^5.0.1",
     "chai": "^4.2.0",
     "codecov": "^3.4.0",
+    "compodoc": "0.0.41",
     "eslint": "^6.0.0",
     "eslint-config-prettier": "^6.0.0",
     "eslint-plugin-node": "^9.0.1",
     "eslint-plugin-prettier": "^3.1.0",
-    "execa": "^1.0.0",
-    "gts": "^1.0.0",
+    "execa": "^2.0.3",
+    "gts": "^1.1.0",
     "hard-rejection": "^2.1.0",
     "intelli-espower-loader": "^1.0.1",
     "js-green-licenses": "^1.0.0",
@@ -89,6 +90,7 @@
     "server-destroy": "^1.0.1",
     "source-map-support": "^0.5.12",
     "tmp": "^0.1.0",
+    "typedoc": "^0.15.0",
     "typescript": "~3.5.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "node": ">=8.10.0"
   },
   "devDependencies": {
-    "@compodoc/compodoc": "^1.1.9",
+    "@compodoc/compodoc": "^1.1.10",
     "@types/chai": "^4.1.7",
     "@types/execa": "^0.9.0",
     "@types/minimist": "^1.2.0",
@@ -65,7 +65,6 @@
     "c8": "^5.0.1",
     "chai": "^4.2.0",
     "codecov": "^3.4.0",
-    "compodoc": "0.0.41",
     "eslint": "^6.0.0",
     "eslint-config-prettier": "^6.0.0",
     "eslint-plugin-node": "^9.0.1",

--- a/test/samples/test.compute.samples.ts
+++ b/test/samples/test.compute.samples.ts
@@ -12,11 +12,11 @@
 // limitations under the License.
 
 import {assert} from 'chai';
-import {shellSync} from 'execa';
+import * as execa from 'execa';
 
 describe('Compute samples', () => {
   it('should list all the VMs', async () => {
-    const res = shellSync('node ../samples/compute/listVMs');
+    const res = execa.sync('node ../samples/compute/listVMs', {shell: true});
     assert.match(res.stdout, /VMs:/);
   });
 });


### PR DESCRIPTION
The most important update in this PR is the introduction of a patched version of `gts` which does not run out of memory when processing a large number of files (I believe `gts` might be why a variety of builds were timing out).
