### PR TITLE
build: switch to GitHub app for publish

### DIFF
--- a/.github/publish.yml
+++ b/.github/publish.yml
@@ -1,0 +1,2 @@
+# an empty publish.yml enables publication,
+# the default settings are sufficient for our app.


### PR DESCRIPTION
let's see if the 9 minute timeout in a cloud function is enough for library publications of google-api-nodejs-client, this would make me confident that we can move to a GitHub app for all of our publications.