### PR TITLE
docs: update readme for drive readme

### DIFF
--- a/samples/drive/README.md
+++ b/samples/drive/README.md
@@ -5,11 +5,25 @@ These samples allow you to list, download, and upload files from Google Drive.
 ## Running the samples
 
 ### **Note: Node.js version 8 or greater is required to run samples.**
-Set the following values in `oauth2.keys.json` (up one directory):
+Set the following values in `oauth2.keys.json` (up one directory) under the `web` key:
 
+* `redirect_uris`
 * `client_id`
 * `project_id`
 * `client_secret`
+
+Your file should look like this:
+
+```json
+{
+  "web" : {
+    "redirect_uris": ["http://localhost:3000/oauth2callback"],
+    "client_id": "<YOUR_CLIENT_ID>",
+    "client_secret": "<YOUR_CLIENT_SECRET>",
+    "project_id": "<YOUR_PROJECT_ID>"
+  }
+}
+```
 
 __Run the `quickstart.js` sample:__
 


### PR DESCRIPTION
## What's in this PR?

I was going through the example for google drive and came across the README, where I was told to create `oauth2.keys.json`.  What wasn't immediately clear was that everything needed to be nested under a key of `web`, [as shown here](https://github.com/googleapis/google-api-nodejs-client/blob/master/samples/drive/quickstart.js#L29). A specific example would have been really helpful, so I added a quick one.