### PR TITLE
build: ignore revision-only updates

### DIFF
--- a/test/test.samplegen.ts
+++ b/test/test.samplegen.ts
@@ -19,7 +19,7 @@ import {addFragments, getAllMethods} from '../src/generator/samplegen';
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const schema = require('../../test/fixtures/discovery/webfonts-v1.json');
 
-describe.only(__filename, () => {
+describe(__filename, () => {
   it('should add fragments', () => {
     addFragments(schema);
     const methods = getAllMethods(schema);


### PR DESCRIPTION
This change ignores updates to the `discovery` directory if they only contain changes to the `revision` or `etag` fields.  It will reduce the noisiness of re-generation after introducing the discovery caching feature.

One important side effect of this change - as it's written here, *APIs that have been removed from the discovery index will not be automatically cleaned up*.  This is consistent with the approach taken by Go.  I'm on the fence 50/50 if it's a good idea to be honest.  The big benefit I see here is that maybe (just maybe) we can avoid bumping the semver major every time we want to ship.  The downside is that we will never really prune missing APIs.  I can go back and add the code to do the cleanup if folks thing it's advisable.  