### PR TITLE
feat(billingbudgets): update the API

### DIFF
--- a/discovery/billingbudgets-v1beta1.json
+++ b/discovery/billingbudgets-v1beta1.json
@@ -256,7 +256,7 @@
       }
     }
   },
-  "revision": "20200502",
+  "revision": "20200516",
   "rootUrl": "https://billingbudgets.googleapis.com/",
   "schemas": {
     "GoogleCloudBillingBudgetsV1beta1AllUpdatesRule": {
@@ -356,6 +356,16 @@
           ],
           "type": "string"
         },
+        "labels": {
+          "additionalProperties": {
+            "items": {
+              "type": "any"
+            },
+            "type": "array"
+          },
+          "description": "Optional. A single label and value pair specifying that usage from only this set of\nlabeled resources should be included in the budget. Multiple entries or\nmultiple values per entry are not allowed. If omitted, the report will\ninclude all labeled and unlabeled usage.",
+          "type": "object"
+        },
         "projects": {
           "description": "Optional. A set of projects of the form `projects/{project}`,\nspecifying that usage from only this set of projects should be\nincluded in the budget. If omitted, the report will include all usage for\nthe billing account, regardless of which project the usage occurred on.\nOnly zero or one project can be specified currently.",
           "items": {
@@ -365,6 +375,13 @@
         },
         "services": {
           "description": "Optional. A set of services of the form `services/{service_id}`,\nspecifying that usage from only this set of services should be\nincluded in the budget. If omitted, the report will include usage for\nall the services.\nThe service names are available through the Catalog API:\nhttps://cloud.google.com/billing/v1/how-tos/catalog-api.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "subaccounts": {
+          "description": "Optional. A set of subaccounts of the form `billingAccounts/{account_id}`, specifying\nthat usage from only this set of subaccounts should be included in the\nbudget. If a subaccount is set to the name of the master account, usage\nfrom the master account will be included. If omitted, the report will\ninclude usage from the master account and all subaccounts, if they exist.",
           "items": {
             "type": "string"
           },

--- a/src/apis/billingbudgets/v1beta1.ts
+++ b/src/apis/billingbudgets/v1beta1.ts
@@ -190,6 +190,10 @@ export namespace billingbudgets_v1beta1 {
      */
     creditTypesTreatment?: string | null;
     /**
+     * Optional. A single label and value pair specifying that usage from only this set of labeled resources should be included in the budget. Multiple entries or multiple values per entry are not allowed. If omitted, the report will include all labeled and unlabeled usage.
+     */
+    labels?: {[key: string]: any[]} | null;
+    /**
      * Optional. A set of projects of the form `projects/{project}`, specifying that usage from only this set of projects should be included in the budget. If omitted, the report will include all usage for the billing account, regardless of which project the usage occurred on. Only zero or one project can be specified currently.
      */
     projects?: string[] | null;
@@ -197,6 +201,10 @@ export namespace billingbudgets_v1beta1 {
      * Optional. A set of services of the form `services/{service_id}`, specifying that usage from only this set of services should be included in the budget. If omitted, the report will include usage for all the services. The service names are available through the Catalog API: https://cloud.google.com/billing/v1/how-tos/catalog-api.
      */
     services?: string[] | null;
+    /**
+     * Optional. A set of subaccounts of the form `billingAccounts/{account_id}`, specifying that usage from only this set of subaccounts should be included in the budget. If a subaccount is set to the name of the master account, usage from the master account will be included. If omitted, the report will include usage from the master account and all subaccounts, if they exist.
+     */
+    subaccounts?: string[] | null;
   }
   /**
    * Describes a budget amount targeted to last period&#39;s spend. At this time, the amount is automatically 100% of last period&#39;s spend; that is, there are no other options yet. Future configuration will be described here (for example, configuring a percentage of last period&#39;s spend).


### PR DESCRIPTION
#### billingbudgets:v1beta1
The following keys were added:
- schemas.GoogleCloudBillingBudgetsV1beta1Filter.properties.labels.additionalProperties.items.type
- schemas.GoogleCloudBillingBudgetsV1beta1Filter.properties.labels.additionalProperties.type
- schemas.GoogleCloudBillingBudgetsV1beta1Filter.properties.labels.description
- schemas.GoogleCloudBillingBudgetsV1beta1Filter.properties.labels.type
- schemas.GoogleCloudBillingBudgetsV1beta1Filter.properties.subaccounts.description
- schemas.GoogleCloudBillingBudgetsV1beta1Filter.properties.subaccounts.items.type
- schemas.GoogleCloudBillingBudgetsV1beta1Filter.properties.subaccounts.type

