### PR TITLE
fix(iamcredentials): update the API

### DIFF
--- a/discovery/iamcredentials-v1.json
+++ b/discovery/iamcredentials-v1.json
@@ -226,7 +226,7 @@
       }
     }
   },
-  "revision": "20200501",
+  "revision": "20200515",
   "rootUrl": "https://iamcredentials.googleapis.com/",
   "schemas": {
     "GenerateAccessTokenRequest": {
@@ -322,11 +322,11 @@
       "id": "SignBlobResponse",
       "properties": {
         "keyId": {
-          "description": "The ID of the key used to sign the blob.",
+          "description": "The ID of the key used to sign the blob. The key used for signing will\nremain valid for at least 12 hours after the blob is signed. To verify the\nsignature, you can retrieve the public key in several formats from the\nfollowing endpoints:\n\n- RSA public key wrapped in an X.509 v3 certificate:\n`https://www.googleapis.com/service_accounts/v1/metadata/x509/{ACCOUNT_EMAIL}`\n- Raw key in JSON format:\n`https://www.googleapis.com/service_accounts/v1/metadata/raw/{ACCOUNT_EMAIL}`\n- JSON Web Key (JWK):\n`https://www.googleapis.com/service_accounts/v1/metadata/jwk/{ACCOUNT_EMAIL}`",
           "type": "string"
         },
         "signedBlob": {
-          "description": "The signature for the blob. Does not include the original blob.",
+          "description": "The signature for the blob. Does not include the original blob.\n\nAfter the key pair referenced by the `key_id` response field expires,\nGoogle no longer exposes the public key that can be used to verify the\nblob. As a result, the receiver can no longer verify the signature.",
           "format": "byte",
           "type": "string"
         }
@@ -354,11 +354,11 @@
       "id": "SignJwtResponse",
       "properties": {
         "keyId": {
-          "description": "The ID of the key used to sign the JWT.",
+          "description": "The ID of the key used to sign the JWT. The key used for signing will\nremain valid for at least 12 hours after the JWT is signed. To verify the\nsignature, you can retrieve the public key in several formats from the\nfollowing endpoints:\n\n- RSA public key wrapped in an X.509 v3 certificate:\n`https://www.googleapis.com/service_accounts/v1/metadata/x509/{ACCOUNT_EMAIL}`\n- Raw key in JSON format:\n`https://www.googleapis.com/service_accounts/v1/metadata/raw/{ACCOUNT_EMAIL}`\n- JSON Web Key (JWK):\n`https://www.googleapis.com/service_accounts/v1/metadata/jwk/{ACCOUNT_EMAIL}`",
           "type": "string"
         },
         "signedJwt": {
-          "description": "The signed JWT. Contains the automatically generated header; the\nclient-supplied payload; and the signature, which is generated using the\nkey referenced by the `kid` field in the header.",
+          "description": "The signed JWT. Contains the automatically generated header; the\nclient-supplied payload; and the signature, which is generated using the\nkey referenced by the `kid` field in the header.\n\nAfter the key pair referenced by the `key_id` response field expires,\nGoogle no longer exposes the public key that can be used to verify the JWT.\nAs a result, the receiver can no longer verify the signature.",
           "type": "string"
         }
       },

--- a/src/apis/iamcredentials/v1.ts
+++ b/src/apis/iamcredentials/v1.ts
@@ -169,11 +169,11 @@ export namespace iamcredentials_v1 {
   }
   export interface Schema$SignBlobResponse {
     /**
-     * The ID of the key used to sign the blob.
+     * The ID of the key used to sign the blob. The key used for signing will remain valid for at least 12 hours after the blob is signed. To verify the signature, you can retrieve the public key in several formats from the following endpoints:  - RSA public key wrapped in an X.509 v3 certificate: `https://www.googleapis.com/service_accounts/v1/metadata/x509/{ACCOUNT_EMAIL}` - Raw key in JSON format: `https://www.googleapis.com/service_accounts/v1/metadata/raw/{ACCOUNT_EMAIL}` - JSON Web Key (JWK): `https://www.googleapis.com/service_accounts/v1/metadata/jwk/{ACCOUNT_EMAIL}`
      */
     keyId?: string | null;
     /**
-     * The signature for the blob. Does not include the original blob.
+     * The signature for the blob. Does not include the original blob.  After the key pair referenced by the `key_id` response field expires, Google no longer exposes the public key that can be used to verify the blob. As a result, the receiver can no longer verify the signature.
      */
     signedBlob?: string | null;
   }
@@ -189,11 +189,11 @@ export namespace iamcredentials_v1 {
   }
   export interface Schema$SignJwtResponse {
     /**
-     * The ID of the key used to sign the JWT.
+     * The ID of the key used to sign the JWT. The key used for signing will remain valid for at least 12 hours after the JWT is signed. To verify the signature, you can retrieve the public key in several formats from the following endpoints:  - RSA public key wrapped in an X.509 v3 certificate: `https://www.googleapis.com/service_accounts/v1/metadata/x509/{ACCOUNT_EMAIL}` - Raw key in JSON format: `https://www.googleapis.com/service_accounts/v1/metadata/raw/{ACCOUNT_EMAIL}` - JSON Web Key (JWK): `https://www.googleapis.com/service_accounts/v1/metadata/jwk/{ACCOUNT_EMAIL}`
      */
     keyId?: string | null;
     /**
-     * The signed JWT. Contains the automatically generated header; the client-supplied payload; and the signature, which is generated using the key referenced by the `kid` field in the header.
+     * The signed JWT. Contains the automatically generated header; the client-supplied payload; and the signature, which is generated using the key referenced by the `kid` field in the header.  After the key pair referenced by the `key_id` response field expires, Google no longer exposes the public key that can be used to verify the JWT. As a result, the receiver can no longer verify the signature.
      */
     signedJwt?: string | null;
   }


### PR DESCRIPTION
#### iamcredentials:v1
The following keys were changed:
- schemas.SignBlobResponse.properties.keyId.description
- schemas.SignBlobResponse.properties.signedBlob.description
- schemas.SignJwtResponse.properties.keyId.description
- schemas.SignJwtResponse.properties.signedJwt.description

