### PR TITLE
fix(websecurityscanner): update the API

### DIFF
--- a/discovery/websecurityscanner-v1.json
+++ b/discovery/websecurityscanner-v1.json
@@ -14,7 +14,7 @@
   "canonicalName": "WebSecurityScanner",
   "description": "Scans your Compute and App Engine apps for common web vulnerabilities.",
   "discoveryVersion": "v1",
-  "documentationLink": "https://cloud.google.com/security-scanner/",
+  "documentationLink": "https://cloud.google.com/security-command-center/docs/concepts-web-security-scanner-overview/",
   "fullyEncodeReservedExpansion": true,
   "icons": {
     "x16": "http://www.google.com/images/icons/product/search-16.gif",
@@ -526,7 +526,7 @@
       }
     }
   },
-  "revision": "20200411",
+  "revision": "20200516",
   "rootUrl": "https://websecurityscanner.googleapis.com/",
   "schemas": {
     "Authentication": {
@@ -609,7 +609,7 @@
           "type": "string"
         },
         "findingType": {
-          "description": "Output only. The type of the Finding.\nDetailed and up-to-date information on findings can be found here:\nhttps://cloud.google.com/security-scanner/docs/scan-result-details",
+          "description": "Output only. The type of the Finding.\nDetailed and up-to-date information on findings can be found here:\nhttps://cloud.google.com/security-command-center/docs/how-to-remediate-web-security-scanner-findings",
           "type": "string"
         },
         "form": {
@@ -884,7 +884,7 @@
           "description": "The authentication configuration. If specified, service will use the\nauthentication configuration during scanning."
         },
         "blacklistPatterns": {
-          "description": "The blacklist URL patterns as described in\nhttps://cloud.google.com/security-scanner/docs/excluded-urls",
+          "description": "The excluded URL patterns as described in\nhttps://cloud.google.com/security-command-center/docs/how-to-use-web-security-scanner#excluding_urls",
           "items": {
             "type": "string"
           },
@@ -895,7 +895,7 @@
           "type": "string"
         },
         "exportToSecurityCommandCenter": {
-          "description": "Controls export of scan configurations and results to Cloud Security\nCommand Center.",
+          "description": "Controls export of scan configurations and results to Security\nCommand Center.",
           "enum": [
             "EXPORT_TO_SECURITY_COMMAND_CENTER_UNSPECIFIED",
             "ENABLED",
@@ -903,13 +903,13 @@
           ],
           "enumDescriptions": [
             "Use default, which is ENABLED.",
-            "Export results of this scan to Cloud Security Command Center.",
-            "Do not export results of this scan to Cloud Security Command Center."
+            "Export results of this scan to Security Command Center.",
+            "Do not export results of this scan to Security Command Center."
           ],
           "type": "string"
         },
         "managedScan": {
-          "description": "Whether the scan config is managed by Cloud Web Security Scanner, output\nonly.",
+          "description": "Whether the scan config is managed by Web Security Scanner, output\nonly.",
           "type": "boolean"
         },
         "maxQps": {
@@ -1055,7 +1055,7 @@
             "One of the seed URLs is mapped to an IP address which is not reserved\nfor the current project.",
             "One of the seed URLs has on-routable IP address.",
             "One of the seed URLs has an IP address that is not reserved\nfor the current project.",
-            "The Cloud Security Scanner service account is not configured under the\nproject.",
+            "The Web Security Scanner service account is not configured under the\nproject.",
             "A project has reached the maximum number of scans.",
             "Resolving the details of the current project fails.",
             "One or more blacklist patterns were in the wrong format.",

--- a/discovery/websecurityscanner-v1alpha.json
+++ b/discovery/websecurityscanner-v1alpha.json
@@ -14,7 +14,7 @@
   "canonicalName": "WebSecurityScanner",
   "description": "Scans your Compute and App Engine apps for common web vulnerabilities.",
   "discoveryVersion": "v1",
-  "documentationLink": "https://cloud.google.com/security-scanner/",
+  "documentationLink": "https://cloud.google.com/security-command-center/docs/concepts-web-security-scanner-overview/",
   "fullyEncodeReservedExpansion": true,
   "icons": {
     "x16": "http://www.google.com/images/icons/product/search-16.gif",
@@ -526,7 +526,7 @@
       }
     }
   },
-  "revision": "20200411",
+  "revision": "20200516",
   "rootUrl": "https://websecurityscanner.googleapis.com/",
   "schemas": {
     "Authentication": {
@@ -874,7 +874,7 @@
           "description": "The authentication configuration. If specified, service will use the\nauthentication configuration during scanning."
         },
         "blacklistPatterns": {
-          "description": "The blacklist URL patterns as described in\nhttps://cloud.google.com/security-scanner/docs/excluded-urls",
+          "description": "The excluded URL patterns as described in\nhttps://cloud.google.com/security-command-center/docs/how-to-use-web-security-scanner#excluding_urls",
           "items": {
             "type": "string"
           },
@@ -909,7 +909,7 @@
           "type": "array"
         },
         "targetPlatforms": {
-          "description": "Set of Cloud Platforms targeted by the scan. If empty, APP_ENGINE will be\nused as a default.",
+          "description": "Set of Google Cloud platforms targeted by the scan. If empty, APP_ENGINE\nwill be used as a default.",
           "enumDescriptions": [
             "The target platform is unknown. Requests with this enum value will be\nrejected with INVALID_ARGUMENT error.",
             "Google App Engine service.",

--- a/discovery/websecurityscanner-v1beta.json
+++ b/discovery/websecurityscanner-v1beta.json
@@ -14,7 +14,7 @@
   "canonicalName": "WebSecurityScanner",
   "description": "Scans your Compute and App Engine apps for common web vulnerabilities.",
   "discoveryVersion": "v1",
-  "documentationLink": "https://cloud.google.com/security-scanner/",
+  "documentationLink": "https://cloud.google.com/security-command-center/docs/concepts-web-security-scanner-overview/",
   "fullyEncodeReservedExpansion": true,
   "icons": {
     "x16": "http://www.google.com/images/icons/product/search-16.gif",
@@ -526,7 +526,7 @@
       }
     }
   },
-  "revision": "20200411",
+  "revision": "20200516",
   "rootUrl": "https://websecurityscanner.googleapis.com/",
   "schemas": {
     "Authentication": {
@@ -609,7 +609,7 @@
           "type": "string"
         },
         "findingType": {
-          "description": "The type of the Finding.\nDetailed and up-to-date information on findings can be found here:\nhttps://cloud.google.com/security-scanner/docs/scan-result-details",
+          "description": "The type of the Finding.\nDetailed and up-to-date information on findings can be found here:\nhttps://cloud.google.com/security-command-center/docs/how-to-remediate-web-security-scanner",
           "type": "string"
         },
         "form": {
@@ -884,7 +884,7 @@
           "description": "The authentication configuration. If specified, service will use the\nauthentication configuration during scanning."
         },
         "blacklistPatterns": {
-          "description": "The blacklist URL patterns as described in\nhttps://cloud.google.com/security-scanner/docs/excluded-urls",
+          "description": "The excluded URL patterns as described in\nhttps://cloud.google.com/security-command-center/docs/how-to-use-web-security-scanner#excluding_urls",
           "items": {
             "type": "string"
           },
@@ -895,7 +895,7 @@
           "type": "string"
         },
         "exportToSecurityCommandCenter": {
-          "description": "Controls export of scan configurations and results to Cloud Security\nCommand Center.",
+          "description": "Controls export of scan configurations and results to Security\nCommand Center.",
           "enum": [
             "EXPORT_TO_SECURITY_COMMAND_CENTER_UNSPECIFIED",
             "ENABLED",
@@ -903,8 +903,8 @@
           ],
           "enumDescriptions": [
             "Use default, which is ENABLED.",
-            "Export results of this scan to Cloud Security Command Center.",
-            "Do not export results of this scan to Cloud Security Command Center."
+            "Export results of this scan to Security Command Center.",
+            "Do not export results of this scan to Security Command Center."
           ],
           "type": "string"
         },
@@ -913,7 +913,7 @@
           "description": "Latest ScanRun if available."
         },
         "managedScan": {
-          "description": "Whether the scan config is managed by Cloud Web Security Scanner, output\nonly.",
+          "description": "Whether the scan config is managed by Web Security Scanner, output\nonly.",
           "type": "boolean"
         },
         "maxQps": {
@@ -955,7 +955,7 @@
           "type": "boolean"
         },
         "targetPlatforms": {
-          "description": "Set of Cloud Platforms targeted by the scan. If empty, APP_ENGINE will be\nused as a default.",
+          "description": "Set of Google Cloud platforms targeted by the scan. If empty, APP_ENGINE\nwill be used as a default.",
           "enumDescriptions": [
             "The target platform is unknown. Requests with this enum value will be\nrejected with INVALID_ARGUMENT error.",
             "Google App Engine service.",
@@ -1076,7 +1076,7 @@
             "One of the seed URLs is mapped to an IP address which is not reserved\nfor the current project.",
             "One of the seed URLs has on-routable IP address.",
             "One of the seed URLs has an IP address that is not reserved\nfor the current project.",
-            "The Cloud Security Scanner service account is not configured under the\nproject.",
+            "The Web Security Scanner service account is not configured under the\nproject.",
             "A project has reached the maximum number of scans.",
             "Resolving the details of the current project fails.",
             "One or more blacklist patterns were in the wrong format.",

--- a/src/apis/websecurityscanner/v1.ts
+++ b/src/apis/websecurityscanner/v1.ts
@@ -185,7 +185,7 @@ export namespace websecurityscanner_v1 {
      */
     finalUrl?: string | null;
     /**
-     * Output only. The type of the Finding. Detailed and up-to-date information on findings can be found here: https://cloud.google.com/security-scanner/docs/scan-result-details
+     * Output only. The type of the Finding. Detailed and up-to-date information on findings can be found here: https://cloud.google.com/security-command-center/docs/how-to-remediate-web-security-scanner-findings
      */
     findingType?: string | null;
     /**
@@ -398,7 +398,7 @@ export namespace websecurityscanner_v1 {
      */
     authentication?: Schema$Authentication;
     /**
-     * The blacklist URL patterns as described in https://cloud.google.com/security-scanner/docs/excluded-urls
+     * The excluded URL patterns as described in https://cloud.google.com/security-command-center/docs/how-to-use-web-security-scanner#excluding_urls
      */
     blacklistPatterns?: string[] | null;
     /**
@@ -406,11 +406,11 @@ export namespace websecurityscanner_v1 {
      */
     displayName?: string | null;
     /**
-     * Controls export of scan configurations and results to Cloud Security Command Center.
+     * Controls export of scan configurations and results to Security Command Center.
      */
     exportToSecurityCommandCenter?: string | null;
     /**
-     * Whether the scan config is managed by Cloud Web Security Scanner, output only.
+     * Whether the scan config is managed by Web Security Scanner, output only.
      */
     managedScan?: boolean | null;
     /**

--- a/src/apis/websecurityscanner/v1alpha.ts
+++ b/src/apis/websecurityscanner/v1alpha.ts
@@ -355,7 +355,7 @@ export namespace websecurityscanner_v1alpha {
      */
     authentication?: Schema$Authentication;
     /**
-     * The blacklist URL patterns as described in https://cloud.google.com/security-scanner/docs/excluded-urls
+     * The excluded URL patterns as described in https://cloud.google.com/security-command-center/docs/how-to-use-web-security-scanner#excluding_urls
      */
     blacklistPatterns?: string[] | null;
     /**
@@ -383,7 +383,7 @@ export namespace websecurityscanner_v1alpha {
      */
     startingUrls?: string[] | null;
     /**
-     * Set of Cloud Platforms targeted by the scan. If empty, APP_ENGINE will be used as a default.
+     * Set of Google Cloud platforms targeted by the scan. If empty, APP_ENGINE will be used as a default.
      */
     targetPlatforms?: string[] | null;
     /**

--- a/src/apis/websecurityscanner/v1beta.ts
+++ b/src/apis/websecurityscanner/v1beta.ts
@@ -185,7 +185,7 @@ export namespace websecurityscanner_v1beta {
      */
     finalUrl?: string | null;
     /**
-     * The type of the Finding. Detailed and up-to-date information on findings can be found here: https://cloud.google.com/security-scanner/docs/scan-result-details
+     * The type of the Finding. Detailed and up-to-date information on findings can be found here: https://cloud.google.com/security-command-center/docs/how-to-remediate-web-security-scanner
      */
     findingType?: string | null;
     /**
@@ -398,7 +398,7 @@ export namespace websecurityscanner_v1beta {
      */
     authentication?: Schema$Authentication;
     /**
-     * The blacklist URL patterns as described in https://cloud.google.com/security-scanner/docs/excluded-urls
+     * The excluded URL patterns as described in https://cloud.google.com/security-command-center/docs/how-to-use-web-security-scanner#excluding_urls
      */
     blacklistPatterns?: string[] | null;
     /**
@@ -406,7 +406,7 @@ export namespace websecurityscanner_v1beta {
      */
     displayName?: string | null;
     /**
-     * Controls export of scan configurations and results to Cloud Security Command Center.
+     * Controls export of scan configurations and results to Security Command Center.
      */
     exportToSecurityCommandCenter?: string | null;
     /**
@@ -414,7 +414,7 @@ export namespace websecurityscanner_v1beta {
      */
     latestRun?: Schema$ScanRun;
     /**
-     * Whether the scan config is managed by Cloud Web Security Scanner, output only.
+     * Whether the scan config is managed by Web Security Scanner, output only.
      */
     managedScan?: boolean | null;
     /**
@@ -442,7 +442,7 @@ export namespace websecurityscanner_v1beta {
      */
     staticIpScan?: boolean | null;
     /**
-     * Set of Cloud Platforms targeted by the scan. If empty, APP_ENGINE will be used as a default.
+     * Set of Google Cloud platforms targeted by the scan. If empty, APP_ENGINE will be used as a default.
      */
     targetPlatforms?: string[] | null;
     /**


### PR DESCRIPTION
#### websecurityscanner:v1alpha
The following keys were changed:
- documentationLink
- schemas.ScanConfig.properties.blacklistPatterns.description
- schemas.ScanConfig.properties.targetPlatforms.description


#### websecurityscanner:v1beta
The following keys were changed:
- documentationLink
- schemas.Finding.properties.findingType.description
- schemas.ScanConfig.properties.blacklistPatterns.description
- schemas.ScanConfig.properties.exportToSecurityCommandCenter.description
- schemas.ScanConfig.properties.exportToSecurityCommandCenter.enumDescriptions
- schemas.ScanConfig.properties.managedScan.description
- schemas.ScanConfig.properties.targetPlatforms.description
- schemas.ScanConfigError.properties.code.enumDescriptions


#### websecurityscanner:v1
The following keys were changed:
- documentationLink
- schemas.Finding.properties.findingType.description
- schemas.ScanConfig.properties.blacklistPatterns.description
- schemas.ScanConfig.properties.exportToSecurityCommandCenter.description
- schemas.ScanConfig.properties.exportToSecurityCommandCenter.enumDescriptions
- schemas.ScanConfig.properties.managedScan.description
- schemas.ScanConfigError.properties.code.enumDescriptions

