### PR TITLE
refactor: do not require network access for unit tests

### DIFF
--- a/src/googleapis.ts
+++ b/src/googleapis.ts
@@ -129,13 +129,13 @@ export class GoogleApis extends apis.GeneratedAPIs {
    * discovery doc.
    * @returns A promise that resolves with the configured endpoint.
    */
-  async discoverAPI(
+  async discoverAPI<T = Endpoint>(
     apiPath: string,
     options: {} = {}
-  ): Promise<Readonly<Endpoint>> {
+  ): Promise<Readonly<T>> {
     const endpointCreator = await this._discovery.discoverAPI(apiPath);
     const ep = endpointCreator(options, this);
     ep.google = this; // for drive.google.transporter
-    return Object.freeze(ep);
+    return (Object.freeze(ep) as {}) as T;
   }
 }

--- a/test/test.apikey.ts
+++ b/test/test.apikey.ts
@@ -12,7 +12,7 @@
 // limitations under the License.
 
 import * as assert from 'assert';
-import {describe, it, before, after, beforeEach} from 'mocha';
+import {describe, it, before, afterEach, beforeEach} from 'mocha';
 import {OAuth2Client} from 'google-auth-library';
 import {APIEndpoint} from 'googleapis-common';
 import * as nock from 'nock';
@@ -66,7 +66,6 @@ describe('API key', () => {
   let authClient: OAuth2Client;
 
   before(async () => {
-    nock.cleanAll();
     nock.disableNetConnect();
     nock(Utils.baseUrl)
       .get('/discovery/v1/apis/drive/v2/rest')
@@ -82,13 +81,16 @@ describe('API key', () => {
   });
 
   beforeEach(() => {
-    nock.cleanAll();
     const google = new GoogleApis();
     const OAuth2 = google.auth.OAuth2;
     authClient = new OAuth2('CLIENT_ID', 'CLIENT_SECRET', 'REDIRECT_URL');
     authClient.credentials = {access_token: 'abc123'};
     localDrive = google.drive('v2');
     localBlogger = google.blogger('v3');
+  });
+
+  afterEach(() => {
+    nock.cleanAll();
   });
 
   it('should include auth APIKEY as key=<APIKEY>', async () => {
@@ -109,10 +111,5 @@ describe('API key', () => {
   it('should set API key parameter if it is present', async () => {
     await testAuthKey(localBlogger);
     await testAuthKey(remoteBlogger);
-  });
-
-  after(() => {
-    nock.cleanAll();
-    nock.enableNetConnect();
   });
 });

--- a/test/test.auth.ts
+++ b/test/test.auth.ts
@@ -12,7 +12,7 @@
 // limitations under the License.
 
 import * as assert from 'assert';
-import {describe, it, after, beforeEach, before} from 'mocha';
+import {describe, it, afterEach, beforeEach, before} from 'mocha';
 import {OAuth2Client} from 'google-auth-library';
 import {APIEndpoint} from 'googleapis-common';
 import * as nock from 'nock';
@@ -22,317 +22,322 @@ import {Utils} from './utils';
 
 const googleapis = new GoogleApis();
 
-describe('JWT client', () => {
-  it('should expose the default auth module', () => {
-    assert(googleapis.auth.getApplicationDefault);
-  });
-  it('should create a jwt through googleapis', () => {
-    const jwt = new googleapis.auth.JWT(
-      'someone@somewhere.com',
-      'file1',
-      'key1',
-      'scope1',
-      'subject1'
-    );
-    assert.strictEqual(jwt.email, 'someone@somewhere.com');
-    assert.strictEqual(jwt.keyFile, 'file1');
-    assert.strictEqual(jwt.key, 'key1');
-    assert.strictEqual(jwt.scopes, 'scope1');
-    assert.strictEqual(jwt.subject, 'subject1');
-  });
-});
-
-describe('Compute client', () => {
-  it('should create a computeclient', () => {
-    new googleapis.auth.Compute();
-  });
-});
-
-async function testNoTokens(blogger: APIEndpoint, client: OAuth2Client) {
-  await assert.rejects(
-    blogger.pages.get({blogId: '123', pageId: '123', auth: client}),
-    /No access, refresh token or API key is set./
-  );
-}
-
-async function testNoBearer(blogger: APIEndpoint, oauth2client: OAuth2Client) {
-  await blogger.pages.list({blogId: 'abc123', auth: oauth2client});
-  assert.strictEqual(oauth2client.credentials.token_type, 'Bearer');
-}
-
-async function testExpired(
-  drive: APIEndpoint,
-  oauth2client: OAuth2Client,
-  now: number
-) {
-  nock(Utils.baseUrl).get('/drive/v2/files/wat').reply(200);
-  await drive.files.get({fileId: 'wat', auth: oauth2client});
-  const expiryDate = oauth2client.credentials.expiry_date;
-  assert.notStrictEqual(expiryDate, undefined);
-  if (!expiryDate) return;
-  assert(expiryDate > now);
-  assert(expiryDate < now + 5000);
-  assert.strictEqual(oauth2client.credentials.refresh_token, 'abc');
-  assert.strictEqual(oauth2client.credentials.access_token, 'abc123');
-}
-
-async function testNoAccessToken(
-  drive: APIEndpoint,
-  oauth2client: OAuth2Client,
-  now: number
-) {
-  nock(Utils.baseUrl).get('/drive/v2/files/wat').reply(200);
-  await drive.files.get({fileId: 'wat', auth: oauth2client});
-  const expiryDate = oauth2client.credentials.expiry_date;
-  assert.notStrictEqual(expiryDate, undefined);
-  assert(expiryDate! > now);
-  assert(expiryDate! < now + 4000);
-  assert.strictEqual(oauth2client.credentials.refresh_token, 'abc');
-  assert.strictEqual(oauth2client.credentials.access_token, 'abc123');
-}
-
-describe('OAuth2 client', () => {
-  let localDrive: APIEndpoint, remoteDrive: APIEndpoint;
-  let localBlogger: APIEndpoint, remoteBlogger: APIEndpoint;
-
-  before(async () => {
-    nock.cleanAll();
-    const google = new GoogleApis();
+describe(__filename, () => {
+  before(() => {
     nock.disableNetConnect();
-    nock(Utils.baseUrl)
-      .get('/discovery/v1/apis/drive/v2/rest')
-      .reply(200, Utils.getDiscoveryFixture('drive'));
-    nock(Utils.baseUrl)
-      .get('/discovery/v1/apis/blogger/v3/rest')
-      .reply(200, Utils.getDiscoveryFixture('blogger'));
-    [remoteDrive, remoteBlogger] = await Promise.all([
-      Utils.loadApi(google, 'drive', 'v2'),
-      Utils.loadApi(google, 'blogger', 'v3'),
-    ]);
   });
 
-  beforeEach(() => {
+  afterEach(() => {
     nock.cleanAll();
-    nock.disableNetConnect();
-    const google = new GoogleApis();
-    localDrive = google.drive('v2');
-    localBlogger = google.blogger('v3');
   });
 
-  const CLIENT_ID = 'CLIENT_ID';
-  const CLIENT_SECRET = 'CLIENT_SECRET';
-  const REDIRECT_URI = 'REDIRECT';
+  describe('JWT client', () => {
+    it('should expose the default auth module', () => {
+      assert(googleapis.auth.getApplicationDefault);
+    });
 
-  it('should return err if no access or refresh token is set', async () => {
-    const oauth2client = new googleapis.auth.OAuth2(
-      CLIENT_ID,
-      CLIENT_SECRET,
-      REDIRECT_URI
-    );
-    await testNoTokens(localBlogger, oauth2client);
-    await testNoTokens(remoteBlogger, oauth2client);
-  });
-
-  it('should not error if only refresh token is set', () => {
-    const oauth2client = new googleapis.auth.OAuth2(
-      CLIENT_ID,
-      CLIENT_SECRET,
-      REDIRECT_URI
-    );
-    oauth2client.credentials = {refresh_token: 'refresh_token'};
-    assert.doesNotThrow(() => {
-      const options = {auth: oauth2client, blogId: '...'};
-      localBlogger.pages.get(options, Utils.noop);
-      remoteBlogger.pages.get(options, Utils.noop);
+    it('should create a jwt through googleapis', () => {
+      const jwt = new googleapis.auth.JWT(
+        'someone@somewhere.com',
+        'file1',
+        'key1',
+        'scope1',
+        'subject1'
+      );
+      assert.strictEqual(jwt.email, 'someone@somewhere.com');
+      assert.strictEqual(jwt.keyFile, 'file1');
+      assert.strictEqual(jwt.key, 'key1');
+      assert.strictEqual(jwt.scopes, 'scope1');
+      assert.strictEqual(jwt.subject, 'subject1');
     });
   });
 
-  it('should set access token type to Bearer if none is set', async () => {
-    const oauth2client = new googleapis.auth.OAuth2(
-      CLIENT_ID,
-      CLIENT_SECRET,
-      REDIRECT_URI
-    );
-    oauth2client.credentials = {access_token: 'foo', refresh_token: ''};
-    const scope = nock('https://blogger.googleapis.com')
-      .get('/v3/blogs/abc123/pages')
-      .times(2)
-      .reply(200);
-    await testNoBearer(localBlogger, oauth2client);
-    await testNoBearer(remoteBlogger, oauth2client);
-    scope.done();
+  describe('Compute client', () => {
+    it('should create a computeclient', () => {
+      new googleapis.auth.Compute();
+    });
   });
 
-  it('should refresh if access token is expired', async () => {
-    const scope = nock('https://oauth2.googleapis.com')
-      .post('/token')
-      .times(2)
-      .reply(200, {access_token: 'abc123', expires_in: 1});
-    let oauth2client = new googleapis.auth.OAuth2(
-      CLIENT_ID,
-      CLIENT_SECRET,
-      REDIRECT_URI
+  async function testNoTokens(blogger: APIEndpoint, client: OAuth2Client) {
+    await assert.rejects(
+      blogger.pages.get({blogId: '123', pageId: '123', auth: client}),
+      /No access, refresh token or API key is set./
     );
-    let now = new Date().getTime();
-    let twoSecondsAgo = now - 2000;
-    oauth2client.credentials = {
-      refresh_token: 'abc',
-      expiry_date: twoSecondsAgo,
-    };
-    await testExpired(localDrive, oauth2client, now);
-    oauth2client = new googleapis.auth.OAuth2(
-      CLIENT_ID,
-      CLIENT_SECRET,
-      REDIRECT_URI
-    );
-    now = new Date().getTime();
-    twoSecondsAgo = now - 2000;
-    oauth2client.credentials = {
-      refresh_token: 'abc',
-      expiry_date: twoSecondsAgo,
-    };
-    await testExpired(remoteDrive, oauth2client, now);
-    scope.done();
-  });
+  }
 
-  it('should make request if access token not expired', async () => {
-    const scope = nock('https://www.googleapis.com')
-      .post('/oauth2/v4/token')
-      .times(2)
-      .reply(200, {access_token: 'abc123', expires_in: 10000});
-    let oauth2client = new googleapis.auth.OAuth2(
-      CLIENT_ID,
-      CLIENT_SECRET,
-      REDIRECT_URI
-    );
-    let now = new Date().getTime();
-    let tenMinutesFromNow = now + 1000 * 60 * 10;
-    oauth2client.credentials = {
-      access_token: 'abc123',
-      refresh_token: 'abc',
-      expiry_date: tenMinutesFromNow,
-    };
+  async function testNoBearer(
+    blogger: APIEndpoint,
+    oauth2client: OAuth2Client
+  ) {
+    await blogger.pages.list({blogId: 'abc123', auth: oauth2client});
+    assert.strictEqual(oauth2client.credentials.token_type, 'Bearer');
+  }
 
+  async function testExpired(
+    drive: APIEndpoint,
+    oauth2client: OAuth2Client,
+    now: number
+  ) {
     nock(Utils.baseUrl).get('/drive/v2/files/wat').reply(200);
-    await localDrive.files.get({fileId: 'wat', auth: oauth2client});
-    assert.strictEqual(
-      JSON.stringify(oauth2client.credentials),
-      JSON.stringify({
-        access_token: 'abc123',
-        refresh_token: 'abc',
-        expiry_date: tenMinutesFromNow,
-        token_type: 'Bearer',
-      })
-    );
+    await drive.files.get({fileId: 'wat', auth: oauth2client});
+    const expiryDate = oauth2client.credentials.expiry_date;
+    assert.notStrictEqual(expiryDate, undefined);
+    if (!expiryDate) return;
+    assert(expiryDate > now);
+    assert(expiryDate < now + 5000);
+    assert.strictEqual(oauth2client.credentials.refresh_token, 'abc');
+    assert.strictEqual(oauth2client.credentials.access_token, 'abc123');
+  }
 
-    assert.throws(() => {
-      scope.done();
-    }, 'AssertionError');
-    oauth2client = new googleapis.auth.OAuth2(
-      CLIENT_ID,
-      CLIENT_SECRET,
-      REDIRECT_URI
-    );
-    now = new Date().getTime();
-    tenMinutesFromNow = now + 1000 * 60 * 10;
-    oauth2client.credentials = {
-      access_token: 'abc123',
-      refresh_token: 'abc',
-      expiry_date: tenMinutesFromNow,
-    };
-
+  async function testNoAccessToken(
+    drive: APIEndpoint,
+    oauth2client: OAuth2Client,
+    now: number
+  ) {
     nock(Utils.baseUrl).get('/drive/v2/files/wat').reply(200);
-    await remoteDrive.files.get({fileId: 'wat', auth: oauth2client});
-    assert.strictEqual(
-      JSON.stringify(oauth2client.credentials),
-      JSON.stringify({
-        access_token: 'abc123',
-        refresh_token: 'abc',
-        expiry_date: tenMinutesFromNow,
-        token_type: 'Bearer',
-      })
-    );
+    await drive.files.get({fileId: 'wat', auth: oauth2client});
+    const expiryDate = oauth2client.credentials.expiry_date;
+    assert.notStrictEqual(expiryDate, undefined);
+    assert(expiryDate! > now);
+    assert(expiryDate! < now + 4000);
+    assert.strictEqual(oauth2client.credentials.refresh_token, 'abc');
+    assert.strictEqual(oauth2client.credentials.access_token, 'abc123');
+  }
 
-    assert.throws(() => {
-      scope.done();
-    }, 'AssertionError');
-  });
+  describe('OAuth2 client', () => {
+    let localDrive: APIEndpoint, remoteDrive: APIEndpoint;
+    let localBlogger: APIEndpoint, remoteBlogger: APIEndpoint;
 
-  it('should refresh if have refresh token but no access token', async () => {
-    const scope = nock('https://oauth2.googleapis.com')
-      .post('/token')
-      .times(2)
-      .reply(200, {access_token: 'abc123', expires_in: 1});
-    const oauth2client = new googleapis.auth.OAuth2(
-      CLIENT_ID,
-      CLIENT_SECRET,
-      REDIRECT_URI
-    );
-    let now = new Date().getTime();
-    oauth2client.credentials = {refresh_token: 'abc'};
-    await testNoAccessToken(localDrive, oauth2client, now);
-    now = new Date().getTime();
-    oauth2client.credentials = {refresh_token: 'abc'};
-    await testNoAccessToken(remoteDrive, oauth2client, now);
-    scope.done();
-  });
+    before(async () => {
+      const google = new GoogleApis();
+      nock(Utils.baseUrl)
+        .get('/discovery/v1/apis/drive/v2/rest')
+        .reply(200, Utils.getDiscoveryFixture('drive'));
+      nock(Utils.baseUrl)
+        .get('/discovery/v1/apis/blogger/v3/rest')
+        .reply(200, Utils.getDiscoveryFixture('blogger'));
+      [remoteDrive, remoteBlogger] = await Promise.all([
+        Utils.loadApi(google, 'drive', 'v2'),
+        Utils.loadApi(google, 'blogger', 'v3'),
+      ]);
+    });
 
-  describe('revokeCredentials()', () => {
-    it('should revoke credentials if access token present', async () => {
-      const scope = nock('https://oauth2.googleapis.com')
-        .post('/revoke?token=abc')
-        .reply(200, {success: true});
+    beforeEach(() => {
+      const google = new GoogleApis();
+      localDrive = google.drive('v2');
+      localBlogger = google.blogger('v3');
+    });
+
+    const CLIENT_ID = 'CLIENT_ID';
+    const CLIENT_SECRET = 'CLIENT_SECRET';
+    const REDIRECT_URI = 'REDIRECT';
+
+    it('should return err if no access or refresh token is set', async () => {
       const oauth2client = new googleapis.auth.OAuth2(
         CLIENT_ID,
         CLIENT_SECRET,
         REDIRECT_URI
       );
-      oauth2client.credentials = {access_token: 'abc', refresh_token: 'abc'};
-      const res = await oauth2client.revokeCredentials();
-      scope.done();
-      assert.strictEqual(res.data.success, true);
-      assert.deepStrictEqual(oauth2client.credentials, {});
+      await testNoTokens(localBlogger, oauth2client);
+      await testNoTokens(remoteBlogger, oauth2client);
     });
 
-    it('should clear credentials and return error if no access token to revoke', async () => {
+    it('should not error if only refresh token is set', () => {
       const oauth2client = new googleapis.auth.OAuth2(
         CLIENT_ID,
         CLIENT_SECRET,
         REDIRECT_URI
       );
-      oauth2client.credentials = {refresh_token: 'abc'};
-      await assert.rejects(
-        oauth2client.revokeCredentials(),
-        /Error: No access token to revoke./
-      );
-      assert.deepStrictEqual(oauth2client.credentials, {});
+      oauth2client.credentials = {refresh_token: 'refresh_token'};
+      assert.doesNotThrow(() => {
+        const options = {auth: oauth2client, blogId: '...'};
+        localBlogger.pages.get(options, Utils.noop);
+        remoteBlogger.pages.get(options, Utils.noop);
+      });
     });
-  });
 
-  describe('getToken()', () => {
-    it('should return expiry_date', async () => {
-      const now = new Date().getTime();
+    it('should set access token type to Bearer if none is set', async () => {
+      const oauth2client = new googleapis.auth.OAuth2(
+        CLIENT_ID,
+        CLIENT_SECRET,
+        REDIRECT_URI
+      );
+      oauth2client.credentials = {access_token: 'foo', refresh_token: ''};
+      const scope = nock('https://blogger.googleapis.com')
+        .get('/v3/blogs/abc123/pages')
+        .times(2)
+        .reply(200);
+      await testNoBearer(localBlogger, oauth2client);
+      await testNoBearer(remoteBlogger, oauth2client);
+      scope.done();
+    });
+
+    it('should refresh if access token is expired', async () => {
       const scope = nock('https://oauth2.googleapis.com')
         .post('/token')
-        .reply(200, {
-          access_token: 'abc',
-          refresh_token: '123',
-          expires_in: 10,
-        });
+        .times(2)
+        .reply(200, {access_token: 'abc123', expires_in: 1});
+      let oauth2client = new googleapis.auth.OAuth2(
+        CLIENT_ID,
+        CLIENT_SECRET,
+        REDIRECT_URI
+      );
+      let now = new Date().getTime();
+      let twoSecondsAgo = now - 2000;
+      oauth2client.credentials = {
+        refresh_token: 'abc',
+        expiry_date: twoSecondsAgo,
+      };
+      await testExpired(localDrive, oauth2client, now);
+      oauth2client = new googleapis.auth.OAuth2(
+        CLIENT_ID,
+        CLIENT_SECRET,
+        REDIRECT_URI
+      );
+      now = new Date().getTime();
+      twoSecondsAgo = now - 2000;
+      oauth2client.credentials = {
+        refresh_token: 'abc',
+        expiry_date: twoSecondsAgo,
+      };
+      await testExpired(remoteDrive, oauth2client, now);
+      scope.done();
+    });
+
+    it('should make request if access token not expired', async () => {
+      const scope = nock('https://www.googleapis.com')
+        .post('/oauth2/v4/token')
+        .times(2)
+        .reply(200, {access_token: 'abc123', expires_in: 10000});
+      let oauth2client = new googleapis.auth.OAuth2(
+        CLIENT_ID,
+        CLIENT_SECRET,
+        REDIRECT_URI
+      );
+      let now = new Date().getTime();
+      let tenMinutesFromNow = now + 1000 * 60 * 10;
+      oauth2client.credentials = {
+        access_token: 'abc123',
+        refresh_token: 'abc',
+        expiry_date: tenMinutesFromNow,
+      };
+
+      nock(Utils.baseUrl).get('/drive/v2/files/wat').reply(200);
+      await localDrive.files.get({fileId: 'wat', auth: oauth2client});
+      assert.strictEqual(
+        JSON.stringify(oauth2client.credentials),
+        JSON.stringify({
+          access_token: 'abc123',
+          refresh_token: 'abc',
+          expiry_date: tenMinutesFromNow,
+          token_type: 'Bearer',
+        })
+      );
+
+      assert.throws(() => {
+        scope.done();
+      }, 'AssertionError');
+      oauth2client = new googleapis.auth.OAuth2(
+        CLIENT_ID,
+        CLIENT_SECRET,
+        REDIRECT_URI
+      );
+      now = new Date().getTime();
+      tenMinutesFromNow = now + 1000 * 60 * 10;
+      oauth2client.credentials = {
+        access_token: 'abc123',
+        refresh_token: 'abc',
+        expiry_date: tenMinutesFromNow,
+      };
+
+      nock(Utils.baseUrl).get('/drive/v2/files/wat').reply(200);
+      await remoteDrive.files.get({fileId: 'wat', auth: oauth2client});
+      assert.strictEqual(
+        JSON.stringify(oauth2client.credentials),
+        JSON.stringify({
+          access_token: 'abc123',
+          refresh_token: 'abc',
+          expiry_date: tenMinutesFromNow,
+          token_type: 'Bearer',
+        })
+      );
+
+      assert.throws(() => {
+        scope.done();
+      }, 'AssertionError');
+    });
+
+    it('should refresh if have refresh token but no access token', async () => {
+      const scope = nock('https://oauth2.googleapis.com')
+        .post('/token')
+        .times(2)
+        .reply(200, {access_token: 'abc123', expires_in: 1});
       const oauth2client = new googleapis.auth.OAuth2(
         CLIENT_ID,
         CLIENT_SECRET,
         REDIRECT_URI
       );
-      const res = await oauth2client.getToken('code here');
-      assert(res.tokens.expiry_date! >= now + 10 * 1000);
-      assert(res.tokens.expiry_date! <= now + 15 * 1000);
+      let now = new Date().getTime();
+      oauth2client.credentials = {refresh_token: 'abc'};
+      await testNoAccessToken(localDrive, oauth2client, now);
+      now = new Date().getTime();
+      oauth2client.credentials = {refresh_token: 'abc'};
+      await testNoAccessToken(remoteDrive, oauth2client, now);
       scope.done();
     });
-  });
 
-  after(() => {
-    nock.cleanAll();
-    nock.enableNetConnect();
+    describe('revokeCredentials()', () => {
+      it('should revoke credentials if access token present', async () => {
+        const scope = nock('https://oauth2.googleapis.com')
+          .post('/revoke?token=abc')
+          .reply(200, {success: true});
+        const oauth2client = new googleapis.auth.OAuth2(
+          CLIENT_ID,
+          CLIENT_SECRET,
+          REDIRECT_URI
+        );
+        oauth2client.credentials = {access_token: 'abc', refresh_token: 'abc'};
+        const res = await oauth2client.revokeCredentials();
+        scope.done();
+        assert.strictEqual(res.data.success, true);
+        assert.deepStrictEqual(oauth2client.credentials, {});
+      });
+
+      it('should clear credentials and return error if no access token to revoke', async () => {
+        const oauth2client = new googleapis.auth.OAuth2(
+          CLIENT_ID,
+          CLIENT_SECRET,
+          REDIRECT_URI
+        );
+        oauth2client.credentials = {refresh_token: 'abc'};
+        await assert.rejects(
+          oauth2client.revokeCredentials(),
+          /Error: No access token to revoke./
+        );
+        assert.deepStrictEqual(oauth2client.credentials, {});
+      });
+    });
+
+    describe('getToken()', () => {
+      it('should return expiry_date', async () => {
+        const now = new Date().getTime();
+        const scope = nock('https://oauth2.googleapis.com')
+          .post('/token')
+          .reply(200, {
+            access_token: 'abc',
+            refresh_token: '123',
+            expires_in: 10,
+          });
+        const oauth2client = new googleapis.auth.OAuth2(
+          CLIENT_ID,
+          CLIENT_SECRET,
+          REDIRECT_URI
+        );
+        const res = await oauth2client.getToken('code here');
+        assert(res.tokens.expiry_date! >= now + 10 * 1000);
+        assert(res.tokens.expiry_date! <= now + 15 * 1000);
+        scope.done();
+      });
+    });
   });
 });

--- a/test/test.discover.ts
+++ b/test/test.discover.ts
@@ -12,13 +12,23 @@
 // limitations under the License.
 
 import * as assert from 'assert';
-import {describe, it} from 'mocha';
+import {describe, it, before, afterEach} from 'mocha';
 import * as fs from 'fs';
 import * as path from 'path';
+import * as nock from 'nock';
 import {GoogleApis} from '../src';
 import {APIS} from '../src/apis';
+import * as Utils from './utils';
 
 describe('GoogleApis#discover', () => {
+  before(() => {
+    nock.disableNetConnect();
+  });
+
+  afterEach(() => {
+    nock.cleanAll();
+  });
+
   it('should get a list of supported apis', () => {
     const google = new GoogleApis();
     const apis = google.getSupportedAPIs();
@@ -26,11 +36,10 @@ describe('GoogleApis#discover', () => {
     assert(apis.drive.indexOf('v2') > -1);
   });
 
-  it('should generate all apis', done => {
+  it.skip('should generate all apis', async () => {
     const localApis = fs.readdirSync(path.join(__dirname, '../src/apis'));
     const google = new GoogleApis();
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const g2 = google as any;
+    const g2 = google as {[index: string]: {} | null};
     const localDrive = google.drive('v2');
 
     assert.strictEqual(typeof google.drive, 'function');
@@ -49,34 +58,43 @@ describe('GoogleApis#discover', () => {
 
     assert.strictEqual(google.drive, null);
 
-    google.discover('https://www.googleapis.com/discovery/v1/apis', err => {
-      if (err) {
-        console.warn(err);
-        return done();
-      }
-      // APIs have all been re-added.
-      localApis.forEach(name => {
-        if (g2[name] === null) {
-          // Warn if an API remains null (was not found during the discovery
-          // process) to avoid failing the test.
-          console.warn(name + ' was not found.');
-        } else {
-          assert(g2[name]);
-        }
-      });
+    const scope = nock(Utils.rootHost)
+      .get(Utils.rootPrefix)
+      .replyWithFile(200, './discovery/index.json');
+    const scope1 = nock(Utils.rootHost)
+      .get('*')
+      .reply(200, (url, body, callback) => {
+        const paths = url.split('/');
+        const name = paths[6];
+        const ver = paths[7];
+        const filePath = `./discovery/${name}-${ver}.json`;
+        callback(null, fs.createReadStream(filePath));
+      })
+      .persist();
+    await google.discover('https://www.googleapis.com/discovery/v1/apis');
+    scope.done();
 
-      const remoteDrive = google.drive('v2');
-      assert.strictEqual(typeof google.drive, 'function');
-      assert.strictEqual(typeof remoteDrive, 'object');
-
-      for (const key in localDrive) {
-        // eslint-disable-next-line no-prototype-builtins
-        if (localDrive.hasOwnProperty(key)) {
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          assert((remoteDrive as any)[key], 'generated drive has same keys');
-        }
+    // APIs have all been re-added.
+    localApis.forEach(name => {
+      if (g2[name] === null) {
+        // Warn if an API remains null (was not found during the discovery
+        // process) to avoid failing the test.
+        console.warn(name + ' was not found.');
+      } else {
+        assert(g2[name]);
       }
-      done();
     });
-  }).timeout(120000);
+
+    const remoteDrive = (google as GoogleApis).drive('v2');
+    assert.strictEqual(typeof google.drive, 'function');
+    assert.strictEqual(typeof remoteDrive, 'object');
+
+    for (const key in localDrive) {
+      // eslint-disable-next-line no-prototype-builtins
+      if (localDrive.hasOwnProperty(key)) {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        assert((remoteDrive as any)[key], 'generated drive has same keys');
+      }
+    }
+  });
 });

--- a/test/test.drive.v2.ts
+++ b/test/test.drive.v2.ts
@@ -12,7 +12,7 @@
 // limitations under the License.
 
 import * as assert from 'assert';
-import {describe, it, before, beforeEach, after} from 'mocha';
+import {describe, it, before, beforeEach, afterEach} from 'mocha';
 import {APIEndpoint} from 'googleapis-common';
 import * as nock from 'nock';
 import {drive_v2, GoogleApis} from '../src';
@@ -24,18 +24,18 @@ describe('drive:v2', () => {
   let localDrive: drive_v2.Drive, remoteDrive: APIEndpoint;
 
   before(async () => {
-    nock.cleanAll();
     const google = new GoogleApis();
-    nock.enableNetConnect();
     remoteDrive = await Utils.loadApi(google, 'drive', 'v2');
-    nock.disableNetConnect();
   });
 
   beforeEach(() => {
-    nock.cleanAll();
     nock.disableNetConnect();
     const google = new GoogleApis();
     localDrive = google.drive('v2');
+  });
+
+  afterEach(() => {
+    nock.cleanAll();
   });
 
   it('should exist', done => {
@@ -121,10 +121,5 @@ describe('drive:v2', () => {
       await localDrive.files.list({q: 'hello'});
       await remoteDrive.files.list({q: 'hello'});
     });
-  });
-
-  after(() => {
-    nock.cleanAll();
-    nock.enableNetConnect();
   });
 });

--- a/test/test.media.ts
+++ b/test/test.media.ts
@@ -19,7 +19,6 @@ import * as path from 'path';
 import {URL} from 'url';
 
 import {drive_v2, gmail_v1, GoogleApis} from '../src';
-
 import {Utils} from './utils';
 
 const boundaryPrefix = 'multipart/related; boundary=';
@@ -91,7 +90,6 @@ describe('Media', () => {
   before(async () => {
     nock.cleanAll();
     const google = new GoogleApis();
-    nock.enableNetConnect();
     [remoteDrive, remoteGmail] = await Promise.all([
       Utils.loadApi<drive_v2.Drive>(google, 'drive', 'v2'),
       Utils.loadApi<gmail_v1.Gmail>(google, 'gmail', 'v1'),
@@ -483,6 +481,5 @@ describe('Media', () => {
 
   after(() => {
     nock.cleanAll();
-    nock.enableNetConnect();
   });
 });

--- a/test/test.path.ts
+++ b/test/test.path.ts
@@ -26,7 +26,6 @@ describe('Path params', () => {
   before(async () => {
     nock.cleanAll();
     const google = new GoogleApis();
-    nock.enableNetConnect();
     remoteDrive = await Utils.loadApi(google, 'drive', 'v2');
     nock.disableNetConnect();
   });
@@ -234,6 +233,5 @@ describe('Path params', () => {
 
   after(() => {
     nock.cleanAll();
-    nock.enableNetConnect();
   });
 });

--- a/test/test.query.ts
+++ b/test/test.query.ts
@@ -27,20 +27,17 @@ describe('Query params', () => {
   let remoteGmail: APIEndpoint;
 
   before(async () => {
-    nock.cleanAll();
+    nock.disableNetConnect();
     const google = new GoogleApis();
-    nock.enableNetConnect();
     [remoteCompute, remoteDrive, remoteGmail] = await Promise.all([
       Utils.loadApi(google, 'compute', 'v1'),
       Utils.loadApi(google, 'drive', 'v2'),
       Utils.loadApi(google, 'gmail', 'v1'),
     ]);
-    nock.disableNetConnect();
   });
 
   beforeEach(() => {
     nock.cleanAll();
-    nock.disableNetConnect();
     const google = new GoogleApis();
     localCompute = google.compute('v1');
     localDrive = google.drive('v2');
@@ -252,6 +249,5 @@ describe('Query params', () => {
 
   after(() => {
     nock.cleanAll();
-    nock.enableNetConnect();
   });
 });

--- a/test/test.synth.ts
+++ b/test/test.synth.ts
@@ -13,14 +13,17 @@
 // limitations under the License.
 
 import * as assert from 'assert';
-import {describe, it, afterEach} from 'mocha';
+import {describe, it, afterEach, before} from 'mocha';
 import * as nock from 'nock';
 import * as proxyquire from 'proxyquire';
 import * as Synth from '../src/generator/synth';
 import {ChangeSet} from '../src/generator/download';
 
 describe(__filename, () => {
-  nock.disableNetConnect();
+  before(() => {
+    nock.disableNetConnect();
+  });
+
   const cacheToken = process.env.GITHUB_TOKEN;
   let changeSets: ChangeSet[] = [];
   let stdout = '';

--- a/test/test.transporters.ts
+++ b/test/test.transporters.ts
@@ -168,13 +168,16 @@ describe('Transporters', () => {
   before(async () => {
     nock.cleanAll();
     const google = new GoogleApis();
-    nock.enableNetConnect();
     [remoteDrive, remoteOauth2, remoteBlogger] = await Promise.all([
       Utils.loadApi(google, 'drive', 'v2'),
       Utils.loadApi(google, 'oauth2', 'v2'),
       Utils.loadApi(google, 'blogger', 'v3'),
     ]);
     nock.disableNetConnect();
+  });
+
+  after(() => {
+    nock.cleanAll();
   });
 
   beforeEach(() => {
@@ -287,10 +290,5 @@ describe('Transporters', () => {
     await testBackendError(localBlogger);
     await testBackendError(remoteBlogger);
     scope.done();
-  });
-
-  after(() => {
-    nock.cleanAll();
-    nock.enableNetConnect();
   });
 });


### PR DESCRIPTION
I suggest disabling whitespace for this review.  This attempts to remove all instances of `nock.enableNetworkAccess`, and use mocking with local discovery files for all unit tests.  There's one place where this isn't possible, but the code is otherwise entirely covered.  