### PR TITLE
build: add repository dispatch trigger

### DIFF
--- a/.github/workflows/generator.yaml
+++ b/.github/workflows/generator.yaml
@@ -2,6 +2,8 @@ name: generator
 on:
   schedule:
     - cron:  '0 4 * * *'
+  repository_dispatch:
+    types: [generate]
 jobs:
   generate:
     runs-on: ubuntu-latest

--- a/src/generator/synth.ts
+++ b/src/generator/synth.ts
@@ -103,7 +103,7 @@ export async function synth(options: SynthOptions = {}) {
     '-m',
     'feat: regenerate index files',
     '--author',
-    '"Yoshi Automation <yoshi-automation@google.com>"',
+    'Yoshi Automation <yoshi-automation@google.com>',
   ]);
   const prefix = getPrefix(totalSemverity);
   await execa('git', ['push', 'origin', branch, '--force']);


### PR DESCRIPTION
Getting the GitHub Action for our cron right has been a bit of a struggle that involves waiting 24 hours and hoping for the best.  This change attempts to fix the current glitch, but adds a repository dispatch hook so a well crafted post with the appropriate auth token can trigger the job.  Firing it looks like this:
https://developer.github.com/v3/repos/#create-a-repository-dispatch-event