### PR TITLE
test: ensure params are not deleted from global options

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   ],
   "dependencies": {
     "google-auth-library": "^6.0.0",
-    "googleapis-common": "^4.2.0"
+    "googleapis-common": "^4.2.1"
   },
   "devDependencies": {
     "@compodoc/compodoc": "^1.1.10",

--- a/src/apis/abusiveexperiencereport/package.json
+++ b/src/apis/abusiveexperiencereport/package.json
@@ -29,7 +29,7 @@
     "webpack": "webpack"
   },
   "dependencies": {
-    "googleapis-common": "^4.2.0"
+    "googleapis-common": "^4.2.1"
   },
   "devDependencies": {
     "gts": "^2.0.0",

--- a/src/apis/acceleratedmobilepageurl/package.json
+++ b/src/apis/acceleratedmobilepageurl/package.json
@@ -29,7 +29,7 @@
     "webpack": "webpack"
   },
   "dependencies": {
-    "googleapis-common": "^4.2.0"
+    "googleapis-common": "^4.2.1"
   },
   "devDependencies": {
     "gts": "^2.0.0",

--- a/src/apis/accessapproval/package.json
+++ b/src/apis/accessapproval/package.json
@@ -29,7 +29,7 @@
     "webpack": "webpack"
   },
   "dependencies": {
-    "googleapis-common": "^4.2.0"
+    "googleapis-common": "^4.2.1"
   },
   "devDependencies": {
     "gts": "^2.0.0",

--- a/src/apis/accesscontextmanager/package.json
+++ b/src/apis/accesscontextmanager/package.json
@@ -29,7 +29,7 @@
     "webpack": "webpack"
   },
   "dependencies": {
-    "googleapis-common": "^4.2.0"
+    "googleapis-common": "^4.2.1"
   },
   "devDependencies": {
     "gts": "^2.0.0",

--- a/src/apis/adexchangebuyer/package.json
+++ b/src/apis/adexchangebuyer/package.json
@@ -29,7 +29,7 @@
     "webpack": "webpack"
   },
   "dependencies": {
-    "googleapis-common": "^4.2.0"
+    "googleapis-common": "^4.2.1"
   },
   "devDependencies": {
     "gts": "^2.0.0",

--- a/src/apis/adexchangebuyer2/package.json
+++ b/src/apis/adexchangebuyer2/package.json
@@ -29,7 +29,7 @@
     "webpack": "webpack"
   },
   "dependencies": {
-    "googleapis-common": "^4.2.0"
+    "googleapis-common": "^4.2.1"
   },
   "devDependencies": {
     "gts": "^2.0.0",

--- a/src/apis/adexperiencereport/package.json
+++ b/src/apis/adexperiencereport/package.json
@@ -29,7 +29,7 @@
     "webpack": "webpack"
   },
   "dependencies": {
-    "googleapis-common": "^4.2.0"
+    "googleapis-common": "^4.2.1"
   },
   "devDependencies": {
     "gts": "^2.0.0",

--- a/src/apis/admin/package.json
+++ b/src/apis/admin/package.json
@@ -29,7 +29,7 @@
     "webpack": "webpack"
   },
   "dependencies": {
-    "googleapis-common": "^4.2.0"
+    "googleapis-common": "^4.2.1"
   },
   "devDependencies": {
     "gts": "^2.0.0",

--- a/src/apis/admob/package.json
+++ b/src/apis/admob/package.json
@@ -29,7 +29,7 @@
     "webpack": "webpack"
   },
   "dependencies": {
-    "googleapis-common": "^4.2.0"
+    "googleapis-common": "^4.2.1"
   },
   "devDependencies": {
     "gts": "^2.0.0",

--- a/src/apis/adsense/package.json
+++ b/src/apis/adsense/package.json
@@ -29,7 +29,7 @@
     "webpack": "webpack"
   },
   "dependencies": {
-    "googleapis-common": "^4.2.0"
+    "googleapis-common": "^4.2.1"
   },
   "devDependencies": {
     "gts": "^2.0.0",

--- a/src/apis/adsensehost/package.json
+++ b/src/apis/adsensehost/package.json
@@ -29,7 +29,7 @@
     "webpack": "webpack"
   },
   "dependencies": {
-    "googleapis-common": "^4.2.0"
+    "googleapis-common": "^4.2.1"
   },
   "devDependencies": {
     "gts": "^2.0.0",

--- a/src/apis/alertcenter/package.json
+++ b/src/apis/alertcenter/package.json
@@ -29,7 +29,7 @@
     "webpack": "webpack"
   },
   "dependencies": {
-    "googleapis-common": "^4.2.0"
+    "googleapis-common": "^4.2.1"
   },
   "devDependencies": {
     "gts": "^2.0.0",

--- a/src/apis/analytics/package.json
+++ b/src/apis/analytics/package.json
@@ -29,7 +29,7 @@
     "webpack": "webpack"
   },
   "dependencies": {
-    "googleapis-common": "^4.2.0"
+    "googleapis-common": "^4.2.1"
   },
   "devDependencies": {
     "gts": "^2.0.0",

--- a/src/apis/analyticsreporting/package.json
+++ b/src/apis/analyticsreporting/package.json
@@ -29,7 +29,7 @@
     "webpack": "webpack"
   },
   "dependencies": {
-    "googleapis-common": "^4.2.0"
+    "googleapis-common": "^4.2.1"
   },
   "devDependencies": {
     "gts": "^2.0.0",

--- a/src/apis/androiddeviceprovisioning/package.json
+++ b/src/apis/androiddeviceprovisioning/package.json
@@ -29,7 +29,7 @@
     "webpack": "webpack"
   },
   "dependencies": {
-    "googleapis-common": "^4.2.0"
+    "googleapis-common": "^4.2.1"
   },
   "devDependencies": {
     "gts": "^2.0.0",

--- a/src/apis/androidenterprise/package.json
+++ b/src/apis/androidenterprise/package.json
@@ -29,7 +29,7 @@
     "webpack": "webpack"
   },
   "dependencies": {
-    "googleapis-common": "^4.2.0"
+    "googleapis-common": "^4.2.1"
   },
   "devDependencies": {
     "gts": "^2.0.0",

--- a/src/apis/androidmanagement/package.json
+++ b/src/apis/androidmanagement/package.json
@@ -29,7 +29,7 @@
     "webpack": "webpack"
   },
   "dependencies": {
-    "googleapis-common": "^4.2.0"
+    "googleapis-common": "^4.2.1"
   },
   "devDependencies": {
     "gts": "^2.0.0",

--- a/src/apis/androidpublisher/package.json
+++ b/src/apis/androidpublisher/package.json
@@ -29,7 +29,7 @@
     "webpack": "webpack"
   },
   "dependencies": {
-    "googleapis-common": "^4.2.0"
+    "googleapis-common": "^4.2.1"
   },
   "devDependencies": {
     "gts": "^2.0.0",

--- a/src/apis/appengine/package.json
+++ b/src/apis/appengine/package.json
@@ -29,7 +29,7 @@
     "webpack": "webpack"
   },
   "dependencies": {
-    "googleapis-common": "^4.2.0"
+    "googleapis-common": "^4.2.1"
   },
   "devDependencies": {
     "gts": "^2.0.0",

--- a/src/apis/appsactivity/package.json
+++ b/src/apis/appsactivity/package.json
@@ -29,7 +29,7 @@
     "webpack": "webpack"
   },
   "dependencies": {
-    "googleapis-common": "^4.2.0"
+    "googleapis-common": "^4.2.1"
   },
   "devDependencies": {
     "gts": "^2.0.0",

--- a/src/apis/artifactregistry/package.json
+++ b/src/apis/artifactregistry/package.json
@@ -29,7 +29,7 @@
     "webpack": "webpack"
   },
   "dependencies": {
-    "googleapis-common": "^4.2.0"
+    "googleapis-common": "^4.2.1"
   },
   "devDependencies": {
     "gts": "^2.0.0",

--- a/src/apis/bigquery/package.json
+++ b/src/apis/bigquery/package.json
@@ -29,7 +29,7 @@
     "webpack": "webpack"
   },
   "dependencies": {
-    "googleapis-common": "^4.2.0"
+    "googleapis-common": "^4.2.1"
   },
   "devDependencies": {
     "gts": "^2.0.0",

--- a/src/apis/bigqueryconnection/package.json
+++ b/src/apis/bigqueryconnection/package.json
@@ -29,7 +29,7 @@
     "webpack": "webpack"
   },
   "dependencies": {
-    "googleapis-common": "^4.2.0"
+    "googleapis-common": "^4.2.1"
   },
   "devDependencies": {
     "gts": "^2.0.0",

--- a/src/apis/bigquerydatatransfer/package.json
+++ b/src/apis/bigquerydatatransfer/package.json
@@ -29,7 +29,7 @@
     "webpack": "webpack"
   },
   "dependencies": {
-    "googleapis-common": "^4.2.0"
+    "googleapis-common": "^4.2.1"
   },
   "devDependencies": {
     "gts": "^2.0.0",

--- a/src/apis/bigqueryreservation/package.json
+++ b/src/apis/bigqueryreservation/package.json
@@ -29,7 +29,7 @@
     "webpack": "webpack"
   },
   "dependencies": {
-    "googleapis-common": "^4.2.0"
+    "googleapis-common": "^4.2.1"
   },
   "devDependencies": {
     "gts": "^2.0.0",

--- a/src/apis/bigtableadmin/package.json
+++ b/src/apis/bigtableadmin/package.json
@@ -29,7 +29,7 @@
     "webpack": "webpack"
   },
   "dependencies": {
-    "googleapis-common": "^4.2.0"
+    "googleapis-common": "^4.2.1"
   },
   "devDependencies": {
     "gts": "^2.0.0",

--- a/src/apis/billingbudgets/package.json
+++ b/src/apis/billingbudgets/package.json
@@ -29,7 +29,7 @@
     "webpack": "webpack"
   },
   "dependencies": {
-    "googleapis-common": "^4.2.0"
+    "googleapis-common": "^4.2.1"
   },
   "devDependencies": {
     "gts": "^2.0.0",

--- a/src/apis/binaryauthorization/package.json
+++ b/src/apis/binaryauthorization/package.json
@@ -29,7 +29,7 @@
     "webpack": "webpack"
   },
   "dependencies": {
-    "googleapis-common": "^4.2.0"
+    "googleapis-common": "^4.2.1"
   },
   "devDependencies": {
     "gts": "^2.0.0",

--- a/src/apis/blogger/package.json
+++ b/src/apis/blogger/package.json
@@ -29,7 +29,7 @@
     "webpack": "webpack"
   },
   "dependencies": {
-    "googleapis-common": "^4.2.0"
+    "googleapis-common": "^4.2.1"
   },
   "devDependencies": {
     "gts": "^2.0.0",

--- a/src/apis/books/package.json
+++ b/src/apis/books/package.json
@@ -29,7 +29,7 @@
     "webpack": "webpack"
   },
   "dependencies": {
-    "googleapis-common": "^4.2.0"
+    "googleapis-common": "^4.2.1"
   },
   "devDependencies": {
     "gts": "^2.0.0",

--- a/src/apis/calendar/package.json
+++ b/src/apis/calendar/package.json
@@ -29,7 +29,7 @@
     "webpack": "webpack"
   },
   "dependencies": {
-    "googleapis-common": "^4.2.0"
+    "googleapis-common": "^4.2.1"
   },
   "devDependencies": {
     "gts": "^2.0.0",

--- a/src/apis/chat/package.json
+++ b/src/apis/chat/package.json
@@ -29,7 +29,7 @@
     "webpack": "webpack"
   },
   "dependencies": {
-    "googleapis-common": "^4.2.0"
+    "googleapis-common": "^4.2.1"
   },
   "devDependencies": {
     "gts": "^2.0.0",

--- a/src/apis/chromeuxreport/package.json
+++ b/src/apis/chromeuxreport/package.json
@@ -29,7 +29,7 @@
     "webpack": "webpack"
   },
   "dependencies": {
-    "googleapis-common": "^4.2.0"
+    "googleapis-common": "^4.2.1"
   },
   "devDependencies": {
     "gts": "^2.0.0",

--- a/src/apis/civicinfo/package.json
+++ b/src/apis/civicinfo/package.json
@@ -29,7 +29,7 @@
     "webpack": "webpack"
   },
   "dependencies": {
-    "googleapis-common": "^4.2.0"
+    "googleapis-common": "^4.2.1"
   },
   "devDependencies": {
     "gts": "^2.0.0",

--- a/src/apis/classroom/package.json
+++ b/src/apis/classroom/package.json
@@ -29,7 +29,7 @@
     "webpack": "webpack"
   },
   "dependencies": {
-    "googleapis-common": "^4.2.0"
+    "googleapis-common": "^4.2.1"
   },
   "devDependencies": {
     "gts": "^2.0.0",

--- a/src/apis/cloudasset/package.json
+++ b/src/apis/cloudasset/package.json
@@ -29,7 +29,7 @@
     "webpack": "webpack"
   },
   "dependencies": {
-    "googleapis-common": "^4.2.0"
+    "googleapis-common": "^4.2.1"
   },
   "devDependencies": {
     "gts": "^2.0.0",

--- a/src/apis/cloudbilling/package.json
+++ b/src/apis/cloudbilling/package.json
@@ -29,7 +29,7 @@
     "webpack": "webpack"
   },
   "dependencies": {
-    "googleapis-common": "^4.2.0"
+    "googleapis-common": "^4.2.1"
   },
   "devDependencies": {
     "gts": "^2.0.0",

--- a/src/apis/cloudbuild/package.json
+++ b/src/apis/cloudbuild/package.json
@@ -29,7 +29,7 @@
     "webpack": "webpack"
   },
   "dependencies": {
-    "googleapis-common": "^4.2.0"
+    "googleapis-common": "^4.2.1"
   },
   "devDependencies": {
     "gts": "^2.0.0",

--- a/src/apis/clouddebugger/package.json
+++ b/src/apis/clouddebugger/package.json
@@ -29,7 +29,7 @@
     "webpack": "webpack"
   },
   "dependencies": {
-    "googleapis-common": "^4.2.0"
+    "googleapis-common": "^4.2.1"
   },
   "devDependencies": {
     "gts": "^2.0.0",

--- a/src/apis/clouderrorreporting/package.json
+++ b/src/apis/clouderrorreporting/package.json
@@ -29,7 +29,7 @@
     "webpack": "webpack"
   },
   "dependencies": {
-    "googleapis-common": "^4.2.0"
+    "googleapis-common": "^4.2.1"
   },
   "devDependencies": {
     "gts": "^2.0.0",

--- a/src/apis/cloudfunctions/package.json
+++ b/src/apis/cloudfunctions/package.json
@@ -29,7 +29,7 @@
     "webpack": "webpack"
   },
   "dependencies": {
-    "googleapis-common": "^4.2.0"
+    "googleapis-common": "^4.2.1"
   },
   "devDependencies": {
     "gts": "^2.0.0",

--- a/src/apis/cloudidentity/package.json
+++ b/src/apis/cloudidentity/package.json
@@ -29,7 +29,7 @@
     "webpack": "webpack"
   },
   "dependencies": {
-    "googleapis-common": "^4.2.0"
+    "googleapis-common": "^4.2.1"
   },
   "devDependencies": {
     "gts": "^2.0.0",

--- a/src/apis/cloudiot/package.json
+++ b/src/apis/cloudiot/package.json
@@ -29,7 +29,7 @@
     "webpack": "webpack"
   },
   "dependencies": {
-    "googleapis-common": "^4.2.0"
+    "googleapis-common": "^4.2.1"
   },
   "devDependencies": {
     "gts": "^2.0.0",

--- a/src/apis/cloudkms/package.json
+++ b/src/apis/cloudkms/package.json
@@ -29,7 +29,7 @@
     "webpack": "webpack"
   },
   "dependencies": {
-    "googleapis-common": "^4.2.0"
+    "googleapis-common": "^4.2.1"
   },
   "devDependencies": {
     "gts": "^2.0.0",

--- a/src/apis/cloudprofiler/package.json
+++ b/src/apis/cloudprofiler/package.json
@@ -29,7 +29,7 @@
     "webpack": "webpack"
   },
   "dependencies": {
-    "googleapis-common": "^4.2.0"
+    "googleapis-common": "^4.2.1"
   },
   "devDependencies": {
     "gts": "^2.0.0",

--- a/src/apis/cloudresourcemanager/package.json
+++ b/src/apis/cloudresourcemanager/package.json
@@ -29,7 +29,7 @@
     "webpack": "webpack"
   },
   "dependencies": {
-    "googleapis-common": "^4.2.0"
+    "googleapis-common": "^4.2.1"
   },
   "devDependencies": {
     "gts": "^2.0.0",

--- a/src/apis/cloudscheduler/package.json
+++ b/src/apis/cloudscheduler/package.json
@@ -29,7 +29,7 @@
     "webpack": "webpack"
   },
   "dependencies": {
-    "googleapis-common": "^4.2.0"
+    "googleapis-common": "^4.2.1"
   },
   "devDependencies": {
     "gts": "^2.0.0",

--- a/src/apis/cloudsearch/package.json
+++ b/src/apis/cloudsearch/package.json
@@ -29,7 +29,7 @@
     "webpack": "webpack"
   },
   "dependencies": {
-    "googleapis-common": "^4.2.0"
+    "googleapis-common": "^4.2.1"
   },
   "devDependencies": {
     "gts": "^2.0.0",

--- a/src/apis/cloudshell/package.json
+++ b/src/apis/cloudshell/package.json
@@ -29,7 +29,7 @@
     "webpack": "webpack"
   },
   "dependencies": {
-    "googleapis-common": "^4.2.0"
+    "googleapis-common": "^4.2.1"
   },
   "devDependencies": {
     "gts": "^2.0.0",

--- a/src/apis/cloudtasks/package.json
+++ b/src/apis/cloudtasks/package.json
@@ -29,7 +29,7 @@
     "webpack": "webpack"
   },
   "dependencies": {
-    "googleapis-common": "^4.2.0"
+    "googleapis-common": "^4.2.1"
   },
   "devDependencies": {
     "gts": "^2.0.0",

--- a/src/apis/cloudtrace/package.json
+++ b/src/apis/cloudtrace/package.json
@@ -29,7 +29,7 @@
     "webpack": "webpack"
   },
   "dependencies": {
-    "googleapis-common": "^4.2.0"
+    "googleapis-common": "^4.2.1"
   },
   "devDependencies": {
     "gts": "^2.0.0",

--- a/src/apis/composer/package.json
+++ b/src/apis/composer/package.json
@@ -29,7 +29,7 @@
     "webpack": "webpack"
   },
   "dependencies": {
-    "googleapis-common": "^4.2.0"
+    "googleapis-common": "^4.2.1"
   },
   "devDependencies": {
     "gts": "^2.0.0",

--- a/src/apis/compute/package.json
+++ b/src/apis/compute/package.json
@@ -29,7 +29,7 @@
     "webpack": "webpack"
   },
   "dependencies": {
-    "googleapis-common": "^4.2.0"
+    "googleapis-common": "^4.2.1"
   },
   "devDependencies": {
     "gts": "^2.0.0",

--- a/src/apis/container/package.json
+++ b/src/apis/container/package.json
@@ -29,7 +29,7 @@
     "webpack": "webpack"
   },
   "dependencies": {
-    "googleapis-common": "^4.2.0"
+    "googleapis-common": "^4.2.1"
   },
   "devDependencies": {
     "gts": "^2.0.0",

--- a/src/apis/containeranalysis/package.json
+++ b/src/apis/containeranalysis/package.json
@@ -29,7 +29,7 @@
     "webpack": "webpack"
   },
   "dependencies": {
-    "googleapis-common": "^4.2.0"
+    "googleapis-common": "^4.2.1"
   },
   "devDependencies": {
     "gts": "^2.0.0",

--- a/src/apis/content/package.json
+++ b/src/apis/content/package.json
@@ -29,7 +29,7 @@
     "webpack": "webpack"
   },
   "dependencies": {
-    "googleapis-common": "^4.2.0"
+    "googleapis-common": "^4.2.1"
   },
   "devDependencies": {
     "gts": "^2.0.0",

--- a/src/apis/customsearch/package.json
+++ b/src/apis/customsearch/package.json
@@ -29,7 +29,7 @@
     "webpack": "webpack"
   },
   "dependencies": {
-    "googleapis-common": "^4.2.0"
+    "googleapis-common": "^4.2.1"
   },
   "devDependencies": {
     "gts": "^2.0.0",

--- a/src/apis/datacatalog/package.json
+++ b/src/apis/datacatalog/package.json
@@ -29,7 +29,7 @@
     "webpack": "webpack"
   },
   "dependencies": {
-    "googleapis-common": "^4.2.0"
+    "googleapis-common": "^4.2.1"
   },
   "devDependencies": {
     "gts": "^2.0.0",

--- a/src/apis/dataflow/package.json
+++ b/src/apis/dataflow/package.json
@@ -29,7 +29,7 @@
     "webpack": "webpack"
   },
   "dependencies": {
-    "googleapis-common": "^4.2.0"
+    "googleapis-common": "^4.2.1"
   },
   "devDependencies": {
     "gts": "^2.0.0",

--- a/src/apis/datafusion/package.json
+++ b/src/apis/datafusion/package.json
@@ -29,7 +29,7 @@
     "webpack": "webpack"
   },
   "dependencies": {
-    "googleapis-common": "^4.2.0"
+    "googleapis-common": "^4.2.1"
   },
   "devDependencies": {
     "gts": "^2.0.0",

--- a/src/apis/dataproc/package.json
+++ b/src/apis/dataproc/package.json
@@ -29,7 +29,7 @@
     "webpack": "webpack"
   },
   "dependencies": {
-    "googleapis-common": "^4.2.0"
+    "googleapis-common": "^4.2.1"
   },
   "devDependencies": {
     "gts": "^2.0.0",

--- a/src/apis/datastore/package.json
+++ b/src/apis/datastore/package.json
@@ -29,7 +29,7 @@
     "webpack": "webpack"
   },
   "dependencies": {
-    "googleapis-common": "^4.2.0"
+    "googleapis-common": "^4.2.1"
   },
   "devDependencies": {
     "gts": "^2.0.0",

--- a/src/apis/deploymentmanager/package.json
+++ b/src/apis/deploymentmanager/package.json
@@ -29,7 +29,7 @@
     "webpack": "webpack"
   },
   "dependencies": {
-    "googleapis-common": "^4.2.0"
+    "googleapis-common": "^4.2.1"
   },
   "devDependencies": {
     "gts": "^2.0.0",

--- a/src/apis/dfareporting/package.json
+++ b/src/apis/dfareporting/package.json
@@ -29,7 +29,7 @@
     "webpack": "webpack"
   },
   "dependencies": {
-    "googleapis-common": "^4.2.0"
+    "googleapis-common": "^4.2.1"
   },
   "devDependencies": {
     "gts": "^2.0.0",

--- a/src/apis/dialogflow/package.json
+++ b/src/apis/dialogflow/package.json
@@ -29,7 +29,7 @@
     "webpack": "webpack"
   },
   "dependencies": {
-    "googleapis-common": "^4.2.0"
+    "googleapis-common": "^4.2.1"
   },
   "devDependencies": {
     "gts": "^2.0.0",

--- a/src/apis/digitalassetlinks/package.json
+++ b/src/apis/digitalassetlinks/package.json
@@ -29,7 +29,7 @@
     "webpack": "webpack"
   },
   "dependencies": {
-    "googleapis-common": "^4.2.0"
+    "googleapis-common": "^4.2.1"
   },
   "devDependencies": {
     "gts": "^2.0.0",

--- a/src/apis/discovery/package.json
+++ b/src/apis/discovery/package.json
@@ -29,7 +29,7 @@
     "webpack": "webpack"
   },
   "dependencies": {
-    "googleapis-common": "^4.2.0"
+    "googleapis-common": "^4.2.1"
   },
   "devDependencies": {
     "gts": "^2.0.0",

--- a/src/apis/displayvideo/package.json
+++ b/src/apis/displayvideo/package.json
@@ -29,7 +29,7 @@
     "webpack": "webpack"
   },
   "dependencies": {
-    "googleapis-common": "^4.2.0"
+    "googleapis-common": "^4.2.1"
   },
   "devDependencies": {
     "gts": "^2.0.0",

--- a/src/apis/dlp/package.json
+++ b/src/apis/dlp/package.json
@@ -29,7 +29,7 @@
     "webpack": "webpack"
   },
   "dependencies": {
-    "googleapis-common": "^4.2.0"
+    "googleapis-common": "^4.2.1"
   },
   "devDependencies": {
     "gts": "^2.0.0",

--- a/src/apis/dns/package.json
+++ b/src/apis/dns/package.json
@@ -29,7 +29,7 @@
     "webpack": "webpack"
   },
   "dependencies": {
-    "googleapis-common": "^4.2.0"
+    "googleapis-common": "^4.2.1"
   },
   "devDependencies": {
     "gts": "^2.0.0",

--- a/src/apis/docs/package.json
+++ b/src/apis/docs/package.json
@@ -29,7 +29,7 @@
     "webpack": "webpack"
   },
   "dependencies": {
-    "googleapis-common": "^4.2.0"
+    "googleapis-common": "^4.2.1"
   },
   "devDependencies": {
     "gts": "^2.0.0",

--- a/src/apis/domainsrdap/package.json
+++ b/src/apis/domainsrdap/package.json
@@ -29,7 +29,7 @@
     "webpack": "webpack"
   },
   "dependencies": {
-    "googleapis-common": "^4.2.0"
+    "googleapis-common": "^4.2.1"
   },
   "devDependencies": {
     "gts": "^2.0.0",

--- a/src/apis/doubleclickbidmanager/package.json
+++ b/src/apis/doubleclickbidmanager/package.json
@@ -29,7 +29,7 @@
     "webpack": "webpack"
   },
   "dependencies": {
-    "googleapis-common": "^4.2.0"
+    "googleapis-common": "^4.2.1"
   },
   "devDependencies": {
     "gts": "^2.0.0",

--- a/src/apis/doubleclicksearch/package.json
+++ b/src/apis/doubleclicksearch/package.json
@@ -29,7 +29,7 @@
     "webpack": "webpack"
   },
   "dependencies": {
-    "googleapis-common": "^4.2.0"
+    "googleapis-common": "^4.2.1"
   },
   "devDependencies": {
     "gts": "^2.0.0",

--- a/src/apis/drive/package.json
+++ b/src/apis/drive/package.json
@@ -29,7 +29,7 @@
     "webpack": "webpack"
   },
   "dependencies": {
-    "googleapis-common": "^4.2.0"
+    "googleapis-common": "^4.2.1"
   },
   "devDependencies": {
     "gts": "^2.0.0",

--- a/src/apis/driveactivity/package.json
+++ b/src/apis/driveactivity/package.json
@@ -29,7 +29,7 @@
     "webpack": "webpack"
   },
   "dependencies": {
-    "googleapis-common": "^4.2.0"
+    "googleapis-common": "^4.2.1"
   },
   "devDependencies": {
     "gts": "^2.0.0",

--- a/src/apis/factchecktools/package.json
+++ b/src/apis/factchecktools/package.json
@@ -29,7 +29,7 @@
     "webpack": "webpack"
   },
   "dependencies": {
-    "googleapis-common": "^4.2.0"
+    "googleapis-common": "^4.2.1"
   },
   "devDependencies": {
     "gts": "^2.0.0",

--- a/src/apis/fcm/package.json
+++ b/src/apis/fcm/package.json
@@ -29,7 +29,7 @@
     "webpack": "webpack"
   },
   "dependencies": {
-    "googleapis-common": "^4.2.0"
+    "googleapis-common": "^4.2.1"
   },
   "devDependencies": {
     "gts": "^2.0.0",

--- a/src/apis/file/package.json
+++ b/src/apis/file/package.json
@@ -29,7 +29,7 @@
     "webpack": "webpack"
   },
   "dependencies": {
-    "googleapis-common": "^4.2.0"
+    "googleapis-common": "^4.2.1"
   },
   "devDependencies": {
     "gts": "^2.0.0",

--- a/src/apis/firebase/package.json
+++ b/src/apis/firebase/package.json
@@ -29,7 +29,7 @@
     "webpack": "webpack"
   },
   "dependencies": {
-    "googleapis-common": "^4.2.0"
+    "googleapis-common": "^4.2.1"
   },
   "devDependencies": {
     "gts": "^2.0.0",

--- a/src/apis/firebasedynamiclinks/package.json
+++ b/src/apis/firebasedynamiclinks/package.json
@@ -29,7 +29,7 @@
     "webpack": "webpack"
   },
   "dependencies": {
-    "googleapis-common": "^4.2.0"
+    "googleapis-common": "^4.2.1"
   },
   "devDependencies": {
     "gts": "^2.0.0",

--- a/src/apis/firebasehosting/package.json
+++ b/src/apis/firebasehosting/package.json
@@ -29,7 +29,7 @@
     "webpack": "webpack"
   },
   "dependencies": {
-    "googleapis-common": "^4.2.0"
+    "googleapis-common": "^4.2.1"
   },
   "devDependencies": {
     "gts": "^2.0.0",

--- a/src/apis/firebaseml/package.json
+++ b/src/apis/firebaseml/package.json
@@ -29,7 +29,7 @@
     "webpack": "webpack"
   },
   "dependencies": {
-    "googleapis-common": "^4.2.0"
+    "googleapis-common": "^4.2.1"
   },
   "devDependencies": {
     "gts": "^2.0.0",

--- a/src/apis/firebaserules/package.json
+++ b/src/apis/firebaserules/package.json
@@ -29,7 +29,7 @@
     "webpack": "webpack"
   },
   "dependencies": {
-    "googleapis-common": "^4.2.0"
+    "googleapis-common": "^4.2.1"
   },
   "devDependencies": {
     "gts": "^2.0.0",

--- a/src/apis/firestore/package.json
+++ b/src/apis/firestore/package.json
@@ -29,7 +29,7 @@
     "webpack": "webpack"
   },
   "dependencies": {
-    "googleapis-common": "^4.2.0"
+    "googleapis-common": "^4.2.1"
   },
   "devDependencies": {
     "gts": "^2.0.0",

--- a/src/apis/fitness/package.json
+++ b/src/apis/fitness/package.json
@@ -29,7 +29,7 @@
     "webpack": "webpack"
   },
   "dependencies": {
-    "googleapis-common": "^4.2.0"
+    "googleapis-common": "^4.2.1"
   },
   "devDependencies": {
     "gts": "^2.0.0",

--- a/src/apis/games/package.json
+++ b/src/apis/games/package.json
@@ -29,7 +29,7 @@
     "webpack": "webpack"
   },
   "dependencies": {
-    "googleapis-common": "^4.2.0"
+    "googleapis-common": "^4.2.1"
   },
   "devDependencies": {
     "gts": "^2.0.0",

--- a/src/apis/gamesConfiguration/package.json
+++ b/src/apis/gamesConfiguration/package.json
@@ -29,7 +29,7 @@
     "webpack": "webpack"
   },
   "dependencies": {
-    "googleapis-common": "^4.2.0"
+    "googleapis-common": "^4.2.1"
   },
   "devDependencies": {
     "gts": "^2.0.0",

--- a/src/apis/gamesManagement/package.json
+++ b/src/apis/gamesManagement/package.json
@@ -29,7 +29,7 @@
     "webpack": "webpack"
   },
   "dependencies": {
-    "googleapis-common": "^4.2.0"
+    "googleapis-common": "^4.2.1"
   },
   "devDependencies": {
     "gts": "^2.0.0",

--- a/src/apis/gameservices/package.json
+++ b/src/apis/gameservices/package.json
@@ -29,7 +29,7 @@
     "webpack": "webpack"
   },
   "dependencies": {
-    "googleapis-common": "^4.2.0"
+    "googleapis-common": "^4.2.1"
   },
   "devDependencies": {
     "gts": "^2.0.0",

--- a/src/apis/genomics/package.json
+++ b/src/apis/genomics/package.json
@@ -29,7 +29,7 @@
     "webpack": "webpack"
   },
   "dependencies": {
-    "googleapis-common": "^4.2.0"
+    "googleapis-common": "^4.2.1"
   },
   "devDependencies": {
     "gts": "^2.0.0",

--- a/src/apis/gmail/package.json
+++ b/src/apis/gmail/package.json
@@ -29,7 +29,7 @@
     "webpack": "webpack"
   },
   "dependencies": {
-    "googleapis-common": "^4.2.0"
+    "googleapis-common": "^4.2.1"
   },
   "devDependencies": {
     "gts": "^2.0.0",

--- a/src/apis/groupsmigration/package.json
+++ b/src/apis/groupsmigration/package.json
@@ -29,7 +29,7 @@
     "webpack": "webpack"
   },
   "dependencies": {
-    "googleapis-common": "^4.2.0"
+    "googleapis-common": "^4.2.1"
   },
   "devDependencies": {
     "gts": "^2.0.0",

--- a/src/apis/groupssettings/package.json
+++ b/src/apis/groupssettings/package.json
@@ -29,7 +29,7 @@
     "webpack": "webpack"
   },
   "dependencies": {
-    "googleapis-common": "^4.2.0"
+    "googleapis-common": "^4.2.1"
   },
   "devDependencies": {
     "gts": "^2.0.0",

--- a/src/apis/healthcare/package.json
+++ b/src/apis/healthcare/package.json
@@ -29,7 +29,7 @@
     "webpack": "webpack"
   },
   "dependencies": {
-    "googleapis-common": "^4.2.0"
+    "googleapis-common": "^4.2.1"
   },
   "devDependencies": {
     "gts": "^2.0.0",

--- a/src/apis/homegraph/package.json
+++ b/src/apis/homegraph/package.json
@@ -29,7 +29,7 @@
     "webpack": "webpack"
   },
   "dependencies": {
-    "googleapis-common": "^4.2.0"
+    "googleapis-common": "^4.2.1"
   },
   "devDependencies": {
     "gts": "^2.0.0",

--- a/src/apis/iam/package.json
+++ b/src/apis/iam/package.json
@@ -29,7 +29,7 @@
     "webpack": "webpack"
   },
   "dependencies": {
-    "googleapis-common": "^4.2.0"
+    "googleapis-common": "^4.2.1"
   },
   "devDependencies": {
     "gts": "^2.0.0",

--- a/src/apis/iamcredentials/package.json
+++ b/src/apis/iamcredentials/package.json
@@ -29,7 +29,7 @@
     "webpack": "webpack"
   },
   "dependencies": {
-    "googleapis-common": "^4.2.0"
+    "googleapis-common": "^4.2.1"
   },
   "devDependencies": {
     "gts": "^2.0.0",

--- a/src/apis/iap/package.json
+++ b/src/apis/iap/package.json
@@ -29,7 +29,7 @@
     "webpack": "webpack"
   },
   "dependencies": {
-    "googleapis-common": "^4.2.0"
+    "googleapis-common": "^4.2.1"
   },
   "devDependencies": {
     "gts": "^2.0.0",

--- a/src/apis/identitytoolkit/package.json
+++ b/src/apis/identitytoolkit/package.json
@@ -29,7 +29,7 @@
     "webpack": "webpack"
   },
   "dependencies": {
-    "googleapis-common": "^4.2.0"
+    "googleapis-common": "^4.2.1"
   },
   "devDependencies": {
     "gts": "^2.0.0",

--- a/src/apis/indexing/package.json
+++ b/src/apis/indexing/package.json
@@ -29,7 +29,7 @@
     "webpack": "webpack"
   },
   "dependencies": {
-    "googleapis-common": "^4.2.0"
+    "googleapis-common": "^4.2.1"
   },
   "devDependencies": {
     "gts": "^2.0.0",

--- a/src/apis/jobs/package.json
+++ b/src/apis/jobs/package.json
@@ -29,7 +29,7 @@
     "webpack": "webpack"
   },
   "dependencies": {
-    "googleapis-common": "^4.2.0"
+    "googleapis-common": "^4.2.1"
   },
   "devDependencies": {
     "gts": "^2.0.0",

--- a/src/apis/kgsearch/package.json
+++ b/src/apis/kgsearch/package.json
@@ -29,7 +29,7 @@
     "webpack": "webpack"
   },
   "dependencies": {
-    "googleapis-common": "^4.2.0"
+    "googleapis-common": "^4.2.1"
   },
   "devDependencies": {
     "gts": "^2.0.0",

--- a/src/apis/language/package.json
+++ b/src/apis/language/package.json
@@ -29,7 +29,7 @@
     "webpack": "webpack"
   },
   "dependencies": {
-    "googleapis-common": "^4.2.0"
+    "googleapis-common": "^4.2.1"
   },
   "devDependencies": {
     "gts": "^2.0.0",

--- a/src/apis/libraryagent/package.json
+++ b/src/apis/libraryagent/package.json
@@ -29,7 +29,7 @@
     "webpack": "webpack"
   },
   "dependencies": {
-    "googleapis-common": "^4.2.0"
+    "googleapis-common": "^4.2.1"
   },
   "devDependencies": {
     "gts": "^2.0.0",

--- a/src/apis/licensing/package.json
+++ b/src/apis/licensing/package.json
@@ -29,7 +29,7 @@
     "webpack": "webpack"
   },
   "dependencies": {
-    "googleapis-common": "^4.2.0"
+    "googleapis-common": "^4.2.1"
   },
   "devDependencies": {
     "gts": "^2.0.0",

--- a/src/apis/lifesciences/package.json
+++ b/src/apis/lifesciences/package.json
@@ -29,7 +29,7 @@
     "webpack": "webpack"
   },
   "dependencies": {
-    "googleapis-common": "^4.2.0"
+    "googleapis-common": "^4.2.1"
   },
   "devDependencies": {
     "gts": "^2.0.0",

--- a/src/apis/logging/package.json
+++ b/src/apis/logging/package.json
@@ -29,7 +29,7 @@
     "webpack": "webpack"
   },
   "dependencies": {
-    "googleapis-common": "^4.2.0"
+    "googleapis-common": "^4.2.1"
   },
   "devDependencies": {
     "gts": "^2.0.0",

--- a/src/apis/managedidentities/package.json
+++ b/src/apis/managedidentities/package.json
@@ -29,7 +29,7 @@
     "webpack": "webpack"
   },
   "dependencies": {
-    "googleapis-common": "^4.2.0"
+    "googleapis-common": "^4.2.1"
   },
   "devDependencies": {
     "gts": "^2.0.0",

--- a/src/apis/manufacturers/package.json
+++ b/src/apis/manufacturers/package.json
@@ -29,7 +29,7 @@
     "webpack": "webpack"
   },
   "dependencies": {
-    "googleapis-common": "^4.2.0"
+    "googleapis-common": "^4.2.1"
   },
   "devDependencies": {
     "gts": "^2.0.0",

--- a/src/apis/memcache/package.json
+++ b/src/apis/memcache/package.json
@@ -29,7 +29,7 @@
     "webpack": "webpack"
   },
   "dependencies": {
-    "googleapis-common": "^4.2.0"
+    "googleapis-common": "^4.2.1"
   },
   "devDependencies": {
     "gts": "^2.0.0",

--- a/src/apis/ml/package.json
+++ b/src/apis/ml/package.json
@@ -29,7 +29,7 @@
     "webpack": "webpack"
   },
   "dependencies": {
-    "googleapis-common": "^4.2.0"
+    "googleapis-common": "^4.2.1"
   },
   "devDependencies": {
     "gts": "^2.0.0",

--- a/src/apis/monitoring/package.json
+++ b/src/apis/monitoring/package.json
@@ -29,7 +29,7 @@
     "webpack": "webpack"
   },
   "dependencies": {
-    "googleapis-common": "^4.2.0"
+    "googleapis-common": "^4.2.1"
   },
   "devDependencies": {
     "gts": "^2.0.0",

--- a/src/apis/networkmanagement/package.json
+++ b/src/apis/networkmanagement/package.json
@@ -29,7 +29,7 @@
     "webpack": "webpack"
   },
   "dependencies": {
-    "googleapis-common": "^4.2.0"
+    "googleapis-common": "^4.2.1"
   },
   "devDependencies": {
     "gts": "^2.0.0",

--- a/src/apis/oauth2/package.json
+++ b/src/apis/oauth2/package.json
@@ -29,7 +29,7 @@
     "webpack": "webpack"
   },
   "dependencies": {
-    "googleapis-common": "^4.2.0"
+    "googleapis-common": "^4.2.1"
   },
   "devDependencies": {
     "gts": "^2.0.0",

--- a/src/apis/osconfig/package.json
+++ b/src/apis/osconfig/package.json
@@ -29,7 +29,7 @@
     "webpack": "webpack"
   },
   "dependencies": {
-    "googleapis-common": "^4.2.0"
+    "googleapis-common": "^4.2.1"
   },
   "devDependencies": {
     "gts": "^2.0.0",

--- a/src/apis/oslogin/package.json
+++ b/src/apis/oslogin/package.json
@@ -29,7 +29,7 @@
     "webpack": "webpack"
   },
   "dependencies": {
-    "googleapis-common": "^4.2.0"
+    "googleapis-common": "^4.2.1"
   },
   "devDependencies": {
     "gts": "^2.0.0",

--- a/src/apis/pagespeedonline/package.json
+++ b/src/apis/pagespeedonline/package.json
@@ -29,7 +29,7 @@
     "webpack": "webpack"
   },
   "dependencies": {
-    "googleapis-common": "^4.2.0"
+    "googleapis-common": "^4.2.1"
   },
   "devDependencies": {
     "gts": "^2.0.0",

--- a/src/apis/people/package.json
+++ b/src/apis/people/package.json
@@ -29,7 +29,7 @@
     "webpack": "webpack"
   },
   "dependencies": {
-    "googleapis-common": "^4.2.0"
+    "googleapis-common": "^4.2.1"
   },
   "devDependencies": {
     "gts": "^2.0.0",

--- a/src/apis/playcustomapp/package.json
+++ b/src/apis/playcustomapp/package.json
@@ -29,7 +29,7 @@
     "webpack": "webpack"
   },
   "dependencies": {
-    "googleapis-common": "^4.2.0"
+    "googleapis-common": "^4.2.1"
   },
   "devDependencies": {
     "gts": "^2.0.0",

--- a/src/apis/plus/package.json
+++ b/src/apis/plus/package.json
@@ -29,7 +29,7 @@
     "webpack": "webpack"
   },
   "dependencies": {
-    "googleapis-common": "^4.2.0"
+    "googleapis-common": "^4.2.1"
   },
   "devDependencies": {
     "gts": "^2.0.0",

--- a/src/apis/policytroubleshooter/package.json
+++ b/src/apis/policytroubleshooter/package.json
@@ -29,7 +29,7 @@
     "webpack": "webpack"
   },
   "dependencies": {
-    "googleapis-common": "^4.2.0"
+    "googleapis-common": "^4.2.1"
   },
   "devDependencies": {
     "gts": "^2.0.0",

--- a/src/apis/poly/package.json
+++ b/src/apis/poly/package.json
@@ -29,7 +29,7 @@
     "webpack": "webpack"
   },
   "dependencies": {
-    "googleapis-common": "^4.2.0"
+    "googleapis-common": "^4.2.1"
   },
   "devDependencies": {
     "gts": "^2.0.0",

--- a/src/apis/prod_tt_sasportal/package.json
+++ b/src/apis/prod_tt_sasportal/package.json
@@ -29,7 +29,7 @@
     "webpack": "webpack"
   },
   "dependencies": {
-    "googleapis-common": "^4.2.0"
+    "googleapis-common": "^4.2.1"
   },
   "devDependencies": {
     "gts": "^2.0.0",

--- a/src/apis/pubsub/package.json
+++ b/src/apis/pubsub/package.json
@@ -29,7 +29,7 @@
     "webpack": "webpack"
   },
   "dependencies": {
-    "googleapis-common": "^4.2.0"
+    "googleapis-common": "^4.2.1"
   },
   "devDependencies": {
     "gts": "^2.0.0",

--- a/src/apis/recommender/package.json
+++ b/src/apis/recommender/package.json
@@ -29,7 +29,7 @@
     "webpack": "webpack"
   },
   "dependencies": {
-    "googleapis-common": "^4.2.0"
+    "googleapis-common": "^4.2.1"
   },
   "devDependencies": {
     "gts": "^2.0.0",

--- a/src/apis/redis/package.json
+++ b/src/apis/redis/package.json
@@ -29,7 +29,7 @@
     "webpack": "webpack"
   },
   "dependencies": {
-    "googleapis-common": "^4.2.0"
+    "googleapis-common": "^4.2.1"
   },
   "devDependencies": {
     "gts": "^2.0.0",

--- a/src/apis/remotebuildexecution/package.json
+++ b/src/apis/remotebuildexecution/package.json
@@ -29,7 +29,7 @@
     "webpack": "webpack"
   },
   "dependencies": {
-    "googleapis-common": "^4.2.0"
+    "googleapis-common": "^4.2.1"
   },
   "devDependencies": {
     "gts": "^2.0.0",

--- a/src/apis/reseller/package.json
+++ b/src/apis/reseller/package.json
@@ -29,7 +29,7 @@
     "webpack": "webpack"
   },
   "dependencies": {
-    "googleapis-common": "^4.2.0"
+    "googleapis-common": "^4.2.1"
   },
   "devDependencies": {
     "gts": "^2.0.0",

--- a/src/apis/run/package.json
+++ b/src/apis/run/package.json
@@ -29,7 +29,7 @@
     "webpack": "webpack"
   },
   "dependencies": {
-    "googleapis-common": "^4.2.0"
+    "googleapis-common": "^4.2.1"
   },
   "devDependencies": {
     "gts": "^2.0.0",

--- a/src/apis/runtimeconfig/package.json
+++ b/src/apis/runtimeconfig/package.json
@@ -29,7 +29,7 @@
     "webpack": "webpack"
   },
   "dependencies": {
-    "googleapis-common": "^4.2.0"
+    "googleapis-common": "^4.2.1"
   },
   "devDependencies": {
     "gts": "^2.0.0",

--- a/src/apis/safebrowsing/package.json
+++ b/src/apis/safebrowsing/package.json
@@ -29,7 +29,7 @@
     "webpack": "webpack"
   },
   "dependencies": {
-    "googleapis-common": "^4.2.0"
+    "googleapis-common": "^4.2.1"
   },
   "devDependencies": {
     "gts": "^2.0.0",

--- a/src/apis/sasportal/package.json
+++ b/src/apis/sasportal/package.json
@@ -29,7 +29,7 @@
     "webpack": "webpack"
   },
   "dependencies": {
-    "googleapis-common": "^4.2.0"
+    "googleapis-common": "^4.2.1"
   },
   "devDependencies": {
     "gts": "^2.0.0",

--- a/src/apis/script/package.json
+++ b/src/apis/script/package.json
@@ -29,7 +29,7 @@
     "webpack": "webpack"
   },
   "dependencies": {
-    "googleapis-common": "^4.2.0"
+    "googleapis-common": "^4.2.1"
   },
   "devDependencies": {
     "gts": "^2.0.0",

--- a/src/apis/searchconsole/package.json
+++ b/src/apis/searchconsole/package.json
@@ -29,7 +29,7 @@
     "webpack": "webpack"
   },
   "dependencies": {
-    "googleapis-common": "^4.2.0"
+    "googleapis-common": "^4.2.1"
   },
   "devDependencies": {
     "gts": "^2.0.0",

--- a/src/apis/secretmanager/package.json
+++ b/src/apis/secretmanager/package.json
@@ -29,7 +29,7 @@
     "webpack": "webpack"
   },
   "dependencies": {
-    "googleapis-common": "^4.2.0"
+    "googleapis-common": "^4.2.1"
   },
   "devDependencies": {
     "gts": "^2.0.0",

--- a/src/apis/securitycenter/package.json
+++ b/src/apis/securitycenter/package.json
@@ -29,7 +29,7 @@
     "webpack": "webpack"
   },
   "dependencies": {
-    "googleapis-common": "^4.2.0"
+    "googleapis-common": "^4.2.1"
   },
   "devDependencies": {
     "gts": "^2.0.0",

--- a/src/apis/serviceconsumermanagement/package.json
+++ b/src/apis/serviceconsumermanagement/package.json
@@ -29,7 +29,7 @@
     "webpack": "webpack"
   },
   "dependencies": {
-    "googleapis-common": "^4.2.0"
+    "googleapis-common": "^4.2.1"
   },
   "devDependencies": {
     "gts": "^2.0.0",

--- a/src/apis/servicecontrol/package.json
+++ b/src/apis/servicecontrol/package.json
@@ -29,7 +29,7 @@
     "webpack": "webpack"
   },
   "dependencies": {
-    "googleapis-common": "^4.2.0"
+    "googleapis-common": "^4.2.1"
   },
   "devDependencies": {
     "gts": "^2.0.0",

--- a/src/apis/servicedirectory/package.json
+++ b/src/apis/servicedirectory/package.json
@@ -29,7 +29,7 @@
     "webpack": "webpack"
   },
   "dependencies": {
-    "googleapis-common": "^4.2.0"
+    "googleapis-common": "^4.2.1"
   },
   "devDependencies": {
     "gts": "^2.0.0",

--- a/src/apis/servicemanagement/package.json
+++ b/src/apis/servicemanagement/package.json
@@ -29,7 +29,7 @@
     "webpack": "webpack"
   },
   "dependencies": {
-    "googleapis-common": "^4.2.0"
+    "googleapis-common": "^4.2.1"
   },
   "devDependencies": {
     "gts": "^2.0.0",

--- a/src/apis/servicenetworking/package.json
+++ b/src/apis/servicenetworking/package.json
@@ -29,7 +29,7 @@
     "webpack": "webpack"
   },
   "dependencies": {
-    "googleapis-common": "^4.2.0"
+    "googleapis-common": "^4.2.1"
   },
   "devDependencies": {
     "gts": "^2.0.0",

--- a/src/apis/serviceusage/package.json
+++ b/src/apis/serviceusage/package.json
@@ -29,7 +29,7 @@
     "webpack": "webpack"
   },
   "dependencies": {
-    "googleapis-common": "^4.2.0"
+    "googleapis-common": "^4.2.1"
   },
   "devDependencies": {
     "gts": "^2.0.0",

--- a/src/apis/sheets/package.json
+++ b/src/apis/sheets/package.json
@@ -29,7 +29,7 @@
     "webpack": "webpack"
   },
   "dependencies": {
-    "googleapis-common": "^4.2.0"
+    "googleapis-common": "^4.2.1"
   },
   "devDependencies": {
     "gts": "^2.0.0",

--- a/src/apis/siteVerification/package.json
+++ b/src/apis/siteVerification/package.json
@@ -29,7 +29,7 @@
     "webpack": "webpack"
   },
   "dependencies": {
-    "googleapis-common": "^4.2.0"
+    "googleapis-common": "^4.2.1"
   },
   "devDependencies": {
     "gts": "^2.0.0",

--- a/src/apis/slides/package.json
+++ b/src/apis/slides/package.json
@@ -29,7 +29,7 @@
     "webpack": "webpack"
   },
   "dependencies": {
-    "googleapis-common": "^4.2.0"
+    "googleapis-common": "^4.2.1"
   },
   "devDependencies": {
     "gts": "^2.0.0",

--- a/src/apis/sourcerepo/package.json
+++ b/src/apis/sourcerepo/package.json
@@ -29,7 +29,7 @@
     "webpack": "webpack"
   },
   "dependencies": {
-    "googleapis-common": "^4.2.0"
+    "googleapis-common": "^4.2.1"
   },
   "devDependencies": {
     "gts": "^2.0.0",

--- a/src/apis/spanner/package.json
+++ b/src/apis/spanner/package.json
@@ -29,7 +29,7 @@
     "webpack": "webpack"
   },
   "dependencies": {
-    "googleapis-common": "^4.2.0"
+    "googleapis-common": "^4.2.1"
   },
   "devDependencies": {
     "gts": "^2.0.0",

--- a/src/apis/speech/package.json
+++ b/src/apis/speech/package.json
@@ -29,7 +29,7 @@
     "webpack": "webpack"
   },
   "dependencies": {
-    "googleapis-common": "^4.2.0"
+    "googleapis-common": "^4.2.1"
   },
   "devDependencies": {
     "gts": "^2.0.0",

--- a/src/apis/sql/package.json
+++ b/src/apis/sql/package.json
@@ -29,7 +29,7 @@
     "webpack": "webpack"
   },
   "dependencies": {
-    "googleapis-common": "^4.2.0"
+    "googleapis-common": "^4.2.1"
   },
   "devDependencies": {
     "gts": "^2.0.0",

--- a/src/apis/storage/package.json
+++ b/src/apis/storage/package.json
@@ -29,7 +29,7 @@
     "webpack": "webpack"
   },
   "dependencies": {
-    "googleapis-common": "^4.2.0"
+    "googleapis-common": "^4.2.1"
   },
   "devDependencies": {
     "gts": "^2.0.0",

--- a/src/apis/storagetransfer/package.json
+++ b/src/apis/storagetransfer/package.json
@@ -29,7 +29,7 @@
     "webpack": "webpack"
   },
   "dependencies": {
-    "googleapis-common": "^4.2.0"
+    "googleapis-common": "^4.2.1"
   },
   "devDependencies": {
     "gts": "^2.0.0",

--- a/src/apis/streetviewpublish/package.json
+++ b/src/apis/streetviewpublish/package.json
@@ -29,7 +29,7 @@
     "webpack": "webpack"
   },
   "dependencies": {
-    "googleapis-common": "^4.2.0"
+    "googleapis-common": "^4.2.1"
   },
   "devDependencies": {
     "gts": "^2.0.0",

--- a/src/apis/tagmanager/package.json
+++ b/src/apis/tagmanager/package.json
@@ -29,7 +29,7 @@
     "webpack": "webpack"
   },
   "dependencies": {
-    "googleapis-common": "^4.2.0"
+    "googleapis-common": "^4.2.1"
   },
   "devDependencies": {
     "gts": "^2.0.0",

--- a/src/apis/tasks/package.json
+++ b/src/apis/tasks/package.json
@@ -29,7 +29,7 @@
     "webpack": "webpack"
   },
   "dependencies": {
-    "googleapis-common": "^4.2.0"
+    "googleapis-common": "^4.2.1"
   },
   "devDependencies": {
     "gts": "^2.0.0",

--- a/src/apis/testing/package.json
+++ b/src/apis/testing/package.json
@@ -29,7 +29,7 @@
     "webpack": "webpack"
   },
   "dependencies": {
-    "googleapis-common": "^4.2.0"
+    "googleapis-common": "^4.2.1"
   },
   "devDependencies": {
     "gts": "^2.0.0",

--- a/src/apis/texttospeech/package.json
+++ b/src/apis/texttospeech/package.json
@@ -29,7 +29,7 @@
     "webpack": "webpack"
   },
   "dependencies": {
-    "googleapis-common": "^4.2.0"
+    "googleapis-common": "^4.2.1"
   },
   "devDependencies": {
     "gts": "^2.0.0",

--- a/src/apis/toolresults/package.json
+++ b/src/apis/toolresults/package.json
@@ -29,7 +29,7 @@
     "webpack": "webpack"
   },
   "dependencies": {
-    "googleapis-common": "^4.2.0"
+    "googleapis-common": "^4.2.1"
   },
   "devDependencies": {
     "gts": "^2.0.0",

--- a/src/apis/tpu/package.json
+++ b/src/apis/tpu/package.json
@@ -29,7 +29,7 @@
     "webpack": "webpack"
   },
   "dependencies": {
-    "googleapis-common": "^4.2.0"
+    "googleapis-common": "^4.2.1"
   },
   "devDependencies": {
     "gts": "^2.0.0",

--- a/src/apis/translate/package.json
+++ b/src/apis/translate/package.json
@@ -29,7 +29,7 @@
     "webpack": "webpack"
   },
   "dependencies": {
-    "googleapis-common": "^4.2.0"
+    "googleapis-common": "^4.2.1"
   },
   "devDependencies": {
     "gts": "^2.0.0",

--- a/src/apis/vault/package.json
+++ b/src/apis/vault/package.json
@@ -29,7 +29,7 @@
     "webpack": "webpack"
   },
   "dependencies": {
-    "googleapis-common": "^4.2.0"
+    "googleapis-common": "^4.2.1"
   },
   "devDependencies": {
     "gts": "^2.0.0",

--- a/src/apis/verifiedaccess/package.json
+++ b/src/apis/verifiedaccess/package.json
@@ -29,7 +29,7 @@
     "webpack": "webpack"
   },
   "dependencies": {
-    "googleapis-common": "^4.2.0"
+    "googleapis-common": "^4.2.1"
   },
   "devDependencies": {
     "gts": "^2.0.0",

--- a/src/apis/videointelligence/package.json
+++ b/src/apis/videointelligence/package.json
@@ -29,7 +29,7 @@
     "webpack": "webpack"
   },
   "dependencies": {
-    "googleapis-common": "^4.2.0"
+    "googleapis-common": "^4.2.1"
   },
   "devDependencies": {
     "gts": "^2.0.0",

--- a/src/apis/vision/package.json
+++ b/src/apis/vision/package.json
@@ -29,7 +29,7 @@
     "webpack": "webpack"
   },
   "dependencies": {
-    "googleapis-common": "^4.2.0"
+    "googleapis-common": "^4.2.1"
   },
   "devDependencies": {
     "gts": "^2.0.0",

--- a/src/apis/webfonts/package.json
+++ b/src/apis/webfonts/package.json
@@ -29,7 +29,7 @@
     "webpack": "webpack"
   },
   "dependencies": {
-    "googleapis-common": "^4.2.0"
+    "googleapis-common": "^4.2.1"
   },
   "devDependencies": {
     "gts": "^2.0.0",

--- a/src/apis/webmasters/package.json
+++ b/src/apis/webmasters/package.json
@@ -29,7 +29,7 @@
     "webpack": "webpack"
   },
   "dependencies": {
-    "googleapis-common": "^4.2.0"
+    "googleapis-common": "^4.2.1"
   },
   "devDependencies": {
     "gts": "^2.0.0",

--- a/src/apis/websecurityscanner/package.json
+++ b/src/apis/websecurityscanner/package.json
@@ -29,7 +29,7 @@
     "webpack": "webpack"
   },
   "dependencies": {
-    "googleapis-common": "^4.2.0"
+    "googleapis-common": "^4.2.1"
   },
   "devDependencies": {
     "gts": "^2.0.0",

--- a/src/apis/youtube/package.json
+++ b/src/apis/youtube/package.json
@@ -29,7 +29,7 @@
     "webpack": "webpack"
   },
   "dependencies": {
-    "googleapis-common": "^4.2.0"
+    "googleapis-common": "^4.2.1"
   },
   "devDependencies": {
     "gts": "^2.0.0",

--- a/src/apis/youtubeAnalytics/package.json
+++ b/src/apis/youtubeAnalytics/package.json
@@ -29,7 +29,7 @@
     "webpack": "webpack"
   },
   "dependencies": {
-    "googleapis-common": "^4.2.0"
+    "googleapis-common": "^4.2.1"
   },
   "devDependencies": {
     "gts": "^2.0.0",

--- a/src/apis/youtubereporting/package.json
+++ b/src/apis/youtubereporting/package.json
@@ -29,7 +29,7 @@
     "webpack": "webpack"
   },
   "dependencies": {
-    "googleapis-common": "^4.2.0"
+    "googleapis-common": "^4.2.1"
   },
   "devDependencies": {
     "gts": "^2.0.0",

--- a/src/generator/templates/package.json.njk
+++ b/src/generator/templates/package.json.njk
@@ -29,7 +29,7 @@
     "webpack": "webpack"
   },
   "dependencies": {
-    "googleapis-common": "^4.2.0"
+    "googleapis-common": "^4.2.1"
   },
   "devDependencies": {
     "gts": "^2.0.0",


### PR DESCRIPTION
This is expected to fail at this moment because of #2029.  When the change in https://github.com/googleapis/nodejs-googleapis-common/pull/285 lands, and a new version of the module ships, this should start to pass 😎 