### PR TITLE
docs: add a sample of using access token auth

### DIFF
--- a/samples/accessTokenAuth.js
+++ b/samples/accessTokenAuth.js
@@ -1,0 +1,46 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+const {google} = require('googleapis');
+
+/**
+ * This example demonstrates authenticating to the Google APIs backend using
+ * an access token only. Generally access tokens are obtained using the standard JWT
+ * and 3-legged-OAuth methods, but from time to time only the access token
+ * is available.
+ */
+async function runSample(accessToken) {
+  const drive = google.drive({
+    version: 'v2',
+    // this header will be present for every request
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+    },
+  });
+
+  // Make an authorized request to list Drive files.
+  const res = await drive.files.list();
+  console.log(res.data);
+
+  return res;
+}
+
+if (module === require.main) {
+  runSample().catch(console.error);
+}
+
+// Exports for unit testing purposes
+module.exports = {runSample};

--- a/samples/package.json
+++ b/samples/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "@google-cloud/local-auth": "^0.1.0",
     "express": "^4.17.1",
-    "googleapis": "^52.0.0",
+    "googleapis": "^51.0.0",
     "nconf": "^0.10.0",
     "open": "^7.0.3",
     "server-destroy": "^1.0.1",

--- a/samples/test/test.samples.auth.js
+++ b/samples/test/test.samples.auth.js
@@ -51,7 +51,6 @@ describe('Auth samples', () => {
   it('should accept an access token header', async () => {
     const scope = nock('https://www.googleapis.com')
       .get('/drive/v2/files')
-      .twice()
       .reply(200, {});
     const res = await samples.accessToken.runSample(12345);
     assert.strictEqual(res.config.headers['Authorization'], 'Bearer 12345');

--- a/samples/test/test.samples.auth.js
+++ b/samples/test/test.samples.auth.js
@@ -23,6 +23,7 @@ nock.disableNetConnect();
 
 const samples = {
   jwt: require('../jwt'),
+  accessToken: require('../accessTokenAuth'),
 };
 
 describe('Auth samples', () => {
@@ -44,6 +45,16 @@ describe('Auth samples', () => {
     }
     const data = await samples.jwt.runSample();
     assert(data);
+    scope.done();
+  });
+
+  it('should accept an access token header', async () => {
+    const scope = nock('https://www.googleapis.com')
+      .get('/drive/v2/files')
+      .twice()
+      .reply(200, {});
+    const res = await samples.accessToken.runSample(12345);
+    assert.strictEqual(res.config.headers['Authorization'], 'Bearer 12345');
     scope.done();
   });
 });


### PR DESCRIPTION
Someone was looking for how to do auth with an access token over here:
https://github.com/googleapis/google-api-nodejs-client/issues/1973

Half to have a sample, and half to make sure my answer was going to work, added this :)