### PR TITLE
build: ensure template package.json gets renovated

### DIFF
--- a/src/generator/generator.ts
+++ b/src/generator/generator.ts
@@ -189,7 +189,7 @@ export class Generator {
           // generate the package.json
           const pkgPath = path.join(apisPath, file, 'package.json');
           const packageData = {name: file, desc};
-          await this.render('package.json.njk', packageData, pkgPath);
+          await this.render('package.json', packageData, pkgPath);
           // generate the README.md
           const rdPath = path.join(apisPath, file, 'README.md');
           const disclaimer = disclaimers.find(disclaimer => {

--- a/src/generator/templates/package.json
+++ b/src/generator/templates/package.json
@@ -34,7 +34,7 @@
   "devDependencies": {
     "gts": "^2.0.0",
     "null-loader": "^4.0.0",
-    "ts-loader": "^7.0.0",
+    "ts-loader": "^8.0.0",
     "typedoc": "^0.17.0",
     "typescript": "~3.7.0",
     "webpack": "^4.35.3",


### PR DESCRIPTION
This prevents the issue where renovate bumps dependencies for the generated code, but doesn't update the template itself. 