### PR TITLE
feat(actions): switch to GitHub action for releases

### DIFF
--- a/.github/release-please.yml
+++ b/.github/release-please.yml
@@ -1,1 +1,0 @@
-releaseType: node

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -24,7 +24,7 @@ jobs:
               await github.issues.addLabels({
                 owner,
                 repo,
-                issue_number: ${{steps.release-please.outputs.pr}},
+                issue_number: ${{steps.release-pr.outputs.pr}},
                 labels: ['autorelease: pending']
               });
               console.log(`Tagged ${{steps.release-pr.outputs.pr}}`)

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -43,9 +43,10 @@ jobs:
         with:
           node-version: 14
           registry-url: 'https://wombat-dressing-room.appspot.com/'
-      - run: |
-          npm install
-          npm publish
+      - name: publish
         if: ${{ steps.tag-release.outputs.release_created }}
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
+        run: |
+          npm install
+          npm publish

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,7 +21,7 @@ jobs:
             github-token: ${{secrets.GITHUB_TOKEN}}
             script: |
               const [owner, repo] = process.env.GITHUB_REPOSITORY.split('/');
-              const latestRelease = await github.issues.addLabels({
+              await github.issues.addLabels({
                 owner,
                 repo,
                 issue_number: ${{steps.release-please.outputs.pr}},

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,51 @@
+on:
+  push:
+    branches:
+      - main
+name: release-please
+jobs:
+  release-please-pr:
+    runs-on: ubuntu-latest
+    steps:
+      - id: release-pr
+        uses: GoogleCloudPlatform/release-please-action@v2
+        with:
+          token: ${{ secrets.FORKING_TOKEN }}
+          release-type: node
+          fork: true
+          package-name: googleapis
+          command: release-pr
+      - id: label
+        uses: actions/github-script@v3    
+        with:
+            github-token: ${{secrets.GITHUB_TOKEN}}
+            script: |
+              const [owner, repo] = process.env.GITHUB_REPOSITORY.split('/');
+              const latestRelease = await github.issues.addLabels({
+                owner,
+                repo,
+                issue_number: ${{steps.release-please.outputs.pr}},
+                labels: ['autorelease: pending']
+              });
+              console.log(`Tagged ${{steps.release-pr.outputs.pr}}`)
+  release-please-release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: GoogleCloudPlatform/release-please-action@v2
+        id: tag-release
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          release-type: node
+          package-name: googleapis
+          command: github-release
+      - uses: actions/setup-node@v1
+        if: ${{ steps.tag-release.outputs.release_created }}
+        with:
+          node-version: 14
+          registry-url: 'https://wombat-dressing-room.appspot.com/'
+      - run: |
+          npm install
+          npm publish
+        if: ${{ steps.tag-release.outputs.release_created }}
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}


### PR DESCRIPTION
This moves us to using a GitHub action for running release-please and publishing to npm, this will make it easier for us to have two release flows in the repo:

1. the top level publication of `googleapis`.
2. the publication of individual libraries inside `src/apis`.

TODO:

- [x] merge https://github.com/googleapis/releasetool/pull/291, so that we stop handling releases with autorelease.
- [x] add kokoro job that publishes docs when we merge  to the main branch.