### PR TITLE
build(kokoro): generate docs on merge to main

### DIFF
--- a/.kokoro/continuous/node12/docs.cfg
+++ b/.kokoro/continuous/node12/docs.cfg
@@ -1,0 +1,26 @@
+# service account used to publish up-to-date docs.
+before_action {
+  fetch_keystore {
+    keystore_resource {
+      keystore_config_id: 73713
+      keyname: "docuploader_service_account"
+    }
+  }
+}
+
+# doc publications use a Python image.
+env_vars: {
+    key: "TRAMPOLINE_IMAGE"
+    value: "gcr.io/cloud-devrel-kokoro-resources/node:10-user"
+}
+
+# Download trampoline resources.
+gfile_resources: "/bigstore/cloud-devrel-kokoro-resources/trampoline"
+
+# Use the trampoline script to run in docker.
+build_file: "google-api-nodejs-client/.kokoro/trampoline_v2.sh"
+
+env_vars: {
+    key: "TRAMPOLINE_BUILD_FILE"
+    value: "github/google-api-nodejs-client/.kokoro/release/docs.sh"
+}

--- a/.kokoro/continuous/node12/docs.cfg
+++ b/.kokoro/continuous/node12/docs.cfg
@@ -8,7 +8,6 @@ before_action {
   }
 }
 
-# doc publications use a Python image.
 env_vars: {
     key: "TRAMPOLINE_IMAGE"
     value: "gcr.io/cloud-devrel-kokoro-resources/node:10-user"

--- a/.kokoro/continuous/node12/docs.cfg
+++ b/.kokoro/continuous/node12/docs.cfg
@@ -10,7 +10,7 @@ before_action {
 
 env_vars: {
     key: "TRAMPOLINE_IMAGE"
-    value: "gcr.io/cloud-devrel-kokoro-resources/node:10-user"
+    value: "gcr.io/cloud-devrel-kokoro-resources/node:12-user"
 }
 
 # Download trampoline resources.


### PR DESCRIPTION
For `googleapis` we will now generate docs when we merge to the min branch, this allows us to decouple docs generation from the publication to npm.