### PR TITLE
build: wrong branch name

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,7 +1,7 @@
 on:
   push:
     branches:
-      - main
+      - master
 name: release-please
 jobs:
   release-please-pr:


### PR DESCRIPTION
We are still using old default branch name on this repo.