### PR TITLE
build: check for PR created; clone repo

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,6 +16,7 @@ jobs:
           package-name: googleapis
           command: release-pr
       - id: label
+        if: ${{ steps.release-pr.outputs.pr }}
         uses: actions/github-script@v3    
         with:
             github-token: ${{secrets.GITHUB_TOKEN}}
@@ -38,6 +39,8 @@ jobs:
           release-type: node
           package-name: googleapis
           command: github-release
+      - uses: actions/checkout@v2
+        if: ${{ steps.tag-release.outputs.release_created }}
       - uses: actions/setup-node@v1
         if: ${{ steps.tag-release.outputs.release_created }}
         with:


### PR DESCRIPTION
* we were not cloning the repository to the workspace, so npm publish did not work.
* we should only label a PR if one was open.