### PR TITLE
build: access should default to public

### DIFF
--- a/.github/workflows/release-submodules.yaml
+++ b/.github/workflows/release-submodules.yaml
@@ -102,7 +102,7 @@ jobs:
         run: |
           cd src/apis/${{ matrix.package }}
           npm install
-          npm publish
+          npm publish --access=public
       - uses: actions/github-script@v3
         id: untag-release
         if: ${{steps.tag-release.outputs.pr}}


### PR DESCRIPTION
Access for new modules should default to public.