### PR TITLE
build: do not replace package.json by default

### DIFF
--- a/.github/workflows/release-submodules.yaml
+++ b/.github/workflows/release-submodules.yaml
@@ -2,7 +2,7 @@ on:
   push:
     branches:
       - master
-name: release-please-monorepo
+name: release-please-submodules
 jobs:
   changeFinder:
     runs-on: ubuntu-latest
@@ -58,7 +58,7 @@ jobs:
            monorepo-tags: true
            command: release-pr
       - id: label
-        if: ${{steps.release-please.outputs.pr}})
+        if: ${{steps.release-please.outputs.pr}}
         uses: actions/github-script@v3    
         with:
             github-token: ${{secrets.GITHUB_TOKEN}}

--- a/src/generator/synth.ts
+++ b/src/generator/synth.ts
@@ -32,7 +32,8 @@ export interface Changelog {
 }
 
 export interface SynthOptions {
-  useCache?: boolean;
+  useCache: boolean;
+  withPackageJson: boolean;
 }
 
 export async function synth(options: SynthOptions = {}) {
@@ -40,7 +41,11 @@ export async function synth(options: SynthOptions = {}) {
   let changeSets: ChangeSet[] = [];
   if (!options.useCache) {
     console.log('Removing old APIs...');
-    changeSets = await gen.generateAllAPIs(DISCOVERY_URL, false);
+    changeSets = await gen.generateAllAPIs(
+      DISCOVERY_URL,
+      options.useCache,
+      options.withPackageJson
+    );
   }
   const statusResult = await execa('git', ['status', '--porcelain']);
   const status = statusResult.stdout;
@@ -193,7 +198,8 @@ export function getSemverity(changeSets: ChangeSet[]) {
 if (require.main === module) {
   const argv = minimist(process.argv.slice(2));
   const useCache = !!argv['use-cache'];
-  synth({useCache}).catch(err => {
+  const withPackageJson = !!argv['with-package-json'];
+  synth({useCache, withPackageJson}).catch(err => {
     console.error(err);
     throw err;
   });

--- a/src/generator/synth.ts
+++ b/src/generator/synth.ts
@@ -36,7 +36,9 @@ export interface SynthOptions {
   withPackageJson: boolean;
 }
 
-export async function synth(options: SynthOptions = {}) {
+export async function synth(
+  options: SynthOptions = {useCache: false, withPackageJson: false}
+) {
   const gen = new Generator();
   let changeSets: ChangeSet[] = [];
   if (!options.useCache) {

--- a/test/test.generator.ts
+++ b/test/test.generator.ts
@@ -30,7 +30,7 @@ describe(__filename, () => {
     const generator = new gen.Generator();
     const genStub = sandbox.stub(generator, 'generateAPI').resolves();
     const idxStub = sandbox.stub(generator, 'generateIndex').resolves();
-    await generator.generateAllAPIs('', true);
+    await generator.generateAllAPIs('', true, false);
     assert.ok(genStub.called);
     assert.ok(idxStub.calledOnce);
   });
@@ -48,7 +48,7 @@ describe(__filename, () => {
     const genStub = sandbox.stub(generator, 'generateAPI').resolves();
     const idxStub = sandbox.stub(generator, 'generateIndex').resolves();
     const discoUrl = 'https://www.googleapis.com/discovery/v1/apis/';
-    await generator.generateAllAPIs(discoUrl, false);
+    await generator.generateAllAPIs(discoUrl, false, false);
     assert.ok(genStub.called);
     assert.ok(idxStub.calledOnce);
     assert.ok(downloadCalled);


### PR DESCRIPTION
Now that we're releasing submodules, we should not overwrite their package.json with each run.