### PR TITLE
build: use existing library version

### DIFF
--- a/.github/workflows/release-submodules.yaml
+++ b/.github/workflows/release-submodules.yaml
@@ -2,7 +2,7 @@ on:
   push:
     branches:
       - master
-name: release-please-monorepo
+name: release-please-submodule
 jobs:
   changeFinder:
     runs-on: ubuntu-latest
@@ -58,7 +58,7 @@ jobs:
            monorepo-tags: true
            command: release-pr
       - id: label
-        if: ${{steps.release-please.outputs.pr}})
+        if: ${{steps.release-please.outputs.pr}}
         uses: actions/github-script@v3    
         with:
             github-token: ${{secrets.GITHUB_TOKEN}}

--- a/src/generator/generator.ts
+++ b/src/generator/generator.ts
@@ -230,7 +230,6 @@ export class Generator {
     const packageData = {name: file, desc, version: defaultVersion};
     // Use the version from the existing package.json, if possible:
     try {
-      // eslint-disable-next-line @typescript-eslint/no-var-requires
       const pkgRaw = await readFile(pkgPath, 'utf8');
       const pkg = JSON.parse(pkgRaw);
       packageData.version = pkg.version;

--- a/src/generator/generator.ts
+++ b/src/generator/generator.ts
@@ -44,6 +44,12 @@ export interface GeneratorOptions {
   includePrivate?: boolean;
 }
 
+interface PkgData {
+  name: string;
+  version: string;
+  desc: string;
+}
+
 export class Generator {
   private env: nunjucks.Environment;
   private options: GeneratorOptions;
@@ -185,9 +191,12 @@ export class Generator {
           const apiIndexData = {name: file, api: apis[file]};
           await this.render('api-index.njk', apiIndexData, apiIdxPath);
           // generate the package.json
-          const pkgPath = path.join(apisPath, file, 'package.json');
-          const packageData = {name: file, desc};
-          await this.render('package.json', packageData, pkgPath);
+          const [pkgPath, pkgData] = await this.getPkgPathAndData(
+            apisPath,
+            file,
+            desc || ''
+          );
+          await this.render('package.json', pkgData, pkgPath);
           // generate the README.md
           const rdPath = path.join(apisPath, file, 'README.md');
           const disclaimer = disclaimers.find(disclaimer => {
@@ -209,6 +218,30 @@ export class Generator {
     }
     await this.render('index.njk', {apis}, indexPath);
     await this.render('root-index.njk', {apis}, rootIndexPath);
+  }
+
+  async getPkgPathAndData(
+    apisPath: string,
+    file: string,
+    desc: string,
+    defaultVersion = '0.1.0'
+  ): Promise<[string, PkgData]> {
+    const pkgPath = path.join(apisPath, file, 'package.json');
+    const packageData = {name: file, desc, version: defaultVersion};
+    // Use the version from the existing package.json, if possible:
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
+      const pkgRaw = await readFile(pkgPath, 'utf8');
+      const pkg = JSON.parse(pkgRaw);
+      packageData.version = pkg.version;
+    } catch (err) {
+      if (err.code === 'ENOENT') {
+        console.info(`${pkgPath} not found`);
+      } else {
+        throw err;
+      }
+    }
+    return [pkgPath, packageData];
   }
 
   /**

--- a/src/generator/templates/package.json
+++ b/src/generator/templates/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@googleapis/{{name}}",
-  "version": "0.1.0",
+  "version": "{{version}}",
   "description": "{{name}}",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/test/test.generator.ts
+++ b/test/test.generator.ts
@@ -53,4 +53,31 @@ describe(__filename, () => {
     assert.ok(idxStub.calledOnce);
     assert.ok(downloadCalled);
   });
+
+  it('loads existing version from package.json', async () => {
+    const generator = new gen.Generator();
+    const [pkgPath, pkgData] = await generator.getPkgPathAndData(
+      'src/apis/',
+      'bigquery',
+      'look I am bigquery',
+      '1.2.3'
+    );
+    assert.strictEqual(pkgPath, 'src/apis/bigquery/package.json');
+    assert.strictEqual(pkgData.version, '0.1.0');
+    assert.strictEqual(pkgData.name, 'bigquery');
+    assert.strictEqual(pkgData.desc, 'look I am bigquery');
+  });
+
+  it('uses default version if no package.json found', async () => {
+    const generator = new gen.Generator();
+    const [pkgPath, pkgData] = await generator.getPkgPathAndData(
+      'src/apis/',
+      'fake-api',
+      'look I am fake'
+    );
+    assert.strictEqual(pkgPath, 'src/apis/fake-api/package.json');
+    assert.strictEqual(pkgData.version, '0.1.0');
+    assert.strictEqual(pkgData.name, 'fake-api');
+    assert.strictEqual(pkgData.desc, 'look I am fake');
+  });
 });

--- a/test/test.generator.ts
+++ b/test/test.generator.ts
@@ -62,7 +62,7 @@ describe(__filename, () => {
       'look I am bigquery',
       '1.2.3'
     );
-    assert.strictEqual(pkgPath, 'src/apis/bigquery/package.json');
+    assert.ok(pkgPath.endsWith('package.json'));
     assert.strictEqual(pkgData.version, '0.1.0');
     assert.strictEqual(pkgData.name, 'bigquery');
     assert.strictEqual(pkgData.desc, 'look I am bigquery');
@@ -75,7 +75,7 @@ describe(__filename, () => {
       'fake-api',
       'look I am fake'
     );
-    assert.strictEqual(pkgPath, 'src/apis/fake-api/package.json');
+    assert.ok(pkgPath.endsWith('package.json'));
     assert.strictEqual(pkgData.version, '0.1.0');
     assert.strictEqual(pkgData.name, 'fake-api');
     assert.strictEqual(pkgData.desc, 'look I am fake');


### PR DESCRIPTION
If possible, use the prior version from the package.json. New libraries will default to `0.1.0`.

Addresses https://github.com/googleapis/google-api-nodejs-client/pull/2479, which is a release due to the package.json reverting on the library.