### PR TITLE
build: fix spawn E2BIG in synth

### DIFF
--- a/src/generator/synth.ts
+++ b/src/generator/synth.ts
@@ -82,7 +82,11 @@ export async function synth(options: SynthOptions = {}) {
     if (statusFiles.filter(x => x.startsWith(`discovery/${dir}-`)).length > 0) {
       await execa('git', ['add', `discovery/${dir}-*`]);
     }
-    const commitParams = ['commit', '-m', title];
+    // Write commit message to file, since it might be large enough to
+    // cause spawn E2BIG in CI/CD:
+    const message = changelog ? `${title}\n\n${changelog}` : title;
+    fs.writeFileSync('message.txt', message, 'utf8');
+    const commitParams = ['commit', '-F', 'message.txt'];
     if (changelog) {
       commitParams.push('-m', changelog);
     }

--- a/src/generator/synth.ts
+++ b/src/generator/synth.ts
@@ -87,6 +87,7 @@ export async function synth(options: SynthOptions = {}) {
     const message = changelog ? `${title}\n\n${changelog}` : title;
     fs.writeFileSync('message.txt', message, 'utf8');
     const commitParams = ['commit', '-F', 'message.txt'];
+    fs.unlinkSync('message.txt');
     if (changelog) {
       commitParams.push('-m', changelog);
     }

--- a/src/generator/synth.ts
+++ b/src/generator/synth.ts
@@ -87,11 +87,8 @@ export async function synth(options: SynthOptions = {}) {
     const message = changelog ? `${title}\n\n${changelog}` : title;
     fs.writeFileSync('message.txt', message, 'utf8');
     const commitParams = ['commit', '-F', 'message.txt'];
-    fs.unlinkSync('message.txt');
-    if (changelog) {
-      commitParams.push('-m', changelog);
-    }
     await execa('git', commitParams);
+    fs.unlinkSync('message.txt');
   }
   await execa('git', ['add', '-A']);
   await execa('git', ['commit', '-m', 'feat: regenerate index files']);


### PR DESCRIPTION
Code generation is failing due to a huge commit message throwing:

```
spawn E2BIG
    at ChildProcess.spawn (internal/child_process.js:403:11)
    at Object.spawn (child_process.js:553:9)
    at execa (/home/kbuilder/.cache/synthtool/google-api-nodejs-client/node_modules/execa/index.js:80:26)
    at synth (/home/kbuilder/.cache/synthtool/google-api-nodejs-client/build/src/generator/synth.js:79:15)
    at processTicksAndRejections (internal/process/task_queues.js:93:5)
```

This code writes the message to disk, and provides it to git with the -F flag.