### PR TITLE
fix: add basic typescript sample and emit additional types

### DIFF
--- a/README.md
+++ b/README.md
@@ -544,7 +544,27 @@ This will return an object with the API name as object property names, and an ar
 This library is written in TypeScript, and provides types out of the box. All classes and interfaces generated for each API are exported under the `${apiName}_${version}` namespace. For example, the Drive v3 API types are all available from the `drive_v3` namespace:
 
 ```ts
-import { drive_v3 } from 'googleapis';
+import {
+  google,   // The top level object used to access services
+  drive_v3, // For every service client, there is an exported namespace
+  Auth,     // Namespace for auth related types
+} from 'googleapis';
+
+// Note: using explicit types like `Auth.GoogleAuth` are only here for
+// demonstration purposes.  Generally with TypeScript, these types would
+// be inferred.
+const auth: Auth.GoogleAuth = new google.auth.GoogleAuth();
+const drive: drive_v3.Drive = google.drive({
+  version: 'v3',
+  auth,
+});
+
+// There are generated types for every set of request parameters
+const listParams: drive_v3.Params$Resource$Files$List = {};
+const res = await drive.files.list(listParams);
+
+// There are generated types for the response fields as well
+const listResults: drive_v3.Schema$FileList = res.data;
 ```
 
 ### HTTP/2

--- a/README.md
+++ b/README.md
@@ -548,6 +548,7 @@ import {
   google,   // The top level object used to access services
   drive_v3, // For every service client, there is an exported namespace
   Auth,     // Namespace for auth related types
+  Common,   // General types used throughout the library
 } from 'googleapis';
 
 // Note: using explicit types like `Auth.GoogleAuth` are only here for

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
   ],
   "dependencies": {
     "google-auth-library": "^7.0.2",
-    "googleapis-common": "^5.0.1"
+    "googleapis-common": "^5.0.2"
   },
   "devDependencies": {
     "@compodoc/compodoc": "^1.1.10",

--- a/samples/package.json
+++ b/samples/package.json
@@ -11,6 +11,7 @@
     "!test/"
   ],
   "scripts": {
+    "prepare": "cd typescript && tsc && cd ..",
     "test": "mocha"
   },
   "dependencies": {
@@ -27,6 +28,7 @@
     "execa": "^5.0.0",
     "mocha": "^8.0.0",
     "nock": "^13.0.0",
-    "proxyquire": "^2.1.3"
+    "proxyquire": "^2.1.3",
+    "typescript": "~4.2.3"
   }
 }

--- a/samples/typescript/tsconfig.json
+++ b/samples/typescript/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "compilerOptions": {
+    "target": "es6",
+    "module": "commonjs",
+    "strict": true,
+    "outDir": "build"
+  }
+}

--- a/samples/typescript/typescript.ts
+++ b/samples/typescript/typescript.ts
@@ -1,4 +1,4 @@
-// Copyright 2014 Google LLC
+// Copyright 2021 Google LLC
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/samples/typescript/typescript.ts
+++ b/samples/typescript/typescript.ts
@@ -15,6 +15,7 @@ import {
   google, // The top level object used to access services
   drive_v3, // For every service client, there is an exported namespace
   Auth, // Namespace for auth related types
+  Common, // General types used throughout the library
 } from 'googleapis';
 
 async function main() {
@@ -27,12 +28,22 @@ async function main() {
     auth,
   });
 
-  // There are generated types for every set of request parameters
-  const listParams: drive_v3.Params$Resource$Files$List = {};
-  const res = await drive.files.list(listParams);
+  try {
+    // There are generated types for every set of request parameters
+    const listParams: drive_v3.Params$Resource$Files$List = {};
+    const res = await drive.files.list(listParams);
 
-  // There are generated types for the response fields as well
-  const listResults: drive_v3.Schema$FileList = res.data;
-  console.log(listResults);
+    // There are generated types for the response fields as well
+    const listResults: drive_v3.Schema$FileList = res.data;
+    console.log(listResults);
+  } catch (e) {
+    // In many cases, errors from the API will come back as `GaxiosError`.
+    // These will include the full HTTP Response (you should check for it first)
+    if (e.response) {
+      const err = e as Common.GaxiosError;
+      console.error(err.response);
+      throw err;
+    }
+  }
 }
 main();

--- a/samples/typescript/typescript.ts
+++ b/samples/typescript/typescript.ts
@@ -1,0 +1,38 @@
+// Copyright 2014 Google LLC
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {
+  google, // The top level object used to access services
+  drive_v3, // For every service client, there is an exported namespace
+  Auth, // Namespace for auth related types
+} from 'googleapis';
+
+async function main() {
+  // Note: using explicit types like `Auth.GoogleAuth` is only here for
+  // demonstration purposes.  Generally with TypeScript, these types would
+  // be inferred.
+  const auth: Auth.GoogleAuth = new google.auth.GoogleAuth();
+  const drive: drive_v3.Drive = google.drive({
+    version: 'v3',
+    auth,
+  });
+
+  // There are generated types for every set of request parameters
+  const listParams: drive_v3.Params$Resource$Files$List = {};
+  const res = await drive.files.list(listParams);
+
+  // There are generated types for the response fields as well
+  const listResults: drive_v3.Schema$FileList = res.data;
+  console.log(listResults);
+}
+main();


### PR DESCRIPTION
This pulls in the latest `googleapis-common`, which directly exports the `gaxios` types asked for in #2367.   It also uses this as a chance to improve the docs, and add a TypeScript specific sample which was asked for in #2453. 
 
Fixes #2453 
Fixes #2367

