### PR TITLE
fix!: stop ignoring YouTube, and re-generate with latest API

### DIFF
--- a/ignore.json
+++ b/ignore.json
@@ -1,6 +1,5 @@
 {
   "ignore": [
-    "apigee:v1",
-    "youtube:v3"
+    "apigee:v1"
   ]
 }

--- a/samples/test/test.samples.youtube.js
+++ b/samples/test/test.samples.youtube.js
@@ -45,7 +45,7 @@ describe('YouTube samples', () => {
   });
 
   it('should upload a video', async () => {
-    const scope = nock('https://www.googleapis.com')
+    const scope = nock('https://youtube.googleapis.com')
       .post(
         '/upload/youtube/v3/videos?part=id%2Csnippet%2Cstatus&notifySubscribers=false&uploadType=multipart'
       )

--- a/src/apis/youtube/v3.ts
+++ b/src/apis/youtube/v3.ts
@@ -23,6 +23,7 @@ import {
   JWT,
   Compute,
   UserRefreshClient,
+  BaseExternalAccountClient,
   GaxiosPromise,
   GoogleConfigurable,
   createAPIRequest,
@@ -50,6 +51,7 @@ export namespace youtube_v3 {
       | JWT
       | Compute
       | UserRefreshClient
+      | BaseExternalAccountClient
       | GoogleAuth;
 
     /**
@@ -104,17 +106,14 @@ export namespace youtube_v3 {
    * The YouTube Data API v3 is an API that provides access to YouTube data, such as videos, playlists, and channels.
    *
    * @example
+   * ```js
    * const {google} = require('googleapis');
    * const youtube = google.youtube('v3');
-   *
-   * @namespace youtube
-   * @type {Function}
-   * @version v3
-   * @variation v3
-   * @param {object=} options Options for Youtube
+   * ```
    */
   export class Youtube {
     context: APIRequestContext;
+    abuseReports: Resource$Abusereports;
     activities: Resource$Activities;
     captions: Resource$Captions;
     channelBanners: Resource$Channelbanners;
@@ -122,7 +121,6 @@ export namespace youtube_v3 {
     channelSections: Resource$Channelsections;
     comments: Resource$Comments;
     commentThreads: Resource$Commentthreads;
-    guideCategories: Resource$Guidecategories;
     i18nLanguages: Resource$I18nlanguages;
     i18nRegions: Resource$I18nregions;
     liveBroadcasts: Resource$Livebroadcasts;
@@ -135,9 +133,10 @@ export namespace youtube_v3 {
     playlistItems: Resource$Playlistitems;
     playlists: Resource$Playlists;
     search: Resource$Search;
-    sponsors: Resource$Sponsors;
     subscriptions: Resource$Subscriptions;
     superChatEvents: Resource$Superchatevents;
+    tests: Resource$Tests;
+    thirdPartyLinks: Resource$Thirdpartylinks;
     thumbnails: Resource$Thumbnails;
     videoAbuseReportReasons: Resource$Videoabusereportreasons;
     videoCategories: Resource$Videocategories;
@@ -150,6 +149,7 @@ export namespace youtube_v3 {
         google,
       };
 
+      this.abuseReports = new Resource$Abusereports(this.context);
       this.activities = new Resource$Activities(this.context);
       this.captions = new Resource$Captions(this.context);
       this.channelBanners = new Resource$Channelbanners(this.context);
@@ -157,7 +157,6 @@ export namespace youtube_v3 {
       this.channelSections = new Resource$Channelsections(this.context);
       this.comments = new Resource$Comments(this.context);
       this.commentThreads = new Resource$Commentthreads(this.context);
-      this.guideCategories = new Resource$Guidecategories(this.context);
       this.i18nLanguages = new Resource$I18nlanguages(this.context);
       this.i18nRegions = new Resource$I18nregions(this.context);
       this.liveBroadcasts = new Resource$Livebroadcasts(this.context);
@@ -170,9 +169,10 @@ export namespace youtube_v3 {
       this.playlistItems = new Resource$Playlistitems(this.context);
       this.playlists = new Resource$Playlists(this.context);
       this.search = new Resource$Search(this.context);
-      this.sponsors = new Resource$Sponsors(this.context);
       this.subscriptions = new Resource$Subscriptions(this.context);
       this.superChatEvents = new Resource$Superchatevents(this.context);
+      this.tests = new Resource$Tests(this.context);
+      this.thirdPartyLinks = new Resource$Thirdpartylinks(this.context);
       this.thumbnails = new Resource$Thumbnails(this.context);
       this.videoAbuseReportReasons = new Resource$Videoabusereportreasons(
         this.context
@@ -183,12 +183,21 @@ export namespace youtube_v3 {
     }
   }
 
+  export interface Schema$AbuseReport {
+    abuseTypes?: Schema$AbuseType[];
+    description?: string | null;
+    relatedEntities?: Schema$RelatedEntity[];
+    subject?: Schema$Entity;
+  }
+  export interface Schema$AbuseType {
+    id?: string | null;
+  }
   /**
    * Rights management policy for YouTube resources.
    */
   export interface Schema$AccessPolicy {
     /**
-     * The value of &lt;code&gt;allowed&lt;/code&gt; indicates whether the access to the policy is allowed or denied by default.
+     * The value of allowed indicates whether the access to the policy is allowed or denied by default.
      */
     allowed?: boolean | null;
     /**
@@ -197,11 +206,11 @@ export namespace youtube_v3 {
     exception?: string[] | null;
   }
   /**
-   * An &lt;code&gt;&lt;strong&gt;activity&lt;/strong&gt;&lt;/code&gt; resource contains information about an action that a particular channel, or user, has taken on YouTube.The actions reported in activity feeds include rating a video, sharing a video, marking a video as a favorite, commenting on a video, uploading a video, and so forth. Each &lt;code&gt;activity&lt;/code&gt; resource identifies the type of action, the channel associated with the action, and the resource(s) associated with the action, such as the video that was rated or uploaded.
+   * An *activity* resource contains information about an action that a particular channel, or user, has taken on YouTube.The actions reported in activity feeds include rating a video, sharing a video, marking a video as a favorite, commenting on a video, uploading a video, and so forth. Each activity resource identifies the type of action, the channel associated with the action, and the resource(s) associated with the action, such as the video that was rated or uploaded.
    */
   export interface Schema$Activity {
     /**
-     * The &lt;code&gt;contentDetails&lt;/code&gt; object contains information about the content associated with the activity. For example, if the &lt;code&gt;snippet.type&lt;/code&gt; value is &lt;code&gt;videoRated&lt;/code&gt;, then the &lt;code&gt;contentDetails&lt;/code&gt; object&#39;s content identifies the rated video.
+     * The contentDetails object contains information about the content associated with the activity. For example, if the snippet.type value is videoRated, then the contentDetails object's content identifies the rated video.
      */
     contentDetails?: Schema$ActivityContentDetails;
     /**
@@ -213,11 +222,11 @@ export namespace youtube_v3 {
      */
     id?: string | null;
     /**
-     * Identifies what kind of resource this is. Value: the fixed string &lt;code&gt;&quot;youtube#activity&quot;&lt;/code&gt;.
+     * Identifies what kind of resource this is. Value: the fixed string "youtube#activity".
      */
     kind?: string | null;
     /**
-     * The &lt;code&gt;snippet&lt;/code&gt; object contains basic details about the activity, including the activity&#39;s type and group ID.
+     * The snippet object contains basic details about the activity, including the activity's type and group ID.
      */
     snippet?: Schema$ActivitySnippet;
   }
@@ -226,47 +235,47 @@ export namespace youtube_v3 {
    */
   export interface Schema$ActivityContentDetails {
     /**
-     * The &lt;code&gt;bulletin&lt;/code&gt; object contains details about a channel bulletin post. This object is only present if the &lt;code&gt;snippet.type&lt;/code&gt; is &lt;code&gt;bulletin&lt;/code&gt;.
+     * The bulletin object contains details about a channel bulletin post. This object is only present if the snippet.type is bulletin.
      */
     bulletin?: Schema$ActivityContentDetailsBulletin;
     /**
-     * The &lt;code&gt;channelItem&lt;/code&gt; object contains details about a resource which was added to a channel. This property is only present if the &lt;code&gt;snippet.type&lt;/code&gt; is &lt;code&gt;channelItem&lt;/code&gt;.
+     * The channelItem object contains details about a resource which was added to a channel. This property is only present if the snippet.type is channelItem.
      */
     channelItem?: Schema$ActivityContentDetailsChannelItem;
     /**
-     * The &lt;code&gt;comment&lt;/code&gt; object contains information about a resource that received a comment. This property is only present if the &lt;code&gt;snippet.type&lt;/code&gt; is &lt;code&gt;comment&lt;/code&gt;.
+     * The comment object contains information about a resource that received a comment. This property is only present if the snippet.type is comment.
      */
     comment?: Schema$ActivityContentDetailsComment;
     /**
-     * The &lt;code&gt;favorite&lt;/code&gt; object contains information about a video that was marked as a favorite video. This property is only present if the &lt;code&gt;snippet.type&lt;/code&gt; is &lt;code&gt;favorite&lt;/code&gt;.
+     * The favorite object contains information about a video that was marked as a favorite video. This property is only present if the snippet.type is favorite.
      */
     favorite?: Schema$ActivityContentDetailsFavorite;
     /**
-     * The &lt;code&gt;like&lt;/code&gt; object contains information about a resource that received a positive (like) rating. This property is only present if the &lt;code&gt;snippet.type&lt;/code&gt; is &lt;code&gt;like&lt;/code&gt;.
+     * The like object contains information about a resource that received a positive (like) rating. This property is only present if the snippet.type is like.
      */
     like?: Schema$ActivityContentDetailsLike;
     /**
-     * The &lt;code&gt;playlistItem&lt;/code&gt; object contains information about a new playlist item. This property is only present if the &lt;code&gt;snippet.type&lt;/code&gt; is &lt;code&gt;playlistItem&lt;/code&gt;.
+     * The playlistItem object contains information about a new playlist item. This property is only present if the snippet.type is playlistItem.
      */
     playlistItem?: Schema$ActivityContentDetailsPlaylistItem;
     /**
-     * The &lt;code&gt;promotedItem&lt;/code&gt; object contains details about a resource which is being promoted. This property is only present if the &lt;code&gt;snippet.type&lt;/code&gt; is &lt;code&gt;promotedItem&lt;/code&gt;.
+     * The promotedItem object contains details about a resource which is being promoted. This property is only present if the snippet.type is promotedItem.
      */
     promotedItem?: Schema$ActivityContentDetailsPromotedItem;
     /**
-     * The &lt;code&gt;recommendation&lt;/code&gt; object contains information about a recommended resource. This property is only present if the &lt;code&gt;snippet.type&lt;/code&gt; is &lt;code&gt;recommendation&lt;/code&gt;.
+     * The recommendation object contains information about a recommended resource. This property is only present if the snippet.type is recommendation.
      */
     recommendation?: Schema$ActivityContentDetailsRecommendation;
     /**
-     * The &lt;code&gt;social&lt;/code&gt; object contains details about a social network post. This property is only present if the &lt;code&gt;snippet.type&lt;/code&gt; is &lt;code&gt;social&lt;/code&gt;.
+     * The social object contains details about a social network post. This property is only present if the snippet.type is social.
      */
     social?: Schema$ActivityContentDetailsSocial;
     /**
-     * The &lt;code&gt;subscription&lt;/code&gt; object contains information about a channel that a user subscribed to. This property is only present if the &lt;code&gt;snippet.type&lt;/code&gt; is &lt;code&gt;subscription&lt;/code&gt;.
+     * The subscription object contains information about a channel that a user subscribed to. This property is only present if the snippet.type is subscription.
      */
     subscription?: Schema$ActivityContentDetailsSubscription;
     /**
-     * The &lt;code&gt;upload&lt;/code&gt; object contains information about the uploaded video. This property is only present if the &lt;code&gt;snippet.type&lt;/code&gt; is &lt;code&gt;upload&lt;/code&gt;.
+     * The upload object contains information about the uploaded video. This property is only present if the snippet.type is upload.
      */
     upload?: Schema$ActivityContentDetailsUpload;
   }
@@ -275,7 +284,7 @@ export namespace youtube_v3 {
    */
   export interface Schema$ActivityContentDetailsBulletin {
     /**
-     * The &lt;code&gt;resourceId&lt;/code&gt; object contains information that identifies the resource associated with a bulletin post. @mutable youtube.activities.insert
+     * The resourceId object contains information that identifies the resource associated with a bulletin post. @mutable youtube.activities.insert
      */
     resourceId?: Schema$ResourceId;
   }
@@ -284,7 +293,7 @@ export namespace youtube_v3 {
    */
   export interface Schema$ActivityContentDetailsChannelItem {
     /**
-     * The &lt;code&gt;resourceId&lt;/code&gt; object contains information that identifies the resource that was added to the channel.
+     * The resourceId object contains information that identifies the resource that was added to the channel.
      */
     resourceId?: Schema$ResourceId;
   }
@@ -293,7 +302,7 @@ export namespace youtube_v3 {
    */
   export interface Schema$ActivityContentDetailsComment {
     /**
-     * The &lt;code&gt;resourceId&lt;/code&gt; object contains information that identifies the resource associated with the comment.
+     * The resourceId object contains information that identifies the resource associated with the comment.
      */
     resourceId?: Schema$ResourceId;
   }
@@ -302,7 +311,7 @@ export namespace youtube_v3 {
    */
   export interface Schema$ActivityContentDetailsFavorite {
     /**
-     * The &lt;code&gt;resourceId&lt;/code&gt; object contains information that identifies the resource that was marked as a favorite.
+     * The resourceId object contains information that identifies the resource that was marked as a favorite.
      */
     resourceId?: Schema$ResourceId;
   }
@@ -311,7 +320,7 @@ export namespace youtube_v3 {
    */
   export interface Schema$ActivityContentDetailsLike {
     /**
-     * The &lt;code&gt;resourceId&lt;/code&gt; object contains information that identifies the rated resource.
+     * The resourceId object contains information that identifies the rated resource.
      */
     resourceId?: Schema$ResourceId;
   }
@@ -328,7 +337,7 @@ export namespace youtube_v3 {
      */
     playlistItemId?: string | null;
     /**
-     * The &lt;code&gt;resourceId&lt;/code&gt; object contains information about the resource that was added to the playlist.
+     * The resourceId object contains information about the resource that was added to the playlist.
      */
     resourceId?: Schema$ResourceId;
   }
@@ -361,7 +370,7 @@ export namespace youtube_v3 {
      */
     descriptionText?: string | null;
     /**
-     * The URL the client should direct the user to, if the user chooses to visit the advertiser&#39;s website.
+     * The URL the client should direct the user to, if the user chooses to visit the advertiser's website.
      */
     destinationUrl?: string | null;
     /**
@@ -386,11 +395,11 @@ export namespace youtube_v3 {
      */
     reason?: string | null;
     /**
-     * The &lt;code&gt;resourceId&lt;/code&gt; object contains information that identifies the recommended resource.
+     * The resourceId object contains information that identifies the recommended resource.
      */
     resourceId?: Schema$ResourceId;
     /**
-     * The &lt;code&gt;seedResourceId&lt;/code&gt; object contains information about the resource that caused the recommendation.
+     * The seedResourceId object contains information about the resource that caused the recommendation.
      */
     seedResourceId?: Schema$ResourceId;
   }
@@ -403,7 +412,7 @@ export namespace youtube_v3 {
      */
     author?: string | null;
     /**
-     * An image of the post&#39;s author.
+     * An image of the post's author.
      */
     imageUrl?: string | null;
     /**
@@ -411,7 +420,7 @@ export namespace youtube_v3 {
      */
     referenceUrl?: string | null;
     /**
-     * The &lt;code&gt;resourceId&lt;/code&gt; object encapsulates information that identifies the resource associated with a social network post.
+     * The resourceId object encapsulates information that identifies the resource associated with a social network post.
      */
     resourceId?: Schema$ResourceId;
     /**
@@ -424,7 +433,7 @@ export namespace youtube_v3 {
    */
   export interface Schema$ActivityContentDetailsSubscription {
     /**
-     * The &lt;code&gt;resourceId&lt;/code&gt; object contains information that identifies the resource that the user subscribed to.
+     * The resourceId object contains information that identifies the resource that the user subscribed to.
      */
     resourceId?: Schema$ResourceId;
   }
@@ -448,11 +457,11 @@ export namespace youtube_v3 {
     eventId?: string | null;
     items?: Schema$Activity[];
     /**
-     * Identifies what kind of resource this is. Value: the fixed string &lt;code&gt;&quot;youtube#activityListResponse&quot;&lt;/code&gt;.
+     * Identifies what kind of resource this is. Value: the fixed string "youtube#activityListResponse".
      */
     kind?: string | null;
     /**
-     * The token that can be used as the value of the &lt;code&gt;pageToken&lt;/code&gt; parameter to retrieve the next page in the result set.
+     * The token that can be used as the value of the pageToken parameter to retrieve the next page in the result set.
      */
     nextPageToken?: string | null;
     /**
@@ -460,12 +469,12 @@ export namespace youtube_v3 {
      */
     pageInfo?: Schema$PageInfo;
     /**
-     * The token that can be used as the value of the &lt;code&gt;pageToken&lt;/code&gt; parameter to retrieve the previous page in the result set.
+     * The token that can be used as the value of the pageToken parameter to retrieve the previous page in the result set.
      */
     prevPageToken?: string | null;
     tokenPagination?: Schema$TokenPagination;
     /**
-     * The &lt;code&gt;visitorId&lt;/code&gt; identifies the visitor.
+     * The visitorId identifies the visitor.
      */
     visitorId?: string | null;
   }
@@ -486,11 +495,11 @@ export namespace youtube_v3 {
      */
     description?: string | null;
     /**
-     * The group ID associated with the activity. A group ID identifies user events that are associated with the same user and resource. For example, if a user rates a video and marks the same video as a favorite, the entries for those events would have the same group ID in the user&#39;s activity feed. In your user interface, you can avoid repetition by grouping events with the same &lt;code&gt;groupId&lt;/code&gt; value.
+     * The group ID associated with the activity. A group ID identifies user events that are associated with the same user and resource. For example, if a user rates a video and marks the same video as a favorite, the entries for those events would have the same group ID in the user's activity feed. In your user interface, you can avoid repetition by grouping events with the same groupId value.
      */
     groupId?: string | null;
     /**
-     * The date and time that the video was uploaded. The value is specified in &lt;a href=&quot;//www.w3.org/TR/NOTE-datetime&quot;&gt;ISO 8601&lt;/a&gt; format.
+     * The date and time that the video was uploaded.
      */
     publishedAt?: string | null;
     /**
@@ -507,7 +516,7 @@ export namespace youtube_v3 {
     type?: string | null;
   }
   /**
-   * A &lt;code&gt;&lt;strong&gt;caption&lt;/strong&gt;&lt;/code&gt; resource represents a YouTube caption track. A caption track is associated with exactly one YouTube video.
+   * A *caption* resource represents a YouTube caption track. A caption track is associated with exactly one YouTube video.
    */
   export interface Schema$Caption {
     /**
@@ -519,11 +528,11 @@ export namespace youtube_v3 {
      */
     id?: string | null;
     /**
-     * Identifies what kind of resource this is. Value: the fixed string &lt;code&gt;&quot;youtube#caption&quot;&lt;/code&gt;.
+     * Identifies what kind of resource this is. Value: the fixed string "youtube#caption".
      */
     kind?: string | null;
     /**
-     * The &lt;code&gt;snippet&lt;/code&gt; object contains basic details about the caption.
+     * The snippet object contains basic details about the caption.
      */
     snippet?: Schema$CaptionSnippet;
   }
@@ -541,11 +550,11 @@ export namespace youtube_v3 {
      */
     items?: Schema$Caption[];
     /**
-     * Identifies what kind of resource this is. Value: the fixed string &lt;code&gt;&quot;youtube#captionListResponse&quot;&lt;/code&gt;.
+     * Identifies what kind of resource this is. Value: the fixed string "youtube#captionListResponse".
      */
     kind?: string | null;
     /**
-     * The &lt;code&gt;visitorId&lt;/code&gt; identifies the visitor.
+     * The visitorId identifies the visitor.
      */
     visitorId?: string | null;
   }
@@ -558,35 +567,35 @@ export namespace youtube_v3 {
      */
     audioTrackType?: string | null;
     /**
-     * The reason that YouTube failed to process the caption track. This property is only present if the &lt;code&gt;&lt;a href=&quot;#state&quot;&gt;state&lt;/a&gt;&lt;/code&gt; property&#39;s value is &lt;code&gt;failed&lt;/code&gt;.
+     * The reason that YouTube failed to process the caption track. This property is only present if the state property's value is failed.
      */
     failureReason?: string | null;
     /**
-     * Indicates whether YouTube synchronized the caption track to the audio track in the video. The value will be &lt;code&gt;true&lt;/code&gt; if a sync was explicitly requested when the caption track was uploaded. For example, when calling the &lt;code&gt;captions.insert&lt;/code&gt; or &lt;code&gt;captions.update&lt;/code&gt; methods, you can set the &lt;code&gt;sync&lt;/code&gt; parameter to &lt;code&gt;true&lt;/code&gt; to instruct YouTube to sync the uploaded track to the video. If the value is &lt;code&gt;false&lt;/code&gt;, YouTube uses the time codes in the uploaded caption track to determine when to display captions.
+     * Indicates whether YouTube synchronized the caption track to the audio track in the video. The value will be true if a sync was explicitly requested when the caption track was uploaded. For example, when calling the captions.insert or captions.update methods, you can set the sync parameter to true to instruct YouTube to sync the uploaded track to the video. If the value is false, YouTube uses the time codes in the uploaded caption track to determine when to display captions.
      */
     isAutoSynced?: boolean | null;
     /**
-     * Indicates whether the track contains closed captions for the deaf and hard of hearing. The default value is &lt;code&gt;false&lt;/code&gt;.
+     * Indicates whether the track contains closed captions for the deaf and hard of hearing. The default value is false.
      */
     isCC?: boolean | null;
     /**
-     * Indicates whether the caption track is a draft. If the value is &lt;code&gt;true&lt;/code&gt;, then the track is not publicly visible. The default value is &lt;code&gt;false&lt;/code&gt;. @mutable youtube.captions.insert youtube.captions.update
+     * Indicates whether the caption track is a draft. If the value is true, then the track is not publicly visible. The default value is false. @mutable youtube.captions.insert youtube.captions.update
      */
     isDraft?: boolean | null;
     /**
-     * Indicates whether caption track is formatted for &quot;easy reader,&quot; meaning it is at a third-grade level for language learners. The default value is &lt;code&gt;false&lt;/code&gt;.
+     * Indicates whether caption track is formatted for "easy reader," meaning it is at a third-grade level for language learners. The default value is false.
      */
     isEasyReader?: boolean | null;
     /**
-     * Indicates whether the caption track uses large text for the vision-impaired. The default value is &lt;code&gt;false&lt;/code&gt;.
+     * Indicates whether the caption track uses large text for the vision-impaired. The default value is false.
      */
     isLarge?: boolean | null;
     /**
-     * The language of the caption track. The property value is a &lt;a href=&quot;http://www.rfc-editor.org/rfc/bcp/bcp47.txt&quot;&gt;BCP-47&lt;/a&gt;  language tag.
+     * The language of the caption track. The property value is a BCP-47 language tag.
      */
     language?: string | null;
     /**
-     * The date and time when the caption track was last updated. The value is specified in &lt;a href=&quot;//www.w3.org/TR/NOTE-datetime&quot;&gt;ISO 8601&lt;/a&gt; format.
+     * The date and time when the caption track was last updated.
      */
     lastUpdated?: string | null;
     /**
@@ -594,11 +603,11 @@ export namespace youtube_v3 {
      */
     name?: string | null;
     /**
-     * The caption track&#39;s status.
+     * The caption track's status.
      */
     status?: string | null;
     /**
-     * The caption track&#39;s type.
+     * The caption track's type.
      */
     trackKind?: string | null;
     /**
@@ -611,7 +620,7 @@ export namespace youtube_v3 {
    */
   export interface Schema$CdnSettings {
     /**
-     * The format of the video stream that you are sending to Youtube. &lt;br&gt;&lt;br&gt;
+     * The format of the video stream that you are sending to Youtube.
      */
     format?: string | null;
     /**
@@ -619,7 +628,7 @@ export namespace youtube_v3 {
      */
     frameRate?: string | null;
     /**
-     * The &lt;code&gt;ingestionInfo&lt;/code&gt; object contains information that YouTube provides that you need to transmit your RTMP or HTTP stream to YouTube.
+     * The ingestionInfo object contains information that YouTube provides that you need to transmit your RTMP or HTTP stream to YouTube.
      */
     ingestionInfo?: Schema$IngestionInfo;
     /**
@@ -632,27 +641,27 @@ export namespace youtube_v3 {
     resolution?: string | null;
   }
   /**
-   * A &lt;code&gt;&lt;strong&gt;channel&lt;/strong&gt;&lt;/code&gt; resource contains information about a YouTube channel.
+   * A *channel* resource contains information about a YouTube channel.
    */
   export interface Schema$Channel {
     /**
-     * The &lt;code&gt;auditionDetails&lt;/code&gt; object encapsulates channel data that is relevant for YouTube Partners during the audition process.
+     * The auditionDetails object encapsulates channel data that is relevant for YouTube Partners during the audition process.
      */
     auditDetails?: Schema$ChannelAuditDetails;
     /**
-     * The &lt;code&gt;brandingSettings&lt;/code&gt; object encapsulates information about the branding of the channel.
+     * The brandingSettings object encapsulates information about the branding of the channel.
      */
     brandingSettings?: Schema$ChannelBrandingSettings;
     /**
-     * The &lt;code&gt;contentDetails&lt;/code&gt; object encapsulates information about the channel&#39;s content.
+     * The contentDetails object encapsulates information about the channel's content.
      */
     contentDetails?: Schema$ChannelContentDetails;
     /**
-     * The &lt;code&gt;contentOwnerDetails&lt;/code&gt; object encapsulates channel data that is relevant for YouTube Partners linked with the channel.
+     * The contentOwnerDetails object encapsulates channel data that is relevant for YouTube Partners linked with the channel.
      */
     contentOwnerDetails?: Schema$ChannelContentOwnerDetails;
     /**
-     * The &lt;code&gt;conversionPings&lt;/code&gt; object encapsulates information about conversion pings that need to be respected by the channel.
+     * The conversionPings object encapsulates information about conversion pings that need to be respected by the channel.
      */
     conversionPings?: Schema$ChannelConversionPings;
     /**
@@ -664,11 +673,7 @@ export namespace youtube_v3 {
      */
     id?: string | null;
     /**
-     * The &lt;code&gt;invideoPromotion&lt;/code&gt; object encapsulates information about promotion campaign associated with the channel.
-     */
-    invideoPromotion?: Schema$InvideoPromotion;
-    /**
-     * Identifies what kind of resource this is. Value: the fixed string &lt;code&gt;&quot;youtube#channel&quot;&lt;/code&gt;.
+     * Identifies what kind of resource this is. Value: the fixed string "youtube#channel".
      */
     kind?: string | null;
     /**
@@ -676,24 +681,24 @@ export namespace youtube_v3 {
      */
     localizations?: {[key: string]: Schema$ChannelLocalization} | null;
     /**
-     * The &lt;code&gt;snippet&lt;/code&gt; object contains basic details about the channel, such as its title, description, and thumbnail images.
+     * The snippet object contains basic details about the channel, such as its title, description, and thumbnail images.
      */
     snippet?: Schema$ChannelSnippet;
     /**
-     * The &lt;code&gt;statistics&lt;/code&gt; object encapsulates statistics for the channel.
+     * The statistics object encapsulates statistics for the channel.
      */
     statistics?: Schema$ChannelStatistics;
     /**
-     * The &lt;code&gt;status&lt;/code&gt; object encapsulates information about the privacy status of the channel.
+     * The status object encapsulates information about the privacy status of the channel.
      */
     status?: Schema$ChannelStatus;
     /**
-     * The &lt;code&gt;topicDetails&lt;/code&gt; object encapsulates information about &lt;a href=&quot;http://www.freebase.com&quot;&gt;Freebase&lt;/a&gt; topics associated with the channel.
+     * The topicDetails object encapsulates information about Freebase topics associated with the channel.
      */
     topicDetails?: Schema$ChannelTopicDetails;
   }
   /**
-   * The &lt;code&gt;auditDetails&lt;/code&gt; object encapsulates channel data that is relevant for YouTube Partners during the audit process.
+   * The auditDetails object encapsulates channel data that is relevant for YouTube Partners during the audit process.
    */
   export interface Schema$ChannelAuditDetails {
     /**
@@ -715,7 +720,7 @@ export namespace youtube_v3 {
   export interface Schema$ChannelBannerResource {
     etag?: string | null;
     /**
-     * Identifies what kind of resource this is. Value: the fixed string &lt;code&gt;&quot;youtube#channelBannerResource&quot;&lt;/code&gt;.
+     * Identifies what kind of resource this is. Value: the fixed string "youtube#channelBannerResource".
      */
     kind?: string | null;
     /**
@@ -757,7 +762,7 @@ export namespace youtube_v3 {
     } | null;
   }
   /**
-   * The &lt;code&gt;contentOwnerDetails&lt;/code&gt; object encapsulates channel data that is relevant for YouTube Partners linked with the channel.
+   * The contentOwnerDetails object encapsulates channel data that is relevant for YouTube Partners linked with the channel.
    */
   export interface Schema$ChannelContentOwnerDetails {
     /**
@@ -765,7 +770,7 @@ export namespace youtube_v3 {
      */
     contentOwner?: string | null;
     /**
-     * The date and time of when the channel was linked to the content owner. The value is specified in &lt;a href=&quot;//www.w3.org/TR/NOTE-datetime&quot;&gt;ISO 8601&lt;/a&gt; format.
+     * The date and time when the channel was linked to the content owner.
      */
     timeLinked?: string | null;
   }
@@ -778,12 +783,12 @@ export namespace youtube_v3 {
      */
     context?: string | null;
     /**
-     * The url (without the schema) that the player shall send the ping to. It&#39;s at caller&#39;s descretion to decide which schema to use (http vs https) Example of a returned url: //googleads.g.doubleclick.net/pagead/ viewthroughconversion/962985656/?data=path%3DtHe_path%3Btype%3D cview%3Butuid%3DGISQtTNGYqaYl4sKxoVvKA&amp;labe=default The caller must append biscotti authentication (ms param in case of mobile, for example) to this ping.
+     * The url (without the schema) that the player shall send the ping to. It's at caller's descretion to decide which schema to use (http vs https) Example of a returned url: //googleads.g.doubleclick.net/pagead/ viewthroughconversion/962985656/?data=path%3DtHe_path%3Btype%3D cview%3Butuid%3DGISQtTNGYqaYl4sKxoVvKA&labe=default The caller must append biscotti authentication (ms param in case of mobile, for example) to this ping.
      */
     conversionUrl?: string | null;
   }
   /**
-   * The &lt;code&gt;conversionPings&lt;/code&gt; object encapsulates information about conversion pings that need to be respected by the channel.
+   * The conversionPings object encapsulates information about conversion pings that need to be respected by the channel.
    */
   export interface Schema$ChannelConversionPings {
     /**
@@ -802,11 +807,11 @@ export namespace youtube_v3 {
     eventId?: string | null;
     items?: Schema$Channel[];
     /**
-     * Identifies what kind of resource this is. Value: the fixed string &lt;code&gt;&quot;youtube#channelListResponse&quot;&lt;/code&gt;.
+     * Identifies what kind of resource this is. Value: the fixed string "youtube#channelListResponse".
      */
     kind?: string | null;
     /**
-     * The token that can be used as the value of the &lt;code&gt;pageToken&lt;/code&gt; parameter to retrieve the next page in the result set.
+     * The token that can be used as the value of the pageToken parameter to retrieve the next page in the result set.
      */
     nextPageToken?: string | null;
     /**
@@ -814,12 +819,12 @@ export namespace youtube_v3 {
      */
     pageInfo?: Schema$PageInfo;
     /**
-     * The token that can be used as the value of the &lt;code&gt;pageToken&lt;/code&gt; parameter to retrieve the previous page in the result set.
+     * The token that can be used as the value of the pageToken parameter to retrieve the previous page in the result set.
      */
     prevPageToken?: string | null;
     tokenPagination?: Schema$TokenPagination;
     /**
-     * The &lt;code&gt;visitorId&lt;/code&gt; identifies the visitor.
+     * The visitorId identifies the visitor.
      */
     visitorId?: string | null;
   }
@@ -828,11 +833,11 @@ export namespace youtube_v3 {
    */
   export interface Schema$ChannelLocalization {
     /**
-     * The localized strings for channel&#39;s description.
+     * The localized strings for channel's description.
      */
     description?: string | null;
     /**
-     * The localized strings for channel&#39;s title.
+     * The localized strings for channel's title.
      */
     title?: string | null;
   }
@@ -842,21 +847,21 @@ export namespace youtube_v3 {
      */
     channelId?: string | null;
     /**
-     * The channel&#39;s URL.
+     * The channel's URL.
      */
     channelUrl?: string | null;
     /**
-     * The channel&#39;s display name.
+     * The channel's display name.
      */
     displayName?: string | null;
     /**
-     * The channels&#39;s avatar URL.
+     * The channels's avatar URL.
      */
     profileImageUrl?: string | null;
   }
   export interface Schema$ChannelSection {
     /**
-     * The &lt;code&gt;contentDetails&lt;/code&gt; object contains details about the channel section content, such as a list of playlists or channels featured in the section.
+     * The contentDetails object contains details about the channel section content, such as a list of playlists or channels featured in the section.
      */
     contentDetails?: Schema$ChannelSectionContentDetails;
     /**
@@ -868,7 +873,7 @@ export namespace youtube_v3 {
      */
     id?: string | null;
     /**
-     * Identifies what kind of resource this is. Value: the fixed string &lt;code&gt;&quot;youtube#channelSection&quot;&lt;/code&gt;.
+     * Identifies what kind of resource this is. Value: the fixed string "youtube#channelSection".
      */
     kind?: string | null;
     /**
@@ -876,11 +881,11 @@ export namespace youtube_v3 {
      */
     localizations?: {[key: string]: Schema$ChannelSectionLocalization} | null;
     /**
-     * The &lt;code&gt;snippet&lt;/code&gt; object contains basic details about the channel section, such as its type, style and title.
+     * The snippet object contains basic details about the channel section, such as its type, style and title.
      */
     snippet?: Schema$ChannelSectionSnippet;
     /**
-     * The &lt;code&gt;targeting&lt;/code&gt; object contains basic targeting settings about the channel section.
+     * The targeting object contains basic targeting settings about the channel section.
      */
     targeting?: Schema$ChannelSectionTargeting;
   }
@@ -911,11 +916,11 @@ export namespace youtube_v3 {
      */
     items?: Schema$ChannelSection[];
     /**
-     * Identifies what kind of resource this is. Value: the fixed string &lt;code&gt;&quot;youtube#channelSectionListResponse&quot;&lt;/code&gt;.
+     * Identifies what kind of resource this is. Value: the fixed string "youtube#channelSectionListResponse".
      */
     kind?: string | null;
     /**
-     * The &lt;code&gt;visitorId&lt;/code&gt; identifies the visitor.
+     * The visitorId identifies the visitor.
      */
     visitorId?: string | null;
   }
@@ -924,7 +929,7 @@ export namespace youtube_v3 {
    */
   export interface Schema$ChannelSectionLocalization {
     /**
-     * The localized strings for channel section&#39;s title.
+     * The localized strings for channel section's title.
      */
     title?: string | null;
   }
@@ -937,7 +942,7 @@ export namespace youtube_v3 {
      */
     channelId?: string | null;
     /**
-     * The language of the channel section&#39;s default title and description.
+     * The language of the channel section's default title and description.
      */
     defaultLanguage?: string | null;
     /**
@@ -953,7 +958,7 @@ export namespace youtube_v3 {
      */
     style?: string | null;
     /**
-     * The channel section&#39;s title for multiple_playlists and multiple_channels.
+     * The channel section's title for multiple_playlists and multiple_channels.
      */
     title?: string | null;
     /**
@@ -1049,7 +1054,7 @@ export namespace youtube_v3 {
      */
     customUrl?: string | null;
     /**
-     * The language of the channel&#39;s default title and description.
+     * The language of the channel's default title and description.
      */
     defaultLanguage?: string | null;
     /**
@@ -1061,15 +1066,15 @@ export namespace youtube_v3 {
      */
     localized?: Schema$ChannelLocalization;
     /**
-     * The date and time that the channel was created. The value is specified in &lt; a href=&quot;//www.w3.org/TR/NOTE-datetime&quot;&gt;ISO 8601&lt;/a&gt; format.
+     * The date and time that the channel was created.
      */
     publishedAt?: string | null;
     /**
-     * A map of thumbnail images associated with the channel. For each object in the map, the key is the name of the thumbnail image, and the value is an object that contains other information about the thumbnail.&lt;br&gt;&lt;br&gt; When displaying thumbnails in your application, make sure that your code uses the image URLs exactly as they are returned in API responses. For example, your application should not use the &lt;code&gt;http&lt;/code&gt; domain instead of the &lt;code&gt;https&lt;/code&gt; domain in a URL returned in an API response.&lt;br&gt;&lt;br&gt; Beginning in July 2018, channel thumbnail URLs will only be available in the &lt;code&gt;https&lt;/code&gt; domain, which is how the URLs appear in API responses. After that time, you might see broken images in your application if it tries to load YouTube images from the &lt;code&gt;http&lt;/code&gt; domain.
+     * A map of thumbnail images associated with the channel. For each object in the map, the key is the name of the thumbnail image, and the value is an object that contains other information about the thumbnail. When displaying thumbnails in your application, make sure that your code uses the image URLs exactly as they are returned in API responses. For example, your application should not use the http domain instead of the https domain in a URL returned in an API response. Beginning in July 2018, channel thumbnail URLs will only be available in the https domain, which is how the URLs appear in API responses. After that time, you might see broken images in your application if it tries to load YouTube images from the http domain. Thumbnail images might be empty for newly created channels and might take up to one day to populate.
      */
     thumbnails?: Schema$ThumbnailDetails;
     /**
-     * The channel&#39;s title.
+     * The channel's title.
      */
     title?: string | null;
   }
@@ -1103,7 +1108,7 @@ export namespace youtube_v3 {
    */
   export interface Schema$ChannelStatus {
     /**
-     * If true, then the user is linked to either a YouTube username or G+ account. Otherwise, the user doesn&#39;t have a public YouTube identity.
+     * If true, then the user is linked to either a YouTube username or G+ account. Otherwise, the user doesn't have a public YouTube identity.
      */
     isLinked?: boolean | null;
     /**
@@ -1122,16 +1127,29 @@ export namespace youtube_v3 {
    */
   export interface Schema$ChannelTopicDetails {
     /**
-     * A list of Wikipedia URLs that describe the channel&#39;s content.
+     * A list of Wikipedia URLs that describe the channel's content.
      */
     topicCategories?: string[] | null;
     /**
-     * A list of Freebase topic IDs associated with the channel. You can retrieve information about each topic using the &lt;a href=&quot;http://wiki.freebase.com/wiki/Topic_API&quot;&gt;Freebase Topic API&lt;/a&gt;.
+     * A list of Freebase topic IDs associated with the channel. You can retrieve information about each topic using the Freebase Topic API.
      */
     topicIds?: string[] | null;
   }
   /**
-   * A &lt;code&gt;&lt;strong&gt;comment&lt;/strong&gt;&lt;/code&gt; represents a single YouTube comment.
+   * Information specific to a store on a merchandising platform linked to a YouTube channel.
+   */
+  export interface Schema$ChannelToStoreLinkDetails {
+    /**
+     * Name of the store.
+     */
+    storeName?: string | null;
+    /**
+     * Landing page of the store.
+     */
+    storeUrl?: string | null;
+  }
+  /**
+   * A *comment* represents a single YouTube comment.
    */
   export interface Schema$Comment {
     /**
@@ -1143,11 +1161,11 @@ export namespace youtube_v3 {
      */
     id?: string | null;
     /**
-     * Identifies what kind of resource this is. Value: the fixed string &lt;code&gt;&quot;youtube#comment&quot;&lt;/code&gt;.
+     * Identifies what kind of resource this is. Value: the fixed string "youtube#comment".
      */
     kind?: string | null;
     /**
-     * The &lt;code&gt;snippet&lt;/code&gt; object contains basic details about the comment.
+     * The snippet object contains basic details about the comment.
      */
     snippet?: Schema$CommentSnippet;
   }
@@ -1165,11 +1183,11 @@ export namespace youtube_v3 {
      */
     items?: Schema$Comment[];
     /**
-     * Identifies what kind of resource this is. Value: the fixed string &lt;code&gt;&quot;youtube#commentListResponse&quot;&lt;/code&gt;.
+     * Identifies what kind of resource this is. Value: the fixed string "youtube#commentListResponse".
      */
     kind?: string | null;
     /**
-     * The token that can be used as the value of the &lt;code&gt;pageToken&lt;/code&gt; parameter to retrieve the next page in the result set.
+     * The token that can be used as the value of the pageToken parameter to retrieve the next page in the result set.
      */
     nextPageToken?: string | null;
     /**
@@ -1178,7 +1196,7 @@ export namespace youtube_v3 {
     pageInfo?: Schema$PageInfo;
     tokenPagination?: Schema$TokenPagination;
     /**
-     * The &lt;code&gt;visitorId&lt;/code&gt; identifies the visitor.
+     * The visitorId identifies the visitor.
      */
     visitorId?: string | null;
   }
@@ -1188,7 +1206,7 @@ export namespace youtube_v3 {
   export interface Schema$CommentSnippet {
     authorChannelId?: Schema$CommentSnippetAuthorChannelId;
     /**
-     * Link to the author&#39;s YouTube channel, if any.
+     * Link to the author's YouTube channel, if any.
      */
     authorChannelUrl?: string | null;
     /**
@@ -1204,7 +1222,7 @@ export namespace youtube_v3 {
      */
     canRate?: boolean | null;
     /**
-     * The id of the corresponding YouTube channel. In case of a channel comment this is the channel the comment refers to. In case of a video comment it&#39;s the video&#39;s channel.
+     * The id of the corresponding YouTube channel. In case of a channel comment this is the channel the comment refers to. In case of a video comment it's the video's channel.
      */
     channelId?: string | null;
     /**
@@ -1212,7 +1230,7 @@ export namespace youtube_v3 {
      */
     likeCount?: number | null;
     /**
-     * The comment&#39;s moderation status. Will not be set if the comments were requested through the id filter.
+     * The comment's moderation status. Will not be set if the comments were requested through the id filter.
      */
     moderationStatus?: string | null;
     /**
@@ -1220,19 +1238,19 @@ export namespace youtube_v3 {
      */
     parentId?: string | null;
     /**
-     * The date and time when the comment was orignally published. The value is specified in &lt;a href=&quot;//www.w3.org/TR/NOTE-datetime&quot;&gt;ISO 8601&lt;/a&gt; format.
+     * The date and time when the comment was originally published.
      */
     publishedAt?: string | null;
     /**
-     * The comment&#39;s text. The format is either plain text or HTML dependent on what has been requested. Even the plain text representation may differ from the text originally posted in that it may replace video links with video titles etc.
+     * The comment's text. The format is either plain text or HTML dependent on what has been requested. Even the plain text representation may differ from the text originally posted in that it may replace video links with video titles etc.
      */
     textDisplay?: string | null;
     /**
-     * The comment&#39;s original raw text as initially posted or last updated. The original text will only be returned if it is accessible to the viewer, which is only guaranteed if the viewer is the comment&#39;s author.
+     * The comment's original raw text as initially posted or last updated. The original text will only be returned if it is accessible to the viewer, which is only guaranteed if the viewer is the comment's author.
      */
     textOriginal?: string | null;
     /**
-     * The date and time when was last updated . The value is specified in &lt;a href=&quot;//www.w3.org/TR/NOTE-datetime&quot;&gt;ISO 8601&lt;/a&gt; format.
+     * The date and time when the comment was last updated.
      */
     updatedAt?: string | null;
     /**
@@ -1245,13 +1263,13 @@ export namespace youtube_v3 {
     viewerRating?: string | null;
   }
   /**
-   * The id of the author&#39;s YouTube channel, if any.
+   * The id of the author's YouTube channel, if any.
    */
   export interface Schema$CommentSnippetAuthorChannelId {
     value?: string | null;
   }
   /**
-   * A &lt;code&gt;&lt;strong&gt;comment thread&lt;/strong&gt;&lt;/code&gt; represents information that applies to a top level comment and all its replies. It can also include the top level comment itself and some of the replies.
+   * A *comment thread* represents information that applies to a top level comment and all its replies. It can also include the top level comment itself and some of the replies.
    */
   export interface Schema$CommentThread {
     /**
@@ -1263,15 +1281,15 @@ export namespace youtube_v3 {
      */
     id?: string | null;
     /**
-     * Identifies what kind of resource this is. Value: the fixed string &lt;code&gt;&quot;youtube#commentThread&quot;&lt;/code&gt;.
+     * Identifies what kind of resource this is. Value: the fixed string "youtube#commentThread".
      */
     kind?: string | null;
     /**
-     * The &lt;code&gt;replies&lt;/code&gt; object contains a limited number of replies (if any) to the top level comment found in the snippet.
+     * The replies object contains a limited number of replies (if any) to the top level comment found in the snippet.
      */
     replies?: Schema$CommentThreadReplies;
     /**
-     * The &lt;code&gt;snippet&lt;/code&gt; object contains basic details about the comment thread and also the top level comment.
+     * The snippet object contains basic details about the comment thread and also the top level comment.
      */
     snippet?: Schema$CommentThreadSnippet;
   }
@@ -1289,11 +1307,11 @@ export namespace youtube_v3 {
      */
     items?: Schema$CommentThread[];
     /**
-     * Identifies what kind of resource this is. Value: the fixed string &lt;code&gt;&quot;youtube#commentThreadListResponse&quot;&lt;/code&gt;.
+     * Identifies what kind of resource this is. Value: the fixed string "youtube#commentThreadListResponse".
      */
     kind?: string | null;
     /**
-     * The token that can be used as the value of the &lt;code&gt;pageToken&lt;/code&gt; parameter to retrieve the next page in the result set.
+     * The token that can be used as the value of the pageToken parameter to retrieve the next page in the result set.
      */
     nextPageToken?: string | null;
     /**
@@ -1302,7 +1320,7 @@ export namespace youtube_v3 {
     pageInfo?: Schema$PageInfo;
     tokenPagination?: Schema$TokenPagination;
     /**
-     * The &lt;code&gt;visitorId&lt;/code&gt; identifies the visitor.
+     * The visitorId identifies the visitor.
      */
     visitorId?: string | null;
   }
@@ -1324,7 +1342,7 @@ export namespace youtube_v3 {
      */
     canReply?: boolean | null;
     /**
-     * The YouTube channel the comments in the thread refer to or the channel with the video the comments refer to. If video_id isn&#39;t set the comments refer to the channel itself.
+     * The YouTube channel the comments in the thread refer to or the channel with the video the comments refer to. If video_id isn't set the comments refer to the channel itself.
      */
     channelId?: string | null;
     /**
@@ -1349,63 +1367,63 @@ export namespace youtube_v3 {
    */
   export interface Schema$ContentRating {
     /**
-     * The video&#39;s Australian Classification Board (ACB) or Australian Communications and Media Authority (ACMA) rating. ACMA ratings are used to classify children&#39;s television programming.
+     * The video's Australian Classification Board (ACB) or Australian Communications and Media Authority (ACMA) rating. ACMA ratings are used to classify children's television programming.
      */
     acbRating?: string | null;
     /**
-     * The video&#39;s rating from Italy&#39;s Autorit&amp;agrave; per le Garanzie nelle Comunicazioni (AGCOM).
+     * The video's rating from Italy's Autorità per le Garanzie nelle Comunicazioni (AGCOM).
      */
     agcomRating?: string | null;
     /**
-     * The video&#39;s Anatel (Asociaci&amp;oacute;n Nacional de Televisi&amp;oacute;n) rating for Chilean television.
+     * The video's Anatel (Asociación Nacional de Televisión) rating for Chilean television.
      */
     anatelRating?: string | null;
     /**
-     * The video&#39;s British Board of Film Classification (BBFC) rating.
+     * The video's British Board of Film Classification (BBFC) rating.
      */
     bbfcRating?: string | null;
     /**
-     * The video&#39;s rating from Thailand&#39;s Board of Film and Video Censors.
+     * The video's rating from Thailand's Board of Film and Video Censors.
      */
     bfvcRating?: string | null;
     /**
-     * The video&#39;s rating from the Austrian Board of Media Classification (Bundesministerium f&amp;uuml;r Unterricht, Kunst und Kultur).
+     * The video's rating from the Austrian Board of Media Classification (Bundesministerium für Unterricht, Kunst und Kultur).
      */
     bmukkRating?: string | null;
     /**
-     * The video&#39;s rating from the Canadian Radio-Television and Telecommunications Commission (CRTC) for Canadian French-language broadcasts. For more information, see the &lt;a href=&quot;http://www.cbsc.ca/english/agvot/frenchsystem.php&quot;&gt;Canadian Broadcast Standards Council&lt;/a&gt; website.
+     * The video's rating from the Canadian Radio-Television and Telecommunications Commission (CRTC) for Canadian French-language broadcasts. For more information, see the Canadian Broadcast Standards Council website.
      */
     catvfrRating?: string | null;
     /**
-     * Rating system for Canadian TV - Canadian TV Classification System The video&#39;s rating from the Canadian Radio-Television and Telecommunications Commission (CRTC) for Canadian English-language broadcasts. For more information, see the &lt;a href=&quot;http://www.cbsc.ca/english/agvot/englishsystem.php&quot;&gt;Canadian Broadcast Standards Council&lt;/a&gt; website.
+     * Rating system for Canadian TV - Canadian TV Classification System The video's rating from the Canadian Radio-Television and Telecommunications Commission (CRTC) for Canadian English-language broadcasts. For more information, see the Canadian Broadcast Standards Council website.
      */
     catvRating?: string | null;
     /**
-     * The video&#39;s Central Board of Film Certification (CBFC - India) rating.
+     * The video's Central Board of Film Certification (CBFC - India) rating.
      */
     cbfcRating?: string | null;
     /**
-     * The video&#39;s Consejo de Calificaci&amp;oacute;n Cinematogr&amp;aacute;fica (Chile) rating.
+     * The video's Consejo de Calificación Cinematográfica (Chile) rating.
      */
     cccRating?: string | null;
     /**
-     * The video&#39;s rating from Portugal&#39;s Comiss&amp;atilde;o de Classifica&amp;ccedil;&amp;atilde;o de Espect&amp;acute;culos.
+     * The video's rating from Portugal's Comissão de Classificação de Espect´culos.
      */
     cceRating?: string | null;
     /**
-     * The video&#39;s rating in Switzerland.
+     * The video's rating in Switzerland.
      */
     chfilmRating?: string | null;
     /**
-     * The video&#39;s Canadian Home Video Rating System (CHVRS) rating.
+     * The video's Canadian Home Video Rating System (CHVRS) rating.
      */
     chvrsRating?: string | null;
     /**
-     * The video&#39;s rating from the Commission de Contr&amp;ocirc;le des Films (Belgium).
+     * The video's rating from the Commission de Contrôle des Films (Belgium).
      */
     cicfRating?: string | null;
     /**
-     * The video&#39;s rating from Romania&#39;s CONSILIUL NATIONAL AL AUDIOVIZUALULUI (CNA).
+     * The video's rating from Romania's CONSILIUL NATIONAL AL AUDIOVIZUALULUI (CNA).
      */
     cnaRating?: string | null;
     /**
@@ -1413,19 +1431,19 @@ export namespace youtube_v3 {
      */
     cncRating?: string | null;
     /**
-     * The video&#39;s rating from France&#39;s Conseil sup&amp;eacute;rieur de l’audiovisuel, which rates broadcast content.
+     * The video's rating from France's Conseil supérieur de l’audiovisuel, which rates broadcast content.
      */
     csaRating?: string | null;
     /**
-     * The video&#39;s rating from Luxembourg&#39;s Commission de surveillance de la classification des films (CSCF).
+     * The video's rating from Luxembourg's Commission de surveillance de la classification des films (CSCF).
      */
     cscfRating?: string | null;
     /**
-     * The video&#39;s rating in the Czech Republic.
+     * The video's rating in the Czech Republic.
      */
     czfilmRating?: string | null;
     /**
-     * The video&#39;s Departamento de Justi&amp;ccedil;a, Classifica&amp;ccedil;&amp;atilde;o, Qualifica&amp;ccedil;&amp;atilde;o e T&amp;iacute;tulos (DJCQT - Brazil) rating.
+     * The video's Departamento de Justiça, Classificação, Qualificação e Títulos (DJCQT - Brazil) rating.
      */
     djctqRating?: string | null;
     /**
@@ -1437,31 +1455,31 @@ export namespace youtube_v3 {
      */
     ecbmctRating?: string | null;
     /**
-     * The video&#39;s rating in Estonia.
+     * The video's rating in Estonia.
      */
     eefilmRating?: string | null;
     /**
-     * The video&#39;s rating in Egypt.
+     * The video's rating in Egypt.
      */
     egfilmRating?: string | null;
     /**
-     * The video&#39;s Eirin (&amp;#26144;&amp;#20523;) rating. Eirin is the Japanese rating system.
+     * The video's Eirin (映倫) rating. Eirin is the Japanese rating system.
      */
     eirinRating?: string | null;
     /**
-     * The video&#39;s rating from Malaysia&#39;s Film Censorship Board.
+     * The video's rating from Malaysia's Film Censorship Board.
      */
     fcbmRating?: string | null;
     /**
-     * The video&#39;s rating from Hong Kong&#39;s Office for Film, Newspaper and Article Administration.
+     * The video's rating from Hong Kong's Office for Film, Newspaper and Article Administration.
      */
     fcoRating?: string | null;
     /**
-     * &lt;span class=&quot;deprecated&quot;&gt;This property has been deprecated. Use the &lt;code&gt;&lt;a href=&quot;#contentDetails.contentRating.cncRating&quot;&gt;contentDetails.contentRating.cncRating&lt;/a&gt;&lt;/code&gt; instead.&lt;/span&gt;
+     * This property has been deprecated. Use the contentDetails.contentRating.cncRating instead.
      */
     fmocRating?: string | null;
     /**
-     * The video&#39;s rating from South Africa&#39;s Film and Publication Board.
+     * The video's rating from South Africa's Film and Publication Board.
      */
     fpbRating?: string | null;
     /**
@@ -1469,67 +1487,67 @@ export namespace youtube_v3 {
      */
     fpbRatingReasons?: string[] | null;
     /**
-     * The video&#39;s Freiwillige Selbstkontrolle der Filmwirtschaft (FSK - Germany) rating.
+     * The video's Freiwillige Selbstkontrolle der Filmwirtschaft (FSK - Germany) rating.
      */
     fskRating?: string | null;
     /**
-     * The video&#39;s rating in Greece.
+     * The video's rating in Greece.
      */
     grfilmRating?: string | null;
     /**
-     * The video&#39;s Instituto de la Cinematograf&amp;iacute;a y de las Artes Audiovisuales (ICAA - Spain) rating.
+     * The video's Instituto de la Cinematografía y de las Artes Audiovisuales (ICAA - Spain) rating.
      */
     icaaRating?: string | null;
     /**
-     * The video&#39;s Irish Film Classification Office (IFCO - Ireland) rating. See the &lt;a href=&quot;http://www.ifco.ie/website/ifco/ifcoweb.nsf/web/classcatintro&quot;&gt;IFCO&lt;/a&gt; website for more information.
+     * The video's Irish Film Classification Office (IFCO - Ireland) rating. See the IFCO website for more information.
      */
     ifcoRating?: string | null;
     /**
-     * The video&#39;s rating in Israel.
+     * The video's rating in Israel.
      */
     ilfilmRating?: string | null;
     /**
-     * The video&#39;s INCAA (Instituto Nacional de Cine y Artes Audiovisuales - Argentina) rating.
+     * The video's INCAA (Instituto Nacional de Cine y Artes Audiovisuales - Argentina) rating.
      */
     incaaRating?: string | null;
     /**
-     * The video&#39;s rating from the Kenya Film Classification Board.
+     * The video's rating from the Kenya Film Classification Board.
      */
     kfcbRating?: string | null;
     /**
-     * The video&#39;s NICAM/Kijkwijzer rating from the Nederlands Instituut voor de Classificatie van Audiovisuele Media (Netherlands).
+     * The video's NICAM/Kijkwijzer rating from the Nederlands Instituut voor de Classificatie van Audiovisuele Media (Netherlands).
      */
     kijkwijzerRating?: string | null;
     /**
-     * The video&#39;s Korea Media Rating Board (&amp;#50689;&amp;#49345;&amp;#47932;&amp;#46321;&amp;#44553;&amp;#50948;&amp;#50896;&amp;#54924;) rating. The KMRB rates videos in South Korea.
+     * The video's Korea Media Rating Board (영상물등급위원회) rating. The KMRB rates videos in South Korea.
      */
     kmrbRating?: string | null;
     /**
-     * The video&#39;s rating from Indonesia&#39;s Lembaga Sensor Film.
+     * The video's rating from Indonesia's Lembaga Sensor Film.
      */
     lsfRating?: string | null;
     /**
-     * The video&#39;s rating from Malta&#39;s Film Age-Classification Board.
+     * The video's rating from Malta's Film Age-Classification Board.
      */
     mccaaRating?: string | null;
     /**
-     * The video&#39;s rating from the Danish Film Institute&#39;s (Det Danske Filminstitut) Media Council for Children and Young People.
+     * The video's rating from the Danish Film Institute's (Det Danske Filminstitut) Media Council for Children and Young People.
      */
     mccypRating?: string | null;
     /**
-     * The video&#39;s rating system for Vietnam - MCST
+     * The video's rating system for Vietnam - MCST
      */
     mcstRating?: string | null;
     /**
-     * The video&#39;s rating from Singapore&#39;s Media Development Authority (MDA) and, specifically, it&#39;s Board of Film Censors (BFC).
+     * The video's rating from Singapore's Media Development Authority (MDA) and, specifically, it's Board of Film Censors (BFC).
      */
     mdaRating?: string | null;
     /**
-     * The video&#39;s rating from Medietilsynet, the Norwegian Media Authority.
+     * The video's rating from Medietilsynet, the Norwegian Media Authority.
      */
     medietilsynetRating?: string | null;
     /**
-     * The video&#39;s rating from Finland&#39;s Kansallinen Audiovisuaalinen Instituutti (National Audiovisual Institute).
+     * The video's rating from Finland's Kansallinen Audiovisuaalinen Instituutti (National Audiovisual Institute).
      */
     mekuRating?: string | null;
     /**
@@ -1537,47 +1555,47 @@ export namespace youtube_v3 {
      */
     menaMpaaRating?: string | null;
     /**
-     * The video&#39;s rating from the Ministero dei Beni e delle Attivit&amp;agrave; Culturali e del Turismo (Italy).
+     * The video's rating from the Ministero dei Beni e delle Attività Culturali e del Turismo (Italy).
      */
     mibacRating?: string | null;
     /**
-     * The video&#39;s Ministerio de Cultura (Colombia) rating.
+     * The video's Ministerio de Cultura (Colombia) rating.
      */
     mocRating?: string | null;
     /**
-     * The video&#39;s rating from Taiwan&#39;s Ministry of Culture (&amp;#25991;&amp;#21270;&amp;#37096;).
+     * The video's rating from Taiwan's Ministry of Culture (文化部).
      */
     moctwRating?: string | null;
     /**
-     * The video&#39;s Motion Picture Association of America (MPAA) rating.
+     * The video's Motion Picture Association of America (MPAA) rating.
      */
     mpaaRating?: string | null;
     /**
-     * The rating system for trailer, DVD, and Ad in the US.  See http://movielabs.com/md/ratings/v2.3/html/US_MPAAT_Ratings.html.
+     * The rating system for trailer, DVD, and Ad in the US. See http://movielabs.com/md/ratings/v2.3/html/US_MPAAT_Ratings.html.
      */
     mpaatRating?: string | null;
     /**
-     * The video&#39;s rating from the Movie and Television Review and Classification Board (Philippines).
+     * The video's rating from the Movie and Television Review and Classification Board (Philippines).
      */
     mtrcbRating?: string | null;
     /**
-     * The video&#39;s rating in Poland.
+     * The video's rating in Poland.
      */
     nbcplRating?: string | null;
     /**
-     * The video&#39;s rating from the Maldives National Bureau of Classification.
+     * The video's rating from the Maldives National Bureau of Classification.
      */
     nbcRating?: string | null;
     /**
-     * The video&#39;s rating from the &lt;a href=&quot;http://www.nfc.bg/&quot;&gt;Bulgarian National Film Center&lt;/a&gt;.
+     * The video's rating from the Bulgarian National Film Center.
      */
     nfrcRating?: string | null;
     /**
-     * The video&#39;s rating from Nigeria&#39;s National Film and Video Censors Board.
+     * The video's rating from Nigeria's National Film and Video Censors Board.
      */
     nfvcbRating?: string | null;
     /**
-     * The video&#39;s rating from the Nacion&amp;atilde;lais Kino centrs (National Film Centre of Latvia).
+     * The video's rating from the Nacionãlais Kino centrs (National Film Centre of Latvia).
      */
     nkclvRating?: string | null;
     /**
@@ -1585,53 +1603,58 @@ export namespace youtube_v3 {
      */
     nmcRating?: string | null;
     /**
-     * The video&#39;s Office of Film and Literature Classification (OFLC - New Zealand) rating.
+     * The video's Office of Film and Literature Classification (OFLC - New Zealand) rating.
      */
     oflcRating?: string | null;
     /**
-     * The video&#39;s rating in Peru.
+     * The video's rating in Peru.
      */
     pefilmRating?: string | null;
     /**
-     * The video&#39;s rating from the Hungarian Nemzeti Filmiroda, the Rating Committee of the National Office of Film.
+     * The video's rating from the Hungarian Nemzeti Filmiroda, the Rating Committee of the National Office of Film.
      */
     rcnofRating?: string | null;
     /**
-     * The video&#39;s rating in Venezuela.
+     * The video's rating in Venezuela.
      */
     resorteviolenciaRating?: string | null;
     /**
-     * The video&#39;s General Directorate of Radio, Television and Cinematography (Mexico) rating.
+     * The video's General Directorate of Radio, Television and Cinematography (Mexico) rating.
      */
     rtcRating?: string | null;
     /**
-     * The video&#39;s rating from Ireland&#39;s Raidi&amp;oacute; Teilif&amp;iacute;s &amp;Eacute;ireann.
+     * The video's rating from Ireland's Raidió Teilifís Éireann.
      */
     rteRating?: string | null;
     /**
-     * The video&#39;s National Film Registry of the Russian Federation (MKRF - Russia) rating.
+     * The video's National Film Registry of the Russian Federation (MKRF - Russia) rating.
      */
     russiaRating?: string | null;
     /**
-     * The video&#39;s rating in Slovakia.
+     * The video's rating in Slovakia.
      */
     skfilmRating?: string | null;
     /**
-     * The video&#39;s rating in Iceland.
+     * The video's rating in Iceland.
      */
     smaisRating?: string | null;
     /**
-     * The video&#39;s rating from Statens medier&amp;aring;d (Sweden&#39;s National Media Council).
+     * The video's rating from Statens medieråd (Sweden's National Media Council).
      */
     smsaRating?: string | null;
     /**
-     * The video&#39;s TV Parental Guidelines (TVPG) rating.
+     * The video's TV Parental Guidelines (TVPG) rating.
      */
     tvpgRating?: string | null;
     /**
      * A rating that YouTube uses to identify age-restricted content.
      */
     ytRating?: string | null;
+  }
+  export interface Schema$Entity {
+    id?: string | null;
+    typeId?: string | null;
+    url?: string | null;
   }
   /**
    * Geographical coordinates of a point, in WGS84.
@@ -1651,70 +1674,7 @@ export namespace youtube_v3 {
     longitude?: number | null;
   }
   /**
-   * A &lt;code&gt;&lt;strong&gt;guideCategory&lt;/strong&gt;&lt;/code&gt; resource identifies a category that YouTube algorithmically assigns based on a channel&#39;s content or other indicators, such as the channel&#39;s popularity. The list is similar to &lt;a href=\&quot;/youtube/v3/docs/videocategory.html\&quot;&gt;video categories&lt;/a&gt;, with the difference being that a video&#39;s uploader can assign a video category but only YouTube can assign a channel category.
-   */
-  export interface Schema$GuideCategory {
-    /**
-     * Etag of this resource.
-     */
-    etag?: string | null;
-    /**
-     * The ID that YouTube uses to uniquely identify the guide category.
-     */
-    id?: string | null;
-    /**
-     * Identifies what kind of resource this is. Value: the fixed string &lt;code&gt;&quot;youtube#guideCategory&quot;&lt;/code&gt;.
-     */
-    kind?: string | null;
-    /**
-     * The &lt;code&gt;snippet&lt;/code&gt; object contains basic details about the category, such as its title.
-     */
-    snippet?: Schema$GuideCategorySnippet;
-  }
-  export interface Schema$GuideCategoryListResponse {
-    /**
-     * Etag of this resource.
-     */
-    etag?: string | null;
-    /**
-     * Serialized EventId of the request which produced this response.
-     */
-    eventId?: string | null;
-    /**
-     * A list of categories that can be associated with YouTube channels. In this map, the category ID is the map key, and its value is the corresponding &lt;code&gt;guideCategory&lt;/code&gt; resource.
-     */
-    items?: Schema$GuideCategory[];
-    /**
-     * Identifies what kind of resource this is. Value: the fixed string &lt;code&gt;&quot;youtube#guideCategoryListResponse&quot;&lt;/code&gt;.
-     */
-    kind?: string | null;
-    /**
-     * The token that can be used as the value of the &lt;code&gt;pageToken&lt;/code&gt; parameter to retrieve the next page in the result set.
-     */
-    nextPageToken?: string | null;
-    pageInfo?: Schema$PageInfo;
-    /**
-     * The token that can be used as the value of the &lt;code&gt;pageToken&lt;/code&gt; parameter to retrieve the previous page in the result set.
-     */
-    prevPageToken?: string | null;
-    tokenPagination?: Schema$TokenPagination;
-    /**
-     * The &lt;code&gt;visitorId&lt;/code&gt; identifies the visitor.
-     */
-    visitorId?: string | null;
-  }
-  /**
-   * Basic details about a guide category.
-   */
-  export interface Schema$GuideCategorySnippet {
-    channelId?: string | null;
-    /**
-     * Description of the guide category.
-     */
-    title?: string | null;
-  }
-  /**
-   * An &lt;code&gt;&lt;strong&gt;i18nLanguage&lt;/strong&gt;&lt;/code&gt; resource identifies a UI language currently supported by YouTube.
+   * An *i18nLanguage* resource identifies a UI language currently supported by YouTube.
    */
   export interface Schema$I18nLanguage {
     /**
@@ -1726,11 +1686,11 @@ export namespace youtube_v3 {
      */
     id?: string | null;
     /**
-     * Identifies what kind of resource this is. Value: the fixed string &lt;code&gt;&quot;youtube#i18nLanguage&quot;&lt;/code&gt;.
+     * Identifies what kind of resource this is. Value: the fixed string "youtube#i18nLanguage".
      */
     kind?: string | null;
     /**
-     * The &lt;code&gt;snippet&lt;/code&gt; object contains basic details about the i18n language, such as language code and human-readable name.
+     * The snippet object contains basic details about the i18n language, such as language code and human-readable name.
      */
     snippet?: Schema$I18nLanguageSnippet;
   }
@@ -1744,15 +1704,15 @@ export namespace youtube_v3 {
      */
     eventId?: string | null;
     /**
-     * A list of supported i18n languages. In this map, the i18n language ID is the map key, and its value is the corresponding &lt;code&gt;i18nLanguage&lt;/code&gt; resource.
+     * A list of supported i18n languages. In this map, the i18n language ID is the map key, and its value is the corresponding i18nLanguage resource.
      */
     items?: Schema$I18nLanguage[];
     /**
-     * Identifies what kind of resource this is. Value: the fixed string &lt;code&gt;&quot;youtube#i18nLanguageListResponse&quot;&lt;/code&gt;.
+     * Identifies what kind of resource this is. Value: the fixed string "youtube#i18nLanguageListResponse".
      */
     kind?: string | null;
     /**
-     * The &lt;code&gt;visitorId&lt;/code&gt; identifies the visitor.
+     * The visitorId identifies the visitor.
      */
     visitorId?: string | null;
   }
@@ -1770,7 +1730,7 @@ export namespace youtube_v3 {
     name?: string | null;
   }
   /**
-   * A &lt;code&gt;&lt;strong&gt;i18nRegion&lt;/strong&gt;&lt;/code&gt; resource identifies a region where YouTube is available.
+   * A *i18nRegion* resource identifies a region where YouTube is available.
    */
   export interface Schema$I18nRegion {
     /**
@@ -1782,11 +1742,11 @@ export namespace youtube_v3 {
      */
     id?: string | null;
     /**
-     * Identifies what kind of resource this is. Value: the fixed string &lt;code&gt;&quot;youtube#i18nRegion&quot;&lt;/code&gt;.
+     * Identifies what kind of resource this is. Value: the fixed string "youtube#i18nRegion".
      */
     kind?: string | null;
     /**
-     * The &lt;code&gt;snippet&lt;/code&gt; object contains basic details about the i18n region, such as region code and human-readable name.
+     * The snippet object contains basic details about the i18n region, such as region code and human-readable name.
      */
     snippet?: Schema$I18nRegionSnippet;
   }
@@ -1800,15 +1760,15 @@ export namespace youtube_v3 {
      */
     eventId?: string | null;
     /**
-     * A list of regions where YouTube is available. In this map, the i18n region ID is the map key, and its value is the corresponding &lt;code&gt;i18nRegion&lt;/code&gt; resource.
+     * A list of regions where YouTube is available. In this map, the i18n region ID is the map key, and its value is the corresponding i18nRegion resource.
      */
     items?: Schema$I18nRegion[];
     /**
-     * Identifies what kind of resource this is. Value: the fixed string &lt;code&gt;&quot;youtube#i18nRegionListResponse&quot;&lt;/code&gt;.
+     * Identifies what kind of resource this is. Value: the fixed string "youtube#i18nRegionListResponse".
      */
     kind?: string | null;
     /**
-     * The &lt;code&gt;visitorId&lt;/code&gt; identifies the visitor.
+     * The visitorId identifies the visitor.
      */
     visitorId?: string | null;
   }
@@ -1834,7 +1794,7 @@ export namespace youtube_v3 {
      */
     backgroundImageUrl?: Schema$LocalizedProperty;
     /**
-     * This is used only in update requests; if it&#39;s set, we use this URL to generate all of the above banner URLs.
+     * This is generated when a ChannelBanner.Insert request has succeeded for the given channel.
      */
     bannerExternalUrl?: string | null;
     /**
@@ -1920,19 +1880,19 @@ export namespace youtube_v3 {
    */
   export interface Schema$IngestionInfo {
     /**
-     * The backup ingestion URL that you should use to stream video to YouTube. You have the option of simultaneously streaming the content that you are sending to the &lt;code&gt;ingestionAddress&lt;/code&gt; to this URL.
+     * The backup ingestion URL that you should use to stream video to YouTube. You have the option of simultaneously streaming the content that you are sending to the ingestionAddress to this URL.
      */
     backupIngestionAddress?: string | null;
     /**
-     * The primary ingestion URL that you should use to stream video to YouTube. You must stream video to this URL.&lt;br&gt;&lt;br&gt; Depending on which application or tool you use to encode your video stream, you may need to enter the stream URL and stream name separately or you may need to concatenate them in the following format:&lt;br&gt;&lt;pre&gt;&lt;strong&gt;STREAM_URL/STREAM_NAME&lt;/strong&gt;&lt;/pre&gt;
+     * The primary ingestion URL that you should use to stream video to YouTube. You must stream video to this URL. Depending on which application or tool you use to encode your video stream, you may need to enter the stream URL and stream name separately or you may need to concatenate them in the following format: *STREAM_URL/STREAM_NAME*
      */
     ingestionAddress?: string | null;
     /**
-     * This ingestion url may be used instead of &lt;code&gt;backupIngestionAddress&lt;/code&gt; in order to stream via RTMPS. Not applicable to non-RTMP streams.
+     * This ingestion url may be used instead of backupIngestionAddress in order to stream via RTMPS. Not applicable to non-RTMP streams.
      */
     rtmpsBackupIngestionAddress?: string | null;
     /**
-     * This ingestion url may be used instead of &lt;code&gt;ingestionAddress&lt;/code&gt; in order to stream via RTMPS. Not applicable to non-RTMP streams.
+     * This ingestion url may be used instead of ingestionAddress in order to stream via RTMPS. Not applicable to non-RTMP streams.
      */
     rtmpsIngestionAddress?: string | null;
     /**
@@ -1979,27 +1939,6 @@ export namespace youtube_v3 {
     type?: string | null;
   }
   /**
-   * Describes an invideo promotion campaign consisting of multiple promoted items. A campaign belongs to a single channel_id.
-   */
-  export interface Schema$InvideoPromotion {
-    /**
-     * The default temporal position within the video where the promoted item will be displayed. Can be overridden by more specific timing in the item.
-     */
-    defaultTiming?: Schema$InvideoTiming;
-    /**
-     * List of promoted items in decreasing priority.
-     */
-    items?: Schema$PromotedItem[];
-    /**
-     * The spatial position within the video where the promoted item will be displayed.
-     */
-    position?: Schema$InvideoPosition;
-    /**
-     * Indicates whether the channel&#39;s promotional campaign uses &quot;smart timing.&quot; This feature attempts to show promotions at a point in the video when they are more likely to be clicked and less likely to disrupt the viewing experience. This feature also picks up a single promotion to show on each video.
-     */
-    useSmartTiming?: boolean | null;
-  }
-  /**
    * Describes a temporal position of a visual widget inside a video.
    */
   export interface Schema$InvideoTiming {
@@ -2008,11 +1947,11 @@ export namespace youtube_v3 {
      */
     durationMs?: string | null;
     /**
-     * Defines the time at which the promotion will appear. Depending on the value of &lt;code&gt;type&lt;/code&gt; the value of the &lt;code&gt;offsetMs&lt;/code&gt; field will represent a time offset from the start or from the end of the video, expressed in milliseconds.
+     * Defines the time at which the promotion will appear. Depending on the value of type the value of the offsetMs field will represent a time offset from the start or from the end of the video, expressed in milliseconds.
      */
     offsetMs?: string | null;
     /**
-     * Describes a timing type. If the value is &lt;code&gt;offsetFromStart&lt;/code&gt;, then the &lt;code&gt;offsetMs&lt;/code&gt; field represents an offset from the start of the video. If the value is &lt;code&gt;offsetFromEnd&lt;/code&gt;, then the &lt;code&gt;offsetMs&lt;/code&gt; field represents an offset from the end of the video.
+     * Describes a timing type. If the value is offsetFromStart, then the offsetMs field represents an offset from the start of the video. If the value is offsetFromEnd, then the offsetMs field represents an offset from the end of the video.
      */
     type?: string | null;
   }
@@ -2026,11 +1965,11 @@ export namespace youtube_v3 {
     displayName?: string | null;
   }
   /**
-   * A &lt;code&gt;&lt;strong&gt;liveBroadcast&lt;/strong&gt;&lt;/code&gt; resource represents an event that will be streamed, via live video, on YouTube.
+   * A *liveBroadcast* resource represents an event that will be streamed, via live video, on YouTube.
    */
   export interface Schema$LiveBroadcast {
     /**
-     * The &lt;code&gt;contentDetails&lt;/code&gt; object contains information about the event&#39;s video content, such as whether the content can be shown in an embedded video player or if it will be archived and therefore available for viewing after the event has concluded.
+     * The contentDetails object contains information about the event's video content, such as whether the content can be shown in an embedded video player or if it will be archived and therefore available for viewing after the event has concluded.
      */
     contentDetails?: Schema$LiveBroadcastContentDetails;
     /**
@@ -2042,19 +1981,19 @@ export namespace youtube_v3 {
      */
     id?: string | null;
     /**
-     * Identifies what kind of resource this is. Value: the fixed string &lt;code&gt;&quot;youtube#liveBroadcast&quot;&lt;/code&gt;.
+     * Identifies what kind of resource this is. Value: the fixed string "youtube#liveBroadcast".
      */
     kind?: string | null;
     /**
-     * The &lt;code&gt;snippet&lt;/code&gt; object contains basic details about the event, including its title, description, start time, and end time.
+     * The snippet object contains basic details about the event, including its title, description, start time, and end time.
      */
     snippet?: Schema$LiveBroadcastSnippet;
     /**
-     * The &lt;code&gt;statistics&lt;/code&gt; object contains info about the event&#39;s current stats. These include concurrent viewers and total chat count. Statistics can change (in either direction) during the lifetime of an event. Statistics are only returned while the event is live.
+     * The statistics object contains info about the event's current stats. These include concurrent viewers and total chat count. Statistics can change (in either direction) during the lifetime of an event. Statistics are only returned while the event is live.
      */
     statistics?: Schema$LiveBroadcastStatistics;
     /**
-     * The &lt;code&gt;status&lt;/code&gt; object contains information about the event&#39;s status.
+     * The status object contains information about the event's status.
      */
     status?: Schema$LiveBroadcastStatus;
   }
@@ -2063,24 +2002,24 @@ export namespace youtube_v3 {
    */
   export interface Schema$LiveBroadcastContentDetails {
     /**
-     * This value uniquely identifies the &lt;code&gt;&lt;a href=&quot;/youtube/v3/live/docs/liveStreams&quot;&gt;live stream&lt;/a&gt;&lt;/code&gt; bound to the broadcast.
+     * This value uniquely identifies the live stream bound to the broadcast.
      */
     boundStreamId?: string | null;
     /**
-     * The date and time that the live stream referenced by &lt;code&gt;boundStreamId&lt;/code&gt; was last updated.
+     * The date and time that the live stream referenced by boundStreamId was last updated.
      */
     boundStreamLastUpdateTimeMs?: string | null;
     closedCaptionsType?: string | null;
     /**
-     * This setting indicates whether auto start is enabled for this broadcast.  The default value for this property is &lt;code&gt;false&lt;/code&gt;.&lt;br&gt;&lt;br&gt;  This setting can only be used by Events.
+     * This setting indicates whether auto start is enabled for this broadcast. The default value for this property is false. This setting can only be used by Events.
      */
     enableAutoStart?: boolean | null;
     /**
-     * This setting indicates whether auto stop is enabled for this broadcast. The default value for this property is &lt;code&gt;false&lt;/code&gt;.&lt;br&gt;&lt;br&gt; This setting can only be used by Events.
+     * This setting indicates whether auto stop is enabled for this broadcast. The default value for this property is false. This setting can only be used by Events.
      */
     enableAutoStop?: boolean | null;
     /**
-     * This setting indicates whether HTTP POST closed captioning is enabled for this broadcast. The ingestion URL of the closed captions is returned through the liveStreams API.  This is mutually exclusive with using the &lt;code&gt;closed_captions_type&lt;/code&gt; property, and is equivalent to setting &lt;code&gt;closed_captions_type&lt;/code&gt; to CLOSED_CAPTIONS_HTTP_POST.
+     * This setting indicates whether HTTP POST closed captioning is enabled for this broadcast. The ingestion URL of the closed captions is returned through the liveStreams API. This is mutually exclusive with using the closed_captions_type property, and is equivalent to setting closed_captions_type to CLOSED_CAPTIONS_HTTP_POST.
      */
     enableClosedCaptions?: boolean | null;
     /**
@@ -2088,11 +2027,11 @@ export namespace youtube_v3 {
      */
     enableContentEncryption?: boolean | null;
     /**
-     * This setting determines whether viewers can access DVR controls while watching the video. DVR controls enable the viewer to control the video playback experience by pausing, rewinding, or fast forwarding content. The default value for this property is &lt;code&gt;true&lt;/code&gt;.&lt;br&gt;&lt;br&gt;  &lt;strong&gt;Important:&lt;/strong&gt; You must set the value to &lt;code&gt;true&lt;/code&gt; and also set the &lt;code&gt;enableArchive&lt;/code&gt; property&#39;s value to &lt;code&gt;true&lt;/code&gt; if you want to make playback available immediately after the broadcast ends.
+     * This setting determines whether viewers can access DVR controls while watching the video. DVR controls enable the viewer to control the video playback experience by pausing, rewinding, or fast forwarding content. The default value for this property is true. *Important:* You must set the value to true and also set the enableArchive property's value to true if you want to make playback available immediately after the broadcast ends.
      */
     enableDvr?: boolean | null;
     /**
-     * This setting indicates whether the broadcast video can be played in an embedded player. If you choose to archive the video (using the &lt;code&gt;enableArchive&lt;/code&gt; property), this setting will also apply to the archived video.
+     * This setting indicates whether the broadcast video can be played in an embedded player. If you choose to archive the video (using the enableArchive property), this setting will also apply to the archived video.
      */
     enableEmbed?: boolean | null;
     /**
@@ -2104,25 +2043,29 @@ export namespace youtube_v3 {
      */
     latencyPreference?: string | null;
     /**
-     * The mesh for projecting the video if &lt;code&gt;projection&lt;/code&gt; is &lt;code&gt;mesh&lt;/code&gt;. The mesh value must be a UTF-8 string containing the base-64 encoding of 3D mesh data that follows the &lt;a href=&quot;https://github.com/google/spatial-media/blob/master/docs/spherical-video-v2-rfc.md&quot;&gt; Spherical Video V2 RFC specification&lt;/a&gt; for an mshp box, excluding the box size and type but including the following four reserved zero bytes for the version and flags.
+     * The mesh for projecting the video if projection is mesh. The mesh value must be a UTF-8 string containing the base-64 encoding of 3D mesh data that follows the Spherical Video V2 RFC specification for an mshp box, excluding the box size and type but including the following four reserved zero bytes for the version and flags.
      */
     mesh?: string | null;
     /**
-     * The &lt;code&gt;monitorStream&lt;/code&gt; object contains information about the monitor stream, which the broadcaster can use to review the event content before the broadcast stream is shown publicly.
+     * The monitorStream object contains information about the monitor stream, which the broadcaster can use to review the event content before the broadcast stream is shown publicly.
      */
     monitorStream?: Schema$MonitorStreamInfo;
     /**
-     * The projection format of this broadcast. This defaults to &lt;code&gt;rectangular&lt;/code&gt;.
+     * The projection format of this broadcast. This defaults to rectangular.
      */
     projection?: string | null;
     /**
-     * Automatically start recording after the event goes live. The default value for this property is &lt;code&gt;true&lt;/code&gt;.&lt;br&gt;&lt;br&gt;  &lt;strong&gt;Important:&lt;/strong&gt; You must also set the &lt;code&gt;enableDvr&lt;/code&gt; property&#39;s value to &lt;code&gt;true&lt;/code&gt; if you want the playback to be available immediately after the broadcast ends. If you set this property&#39;s value to &lt;code&gt;true&lt;/code&gt; but do not also set the &lt;code&gt;enableDvr&lt;/code&gt; property to &lt;code&gt;true&lt;/code&gt;, there may be a delay of around one day before the archived video will be available for playback.
+     * Automatically start recording after the event goes live. The default value for this property is true. *Important:* You must also set the enableDvr property's value to true if you want the playback to be available immediately after the broadcast ends. If you set this property's value to true but do not also set the enableDvr property to true, there may be a delay of around one day before the archived video will be available for playback.
      */
     recordFromStart?: boolean | null;
     /**
-     * This setting indicates whether the broadcast should automatically begin with an &lt;a href=&quot;/youtube/v3/live/getting-started#Displaying_Slates&quot;&gt;in-stream slate&lt;/a&gt; when you update the broadcast&#39;s status to &lt;code&gt;live&lt;/code&gt;. After updating the status, you then need to send a &lt;code&gt;&lt;a href=&quot;/youtube/v3/live/docs/liveCuepoints/insert&quot;&gt;liveCuepoints.insert&lt;/a&gt;&lt;/code&gt; request that sets the cuepoint&#39;s &lt;code&gt;eventState&lt;/code&gt; to &lt;code&gt;end&lt;/code&gt; to remove the in-stream slate and make your broadcast stream visible to viewers.
+     * This setting indicates whether the broadcast should automatically begin with an in-stream slate when you update the broadcast's status to live. After updating the status, you then need to send a liveCuepoints.insert request that sets the cuepoint's eventState to end to remove the in-stream slate and make your broadcast stream visible to viewers.
      */
     startWithSlate?: boolean | null;
+    /**
+     * The 3D stereo layout of this broadcast. This defaults to mono.
+     */
+    stereoLayout?: string | null;
   }
   export interface Schema$LiveBroadcastListResponse {
     /**
@@ -2138,11 +2081,11 @@ export namespace youtube_v3 {
      */
     items?: Schema$LiveBroadcast[];
     /**
-     * Identifies what kind of resource this is. Value: the fixed string &lt;code&gt;&quot;youtube#liveBroadcastListResponse&quot;&lt;/code&gt;.
+     * Identifies what kind of resource this is. Value: the fixed string "youtube#liveBroadcastListResponse".
      */
     kind?: string | null;
     /**
-     * The token that can be used as the value of the &lt;code&gt;pageToken&lt;/code&gt; parameter to retrieve the next page in the result set.
+     * The token that can be used as the value of the pageToken parameter to retrieve the next page in the result set.
      */
     nextPageToken?: string | null;
     /**
@@ -2150,12 +2093,12 @@ export namespace youtube_v3 {
      */
     pageInfo?: Schema$PageInfo;
     /**
-     * The token that can be used as the value of the &lt;code&gt;pageToken&lt;/code&gt; parameter to retrieve the previous page in the result set.
+     * The token that can be used as the value of the pageToken parameter to retrieve the previous page in the result set.
      */
     prevPageToken?: string | null;
     tokenPagination?: Schema$TokenPagination;
     /**
-     * The &lt;code&gt;visitorId&lt;/code&gt; identifies the visitor.
+     * The visitorId identifies the visitor.
      */
     visitorId?: string | null;
   }
@@ -2164,11 +2107,11 @@ export namespace youtube_v3 {
    */
   export interface Schema$LiveBroadcastSnippet {
     /**
-     * The date and time that the broadcast actually ended. This information is only available once the broadcast&#39;s state is &lt;code&gt;complete&lt;/code&gt;. The value is specified in &lt;a href=&quot;//www.w3.org/TR/NOTE-datetime&quot;&gt;ISO 8601&lt;/a&gt; format.
+     * The date and time that the broadcast actually ended. This information is only available once the broadcast's state is complete.
      */
     actualEndTime?: string | null;
     /**
-     * The date and time that the broadcast actually started. This information is only available once the broadcast&#39;s state is &lt;code&gt;live&lt;/code&gt;. The value is specified in &lt;a href=&quot;//www.w3.org/TR/NOTE-datetime&quot;&gt;ISO 8601&lt;/a&gt; format.
+     * The date and time that the broadcast actually started. This information is only available once the broadcast's state is live.
      */
     actualStartTime?: string | null;
     /**
@@ -2176,7 +2119,7 @@ export namespace youtube_v3 {
      */
     channelId?: string | null;
     /**
-     * The broadcast&#39;s description. As with the &lt;code&gt;title&lt;/code&gt;, you can set this field by modifying the broadcast resource or by setting the &lt;code&gt;&lt;a href=&quot;/youtube/v3/docs/videos#snippet.description&quot;&gt;description&lt;/a&gt;&lt;/code&gt; field of the corresponding video resource.
+     * The broadcast's description. As with the title, you can set this field by modifying the broadcast resource or by setting the description field of the corresponding video resource.
      */
     description?: string | null;
     /**
@@ -2188,15 +2131,15 @@ export namespace youtube_v3 {
      */
     liveChatId?: string | null;
     /**
-     * The date and time that the broadcast was added to YouTube&#39;s live broadcast schedule. The value is specified in &lt;a href=&quot;//www.w3.org/TR/NOTE-datetime&quot;&gt;ISO 8601&lt;/a&gt; format.
+     * The date and time that the broadcast was added to YouTube's live broadcast schedule.
      */
     publishedAt?: string | null;
     /**
-     * The date and time that the broadcast is scheduled to end. The value is specified in &lt;a href=&quot;//www.w3.org/TR/NOTE-datetime&quot;&gt;ISO 8601&lt;/a&gt; format.
+     * The date and time that the broadcast is scheduled to start.
      */
     scheduledEndTime?: string | null;
     /**
-     * The date and time that the broadcast is scheduled to start. The value is specified in &lt;a href=&quot;//www.w3.org/TR/NOTE-datetime&quot;&gt;ISO 8601&lt;/a&gt; format.
+     * The date and time that the broadcast is scheduled to end.
      */
     scheduledStartTime?: string | null;
     /**
@@ -2204,7 +2147,7 @@ export namespace youtube_v3 {
      */
     thumbnails?: Schema$ThumbnailDetails;
     /**
-     * The broadcast&#39;s title. Note that the broadcast represents exactly one YouTube video. You can set this field by modifying the broadcast resource or by setting the &lt;code&gt;&lt;a href=&quot;/youtube/v3/docs/videos#snippet.title&quot;&gt;title&lt;/a&gt;&lt;/code&gt; field of the corresponding video resource.
+     * The broadcast's title. Note that the broadcast represents exactly one YouTube video. You can set this field by modifying the broadcast resource or by setting the title field of the corresponding video resource.
      */
     title?: string | null;
   }
@@ -2222,7 +2165,7 @@ export namespace youtube_v3 {
    */
   export interface Schema$LiveBroadcastStatus {
     /**
-     * The broadcast&#39;s status. The status can be updated using the API&#39;s &lt;code&gt;&lt;a href=&quot;/youtube/v3/live/docs/liveBroadcasts/transition&quot; &gt;liveBroadcasts.transition&lt;/a&gt;&lt;/code&gt; method.
+     * The broadcast's status. The status can be updated using the API's liveBroadcasts.transition method.
      */
     lifeCycleStatus?: string | null;
     /**
@@ -2234,11 +2177,11 @@ export namespace youtube_v3 {
      */
     madeForKids?: boolean | null;
     /**
-     * The broadcast&#39;s privacy status. Note that the broadcast represents exactly one YouTube video, so the privacy settings are identical to those supported for videos. In addition, you can set this field by modifying the broadcast resource or by setting the &lt;code&gt;&lt;a href=&quot;/youtube/v3/docs/videos#status.privacyStatus&quot; &gt;privacyStatus&lt;/a&gt;&lt;/code&gt; field of the corresponding video resource.
+     * The broadcast's privacy status. Note that the broadcast represents exactly one YouTube video, so the privacy settings are identical to those supported for videos. In addition, you can set this field by modifying the broadcast resource or by setting the privacyStatus field of the corresponding video resource.
      */
     privacyStatus?: string | null;
     /**
-     * The broadcast&#39;s recording status.
+     * The broadcast's recording status.
      */
     recordingStatus?: string | null;
     /**
@@ -2259,7 +2202,7 @@ export namespace youtube_v3 {
      */
     id?: string | null;
     /**
-     * Identifies what kind of resource this is. Value: the fixed string `&quot;youtube#liveChatBan&quot;`.
+     * Identifies what kind of resource this is. Value: the fixed string `"youtube#liveChatBan"`.
      */
     kind?: string | null;
     /**
@@ -2301,11 +2244,11 @@ export namespace youtube_v3 {
     userComment?: string | null;
   }
   /**
-   * A &lt;code&gt;&lt;strong&gt;liveChatMessage&lt;/strong&gt;&lt;/code&gt; resource represents a chat message in a YouTube Live Chat.
+   * A *liveChatMessage* resource represents a chat message in a YouTube Live Chat.
    */
   export interface Schema$LiveChatMessage {
     /**
-     * The &lt;code&gt;authorDetails&lt;/code&gt; object contains basic details about the user that posted this message.
+     * The authorDetails object contains basic details about the user that posted this message.
      */
     authorDetails?: Schema$LiveChatMessageAuthorDetails;
     /**
@@ -2317,11 +2260,11 @@ export namespace youtube_v3 {
      */
     id?: string | null;
     /**
-     * Identifies what kind of resource this is. Value: the fixed string &lt;code&gt;&quot;youtube#liveChatMessage&quot;&lt;/code&gt;.
+     * Identifies what kind of resource this is. Value: the fixed string "youtube#liveChatMessage".
      */
     kind?: string | null;
     /**
-     * The &lt;code&gt;snippet&lt;/code&gt; object contains basic details about the message.
+     * The snippet object contains basic details about the message.
      */
     snippet?: Schema$LiveChatMessageSnippet;
   }
@@ -2331,11 +2274,11 @@ export namespace youtube_v3 {
      */
     channelId?: string | null;
     /**
-     * The channel&#39;s URL.
+     * The channel's URL.
      */
     channelUrl?: string | null;
     /**
-     * The channel&#39;s display name.
+     * The channel's display name.
      */
     displayName?: string | null;
     /**
@@ -2351,11 +2294,11 @@ export namespace youtube_v3 {
      */
     isChatSponsor?: boolean | null;
     /**
-     * Whether the author&#39;s identity has been verified by YouTube.
+     * Whether the author's identity has been verified by YouTube.
      */
     isVerified?: boolean | null;
     /**
-     * The channels&#39;s avatar URL.
+     * The channels's avatar URL.
      */
     profileImageUrl?: string | null;
   }
@@ -2373,12 +2316,12 @@ export namespace youtube_v3 {
     eventId?: string | null;
     items?: Schema$LiveChatMessage[];
     /**
-     * Identifies what kind of resource this is. Value: the fixed string &lt;code&gt;&quot;youtube#liveChatMessageListResponse&quot;&lt;/code&gt;.
+     * Identifies what kind of resource this is. Value: the fixed string "youtube#liveChatMessageListResponse".
      */
     kind?: string | null;
     nextPageToken?: string | null;
     /**
-     * The date and time when the underlying stream went offline. The value is specified in &lt;a href=&quot;//www.w3.org/TR/NOTE-datetime&quot;&gt;ISO 8601&lt;/a&gt; format.
+     * The date and time when the underlying stream went offline.
      */
     offlineAt?: string | null;
     /**
@@ -2391,7 +2334,7 @@ export namespace youtube_v3 {
     pollingIntervalMillis?: number | null;
     tokenPagination?: Schema$TokenPagination;
     /**
-     * The &lt;code&gt;visitorId&lt;/code&gt; identifies the visitor.
+     * The visitorId identifies the visitor.
      */
     visitorId?: string | null;
   }
@@ -2408,7 +2351,7 @@ export namespace youtube_v3 {
      */
     displayMessage?: string | null;
     /**
-     * Details about the funding event, this is only set if the type is &#39;fanFundingEvent&#39;.
+     * Details about the funding event, this is only set if the type is 'fanFundingEvent'.
      */
     fanFundingEventDetails?: Schema$LiveChatFanFundingEventDetails;
     /**
@@ -2419,19 +2362,19 @@ export namespace youtube_v3 {
     messageDeletedDetails?: Schema$LiveChatMessageDeletedDetails;
     messageRetractedDetails?: Schema$LiveChatMessageRetractedDetails;
     /**
-     * The date and time when the message was orignally published. The value is specified in &lt;a href=&quot;//www.w3.org/TR/NOTE-datetime&quot;&gt;ISO 8601&lt;/a&gt; format.
+     * The date and time when the message was orignally published.
      */
     publishedAt?: string | null;
     /**
-     * Details about the Super Chat event, this is only set if the type is &#39;superChatEvent&#39;.
+     * Details about the Super Chat event, this is only set if the type is 'superChatEvent'.
      */
     superChatDetails?: Schema$LiveChatSuperChatDetails;
     /**
-     * Details about the Super Sticker event, this is only set if the type is &#39;superStickerEvent&#39;.
+     * Details about the Super Sticker event, this is only set if the type is 'superStickerEvent'.
      */
     superStickerDetails?: Schema$LiveChatSuperStickerDetails;
     /**
-     * Details about the text message, this is only set if the type is &#39;textMessageEvent&#39;.
+     * Details about the text message, this is only set if the type is 'textMessageEvent'.
      */
     textMessageDetails?: Schema$LiveChatTextMessageDetails;
     /**
@@ -2441,7 +2384,7 @@ export namespace youtube_v3 {
     userBannedDetails?: Schema$LiveChatUserBannedMessageDetails;
   }
   /**
-   * A &lt;code&gt;&lt;strong&gt;liveChatModerator&lt;/strong&gt;&lt;/code&gt; resource represents a moderator for a YouTube live chat. A chat moderator has the ability to ban/unban users from a chat, remove message, etc.
+   * A *liveChatModerator* resource represents a moderator for a YouTube live chat. A chat moderator has the ability to ban/unban users from a chat, remove message, etc.
    */
   export interface Schema$LiveChatModerator {
     /**
@@ -2453,11 +2396,11 @@ export namespace youtube_v3 {
      */
     id?: string | null;
     /**
-     * Identifies what kind of resource this is. Value: the fixed string &lt;code&gt;&quot;youtube#liveChatModerator&quot;&lt;/code&gt;.
+     * Identifies what kind of resource this is. Value: the fixed string "youtube#liveChatModerator".
      */
     kind?: string | null;
     /**
-     * The &lt;code&gt;snippet&lt;/code&gt; object contains basic details about the moderator.
+     * The snippet object contains basic details about the moderator.
      */
     snippet?: Schema$LiveChatModeratorSnippet;
   }
@@ -2475,11 +2418,11 @@ export namespace youtube_v3 {
      */
     items?: Schema$LiveChatModerator[];
     /**
-     * Identifies what kind of resource this is. Value: the fixed string &lt;code&gt;&quot;youtube#liveChatModeratorListResponse&quot;&lt;/code&gt;.
+     * Identifies what kind of resource this is. Value: the fixed string "youtube#liveChatModeratorListResponse".
      */
     kind?: string | null;
     /**
-     * The token that can be used as the value of the &lt;code&gt;pageToken&lt;/code&gt; parameter to retrieve the next page in the result set.
+     * The token that can be used as the value of the pageToken parameter to retrieve the next page in the result set.
      */
     nextPageToken?: string | null;
     /**
@@ -2487,12 +2430,12 @@ export namespace youtube_v3 {
      */
     pageInfo?: Schema$PageInfo;
     /**
-     * The token that can be used as the value of the &lt;code&gt;pageToken&lt;/code&gt; parameter to retrieve the previous page in the result set.
+     * The token that can be used as the value of the pageToken parameter to retrieve the previous page in the result set.
      */
     prevPageToken?: string | null;
     tokenPagination?: Schema$TokenPagination;
     /**
-     * The &lt;code&gt;visitorId&lt;/code&gt; identifies the visitor.
+     * The visitorId identifies the visitor.
      */
     visitorId?: string | null;
   }
@@ -2520,7 +2463,7 @@ export namespace youtube_v3 {
      */
     currency?: string | null;
     /**
-     * The tier in which the amount belongs. Lower amounts belong to lower tiers. The lowest tier is &lt;code&gt;1&lt;/code&gt;.
+     * The tier in which the amount belongs. Lower amounts belong to lower tiers. The lowest tier is 1.
      */
     tier?: number | null;
     /**
@@ -2546,19 +2489,19 @@ export namespace youtube_v3 {
      */
     superStickerMetadata?: Schema$SuperStickerMetadata;
     /**
-     * The tier in which the amount belongs. Lower amounts belong to lower tiers. The lowest tier is &lt;code&gt;1&lt;/code&gt;.
+     * The tier in which the amount belongs. Lower amounts belong to lower tiers. The lowest tier is 1.
      */
     tier?: number | null;
   }
   export interface Schema$LiveChatTextMessageDetails {
     /**
-     * The user&#39;s message.
+     * The user's message.
      */
     messageText?: string | null;
   }
   export interface Schema$LiveChatUserBannedMessageDetails {
     /**
-     * The duration of the ban. This property is only present if the &lt;code&gt;banType&lt;/code&gt; is &lt;code&gt;temporary&lt;/code&gt;.
+     * The duration of the ban. This property is only present if the banType is temporary.
      */
     banDurationSeconds?: string | null;
     /**
@@ -2575,11 +2518,11 @@ export namespace youtube_v3 {
    */
   export interface Schema$LiveStream {
     /**
-     * The &lt;code&gt;cdn&lt;/code&gt; object defines the live stream&#39;s content delivery network (CDN) settings. These settings provide details about the manner in which you stream your content to YouTube.
+     * The cdn object defines the live stream's content delivery network (CDN) settings. These settings provide details about the manner in which you stream your content to YouTube.
      */
     cdn?: Schema$CdnSettings;
     /**
-     * The &lt;code&gt;content_details&lt;/code&gt; object contains information about the stream, including the closed captions ingestion URL.
+     * The content_details object contains information about the stream, including the closed captions ingestion URL.
      */
     contentDetails?: Schema$LiveStreamContentDetails;
     /**
@@ -2591,15 +2534,15 @@ export namespace youtube_v3 {
      */
     id?: string | null;
     /**
-     * Identifies what kind of resource this is. Value: the fixed string &lt;code&gt;&quot;youtube#liveStream&quot;&lt;/code&gt;.
+     * Identifies what kind of resource this is. Value: the fixed string "youtube#liveStream".
      */
     kind?: string | null;
     /**
-     * The &lt;code&gt;snippet&lt;/code&gt; object contains basic details about the stream, including its channel, title, and description.
+     * The snippet object contains basic details about the stream, including its channel, title, and description.
      */
     snippet?: Schema$LiveStreamSnippet;
     /**
-     * The &lt;code&gt;status&lt;/code&gt; object contains information about live stream&#39;s status.
+     * The status object contains information about live stream's status.
      */
     status?: Schema$LiveStreamStatus;
   }
@@ -2630,7 +2573,7 @@ export namespace youtube_v3 {
      */
     closedCaptionsIngestionUrl?: string | null;
     /**
-     * Indicates whether the stream is reusable, which means that it can be bound to multiple broadcasts. It is common for broadcasters to reuse the same stream for many different broadcasts if those broadcasts occur at different times.&lt;br&gt;&lt;br&gt; If you set this value to &lt;code&gt;false&lt;/code&gt;, then the stream will not be reusable, which means that it can only be bound to one broadcast. Non-reusable streams differ from reusable streams in the following ways: &lt;ul&gt;   &lt;li&gt;A non-reusable stream can only be bound to one broadcast.&lt;/li&gt;   &lt;li&gt;A non-reusable stream might be deleted by an automated process     after the broadcast ends.&lt;/li&gt;   &lt;li&gt;The &lt;code&gt;&lt;a href=&quot;/youtube/v3/live/docs/liveStreams/list&quot;&gt;     liveStreams.list&lt;/a&gt;&lt;/code&gt; method does not list non-reusable streams     if you call the method and set the &lt;code&gt;mine&lt;/code&gt; parameter to     &lt;code&gt;true&lt;/code&gt;. The only way to use that method to retrieve the     resource for a non-reusable stream is to use the &lt;code&gt;id&lt;/code&gt;     parameter to identify the stream.&lt;/li&gt; &lt;/ul&gt;
+     * Indicates whether the stream is reusable, which means that it can be bound to multiple broadcasts. It is common for broadcasters to reuse the same stream for many different broadcasts if those broadcasts occur at different times. If you set this value to false, then the stream will not be reusable, which means that it can only be bound to one broadcast. Non-reusable streams differ from reusable streams in the following ways: - A non-reusable stream can only be bound to one broadcast. - A non-reusable stream might be deleted by an automated process after the broadcast ends. - The liveStreams.list method does not list non-reusable streams if you call the method and set the mine parameter to true. The only way to use that method to retrieve the resource for a non-reusable stream is to use the id parameter to identify the stream.
      */
     isReusable?: boolean | null;
   }
@@ -2662,21 +2605,21 @@ export namespace youtube_v3 {
      */
     items?: Schema$LiveStream[];
     /**
-     * Identifies what kind of resource this is. Value: the fixed string &lt;code&gt;&quot;youtube#liveStreamListResponse&quot;&lt;/code&gt;.
+     * Identifies what kind of resource this is. Value: the fixed string "youtube#liveStreamListResponse".
      */
     kind?: string | null;
     /**
-     * The token that can be used as the value of the &lt;code&gt;pageToken&lt;/code&gt; parameter to retrieve the next page in the result set.
+     * The token that can be used as the value of the pageToken parameter to retrieve the next page in the result set.
      */
     nextPageToken?: string | null;
     pageInfo?: Schema$PageInfo;
     /**
-     * The token that can be used as the value of the &lt;code&gt;pageToken&lt;/code&gt; parameter to retrieve the previous page in the result set.
+     * The token that can be used as the value of the pageToken parameter to retrieve the previous page in the result set.
      */
     prevPageToken?: string | null;
     tokenPagination?: Schema$TokenPagination;
     /**
-     * The &lt;code&gt;visitorId&lt;/code&gt; identifies the visitor.
+     * The visitorId identifies the visitor.
      */
     visitorId?: string | null;
   }
@@ -2686,16 +2629,16 @@ export namespace youtube_v3 {
      */
     channelId?: string | null;
     /**
-     * The stream&#39;s description. The value cannot be longer than 10000 characters.
+     * The stream's description. The value cannot be longer than 10000 characters.
      */
     description?: string | null;
     isDefaultStream?: boolean | null;
     /**
-     * The date and time that the stream was created. The value is specified in &lt;a href=&quot;//www.w3.org/TR/NOTE-datetime&quot;&gt;ISO 8601&lt;/a&gt; format.
+     * The date and time that the stream was created.
      */
     publishedAt?: string | null;
     /**
-     * The stream&#39;s title. The value must be between 1 and 128 characters long.
+     * The stream's title. The value must be between 1 and 128 characters long.
      */
     title?: string | null;
   }
@@ -2722,7 +2665,7 @@ export namespace youtube_v3 {
     value?: string | null;
   }
   /**
-   * A &lt;code&gt;&lt;strong&gt;member&lt;/strong&gt;&lt;/code&gt; resource represents a member for a YouTube channel. A member provides recurring monetary support to a creator and receives special benefits.
+   * A *member* resource represents a member for a YouTube channel. A member provides recurring monetary support to a creator and receives special benefits.
    */
   export interface Schema$Member {
     /**
@@ -2730,11 +2673,11 @@ export namespace youtube_v3 {
      */
     etag?: string | null;
     /**
-     * Identifies what kind of resource this is. Value: the fixed string &lt;code&gt;&quot;youtube#member&quot;&lt;/code&gt;.
+     * Identifies what kind of resource this is. Value: the fixed string "youtube#member".
      */
     kind?: string | null;
     /**
-     * The &lt;code&gt;snippet&lt;/code&gt; object contains basic details about the member.
+     * The snippet object contains basic details about the member.
      */
     snippet?: Schema$MemberSnippet;
   }
@@ -2752,17 +2695,17 @@ export namespace youtube_v3 {
      */
     items?: Schema$Member[];
     /**
-     * Identifies what kind of resource this is. Value: the fixed string &lt;code&gt;&quot;youtube#memberListResponse&quot;&lt;/code&gt;.
+     * Identifies what kind of resource this is. Value: the fixed string "youtube#memberListResponse".
      */
     kind?: string | null;
     /**
-     * The token that can be used as the value of the &lt;code&gt;pageToken&lt;/code&gt; parameter to retrieve the next page in the result set.
+     * The token that can be used as the value of the pageToken parameter to retrieve the next page in the result set.
      */
     nextPageToken?: string | null;
     pageInfo?: Schema$PageInfo;
     tokenPagination?: Schema$TokenPagination;
     /**
-     * The &lt;code&gt;visitorId&lt;/code&gt; identifies the visitor.
+     * The visitorId identifies the visitor.
      */
     visitorId?: string | null;
   }
@@ -2813,7 +2756,7 @@ export namespace youtube_v3 {
     memberTotalDurationMonths?: number | null;
   }
   /**
-   * A &lt;code&gt;&lt;strong&gt;membershipsLevel&lt;/strong&gt;&lt;/code&gt; resource represents an offer made by YouTube creators for their fans. Users can become members of the channel by joining one of the available levels. They will provide recurring monetary support and receives special benefits.
+   * A *membershipsLevel* resource represents an offer made by YouTube creators for their fans. Users can become members of the channel by joining one of the available levels. They will provide recurring monetary support and receives special benefits.
    */
   export interface Schema$MembershipsLevel {
     /**
@@ -2825,11 +2768,11 @@ export namespace youtube_v3 {
      */
     id?: string | null;
     /**
-     * Identifies what kind of resource this is. Value: the fixed string &lt;code&gt;&quot;youtube#membershipsLevelListResponse&quot;&lt;/code&gt;.
+     * Identifies what kind of resource this is. Value: the fixed string "youtube#membershipsLevelListResponse".
      */
     kind?: string | null;
     /**
-     * The &lt;code&gt;snippet&lt;/code&gt; object contains basic details about the level.
+     * The snippet object contains basic details about the level.
      */
     snippet?: Schema$MembershipsLevelSnippet;
   }
@@ -2847,17 +2790,17 @@ export namespace youtube_v3 {
      */
     items?: Schema$MembershipsLevel[];
     /**
-     * Identifies what kind of resource this is. Value: the fixed string &lt;code&gt;&quot;youtube#membershipsLevelListResponse&quot;&lt;/code&gt;.
+     * Identifies what kind of resource this is. Value: the fixed string "youtube#membershipsLevelListResponse".
      */
     kind?: string | null;
     /**
-     * The &lt;code&gt;visitorId&lt;/code&gt; identifies the visitor.
+     * The visitorId identifies the visitor.
      */
     visitorId?: string | null;
   }
   export interface Schema$MembershipsLevelSnippet {
     /**
-     * The id of the channel that&#39;s offering channel memberships.
+     * The id of the channel that's offering channel memberships.
      */
     creatorChannelId?: string | null;
     /**
@@ -2867,7 +2810,7 @@ export namespace youtube_v3 {
   }
   export interface Schema$MemberSnippet {
     /**
-     * The id of the channel that&#39;s offering memberships.
+     * The id of the channel that's offering memberships.
      */
     creatorChannelId?: string | null;
     /**
@@ -2875,7 +2818,7 @@ export namespace youtube_v3 {
      */
     memberDetails?: Schema$ChannelProfileDetails;
     /**
-     * Details about the user&#39;s membership.
+     * Details about the user's membership.
      */
     membershipsDetails?: Schema$MembershipsDetails;
   }
@@ -2884,7 +2827,7 @@ export namespace youtube_v3 {
    */
   export interface Schema$MonitorStreamInfo {
     /**
-     * If you have set the &lt;code&gt;&lt;a href=&quot;#enableMonitorStream&quot;&gt;enableMonitorStream&lt;/a&gt;&lt;/code&gt; property to &lt;code&gt;true&lt;/code&gt;, then this property determines the length of the live broadcast delay.
+     * If you have set the enableMonitorStream property to true, then this property determines the length of the live broadcast delay.
      */
     broadcastStreamDelayMs?: number | null;
     /**
@@ -2892,7 +2835,7 @@ export namespace youtube_v3 {
      */
     embedHtml?: string | null;
     /**
-     * This value determines whether the monitor stream is enabled for the broadcast. If the monitor stream is enabled, then YouTube will broadcast the event content on a special stream intended only for the broadcaster&#39;s consumption. The broadcaster can use the stream to review the event content and also to identify the optimal times to insert cuepoints.&lt;br&gt;&lt;br&gt; You need to set this value to &lt;code&gt;true&lt;/code&gt; if you intend to have a broadcast delay for your event.&lt;br&gt;&lt;br&gt; &lt;strong&gt;Note:&lt;/strong&gt; This property cannot be updated once the broadcast is in the &lt;code&gt;testing&lt;/code&gt; or &lt;code&gt;live&lt;/code&gt; state.
+     * This value determines whether the monitor stream is enabled for the broadcast. If the monitor stream is enabled, then YouTube will broadcast the event content on a special stream intended only for the broadcaster's consumption. The broadcaster can use the stream to review the event content and also to identify the optimal times to insert cuepoints. You need to set this value to true if you intend to have a broadcast delay for your event. *Note:* This property cannot be updated once the broadcast is in the testing or live state.
      */
     enableMonitorStream?: boolean | null;
   }
@@ -2910,11 +2853,11 @@ export namespace youtube_v3 {
     totalResults?: number | null;
   }
   /**
-   * A &lt;code&gt;&lt;strong&gt;playlist&lt;/strong&gt;&lt;/code&gt; resource represents a YouTube playlist. A playlist is a collection of videos that can be viewed sequentially and shared with other users. A playlist can contain up to 200 videos, and YouTube does not limit the number of playlists that each user creates. By default, playlists are publicly visible to other users, but playlists can be public or private.  &lt;br/&gt;&lt;br/&gt; YouTube also uses playlists to identify special collections of videos for a channel, such as:   &lt;ul&gt;     &lt;li&gt;uploaded videos&lt;/li&gt;     &lt;li&gt;favorite videos&lt;/li&gt;     &lt;li&gt;positively rated (liked) videos&lt;/li&gt;     &lt;li&gt;watch history&lt;/li&gt;     &lt;li&gt;watch later&lt;/li&gt;   &lt;/ul&gt; To be more specific, these lists are associated with a channel, which is a collection of a person, group, or company&#39;s videos, playlists, and other YouTube information.  You can retrieve the playlist IDs for each of these lists from the &lt;code&gt;&lt;a href=\&quot;/youtube/v3/docs/channels\&quot;&gt; channel resource&lt;/a&gt;&lt;/code&gt; for a given channel.&lt;br/&gt;&lt;br/&gt; You can then use the &lt;code&gt; &lt;a href=\&quot;/youtube/v3/docs/playlistItems/list\&quot;&gt; playlistItems.list&lt;/a&gt;&lt;/code&gt; method to retrieve any of those lists. You can also add or remove items from those lists by calling the &lt;code&gt; &lt;a href=\&quot;/youtube/v3/docs/playlistItems/insert\&quot;&gt; playlistItems.insert&lt;/a&gt;&lt;/code&gt; and &lt;code&gt; &lt;a href=\&quot;/youtube/v3/docs/playlistItems/delete\&quot;&gt; playlistItems.delete&lt;/a&gt;&lt;/code&gt; methods.
+   * A *playlist* resource represents a YouTube playlist. A playlist is a collection of videos that can be viewed sequentially and shared with other users. A playlist can contain up to 200 videos, and YouTube does not limit the number of playlists that each user creates. By default, playlists are publicly visible to other users, but playlists can be public or private. YouTube also uses playlists to identify special collections of videos for a channel, such as: - uploaded videos - favorite videos - positively rated (liked) videos - watch history - watch later To be more specific, these lists are associated with a channel, which is a collection of a person, group, or company's videos, playlists, and other YouTube information. You can retrieve the playlist IDs for each of these lists from the channel resource for a given channel. You can then use the playlistItems.list method to retrieve any of those lists. You can also add or remove items from those lists by calling the playlistItems.insert and playlistItems.delete methods.
    */
   export interface Schema$Playlist {
     /**
-     * The &lt;code&gt;contentDetails&lt;/code&gt; object contains information like video count.
+     * The contentDetails object contains information like video count.
      */
     contentDetails?: Schema$PlaylistContentDetails;
     /**
@@ -2926,7 +2869,7 @@ export namespace youtube_v3 {
      */
     id?: string | null;
     /**
-     * Identifies what kind of resource this is. Value: the fixed string &lt;code&gt;&quot;youtube#playlist&quot;&lt;/code&gt;.
+     * Identifies what kind of resource this is. Value: the fixed string "youtube#playlist".
      */
     kind?: string | null;
     /**
@@ -2934,15 +2877,15 @@ export namespace youtube_v3 {
      */
     localizations?: {[key: string]: Schema$PlaylistLocalization} | null;
     /**
-     * The &lt;code&gt;player&lt;/code&gt; object contains information that you would use to play the playlist in an embedded player.
+     * The player object contains information that you would use to play the playlist in an embedded player.
      */
     player?: Schema$PlaylistPlayer;
     /**
-     * The &lt;code&gt;snippet&lt;/code&gt; object contains basic details about the playlist, such as its title and description.
+     * The snippet object contains basic details about the playlist, such as its title and description.
      */
     snippet?: Schema$PlaylistSnippet;
     /**
-     * The &lt;code&gt;status&lt;/code&gt; object contains status information for the playlist.
+     * The status object contains status information for the playlist.
      */
     status?: Schema$PlaylistStatus;
   }
@@ -2953,11 +2896,11 @@ export namespace youtube_v3 {
     itemCount?: number | null;
   }
   /**
-   * A &lt;code&gt;&lt;strong&gt;playlistItem&lt;/strong&gt;&lt;/code&gt; resource identifies another resource, such as a video, that is included in a playlist. In addition, the &lt;code&gt;playlistItem &lt;/code&gt; resource contains details about the included resource that pertain specifically to how that resource is used in that playlist.&lt;br/&gt;&lt;br/&gt; YouTube uses playlists to identify special collections of videos for a channel, such as:   &lt;ul&gt;     &lt;li&gt;uploaded videos&lt;/li&gt;     &lt;li&gt;favorite videos&lt;/li&gt;     &lt;li&gt;positively rated (liked) videos&lt;/li&gt;     &lt;li&gt;watch history&lt;/li&gt;     &lt;li&gt;watch later&lt;/li&gt;   &lt;/ul&gt;  To be more specific, these lists are associated with a channel, which is a collection of a person, group, or company&#39;s videos, playlists, and other YouTube information. &lt;br/&gt;&lt;br/&gt;  You can retrieve the playlist IDs for each of these lists from the &lt;code&gt; &lt;a href=\&quot;/youtube/v3/docs/channels\&quot;&gt;channel resource&lt;/a&gt; &lt;/code&gt; for a given channel. You can then use the &lt;code&gt; &lt;a href=\&quot;/youtube/v3/docs/playlistItems/list\&quot;&gt; playlistItems.list&lt;/a&gt;&lt;/code&gt; method to retrieve any of those lists. You can also add or remove items from those lists by calling the &lt;code&gt; &lt;a href=\&quot;/youtube/v3/docs/playlistItems/insert\&quot;&gt; playlistItems.insert&lt;/a&gt;&lt;/code&gt; and &lt;code&gt; &lt;a href=\&quot;/youtube/v3/docs/playlistItems/delete\&quot;&gt; playlistItems.delete&lt;/a&gt;&lt;/code&gt; methods. For example, if a user gives a positive rating to a video, you would insert that video into the liked videos playlist for that user&#39;s channel.
+   * A *playlistItem* resource identifies another resource, such as a video, that is included in a playlist. In addition, the playlistItem resource contains details about the included resource that pertain specifically to how that resource is used in that playlist. YouTube uses playlists to identify special collections of videos for a channel, such as: - uploaded videos - favorite videos - positively rated (liked) videos - watch history - watch later To be more specific, these lists are associated with a channel, which is a collection of a person, group, or company's videos, playlists, and other YouTube information. You can retrieve the playlist IDs for each of these lists from the channel resource for a given channel. You can then use the playlistItems.list method to retrieve any of those lists. You can also add or remove items from those lists by calling the playlistItems.insert and playlistItems.delete methods. For example, if a user gives a positive rating to a video, you would insert that video into the liked videos playlist for that user's channel.
    */
   export interface Schema$PlaylistItem {
     /**
-     * The &lt;code&gt;contentDetails&lt;/code&gt; object is included in the resource if the included item is a YouTube video. The object contains additional information about the video.
+     * The contentDetails object is included in the resource if the included item is a YouTube video. The object contains additional information about the video.
      */
     contentDetails?: Schema$PlaylistItemContentDetails;
     /**
@@ -2969,21 +2912,21 @@ export namespace youtube_v3 {
      */
     id?: string | null;
     /**
-     * Identifies what kind of resource this is. Value: the fixed string &lt;code&gt;&quot;youtube#playlistItem&quot;&lt;/code&gt;.
+     * Identifies what kind of resource this is. Value: the fixed string "youtube#playlistItem".
      */
     kind?: string | null;
     /**
-     * The &lt;code&gt;snippet&lt;/code&gt; object contains basic details about the playlist item, such as its title and position in the playlist.
+     * The snippet object contains basic details about the playlist item, such as its title and position in the playlist.
      */
     snippet?: Schema$PlaylistItemSnippet;
     /**
-     * The &lt;code&gt;status&lt;/code&gt; object contains information about the playlist item&#39;s privacy status.
+     * The status object contains information about the playlist item's privacy status.
      */
     status?: Schema$PlaylistItemStatus;
   }
   export interface Schema$PlaylistItemContentDetails {
     /**
-     * The time, measured in seconds from the start of the video, when the video should stop playing. (The playlist owner can specify the times when the video should start and stop playing when the video is played in the context of the playlist.) By default, assume that the &lt;code&gt;video.endTime&lt;/code&gt; is the end of the video.
+     * The time, measured in seconds from the start of the video, when the video should stop playing. (The playlist owner can specify the times when the video should start and stop playing when the video is played in the context of the playlist.) By default, assume that the video.endTime is the end of the video.
      */
     endAt?: string | null;
     /**
@@ -2991,15 +2934,15 @@ export namespace youtube_v3 {
      */
     note?: string | null;
     /**
-     * The time, measured in seconds from the start of the video, when the video should start playing. (The playlist owner can specify the times when the video should start and stop playing when the video is played in the context of the playlist.) The default value is &lt;code&gt;0&lt;/code&gt;.
+     * The time, measured in seconds from the start of the video, when the video should start playing. (The playlist owner can specify the times when the video should start and stop playing when the video is played in the context of the playlist.) The default value is 0.
      */
     startAt?: string | null;
     /**
-     * The ID that YouTube uses to uniquely identify a video. To &lt;a href=&quot;/youtube/v3/docs/video/list.html&quot;&gt;retrieve the &lt;code&gt;video&lt;/code&gt; resource&lt;/a&gt;, set the &lt;code&gt;id&lt;/code&gt; query parameter to this value in your API request.
+     * The ID that YouTube uses to uniquely identify a video. To retrieve the video resource, set the id query parameter to this value in your API request.
      */
     videoId?: string | null;
     /**
-     * The date and time that the video was published to YouTube. The value is specified in &lt;a href=&quot;//www.w3.org/TR/NOTE-datetime&quot;&gt;ISO 8601&lt;/a&gt; format.
+     * The date and time that the video was published to YouTube.
      */
     videoPublishedAt?: string | null;
   }
@@ -3014,11 +2957,11 @@ export namespace youtube_v3 {
      */
     items?: Schema$PlaylistItem[];
     /**
-     * Identifies what kind of resource this is. Value: the fixed string &lt;code&gt;&quot;youtube#playlistItemListResponse&quot;&lt;/code&gt;. Etag of this resource.
+     * Identifies what kind of resource this is. Value: the fixed string "youtube#playlistItemListResponse". Etag of this resource.
      */
     kind?: string | null;
     /**
-     * The token that can be used as the value of the &lt;code&gt;pageToken&lt;/code&gt; parameter to retrieve the next page in the result set.
+     * The token that can be used as the value of the pageToken parameter to retrieve the next page in the result set.
      */
     nextPageToken?: string | null;
     /**
@@ -3026,17 +2969,17 @@ export namespace youtube_v3 {
      */
     pageInfo?: Schema$PageInfo;
     /**
-     * The token that can be used as the value of the &lt;code&gt;pageToken&lt;/code&gt; parameter to retrieve the previous page in the result set.
+     * The token that can be used as the value of the pageToken parameter to retrieve the previous page in the result set.
      */
     prevPageToken?: string | null;
     tokenPagination?: Schema$TokenPagination;
     /**
-     * The &lt;code&gt;visitorId&lt;/code&gt; identifies the visitor.
+     * The visitorId identifies the visitor.
      */
     visitorId?: string | null;
   }
   /**
-   * Basic details about a playlist, including title, description and thumbnails. Basic details of a YouTube Playlist item provided by the author. Next ID: 13
+   * Basic details about a playlist, including title, description and thumbnails. Basic details of a YouTube Playlist item provided by the author. Next ID: 15
    */
   export interface Schema$PlaylistItemSnippet {
     /**
@@ -3048,7 +2991,7 @@ export namespace youtube_v3 {
      */
     channelTitle?: string | null;
     /**
-     * The item&#39;s description.
+     * The item's description.
      */
     description?: string | null;
     /**
@@ -3056,15 +2999,15 @@ export namespace youtube_v3 {
      */
     playlistId?: string | null;
     /**
-     * The order in which the item appears in the playlist. The value uses a zero-based index, so the first item has a position of &lt;code&gt;0&lt;/code&gt;, the second item has a position of &lt;code&gt;1&lt;/code&gt;, and so forth.
+     * The order in which the item appears in the playlist. The value uses a zero-based index, so the first item has a position of 0, the second item has a position of 1, and so forth.
      */
     position?: number | null;
     /**
-     * The date and time that the item was added to the playlist. The value is specified in &lt;a href=&quot;//www.w3.org/TR/NOTE-datetime&quot;&gt;ISO 8601&lt;/a&gt; format.
+     * The date and time that the item was added to the playlist.
      */
     publishedAt?: string | null;
     /**
-     * The &lt;code&gt;id&lt;/code&gt; object contains information that can be used to uniquely identify the resource that is included in the playlist as the playlist item.
+     * The id object contains information that can be used to uniquely identify the resource that is included in the playlist as the playlist item.
      */
     resourceId?: Schema$ResourceId;
     /**
@@ -3072,16 +3015,24 @@ export namespace youtube_v3 {
      */
     thumbnails?: Schema$ThumbnailDetails;
     /**
-     * The item&#39;s title.
+     * The item's title.
      */
     title?: string | null;
+    /**
+     * Channel id for the channel this video belongs to.
+     */
+    videoOwnerChannelId?: string | null;
+    /**
+     * Channel title for the channel this video belongs to.
+     */
+    videoOwnerChannelTitle?: string | null;
   }
   /**
-   * Information about the playlist item&#39;s privacy status.
+   * Information about the playlist item's privacy status.
    */
   export interface Schema$PlaylistItemStatus {
     /**
-     * This resource&#39;s privacy status.
+     * This resource's privacy status.
      */
     privacyStatus?: string | null;
   }
@@ -3099,11 +3050,11 @@ export namespace youtube_v3 {
      */
     items?: Schema$Playlist[];
     /**
-     * Identifies what kind of resource this is. Value: the fixed string &lt;code&gt;&quot;youtube#playlistListResponse&quot;&lt;/code&gt;.
+     * Identifies what kind of resource this is. Value: the fixed string "youtube#playlistListResponse".
      */
     kind?: string | null;
     /**
-     * The token that can be used as the value of the &lt;code&gt;pageToken&lt;/code&gt; parameter to retrieve the next page in the result set.
+     * The token that can be used as the value of the pageToken parameter to retrieve the next page in the result set.
      */
     nextPageToken?: string | null;
     /**
@@ -3111,12 +3062,12 @@ export namespace youtube_v3 {
      */
     pageInfo?: Schema$PageInfo;
     /**
-     * The token that can be used as the value of the &lt;code&gt;pageToken&lt;/code&gt; parameter to retrieve the previous page in the result set.
+     * The token that can be used as the value of the pageToken parameter to retrieve the previous page in the result set.
      */
     prevPageToken?: string | null;
     tokenPagination?: Schema$TokenPagination;
     /**
-     * The &lt;code&gt;visitorId&lt;/code&gt; identifies the visitor.
+     * The visitorId identifies the visitor.
      */
     visitorId?: string | null;
   }
@@ -3125,17 +3076,17 @@ export namespace youtube_v3 {
    */
   export interface Schema$PlaylistLocalization {
     /**
-     * The localized strings for playlist&#39;s description.
+     * The localized strings for playlist's description.
      */
     description?: string | null;
     /**
-     * The localized strings for playlist&#39;s title.
+     * The localized strings for playlist's title.
      */
     title?: string | null;
   }
   export interface Schema$PlaylistPlayer {
     /**
-     * An &lt;code&gt;&amp;lt;iframe&amp;gt;&lt;/code&gt; tag that embeds a player that will play the playlist.
+     * An <iframe\> tag that embeds a player that will play the playlist.
      */
     embedHtml?: string | null;
   }
@@ -3152,11 +3103,11 @@ export namespace youtube_v3 {
      */
     channelTitle?: string | null;
     /**
-     * The language of the playlist&#39;s default title and description.
+     * The language of the playlist's default title and description.
      */
     defaultLanguage?: string | null;
     /**
-     * The playlist&#39;s description.
+     * The playlist's description.
      */
     description?: string | null;
     /**
@@ -3164,7 +3115,7 @@ export namespace youtube_v3 {
      */
     localized?: Schema$PlaylistLocalization;
     /**
-     * The date and time that the playlist was created. The value is specified in &lt;a href=&quot;//www.w3.org/TR/NOTE-datetime&quot;&gt;ISO 8601&lt;/a&gt; format.
+     * The date and time that the playlist was created.
      */
     publishedAt?: string | null;
     /**
@@ -3176,57 +3127,19 @@ export namespace youtube_v3 {
      */
     thumbnails?: Schema$ThumbnailDetails;
     /**
-     * The playlist&#39;s title.
+     * Note: if the playlist has a custom thumbnail, this field will not be populated. The video id selected by the user that will be used as the thumbnail of this playlist. This field defaults to the first publicly viewable video in the playlist, if: 1. The user has never selected a video to be the thumbnail of the playlist. 2. The user selects a video to be the thumbnail, and then removes that video from the playlist. 3. The user selects a non-owned video to be the thumbnail, but that video becomes private, or gets deleted.
+     */
+    thumbnailVideoId?: string | null;
+    /**
+     * The playlist's title.
      */
     title?: string | null;
   }
   export interface Schema$PlaylistStatus {
     /**
-     * The playlist&#39;s privacy status.
+     * The playlist's privacy status.
      */
     privacyStatus?: string | null;
-  }
-  /**
-   * Describes a single promoted item.
-   */
-  export interface Schema$PromotedItem {
-    /**
-     * A custom message to display for this promotion. This field is currently ignored unless the promoted item is a website.
-     */
-    customMessage?: string | null;
-    /**
-     * Identifies the promoted item.
-     */
-    id?: Schema$PromotedItemId;
-    /**
-     * If true, the content owner&#39;s name will be used when displaying the promotion. This field can only be set when the update is made on behalf of the content owner.
-     */
-    promotedByContentOwner?: boolean | null;
-    /**
-     * The temporal position within the video where the promoted item will be displayed. If present, it overrides the default timing.
-     */
-    timing?: Schema$InvideoTiming;
-  }
-  /**
-   * Describes a single promoted item id. It is a union of various possible types.
-   */
-  export interface Schema$PromotedItemId {
-    /**
-     * If type is recentUpload, this field identifies the channel from which to take the recent upload. If missing, the channel is assumed to be the same channel for which the invideoPromotion is set.
-     */
-    recentlyUploadedBy?: string | null;
-    /**
-     * Describes the type of the promoted item.
-     */
-    type?: string | null;
-    /**
-     * If the promoted item represents a video, this field represents the unique YouTube ID identifying it. This field will be present only if &lt;code&gt;type&lt;/code&gt; has the value &lt;code&gt;video&lt;/code&gt;.
-     */
-    videoId?: string | null;
-    /**
-     * If the promoted item represents a website, this field represents the url pointing to the website. This field will be present only if &lt;code&gt;type&lt;/code&gt; has the value &lt;code&gt;website&lt;/code&gt;.
-     */
-    websiteUrl?: string | null;
   }
   /**
    * A pair Property / Value.
@@ -3237,16 +3150,19 @@ export namespace youtube_v3 {
      */
     property?: string | null;
     /**
-     * The property&#39;s value.
+     * The property's value.
      */
     value?: string | null;
+  }
+  export interface Schema$RelatedEntity {
+    entity?: Schema$Entity;
   }
   /**
    * A resource id is a generic reference that points to another YouTube resource.
    */
   export interface Schema$ResourceId {
     /**
-     * The ID that YouTube uses to uniquely identify the referred resource, if that resource is a channel. This property is only present if the &lt;code&gt;resourceId.kind&lt;/code&gt; value is &lt;code&gt;youtube#channel&lt;/code&gt;.
+     * The ID that YouTube uses to uniquely identify the referred resource, if that resource is a channel. This property is only present if the resourceId.kind value is youtube#channel.
      */
     channelId?: string | null;
     /**
@@ -3254,11 +3170,11 @@ export namespace youtube_v3 {
      */
     kind?: string | null;
     /**
-     * The ID that YouTube uses to uniquely identify the referred resource, if that resource is a playlist. This property is only present if the &lt;code&gt;resourceId.kind&lt;/code&gt; value is &lt;code&gt;youtube#playlist&lt;/code&gt;.
+     * The ID that YouTube uses to uniquely identify the referred resource, if that resource is a playlist. This property is only present if the resourceId.kind value is youtube#playlist.
      */
     playlistId?: string | null;
     /**
-     * The ID that YouTube uses to uniquely identify the referred resource, if that resource is a video. This property is only present if the &lt;code&gt;resourceId.kind&lt;/code&gt; value is &lt;code&gt;youtube#video&lt;/code&gt;.
+     * The ID that YouTube uses to uniquely identify the referred resource, if that resource is a video. This property is only present if the resourceId.kind value is youtube#video.
      */
     videoId?: string | null;
   }
@@ -3276,11 +3192,11 @@ export namespace youtube_v3 {
      */
     items?: Schema$SearchResult[];
     /**
-     * Identifies what kind of resource this is. Value: the fixed string &lt;code&gt;&quot;youtube#searchListResponse&quot;&lt;/code&gt;.
+     * Identifies what kind of resource this is. Value: the fixed string "youtube#searchListResponse".
      */
     kind?: string | null;
     /**
-     * The token that can be used as the value of the &lt;code&gt;pageToken&lt;/code&gt; parameter to retrieve the next page in the result set.
+     * The token that can be used as the value of the pageToken parameter to retrieve the next page in the result set.
      */
     nextPageToken?: string | null;
     /**
@@ -3288,13 +3204,13 @@ export namespace youtube_v3 {
      */
     pageInfo?: Schema$PageInfo;
     /**
-     * The token that can be used as the value of the &lt;code&gt;pageToken&lt;/code&gt; parameter to retrieve the previous page in the result set.
+     * The token that can be used as the value of the pageToken parameter to retrieve the previous page in the result set.
      */
     prevPageToken?: string | null;
     regionCode?: string | null;
     tokenPagination?: Schema$TokenPagination;
     /**
-     * The &lt;code&gt;visitorId&lt;/code&gt; identifies the visitor.
+     * The visitorId identifies the visitor.
      */
     visitorId?: string | null;
   }
@@ -3307,15 +3223,15 @@ export namespace youtube_v3 {
      */
     etag?: string | null;
     /**
-     * The &lt;code&gt;id&lt;/code&gt; object contains information that can be used to uniquely identify the resource that matches the search request.
+     * The id object contains information that can be used to uniquely identify the resource that matches the search request.
      */
     id?: Schema$ResourceId;
     /**
-     * Identifies what kind of resource this is. Value: the fixed string &lt;code&gt;&quot;youtube#searchResult&quot;&lt;/code&gt;.
+     * Identifies what kind of resource this is. Value: the fixed string "youtube#searchResult".
      */
     kind?: string | null;
     /**
-     * The &lt;code&gt;snippet&lt;/code&gt; object contains basic details about a search result, such as its title or description. For example, if the search result is a video, then the title will be the video&#39;s title and the description will be the video&#39;s description.
+     * The snippet object contains basic details about a search result, such as its title or description. For example, if the search result is a video, then the title will be the video's title and the description will be the video's description.
      */
     snippet?: Schema$SearchResultSnippet;
   }
@@ -3336,11 +3252,11 @@ export namespace youtube_v3 {
      */
     description?: string | null;
     /**
-     * It indicates if the resource (video or channel) has upcoming/active live broadcast content. Or it&#39;s &quot;none&quot; if there is not any upcoming/active live broadcasts.
+     * It indicates if the resource (video or channel) has upcoming/active live broadcast content. Or it's "none" if there is not any upcoming/active live broadcasts.
      */
     liveBroadcastContent?: string | null;
     /**
-     * The creation date and time of the resource that the search result identifies. The value is specified in &lt;a href=&quot;//www.w3.org/TR/NOTE-datetime&quot;&gt;ISO 8601&lt;/a&gt; format.
+     * The creation date and time of the resource that the search result identifies.
      */
     publishedAt?: string | null;
     /**
@@ -3353,74 +3269,11 @@ export namespace youtube_v3 {
     title?: string | null;
   }
   /**
-   * A `__sponsor__` resource represents a sponsor for a YouTube channel.  A sponsor provides recurring monetary support to a creator and receives special benefits.
-   */
-  export interface Schema$Sponsor {
-    /**
-     * Etag of this resource.
-     */
-    etag?: string | null;
-    /**
-     * Identifies what kind of resource this is. Value: the fixed string `&quot;youtube#sponsor&quot;`.
-     */
-    kind?: string | null;
-    /**
-     * The `snippet` object contains basic details about the sponsor.
-     */
-    snippet?: Schema$SponsorSnippet;
-  }
-  export interface Schema$SponsorListResponse {
-    /**
-     * Etag of this resource.
-     */
-    etag?: string | null;
-    /**
-     * Serialized EventId of the request which produced this response.
-     */
-    eventId?: string | null;
-    /**
-     * A list of sponsors that match the request criteria.
-     */
-    items?: Schema$Sponsor[];
-    /**
-     * Identifies what kind of resource this is. Value: the fixed string `&quot;youtube#sponsorListResponse&quot;.
-     */
-    kind?: string | null;
-    /**
-     * The token that can be used as the value of the `pageToken` parameter to retrieve the next page in the result set.
-     */
-    nextPageToken?: string | null;
-    pageInfo?: Schema$PageInfo;
-    tokenPagination?: Schema$TokenPagination;
-    /**
-     * The `visitorId` identifies the visitor.
-     */
-    visitorId?: string | null;
-  }
-  export interface Schema$SponsorSnippet {
-    /**
-     * The id of the channel being sponsored.
-     */
-    channelId?: string | null;
-    /**
-     * The cumulative time a user has been a sponsor in months.
-     */
-    cumulativeDurationMonths?: number | null;
-    /**
-     * Details about the sponsor.
-     */
-    sponsorDetails?: Schema$ChannelProfileDetails;
-    /**
-     * The date and time when the user became a sponsor. The value is specified in &lt;a href=&quot;//www.w3.org/TR/NOTE-datetime&quot;&gt;ISO 8601&lt;/a&gt; (`YYYY-MM-DDThh:mm:ss.sZ`) format.
-     */
-    sponsorSince?: string | null;
-  }
-  /**
-   * A &lt;code&gt;&lt;strong&gt;subscription&lt;/strong&gt;&lt;/code&gt; resource contains information about a YouTube user subscription.  A subscription notifies a user when new videos are added to a channel or when another user takes one of several actions on YouTube, such as uploading a video, rating a video, or commenting on a video.
+   * A *subscription* resource contains information about a YouTube user subscription. A subscription notifies a user when new videos are added to a channel or when another user takes one of several actions on YouTube, such as uploading a video, rating a video, or commenting on a video.
    */
   export interface Schema$Subscription {
     /**
-     * The &lt;code&gt;contentDetails&lt;/code&gt; object contains basic statistics about the subscription.
+     * The contentDetails object contains basic statistics about the subscription.
      */
     contentDetails?: Schema$SubscriptionContentDetails;
     /**
@@ -3432,15 +3285,15 @@ export namespace youtube_v3 {
      */
     id?: string | null;
     /**
-     * Identifies what kind of resource this is. Value: the fixed string &lt;code&gt;&quot;youtube#subscription&quot;&lt;/code&gt;.
+     * Identifies what kind of resource this is. Value: the fixed string "youtube#subscription".
      */
     kind?: string | null;
     /**
-     * The &lt;code&gt;snippet&lt;/code&gt; object contains basic details about the subscription, including its title and the channel that the user subscribed to.
+     * The snippet object contains basic details about the subscription, including its title and the channel that the user subscribed to.
      */
     snippet?: Schema$SubscriptionSnippet;
     /**
-     * The &lt;code&gt;subscriberSnippet&lt;/code&gt; object contains basic details about the subscriber.
+     * The subscriberSnippet object contains basic details about the subscriber.
      */
     subscriberSnippet?: Schema$SubscriptionSubscriberSnippet;
   }
@@ -3475,21 +3328,21 @@ export namespace youtube_v3 {
      */
     items?: Schema$Subscription[];
     /**
-     * Identifies what kind of resource this is. Value: the fixed string &lt;code&gt;&quot;youtube#subscriptionListResponse&quot;&lt;/code&gt;.
+     * Identifies what kind of resource this is. Value: the fixed string "youtube#subscriptionListResponse".
      */
     kind?: string | null;
     /**
-     * The token that can be used as the value of the &lt;code&gt;pageToken&lt;/code&gt; parameter to retrieve the next page in the result set.
+     * The token that can be used as the value of the pageToken parameter to retrieve the next page in the result set.
      */
     nextPageToken?: string | null;
     pageInfo?: Schema$PageInfo;
     /**
-     * The token that can be used as the value of the &lt;code&gt;pageToken&lt;/code&gt; parameter to retrieve the previous page in the result set.
+     * The token that can be used as the value of the pageToken parameter to retrieve the previous page in the result set.
      */
     prevPageToken?: string | null;
     tokenPagination?: Schema$TokenPagination;
     /**
-     * The &lt;code&gt;visitorId&lt;/code&gt; identifies the visitor.
+     * The visitorId identifies the visitor.
      */
     visitorId?: string | null;
   }
@@ -3498,7 +3351,7 @@ export namespace youtube_v3 {
    */
   export interface Schema$SubscriptionSnippet {
     /**
-     * The ID that YouTube uses to uniquely identify the subscriber&#39;s channel.
+     * The ID that YouTube uses to uniquely identify the subscriber's channel.
      */
     channelId?: string | null;
     /**
@@ -3506,15 +3359,15 @@ export namespace youtube_v3 {
      */
     channelTitle?: string | null;
     /**
-     * The subscription&#39;s details.
+     * The subscription's details.
      */
     description?: string | null;
     /**
-     * The date and time that the subscription was created. The value is specified in &lt;a href=&quot;//www.w3.org/TR/NOTE-datetime&quot;&gt;ISO 8601&lt;/a&gt; format.
+     * The date and time that the subscription was created.
      */
     publishedAt?: string | null;
     /**
-     * The &lt;code&gt;id&lt;/code&gt; object contains information about the channel that the user subscribed to.
+     * The id object contains information about the channel that the user subscribed to.
      */
     resourceId?: Schema$ResourceId;
     /**
@@ -3522,12 +3375,12 @@ export namespace youtube_v3 {
      */
     thumbnails?: Schema$ThumbnailDetails;
     /**
-     * The subscription&#39;s title.
+     * The subscription's title.
      */
     title?: string | null;
   }
   /**
-   * Basic details about a subscription&#39;s subscriber including title, description, channel ID and thumbnails.
+   * Basic details about a subscription's subscriber including title, description, channel ID and thumbnails.
    */
   export interface Schema$SubscriptionSubscriberSnippet {
     /**
@@ -3560,7 +3413,7 @@ export namespace youtube_v3 {
      */
     id?: string | null;
     /**
-     * Identifies what kind of resource this is. Value: the fixed string `&quot;youtube#superChatEvent&quot;`.
+     * Identifies what kind of resource this is. Value: the fixed string `"youtube#superChatEvent"`.
      */
     kind?: string | null;
     /**
@@ -3582,23 +3435,23 @@ export namespace youtube_v3 {
      */
     items?: Schema$SuperChatEvent[];
     /**
-     * Identifies what kind of resource this is. Value: the fixed string &lt;code&gt;&quot;youtube#superChatEventListResponse&quot;&lt;/code&gt;.
+     * Identifies what kind of resource this is. Value: the fixed string "youtube#superChatEventListResponse".
      */
     kind?: string | null;
     /**
-     * The token that can be used as the value of the &lt;code&gt;pageToken&lt;/code&gt; parameter to retrieve the next page in the result set.
+     * The token that can be used as the value of the pageToken parameter to retrieve the next page in the result set.
      */
     nextPageToken?: string | null;
     pageInfo?: Schema$PageInfo;
     tokenPagination?: Schema$TokenPagination;
     /**
-     * The &lt;code&gt;visitorId&lt;/code&gt; identifies the visitor.
+     * The visitorId identifies the visitor.
      */
     visitorId?: string | null;
   }
   export interface Schema$SuperChatEventSnippet {
     /**
-     * The purchase amount, in micros of the purchase currency.  e.g., 1 is represented as 1000000.
+     * The purchase amount, in micros of the purchase currency. e.g., 1 is represented as 1000000.
      */
     amountMicros?: string | null;
     /**
@@ -3610,15 +3463,15 @@ export namespace youtube_v3 {
      */
     commentText?: string | null;
     /**
-     * The date and time when the event occurred. The value is specified in &lt;a href=&quot;//www.w3.org/TR/NOTE-datetime&quot;&gt;ISO 8601&lt;/a&gt; format.
+     * The date and time when the event occurred.
      */
     createdAt?: string | null;
     /**
-     * The currency in which the purchase was made.  ISO 4217.
+     * The currency in which the purchase was made. ISO 4217.
      */
     currency?: string | null;
     /**
-     * A rendered string that displays the purchase amount and currency (e.g., &quot;$1.00&quot;).  The string is rendered for the given language.
+     * A rendered string that displays the purchase amount and currency (e.g., "$1.00"). The string is rendered for the given language.
      */
     displayString?: string | null;
     /**
@@ -3652,6 +3505,56 @@ export namespace youtube_v3 {
      */
     stickerId?: string | null;
   }
+  export interface Schema$TestItem {
+    gaia?: string | null;
+    id?: string | null;
+    snippet?: Schema$TestItemTestItemSnippet;
+  }
+  export interface Schema$TestItemTestItemSnippet {}
+  /**
+   * A *third party account link* resource represents a link between a YouTube account or a channel and an account on a third-party service.
+   */
+  export interface Schema$ThirdPartyLink {
+    /**
+     * Etag of this resource
+     */
+    etag?: string | null;
+    /**
+     * Identifies what kind of resource this is. Value: the fixed string "youtube#thirdPartyLink".
+     */
+    kind?: string | null;
+    /**
+     * The linking_token identifies a YouTube account and channel with which the third party account is linked.
+     */
+    linkingToken?: string | null;
+    /**
+     * The snippet object contains basic details about the third- party account link.
+     */
+    snippet?: Schema$ThirdPartyLinkSnippet;
+    /**
+     * The status object contains information about the status of the link.
+     */
+    status?: Schema$ThirdPartyLinkStatus;
+  }
+  /**
+   * Basic information about a third party account link, including its type and type-specific information.
+   */
+  export interface Schema$ThirdPartyLinkSnippet {
+    /**
+     * Information specific to a link between a channel and a store on a merchandising platform.
+     */
+    channelToStoreLink?: Schema$ChannelToStoreLinkDetails;
+    /**
+     * Type of the link named after the entities that are being linked.
+     */
+    type?: string | null;
+  }
+  /**
+   * The third-party link status object contains information about the status of the link.
+   */
+  export interface Schema$ThirdPartyLinkStatus {
+    linkStatus?: string | null;
+  }
   /**
    * A thumbnail is an image representing a YouTube resource.
    */
@@ -3661,7 +3564,7 @@ export namespace youtube_v3 {
      */
     height?: number | null;
     /**
-     * The thumbnail image&#39;s URL.
+     * The thumbnail image's URL.
      */
     url?: string | null;
     /**
@@ -3708,11 +3611,11 @@ export namespace youtube_v3 {
      */
     items?: Schema$ThumbnailDetails[];
     /**
-     * Identifies what kind of resource this is. Value: the fixed string &lt;code&gt;&quot;youtube#thumbnailSetResponse&quot;&lt;/code&gt;.
+     * Identifies what kind of resource this is. Value: the fixed string "youtube#thumbnailSetResponse".
      */
     kind?: string | null;
     /**
-     * The &lt;code&gt;visitorId&lt;/code&gt; identifies the visitor.
+     * The visitorId identifies the visitor.
      */
     visitorId?: string | null;
   }
@@ -3721,7 +3624,7 @@ export namespace youtube_v3 {
    */
   export interface Schema$TokenPagination {}
   /**
-   * A &lt;code&gt;&lt;strong&gt;video&lt;/strong&gt;&lt;/code&gt; resource represents a YouTube video.
+   * A *video* resource represents a YouTube video.
    */
   export interface Schema$Video {
     /**
@@ -3729,7 +3632,7 @@ export namespace youtube_v3 {
      */
     ageGating?: Schema$VideoAgeGating;
     /**
-     * The &lt;code&gt;contentDetails&lt;/code&gt; object contains information about the video content, including the length of the video and its aspect ratio.
+     * The contentDetails object contains information about the video content, including the length of the video and its aspect ratio.
      */
     contentDetails?: Schema$VideoContentDetails;
     /**
@@ -3737,7 +3640,7 @@ export namespace youtube_v3 {
      */
     etag?: string | null;
     /**
-     * The &lt;code&gt;fileDetails&lt;/code&gt; object encapsulates information about the video file that was uploaded to YouTube, including the file&#39;s resolution, duration, audio and video codecs, stream bitrates, and more. This data can only be retrieved by the video owner.
+     * The fileDetails object encapsulates information about the video file that was uploaded to YouTube, including the file's resolution, duration, audio and video codecs, stream bitrates, and more. This data can only be retrieved by the video owner.
      */
     fileDetails?: Schema$VideoFileDetails;
     /**
@@ -3745,55 +3648,55 @@ export namespace youtube_v3 {
      */
     id?: string | null;
     /**
-     * Identifies what kind of resource this is. Value: the fixed string &lt;code&gt;&quot;youtube#video&quot;&lt;/code&gt;.
+     * Identifies what kind of resource this is. Value: the fixed string "youtube#video".
      */
     kind?: string | null;
     /**
-     * The &lt;code&gt;liveStreamingDetails&lt;/code&gt; object contains metadata about a live video broadcast. The object will only be present in a &lt;code&gt;video&lt;/code&gt; resource if the video is an upcoming, live, or completed live broadcast.
+     * The liveStreamingDetails object contains metadata about a live video broadcast. The object will only be present in a video resource if the video is an upcoming, live, or completed live broadcast.
      */
     liveStreamingDetails?: Schema$VideoLiveStreamingDetails;
     /**
-     * The &lt;code&gt;localizations&lt;/code&gt; object contains localized versions of the basic details about the video, such as its title and description.
+     * The localizations object contains localized versions of the basic details about the video, such as its title and description.
      */
     localizations?: {[key: string]: Schema$VideoLocalization} | null;
     /**
-     * The &lt;code&gt;monetizationDetails&lt;/code&gt; object encapsulates information about the monetization status of the video.
+     * The monetizationDetails object encapsulates information about the monetization status of the video.
      */
     monetizationDetails?: Schema$VideoMonetizationDetails;
     /**
-     * The &lt;code&gt;player&lt;/code&gt; object contains information that you would use to play the video in an embedded player.
+     * The player object contains information that you would use to play the video in an embedded player.
      */
     player?: Schema$VideoPlayer;
     /**
-     * The &lt;code&gt;processingDetails&lt;/code&gt; object encapsulates information about YouTube&#39;s progress in processing the uploaded video file. The properties in the object identify the current processing status and an estimate of the time remaining until YouTube finishes processing the video. This part also indicates whether different types of data or content, such as file details or thumbnail images, are available for the video.&lt;br&gt;&lt;br&gt; The &lt;code&gt;processingProgress&lt;/code&gt; object is designed to be polled so that the video uploaded can track the progress that YouTube has made in processing the uploaded video file. This data can only be retrieved by the video owner.
+     * The processingDetails object encapsulates information about YouTube's progress in processing the uploaded video file. The properties in the object identify the current processing status and an estimate of the time remaining until YouTube finishes processing the video. This part also indicates whether different types of data or content, such as file details or thumbnail images, are available for the video. The processingProgress object is designed to be polled so that the video uploaded can track the progress that YouTube has made in processing the uploaded video file. This data can only be retrieved by the video owner.
      */
     processingDetails?: Schema$VideoProcessingDetails;
     /**
-     * The &lt;code&gt;projectDetails&lt;/code&gt; object contains information about the project specific video metadata.
+     * The projectDetails object contains information about the project specific video metadata. b/157517979: This part was never populated after it was added. However, it sees non-zero traffic because there is generated client code in the wild that refers to it [1]. We keep this field and do NOT remove it because otherwise V3 would return an error when this part gets requested [2]. [1] https://developers.google.com/resources/api-libraries/documentation/youtube/v3/csharp/latest/classGoogle_1_1Apis_1_1YouTube_1_1v3_1_1Data_1_1VideoProjectDetails.html [2] http://google3/video/youtube/src/python/servers/data_api/common.py?l=1565-1569&rcl=344141677
      */
     projectDetails?: Schema$VideoProjectDetails;
     /**
-     * The &lt;code&gt;recordingDetails&lt;/code&gt; object encapsulates information about the location, date and address where the video was recorded.
+     * The recordingDetails object encapsulates information about the location, date and address where the video was recorded.
      */
     recordingDetails?: Schema$VideoRecordingDetails;
     /**
-     * The &lt;code&gt;snippet&lt;/code&gt; object contains basic details about the video, such as its title, description, and category.
+     * The snippet object contains basic details about the video, such as its title, description, and category.
      */
     snippet?: Schema$VideoSnippet;
     /**
-     * The &lt;code&gt;statistics&lt;/code&gt; object contains statistics about the video.
+     * The statistics object contains statistics about the video.
      */
     statistics?: Schema$VideoStatistics;
     /**
-     * The &lt;code&gt;status&lt;/code&gt; object contains information about the video&#39;s uploading, processing, and privacy statuses.
+     * The status object contains information about the video's uploading, processing, and privacy statuses.
      */
     status?: Schema$VideoStatus;
     /**
-     * The &lt;code&gt;suggestions&lt;/code&gt; object encapsulates suggestions that identify opportunities to improve the video quality or the metadata for the uploaded video. This data can only be retrieved by the video owner.
+     * The suggestions object encapsulates suggestions that identify opportunities to improve the video quality or the metadata for the uploaded video. This data can only be retrieved by the video owner.
      */
     suggestions?: Schema$VideoSuggestions;
     /**
-     * The &lt;code&gt;topicDetails&lt;/code&gt; object encapsulates information about &lt;a href=&quot;http://www.freebase.com&quot;&gt;Freebase&lt;/a&gt; topics associated with the video.
+     * The topicDetails object encapsulates information about Freebase topics associated with the video.
      */
     topicDetails?: Schema$VideoTopicDetails;
   }
@@ -3832,7 +3735,7 @@ export namespace youtube_v3 {
      */
     id?: string | null;
     /**
-     * Identifies what kind of resource this is. Value: the fixed string `&quot;youtube#videoAbuseReportReason&quot;`.
+     * Identifies what kind of resource this is. Value: the fixed string `"youtube#videoAbuseReportReason"`.
      */
     kind?: string | null;
     /**
@@ -3854,7 +3757,7 @@ export namespace youtube_v3 {
      */
     items?: Schema$VideoAbuseReportReason[];
     /**
-     * Identifies what kind of resource this is. Value: the fixed string `&quot;youtube#videoAbuseReportReasonListResponse&quot;`.
+     * Identifies what kind of resource this is. Value: the fixed string `"youtube#videoAbuseReportReasonListResponse"`.
      */
     kind?: string | null;
     /**
@@ -3891,7 +3794,7 @@ export namespace youtube_v3 {
      */
     alcoholContent?: boolean | null;
     /**
-     * Age-restricted trailers. For redband trailers and adult-rated video-games. Only users aged 18+ can view the content. The the field is &lt;code&gt;true&lt;/code&gt; the content is restricted to viewers aged 18+. Otherwise The field won&#39;t be present.
+     * Age-restricted trailers. For redband trailers and adult-rated video-games. Only users aged 18+ can view the content. The the field is true the content is restricted to viewers aged 18+. Otherwise The field won't be present.
      */
     restricted?: boolean | null;
     /**
@@ -3900,7 +3803,7 @@ export namespace youtube_v3 {
     videoGameRating?: string | null;
   }
   /**
-   * A &lt;code&gt;&lt;strong&gt;videoCategory&lt;/strong&gt;&lt;/code&gt; resource identifies a category that has been or could be associated with uploaded videos.
+   * A *videoCategory* resource identifies a category that has been or could be associated with uploaded videos.
    */
   export interface Schema$VideoCategory {
     /**
@@ -3912,11 +3815,11 @@ export namespace youtube_v3 {
      */
     id?: string | null;
     /**
-     * Identifies what kind of resource this is. Value: the fixed string &lt;code&gt;&quot;youtube#videoCategory&quot;&lt;/code&gt;.
+     * Identifies what kind of resource this is. Value: the fixed string "youtube#videoCategory".
      */
     kind?: string | null;
     /**
-     * The &lt;code&gt;snippet&lt;/code&gt; object contains basic details about the video category, including its title.
+     * The snippet object contains basic details about the video category, including its title.
      */
     snippet?: Schema$VideoCategorySnippet;
   }
@@ -3930,15 +3833,15 @@ export namespace youtube_v3 {
      */
     eventId?: string | null;
     /**
-     * A list of video categories that can be associated with YouTube videos. In this map, the video category ID is the map key, and its value is the corresponding &lt;code&gt;videoCategory&lt;/code&gt; resource.
+     * A list of video categories that can be associated with YouTube videos. In this map, the video category ID is the map key, and its value is the corresponding videoCategory resource.
      */
     items?: Schema$VideoCategory[];
     /**
-     * Identifies what kind of resource this is. Value: the fixed string &lt;code&gt;&quot;youtube#videoCategoryListResponse&quot;&lt;/code&gt;.
+     * Identifies what kind of resource this is. Value: the fixed string "youtube#videoCategoryListResponse".
      */
     kind?: string | null;
     /**
-     * The token that can be used as the value of the &lt;code&gt;pageToken&lt;/code&gt; parameter to retrieve the next page in the result set.
+     * The token that can be used as the value of the pageToken parameter to retrieve the next page in the result set.
      */
     nextPageToken?: string | null;
     /**
@@ -3946,12 +3849,12 @@ export namespace youtube_v3 {
      */
     pageInfo?: Schema$PageInfo;
     /**
-     * The token that can be used as the value of the &lt;code&gt;pageToken&lt;/code&gt; parameter to retrieve the previous page in the result set.
+     * The token that can be used as the value of the pageToken parameter to retrieve the previous page in the result set.
      */
     prevPageToken?: string | null;
     tokenPagination?: Schema$TokenPagination;
     /**
-     * The &lt;code&gt;visitorId&lt;/code&gt; identifies the visitor.
+     * The visitorId identifies the visitor.
      */
     visitorId?: string | null;
   }
@@ -3965,7 +3868,7 @@ export namespace youtube_v3 {
      */
     channelId?: string | null;
     /**
-     * The video category&#39;s title.
+     * The video category's title.
      */
     title?: string | null;
   }
@@ -3974,7 +3877,7 @@ export namespace youtube_v3 {
    */
   export interface Schema$VideoContentDetails {
     /**
-     * The value of &lt;code&gt;captions&lt;/code&gt; indicates whether the video has captions or not.
+     * The value of captions indicates whether the video has captions or not.
      */
     caption?: string | null;
     /**
@@ -3982,19 +3885,19 @@ export namespace youtube_v3 {
      */
     contentRating?: Schema$ContentRating;
     /**
-     * The &lt;code&gt;countryRestriction&lt;/code&gt; object contains information about the countries where a video is (or is not) viewable.
+     * The countryRestriction object contains information about the countries where a video is (or is not) viewable.
      */
     countryRestriction?: Schema$AccessPolicy;
     /**
-     * The value of &lt;code&gt;definition&lt;/code&gt; indicates whether the video is available in high definition or only in standard definition.
+     * The value of definition indicates whether the video is available in high definition or only in standard definition.
      */
     definition?: string | null;
     /**
-     * The value of &lt;code&gt;dimension&lt;/code&gt; indicates whether the video is available in 3D or in 2D.
+     * The value of dimension indicates whether the video is available in 3D or in 2D.
      */
     dimension?: string | null;
     /**
-     * The length of the video. The tag value is an &lt;a href=&quot;//en.wikipedia.org/wiki/ISO_8601#Durations&quot;&gt;ISO 8601&lt;/a&gt; duration in the format &lt;code&gt;PT#M#S&lt;/code&gt;, in which the letters &lt;code&gt;PT&lt;/code&gt; indicate that the value specifies a period of time, and the letters &lt;code&gt;M&lt;/code&gt; and &lt;code&gt;S&lt;/code&gt; refer to length in minutes and seconds, respectively. The &lt;code&gt;#&lt;/code&gt; characters preceding the &lt;code&gt;M&lt;/code&gt; and &lt;code&gt;S&lt;/code&gt; letters are both integers that specify the number of minutes (or seconds) of the video. For example, a value of &lt;code&gt;PT15M51S&lt;/code&gt; indicates that the video is 15 minutes and 51 seconds long.
+     * The length of the video. The tag value is an ISO 8601 duration in the format PT#M#S, in which the letters PT indicate that the value specifies a period of time, and the letters M and S refer to length in minutes and seconds, respectively. The # characters preceding the M and S letters are both integers that specify the number of minutes (or seconds) of the video. For example, a value of PT15M51S indicates that the video is 15 minutes and 51 seconds long.
      */
     duration?: string | null;
     /**
@@ -4002,7 +3905,7 @@ export namespace youtube_v3 {
      */
     hasCustomThumbnail?: boolean | null;
     /**
-     * The value of &lt;code&gt;is_license_content&lt;/code&gt; indicates whether the video is licensed content.
+     * The value of is_license_content indicates whether the video is licensed content.
      */
     licensedContent?: boolean | null;
     /**
@@ -4010,7 +3913,7 @@ export namespace youtube_v3 {
      */
     projection?: string | null;
     /**
-     * The &lt;code&gt;regionRestriction&lt;/code&gt; object contains information about the countries where a video is (or is not) viewable. The object will contain either the &lt;code&gt;contentDetails.regionRestriction.allowed&lt;/code&gt; property or the &lt;code&gt;contentDetails.regionRestriction.blocked&lt;/code&gt; property.
+     * The regionRestriction object contains information about the countries where a video is (or is not) viewable. The object will contain either the contentDetails.regionRestriction.allowed property or the contentDetails.regionRestriction.blocked property.
      */
     regionRestriction?: Schema$VideoContentDetailsRegionRestriction;
   }
@@ -4036,15 +3939,15 @@ export namespace youtube_v3 {
      */
     audioStreams?: Schema$VideoFileDetailsAudioStream[];
     /**
-     * The uploaded video file&#39;s combined (video and audio) bitrate in bits per second.
+     * The uploaded video file's combined (video and audio) bitrate in bits per second.
      */
     bitrateBps?: string | null;
     /**
-     * The uploaded video file&#39;s container format.
+     * The uploaded video file's container format.
      */
     container?: string | null;
     /**
-     * The date and time when the uploaded video file was created. The value is specified in &lt;a href=&quot;http://www.w3.org/TR/NOTE-datetime&quot;&gt;ISO 8601&lt;/a&gt; format. Currently, the following ISO 8601 formats are supported: &lt;ul&gt; &lt;li&gt;Date only: &lt;code&gt;YYYY-MM-DD&lt;/code&gt;&lt;/li&gt; &lt;li&gt;Naive time: &lt;code&gt;YYYY-MM-DDTHH:MM:SS&lt;/code&gt;&lt;/li&gt; &lt;li&gt;Time with timezone: &lt;code&gt;YYYY-MM-DDTHH:MM:SS+HH:MM&lt;/code&gt;&lt;/li&gt; &lt;/ul&gt;
+     * The date and time when the uploaded video file was created. The value is specified in ISO 8601 format. Currently, the following ISO 8601 formats are supported: - Date only: YYYY-MM-DD - Naive time: YYYY-MM-DDTHH:MM:SS - Time with timezone: YYYY-MM-DDTHH:MM:SS+HH:MM
      */
     creationTime?: string | null;
     /**
@@ -4052,15 +3955,15 @@ export namespace youtube_v3 {
      */
     durationMs?: string | null;
     /**
-     * The uploaded file&#39;s name. This field is present whether a video file or another type of file was uploaded.
+     * The uploaded file's name. This field is present whether a video file or another type of file was uploaded.
      */
     fileName?: string | null;
     /**
-     * The uploaded file&#39;s size in bytes. This field is present whether a video file or another type of file was uploaded.
+     * The uploaded file's size in bytes. This field is present whether a video file or another type of file was uploaded.
      */
     fileSize?: string | null;
     /**
-     * The uploaded file&#39;s type as detected by YouTube&#39;s video processing engine. Currently, YouTube only processes video files, but this field is present whether a video file or another type of file was uploaded.
+     * The uploaded file's type as detected by YouTube's video processing engine. Currently, YouTube only processes video files, but this field is present whether a video file or another type of file was uploaded.
      */
     fileType?: string | null;
     /**
@@ -4073,7 +3976,7 @@ export namespace youtube_v3 {
    */
   export interface Schema$VideoFileDetailsAudioStream {
     /**
-     * The audio stream&#39;s bitrate, in bits per second.
+     * The audio stream's bitrate, in bits per second.
      */
     bitrateBps?: string | null;
     /**
@@ -4094,11 +3997,11 @@ export namespace youtube_v3 {
    */
   export interface Schema$VideoFileDetailsVideoStream {
     /**
-     * The video content&#39;s display aspect ratio, which specifies the aspect ratio in which the video should be displayed.
+     * The video content's display aspect ratio, which specifies the aspect ratio in which the video should be displayed.
      */
     aspectRatio?: number | null;
     /**
-     * The video stream&#39;s bitrate, in bits per second.
+     * The video stream's bitrate, in bits per second.
      */
     bitrateBps?: string | null;
     /**
@@ -4106,11 +4009,11 @@ export namespace youtube_v3 {
      */
     codec?: string | null;
     /**
-     * The video stream&#39;s frame rate, in frames per second.
+     * The video stream's frame rate, in frames per second.
      */
     frameRateFps?: number | null;
     /**
-     * The encoded video content&#39;s height in pixels.
+     * The encoded video content's height in pixels.
      */
     heightPixels?: number | null;
     /**
@@ -4122,7 +4025,7 @@ export namespace youtube_v3 {
      */
     vendor?: string | null;
     /**
-     * The encoded video content&#39;s width in pixels. You can calculate the video&#39;s encoding aspect ratio as &lt;code&gt;width_pixels&lt;/code&gt;&amp;nbsp;/&amp;nbsp;&lt;code&gt;height_pixels&lt;/code&gt;.
+     * The encoded video content's width in pixels. You can calculate the video's encoding aspect ratio as width_pixels / height_pixels.
      */
     widthPixels?: number | null;
   }
@@ -4137,11 +4040,11 @@ export namespace youtube_v3 {
     eventId?: string | null;
     items?: Schema$Video[];
     /**
-     * Identifies what kind of resource this is. Value: the fixed string &lt;code&gt;&quot;youtube#videoListResponse&quot;&lt;/code&gt;.
+     * Identifies what kind of resource this is. Value: the fixed string "youtube#videoListResponse".
      */
     kind?: string | null;
     /**
-     * The token that can be used as the value of the &lt;code&gt;pageToken&lt;/code&gt; parameter to retrieve the next page in the result set.
+     * The token that can be used as the value of the pageToken parameter to retrieve the next page in the result set.
      */
     nextPageToken?: string | null;
     /**
@@ -4149,12 +4052,12 @@ export namespace youtube_v3 {
      */
     pageInfo?: Schema$PageInfo;
     /**
-     * The token that can be used as the value of the &lt;code&gt;pageToken&lt;/code&gt; parameter to retrieve the previous page in the result set.
+     * The token that can be used as the value of the pageToken parameter to retrieve the previous page in the result set.
      */
     prevPageToken?: string | null;
     tokenPagination?: Schema$TokenPagination;
     /**
-     * The &lt;code&gt;visitorId&lt;/code&gt; identifies the visitor.
+     * The visitorId identifies the visitor.
      */
     visitorId?: string | null;
   }
@@ -4167,11 +4070,11 @@ export namespace youtube_v3 {
      */
     activeLiveChatId?: string | null;
     /**
-     * The time that the broadcast actually ended. The value is specified in &lt;a href=&quot;//www.w3.org/TR/NOTE-datetime&quot;&gt;ISO 8601&lt;/a&gt; format. This value will not be available until the broadcast is over.
+     * The time that the broadcast actually ended. This value will not be available until the broadcast is over.
      */
     actualEndTime?: string | null;
     /**
-     * The time that the broadcast actually started. The value is specified in &lt;a href=&quot;//www.w3.org/TR/NOTE-datetime&quot;&gt;ISO 8601&lt;/a&gt; format. This value will not be available until the broadcast begins.
+     * The time that the broadcast actually started. This value will not be available until the broadcast begins.
      */
     actualStartTime?: string | null;
     /**
@@ -4179,11 +4082,11 @@ export namespace youtube_v3 {
      */
     concurrentViewers?: string | null;
     /**
-     * The time that the broadcast is scheduled to end. The value is specified in &lt;a href=&quot;//www.w3.org/TR/NOTE-datetime&quot;&gt;ISO 8601&lt;/a&gt; format. If the value is empty or the property is not present, then the broadcast is scheduled to continue indefinitely.
+     * The time that the broadcast is scheduled to end. If the value is empty or the property is not present, then the broadcast is scheduled to contiue indefinitely.
      */
     scheduledEndTime?: string | null;
     /**
-     * The time that the broadcast is scheduled to begin. The value is specified in &lt;a href=&quot;//www.w3.org/TR/NOTE-datetime&quot;&gt;ISO 8601&lt;/a&gt; format.
+     * The time that the broadcast is scheduled to begin.
      */
     scheduledStartTime?: string | null;
   }
@@ -4192,11 +4095,11 @@ export namespace youtube_v3 {
    */
   export interface Schema$VideoLocalization {
     /**
-     * Localized version of the video&#39;s description.
+     * Localized version of the video's description.
      */
     description?: string | null;
     /**
-     * Localized version of the video&#39;s title.
+     * Localized version of the video's title.
      */
     title?: string | null;
   }
@@ -4205,7 +4108,7 @@ export namespace youtube_v3 {
    */
   export interface Schema$VideoMonetizationDetails {
     /**
-     * The value of &lt;code&gt;access&lt;/code&gt; indicates whether the video can be monetized or not.
+     * The value of access indicates whether the video can be monetized or not.
      */
     access?: Schema$AccessPolicy;
   }
@@ -4215,7 +4118,7 @@ export namespace youtube_v3 {
   export interface Schema$VideoPlayer {
     embedHeight?: string | null;
     /**
-     * An &lt;code&gt;&amp;lt;iframe&amp;gt;&lt;/code&gt; tag that embeds a player that will play the video.
+     * An <iframe\> tag that embeds a player that will play the video.
      */
     embedHtml?: string | null;
     /**
@@ -4228,31 +4131,31 @@ export namespace youtube_v3 {
    */
   export interface Schema$VideoProcessingDetails {
     /**
-     * This value indicates whether video editing suggestions, which might improve video quality or the playback experience, are available for the video. You can retrieve these suggestions by requesting the &lt;code&gt;suggestions&lt;/code&gt; part in your &lt;code&gt;videos.list()&lt;/code&gt; request.
+     * This value indicates whether video editing suggestions, which might improve video quality or the playback experience, are available for the video. You can retrieve these suggestions by requesting the suggestions part in your videos.list() request.
      */
     editorSuggestionsAvailability?: string | null;
     /**
-     * This value indicates whether file details are available for the uploaded video. You can retrieve a video&#39;s file details by requesting the &lt;code&gt;fileDetails&lt;/code&gt; part in your &lt;code&gt;videos.list()&lt;/code&gt; request.
+     * This value indicates whether file details are available for the uploaded video. You can retrieve a video's file details by requesting the fileDetails part in your videos.list() request.
      */
     fileDetailsAvailability?: string | null;
     /**
-     * The reason that YouTube failed to process the video. This property will only have a value if the &lt;code&gt;processingStatus&lt;/code&gt; property&#39;s value is &lt;code&gt;failed&lt;/code&gt;.
+     * The reason that YouTube failed to process the video. This property will only have a value if the processingStatus property's value is failed.
      */
     processingFailureReason?: string | null;
     /**
-     * This value indicates whether the video processing engine has generated suggestions that might improve YouTube&#39;s ability to process the the video, warnings that explain video processing problems, or errors that cause video processing problems. You can retrieve these suggestions by requesting the &lt;code&gt;suggestions&lt;/code&gt; part in your &lt;code&gt;videos.list()&lt;/code&gt; request.
+     * This value indicates whether the video processing engine has generated suggestions that might improve YouTube's ability to process the the video, warnings that explain video processing problems, or errors that cause video processing problems. You can retrieve these suggestions by requesting the suggestions part in your videos.list() request.
      */
     processingIssuesAvailability?: string | null;
     /**
-     * The &lt;code&gt;processingProgress&lt;/code&gt; object contains information about the progress YouTube has made in processing the video. The values are really only relevant if the video&#39;s processing status is &lt;code&gt;processing&lt;/code&gt;.
+     * The processingProgress object contains information about the progress YouTube has made in processing the video. The values are really only relevant if the video's processing status is processing.
      */
     processingProgress?: Schema$VideoProcessingDetailsProcessingProgress;
     /**
-     * The video&#39;s processing status. This value indicates whether YouTube was able to process the video or if the video is still being processed.
+     * The video's processing status. This value indicates whether YouTube was able to process the video or if the video is still being processed.
      */
     processingStatus?: string | null;
     /**
-     * This value indicates whether keyword (tag) suggestions are available for the video. Tags can be added to a video&#39;s metadata to make it easier for other users to find the video. You can retrieve these suggestions by requesting the &lt;code&gt;suggestions&lt;/code&gt; part in your &lt;code&gt;videos.list()&lt;/code&gt; request.
+     * This value indicates whether keyword (tag) suggestions are available for the video. Tags can be added to a video's metadata to make it easier for other users to find the video. You can retrieve these suggestions by requesting the suggestions part in your videos.list() request.
      */
     tagSuggestionsAvailability?: string | null;
     /**
@@ -4265,7 +4168,7 @@ export namespace youtube_v3 {
    */
   export interface Schema$VideoProcessingDetailsProcessingProgress {
     /**
-     * The number of parts of the video that YouTube has already processed. You can estimate the percentage of the video that YouTube has already processed by calculating:&lt;br&gt; &lt;code&gt;100 * parts_processed / parts_total&lt;/code&gt;&lt;br&gt;&lt;br&gt; Note that since the estimated number of parts could increase without a corresponding increase in the number of parts that have already been processed, it is possible that the calculated progress could periodically decrease while YouTube processes a video.
+     * The number of parts of the video that YouTube has already processed. You can estimate the percentage of the video that YouTube has already processed by calculating: 100 * parts_processed / parts_total Note that since the estimated number of parts could increase without a corresponding increase in the number of parts that have already been processed, it is possible that the calculated progress could periodically decrease while YouTube processes a video.
      */
     partsProcessed?: string | null;
     /**
@@ -4278,14 +4181,9 @@ export namespace youtube_v3 {
     timeLeftMs?: string | null;
   }
   /**
-   * Project specific details about the content of a YouTube Video.
+   * DEPRECATED. b/157517979: This part was never populated after it was added. However, it sees non-zero traffic because there is generated client code in the wild that refers to it [1]. We keep this field and do NOT remove it because otherwise V3 would return an error when this part gets requested [2]. [1] https://developers.google.com/resources/api-libraries/documentation/youtube/v3/csharp/latest/classGoogle_1_1Apis_1_1YouTube_1_1v3_1_1Data_1_1VideoProjectDetails.html [2] http://google3/video/youtube/src/python/servers/data_api/common.py?l=1565-1569&rcl=344141677
    */
-  export interface Schema$VideoProjectDetails {
-    /**
-     * A list of project tags associated with the video during the upload.
-     */
-    tags?: string[] | null;
-  }
+  export interface Schema$VideoProjectDetails {}
   /**
    * Basic details about rating of a video.
    */
@@ -4313,11 +4211,11 @@ export namespace youtube_v3 {
      */
     items?: Schema$VideoRating[];
     /**
-     * Identifies what kind of resource this is. Value: the fixed string &lt;code&gt;&quot;youtube#videoGetRatingResponse&quot;&lt;/code&gt;.
+     * Identifies what kind of resource this is. Value: the fixed string "youtube#videoGetRatingResponse".
      */
     kind?: string | null;
     /**
-     * The &lt;code&gt;visitorId&lt;/code&gt; identifies the visitor.
+     * The visitorId identifies the visitor.
      */
     visitorId?: string | null;
   }
@@ -4334,7 +4232,7 @@ export namespace youtube_v3 {
      */
     locationDescription?: string | null;
     /**
-     * The date and time when the video was recorded. The value is specified in &lt;a href=&quot;//www.w3.org/TR/NOTE-datetime&quot;&gt;ISO 8601&lt;/a&gt; (&lt;code&gt;YYYY-MM-DDThh:mm:ss.sssZ&lt;/code&gt;) format.
+     * The date and time when the video was recorded.
      */
     recordingDate?: string | null;
   }
@@ -4343,7 +4241,7 @@ export namespace youtube_v3 {
    */
   export interface Schema$VideoSnippet {
     /**
-     * The YouTube &lt;a href=&quot;/youtube/v3/docs/videoCategories/list&quot;&gt;video category&lt;/a&gt; associated with the video.
+     * The YouTube video category associated with the video.
      */
     categoryId?: string | null;
     /**
@@ -4355,19 +4253,19 @@ export namespace youtube_v3 {
      */
     channelTitle?: string | null;
     /**
-     * The &lt;code&gt;default_audio_language&lt;/code&gt; property specifies the language spoken in the video&#39;s default audio track.
+     * The default_audio_language property specifies the language spoken in the video's default audio track.
      */
     defaultAudioLanguage?: string | null;
     /**
-     * The language of the videos&#39;s default snippet.
+     * The language of the videos's default snippet.
      */
     defaultLanguage?: string | null;
     /**
-     * The video&#39;s description. @mutable youtube.videos.insert youtube.videos.update
+     * The video's description. @mutable youtube.videos.insert youtube.videos.update
      */
     description?: string | null;
     /**
-     * Indicates if the video is an upcoming/active live broadcast. Or it&#39;s &quot;none&quot; if the video is not an upcoming/active live broadcast.
+     * Indicates if the video is an upcoming/active live broadcast. Or it's "none" if the video is not an upcoming/active live broadcast.
      */
     liveBroadcastContent?: string | null;
     /**
@@ -4375,7 +4273,7 @@ export namespace youtube_v3 {
      */
     localized?: Schema$VideoLocalization;
     /**
-     * The date and time that the video was uploaded. The value is specified in &lt;a href=&quot;//www.w3.org/TR/NOTE-datetime&quot;&gt;ISO 8601&lt;/a&gt; format.
+     * The date and time when the video was uploaded.
      */
     publishedAt?: string | null;
     /**
@@ -4387,7 +4285,7 @@ export namespace youtube_v3 {
      */
     thumbnails?: Schema$ThumbnailDetails;
     /**
-     * The video&#39;s title. @mutable youtube.videos.insert youtube.videos.update
+     * The video's title. @mutable youtube.videos.insert youtube.videos.update
      */
     title?: string | null;
   }
@@ -4417,7 +4315,7 @@ export namespace youtube_v3 {
     viewCount?: string | null;
   }
   /**
-   * Basic details about a video category, such as its localized title. Next Id: 16
+   * Basic details about a video category, such as its localized title. Next Id: 17
    */
   export interface Schema$VideoStatus {
     /**
@@ -4425,16 +4323,16 @@ export namespace youtube_v3 {
      */
     embeddable?: boolean | null;
     /**
-     * This value explains why a video failed to upload. This property is only present if the &lt;code&gt;uploadStatus&lt;/code&gt; property indicates that the upload failed.
+     * This value explains why a video failed to upload. This property is only present if the uploadStatus property indicates that the upload failed.
      */
     failureReason?: string | null;
     /**
-     * The video&#39;s license. @mutable youtube.videos.insert youtube.videos.update
+     * The video's license. @mutable youtube.videos.insert youtube.videos.update
      */
     license?: string | null;
     madeForKids?: boolean | null;
     /**
-     * The video&#39;s privacy status.
+     * The video's privacy status.
      */
     privacyStatus?: string | null;
     /**
@@ -4442,11 +4340,11 @@ export namespace youtube_v3 {
      */
     publicStatsViewable?: boolean | null;
     /**
-     * The date and time when the video is scheduled to publish. It can be set only if the privacy status of the video is private. The value is specified in &lt;a href=&quot;//www.w3.org/TR/NOTE-datetime&quot;&gt;ISO 8601&lt;/a&gt; format.
+     * The date and time when the video is scheduled to publish. It can be set only if the privacy status of the video is private..
      */
     publishAt?: string | null;
     /**
-     * This value explains why YouTube rejected an uploaded video. This property is only present if the &lt;code&gt;uploadStatus&lt;/code&gt; property indicates that the upload was rejected.
+     * This value explains why YouTube rejected an uploaded video. This property is only present if the uploadStatus property indicates that the upload was rejected.
      */
     rejectionReason?: string | null;
     selfDeclaredMadeForKids?: boolean | null;
@@ -4464,11 +4362,11 @@ export namespace youtube_v3 {
      */
     editorSuggestions?: string[] | null;
     /**
-     * A list of errors that will prevent YouTube from successfully processing the uploaded video video. These errors indicate that, regardless of the video&#39;s current &lt;a href=&quot;#processingProgress.processingStatus&quot;&gt;processing status&lt;/a&gt;, eventually, that status will almost certainly be &lt;code&gt;failed&lt;/code&gt;.
+     * A list of errors that will prevent YouTube from successfully processing the uploaded video video. These errors indicate that, regardless of the video's current processing status, eventually, that status will almost certainly be failed.
      */
     processingErrors?: string[] | null;
     /**
-     * A list of suggestions that may improve YouTube&#39;s ability to process the video.
+     * A list of suggestions that may improve YouTube's ability to process the video.
      */
     processingHints?: string[] | null;
     /**
@@ -4476,12 +4374,12 @@ export namespace youtube_v3 {
      */
     processingWarnings?: string[] | null;
     /**
-     * A list of keyword tags that could be added to the video&#39;s metadata to increase the likelihood that users will locate your video when searching or browsing on YouTube.
+     * A list of keyword tags that could be added to the video's metadata to increase the likelihood that users will locate your video when searching or browsing on YouTube.
      */
     tagSuggestions?: Schema$VideoSuggestionsTagSuggestion[];
   }
   /**
-   * A single tag suggestion with it&#39;s relevance information.
+   * A single tag suggestion with it's relevance information.
    */
   export interface Schema$VideoSuggestionsTagSuggestion {
     /**
@@ -4498,15 +4396,15 @@ export namespace youtube_v3 {
    */
   export interface Schema$VideoTopicDetails {
     /**
-     * Similar to topic_id, except that these topics are merely relevant to the video. These are topics that may be mentioned in, or appear in the video. You can retrieve information about each topic using &lt;a href=&quot;http://wiki.freebase.com/wiki/Topic_API&quot;&gt;Freebase Topic API&lt;/a&gt;.
+     * Similar to topic_id, except that these topics are merely relevant to the video. These are topics that may be mentioned in, or appear in the video. You can retrieve information about each topic using Freebase Topic API.
      */
     relevantTopicIds?: string[] | null;
     /**
-     * A list of Wikipedia URLs that provide a high-level description of the video&#39;s content.
+     * A list of Wikipedia URLs that provide a high-level description of the video's content.
      */
     topicCategories?: string[] | null;
     /**
-     * A list of Freebase topic IDs that are centrally associated with the video. These are topics that are centrally featured in the video, and it can be said that the video is mainly about each of these. You can retrieve information about each topic using the &lt; a href=&quot;http://wiki.freebase.com/wiki/Topic_API&quot;&gt;Freebase Topic API&lt;/a&gt;.
+     * A list of Freebase topic IDs that are centrally associated with the video. These are topics that are centrally featured in the video, and it can be said that the video is mainly about each of these. You can retrieve information about each topic using the < a href="http://wiki.freebase.com/wiki/Topic_API"\>Freebase Topic API.
      */
     topicIds?: string[] | null;
   }
@@ -4515,7 +4413,7 @@ export namespace youtube_v3 {
    */
   export interface Schema$WatchSettings {
     /**
-     * The text color for the video watch page&#39;s branded area.
+     * The text color for the video watch page's branded area.
      */
     backgroundColor?: string | null;
     /**
@@ -4523,9 +4421,175 @@ export namespace youtube_v3 {
      */
     featuredPlaylistId?: string | null;
     /**
-     * The background color for the video watch page&#39;s branded area.
+     * The background color for the video watch page's branded area.
      */
     textColor?: string | null;
+  }
+
+  export class Resource$Abusereports {
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
+
+    /**
+     * Inserts a new resource into this collection.
+     * @example
+     * ```js
+     * // Before running the sample:
+     * // - Enable the API at:
+     * //   https://console.developers.google.com/apis/api/youtube.googleapis.com
+     * // - Login into gcloud by running:
+     * //   `$ gcloud auth application-default login`
+     * // - Install the npm module by running:
+     * //   `$ npm install googleapis`
+     *
+     * const {google} = require('googleapis');
+     * const youtube = google.youtube('v3');
+     *
+     * async function main() {
+     *   const auth = new google.auth.GoogleAuth({
+     *     // Scopes can be specified either as an array or as a single, space-delimited string.
+     *     scopes: [
+     *       'https://www.googleapis.com/auth/youtube',
+     *       'https://www.googleapis.com/auth/youtube.force-ssl',
+     *     ],
+     *   });
+     *
+     *   // Acquire an auth client, and bind it to all future calls
+     *   const authClient = await auth.getClient();
+     *   google.options({auth: authClient});
+     *
+     *   // Do the magic
+     *   const res = await youtube.abuseReports.insert({
+     *     // The *part* parameter serves two purposes in this operation. It identifies the properties that the write operation will set as well as the properties that the API response will include.
+     *     part: 'placeholder-value',
+     *
+     *     // Request body metadata
+     *     requestBody: {
+     *       // request body parameters
+     *       // {
+     *       //   "abuseTypes": [],
+     *       //   "description": "my_description",
+     *       //   "relatedEntities": [],
+     *       //   "subject": {}
+     *       // }
+     *     },
+     *   });
+     *   console.log(res.data);
+     *
+     *   // Example response
+     *   // {
+     *   //   "abuseTypes": [],
+     *   //   "description": "my_description",
+     *   //   "relatedEntities": [],
+     *   //   "subject": {}
+     *   // }
+     * }
+     *
+     * main().catch(e => {
+     *   console.error(e);
+     *   throw e;
+     * });
+     *
+     * ```
+     *
+     * @param params - Parameters for request
+     * @param options - Optionally override request options, such as `url`, `method`, and `encoding`.
+     * @param callback - Optional callback that handles the response.
+     * @returns A promise if used with async/await, or void if used with a callback.
+     */
+    insert(
+      params: Params$Resource$Abusereports$Insert,
+      options: StreamMethodOptions
+    ): GaxiosPromise<Readable>;
+    insert(
+      params?: Params$Resource$Abusereports$Insert,
+      options?: MethodOptions
+    ): GaxiosPromise<Schema$AbuseReport>;
+    insert(
+      params: Params$Resource$Abusereports$Insert,
+      options: StreamMethodOptions | BodyResponseCallback<Readable>,
+      callback: BodyResponseCallback<Readable>
+    ): void;
+    insert(
+      params: Params$Resource$Abusereports$Insert,
+      options: MethodOptions | BodyResponseCallback<Schema$AbuseReport>,
+      callback: BodyResponseCallback<Schema$AbuseReport>
+    ): void;
+    insert(
+      params: Params$Resource$Abusereports$Insert,
+      callback: BodyResponseCallback<Schema$AbuseReport>
+    ): void;
+    insert(callback: BodyResponseCallback<Schema$AbuseReport>): void;
+    insert(
+      paramsOrCallback?:
+        | Params$Resource$Abusereports$Insert
+        | BodyResponseCallback<Schema$AbuseReport>
+        | BodyResponseCallback<Readable>,
+      optionsOrCallback?:
+        | MethodOptions
+        | StreamMethodOptions
+        | BodyResponseCallback<Schema$AbuseReport>
+        | BodyResponseCallback<Readable>,
+      callback?:
+        | BodyResponseCallback<Schema$AbuseReport>
+        | BodyResponseCallback<Readable>
+    ): void | GaxiosPromise<Schema$AbuseReport> | GaxiosPromise<Readable> {
+      let params = (paramsOrCallback ||
+        {}) as Params$Resource$Abusereports$Insert;
+      let options = (optionsOrCallback || {}) as MethodOptions;
+
+      if (typeof paramsOrCallback === 'function') {
+        callback = paramsOrCallback;
+        params = {} as Params$Resource$Abusereports$Insert;
+        options = {};
+      }
+
+      if (typeof optionsOrCallback === 'function') {
+        callback = optionsOrCallback;
+        options = {};
+      }
+
+      const rootUrl = options.rootUrl || 'https://youtube.googleapis.com/';
+      const parameters = {
+        options: Object.assign(
+          {
+            url: (rootUrl + '/youtube/v3/abuseReports').replace(
+              /([^:]\/)\/+/g,
+              '$1'
+            ),
+            method: 'POST',
+          },
+          options
+        ),
+        params,
+        requiredParams: ['part'],
+        pathParams: [],
+        context: this.context,
+      };
+      if (callback) {
+        createAPIRequest<Schema$AbuseReport>(
+          parameters,
+          callback as BodyResponseCallback<unknown>
+        );
+      } else {
+        return createAPIRequest<Schema$AbuseReport>(parameters);
+      }
+    }
+  }
+
+  export interface Params$Resource$Abusereports$Insert
+    extends StandardParameters {
+    /**
+     * The *part* parameter serves two purposes in this operation. It identifies the properties that the write operation will set as well as the properties that the API response will include.
+     */
+    part?: string[];
+
+    /**
+     * Request body metadata
+     */
+    requestBody?: Schema$AbuseReport;
   }
 
   export class Resource$Activities {
@@ -4535,9 +4599,9 @@ export namespace youtube_v3 {
     }
 
     /**
-     * youtube.activities.list
-     * @desc Retrieves a list of resources, possibly filtered.
+     * Retrieves a list of resources, possibly filtered.
      * @example
+     * ```js
      * // Before running the sample:
      * // - Enable the API at:
      * //   https://console.developers.google.com/apis/api/youtube.googleapis.com
@@ -4568,25 +4632,13 @@ export namespace youtube_v3 {
      *     channelId: 'placeholder-value',
      *
      *     home: 'placeholder-value',
-     *     // The <code><strong>maxResults</strong></code> parameter specifies the
-     *     // maximum number of items that should be returned in the result set.
+     *     // The *maxResults* parameter specifies the maximum number of items that should be returned in the result set.
      *     maxResults: 'placeholder-value',
      *
      *     mine: 'placeholder-value',
-     *     // The <code><strong>pageToken</strong></code> parameter identifies a specific
-     *     // page in the result set that should be returned. In an API response, the
-     *     // <code>nextPageToken</code> and <code>prevPageToken</code> properties
-     *     // identify other pages that could be retrieved.
+     *     // The *pageToken* parameter identifies a specific page in the result set that should be returned. In an API response, the nextPageToken and prevPageToken properties identify other pages that could be retrieved.
      *     pageToken: 'placeholder-value',
-     *     // The <code><strong>part</strong></code> parameter specifies a
-     *     // comma-separated list of one or more <code>activity</code> resource
-     *     // properties that the API response will include.<br><br>If the parameter
-     *     // identifies a property that contains child properties, the child properties
-     *     // will be included in the response. For example, in an <code>activity</code>
-     *     // resource, the <code>snippet</code> property contains other properties that
-     *     // identify the type of activity, a display title for the activity, and so
-     *     // forth. If you set <code><strong>part=snippet</strong></code>, the API
-     *     // response will also contain all of those nested properties.
+     *     // The *part* parameter specifies a comma-separated list of one or more activity resource properties that the API response will include. If the parameter identifies a property that contains child properties, the child properties will be included in the response. For example, in an activity resource, the snippet property contains other properties that identify the type of activity, a display title for the activity, and so forth. If you set *part=snippet*, the API response will also contain all of those nested properties.
      *     part: 'placeholder-value',
      *
      *     publishedAfter: 'placeholder-value',
@@ -4616,22 +4668,12 @@ export namespace youtube_v3 {
      *   throw e;
      * });
      *
-     * @alias youtube.activities.list
-     * @memberOf! ()
+     * ```
      *
-     * @param {object} params Parameters for request
-     * @param {string=} params.channelId
-     * @param {boolean=} params.home
-     * @param {integer=} params.maxResults The <code><strong>maxResults</strong></code> parameter specifies the maximum number of items that should be returned in the result set.
-     * @param {boolean=} params.mine
-     * @param {string=} params.pageToken The <code><strong>pageToken</strong></code> parameter identifies a specific page in the result set that should be returned. In an API response, the <code>nextPageToken</code> and <code>prevPageToken</code> properties identify other pages that could be retrieved.
-     * @param {string} params.part The <code><strong>part</strong></code> parameter specifies a comma-separated list of one or more <code>activity</code> resource properties that the API response will include.<br><br>If the parameter identifies a property that contains child properties, the child properties will be included in the response. For example, in an <code>activity</code> resource, the <code>snippet</code> property contains other properties that identify the type of activity, a display title for the activity, and so forth. If you set <code><strong>part=snippet</strong></code>, the API response will also contain all of those nested properties.
-     * @param {string=} params.publishedAfter
-     * @param {string=} params.publishedBefore
-     * @param {string=} params.regionCode
-     * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-     * @param {callback} callback The callback that handles the response.
-     * @return {object} Request object
+     * @param params - Parameters for request
+     * @param options - Optionally override request options, such as `url`, `method`, and `encoding`.
+     * @param callback - Optional callback that handles the response.
+     * @returns A promise if used with async/await, or void if used with a callback.
      */
     list(
       params: Params$Resource$Activities$List,
@@ -4689,7 +4731,7 @@ export namespace youtube_v3 {
         options = {};
       }
 
-      const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+      const rootUrl = options.rootUrl || 'https://youtube.googleapis.com/';
       const parameters = {
         options: Object.assign(
           {
@@ -4709,7 +4751,7 @@ export namespace youtube_v3 {
       if (callback) {
         createAPIRequest<Schema$ActivityListResponse>(
           parameters,
-          callback as BodyResponseCallback<{} | void>
+          callback as BodyResponseCallback<unknown>
         );
       } else {
         return createAPIRequest<Schema$ActivityListResponse>(parameters);
@@ -4727,7 +4769,7 @@ export namespace youtube_v3 {
      */
     home?: boolean;
     /**
-     * The <code><strong>maxResults</strong></code> parameter specifies the maximum number of items that should be returned in the result set.
+     * The *maxResults* parameter specifies the maximum number of items that should be returned in the result set.
      */
     maxResults?: number;
     /**
@@ -4735,11 +4777,11 @@ export namespace youtube_v3 {
      */
     mine?: boolean;
     /**
-     * The <code><strong>pageToken</strong></code> parameter identifies a specific page in the result set that should be returned. In an API response, the <code>nextPageToken</code> and <code>prevPageToken</code> properties identify other pages that could be retrieved.
+     * The *pageToken* parameter identifies a specific page in the result set that should be returned. In an API response, the nextPageToken and prevPageToken properties identify other pages that could be retrieved.
      */
     pageToken?: string;
     /**
-     * The <code><strong>part</strong></code> parameter specifies a comma-separated list of one or more <code>activity</code> resource properties that the API response will include.<br><br>If the parameter identifies a property that contains child properties, the child properties will be included in the response. For example, in an <code>activity</code> resource, the <code>snippet</code> property contains other properties that identify the type of activity, a display title for the activity, and so forth. If you set <code><strong>part=snippet</strong></code>, the API response will also contain all of those nested properties.
+     * The *part* parameter specifies a comma-separated list of one or more activity resource properties that the API response will include. If the parameter identifies a property that contains child properties, the child properties will be included in the response. For example, in an activity resource, the snippet property contains other properties that identify the type of activity, a display title for the activity, and so forth. If you set *part=snippet*, the API response will also contain all of those nested properties.
      */
     part?: string[];
     /**
@@ -4763,9 +4805,9 @@ export namespace youtube_v3 {
     }
 
     /**
-     * youtube.captions.delete
-     * @desc Deletes a resource.
+     * Deletes a resource.
      * @example
+     * ```js
      * // Before running the sample:
      * // - Enable the API at:
      * //   https://console.developers.google.com/apis/api/youtube.googleapis.com
@@ -4795,17 +4837,7 @@ export namespace youtube_v3 {
      *     id: 'placeholder-value',
      *     // ID of the Google+ Page for the channel that the request is be on behalf of
      *     onBehalfOf: 'placeholder-value',
-     *     // <strong>Note:</strong> This parameter is intended exclusively for YouTube
-     *     // content partners.<br><br>The
-     *     // <code><strong>onBehalfOfContentOwner</strong></code> parameter indicates
-     *     // that the request's authorization credentials identify a YouTube CMS user
-     *     // who is acting on behalf of the content owner specified in the parameter
-     *     // value. This parameter is intended for YouTube content partners that own and
-     *     // manage many different YouTube channels. It allows content owners to
-     *     // authenticate once and get access to all their video and channel data,
-     *     // without having to provide authentication credentials for each individual
-     *     // channel. The actual CMS account that the user authenticates with must be
-     *     // linked to the specified YouTube content owner.
+     *     // *Note:* This parameter is intended exclusively for YouTube content partners. The *onBehalfOfContentOwner* parameter indicates that the request's authorization credentials identify a YouTube CMS user who is acting on behalf of the content owner specified in the parameter value. This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and get access to all their video and channel data, without having to provide authentication credentials for each individual channel. The actual CMS account that the user authenticates with must be linked to the specified YouTube content owner.
      *     onBehalfOfContentOwner: 'placeholder-value',
      *   });
      *   console.log(res.data);
@@ -4816,16 +4848,12 @@ export namespace youtube_v3 {
      *   throw e;
      * });
      *
-     * @alias youtube.captions.delete
-     * @memberOf! ()
+     * ```
      *
-     * @param {object} params Parameters for request
-     * @param {string} params.id
-     * @param {string=} params.onBehalfOf ID of the Google+ Page for the channel that the request is be on behalf of
-     * @param {string=} params.onBehalfOfContentOwner <strong>Note:</strong> This parameter is intended exclusively for YouTube content partners.<br><br>The <code><strong>onBehalfOfContentOwner</strong></code> parameter indicates that the request's authorization credentials identify a YouTube CMS user who is acting on behalf of the content owner specified in the parameter value. This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and get access to all their video and channel data, without having to provide authentication credentials for each individual channel. The actual CMS account that the user authenticates with must be linked to the specified YouTube content owner.
-     * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-     * @param {callback} callback The callback that handles the response.
-     * @return {object} Request object
+     * @param params - Parameters for request
+     * @param options - Optionally override request options, such as `url`, `method`, and `encoding`.
+     * @param callback - Optional callback that handles the response.
+     * @returns A promise if used with async/await, or void if used with a callback.
      */
     delete(
       params: Params$Resource$Captions$Delete,
@@ -4876,7 +4904,7 @@ export namespace youtube_v3 {
         options = {};
       }
 
-      const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+      const rootUrl = options.rootUrl || 'https://youtube.googleapis.com/';
       const parameters = {
         options: Object.assign(
           {
@@ -4896,7 +4924,7 @@ export namespace youtube_v3 {
       if (callback) {
         createAPIRequest<void>(
           parameters,
-          callback as BodyResponseCallback<{} | void>
+          callback as BodyResponseCallback<unknown>
         );
       } else {
         return createAPIRequest<void>(parameters);
@@ -4904,9 +4932,9 @@ export namespace youtube_v3 {
     }
 
     /**
-     * youtube.captions.download
-     * @desc Downloads a caption track.
+     * Downloads a caption track.
      * @example
+     * ```js
      * // Before running the sample:
      * // - Enable the API at:
      * //   https://console.developers.google.com/apis/api/youtube.googleapis.com
@@ -4937,23 +4965,11 @@ export namespace youtube_v3 {
      *     id: 'placeholder-value',
      *     // ID of the Google+ Page for the channel that the request is be on behalf of
      *     onBehalfOf: 'placeholder-value',
-     *     // <strong>Note:</strong> This parameter is intended exclusively for YouTube
-     *     // content partners.<br><br>The
-     *     // <code><strong>onBehalfOfContentOwner</strong></code> parameter indicates
-     *     // that the request's authorization credentials identify a YouTube CMS user
-     *     // who is acting on behalf of the content owner specified in the parameter
-     *     // value. This parameter is intended for YouTube content partners that own and
-     *     // manage many different YouTube channels. It allows content owners to
-     *     // authenticate once and get access to all their video and channel data,
-     *     // without having to provide authentication credentials for each individual
-     *     // channel. The actual CMS account that the user authenticates with must be
-     *     // linked to the specified YouTube content owner.
+     *     // *Note:* This parameter is intended exclusively for YouTube content partners. The *onBehalfOfContentOwner* parameter indicates that the request's authorization credentials identify a YouTube CMS user who is acting on behalf of the content owner specified in the parameter value. This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and get access to all their video and channel data, without having to provide authentication credentials for each individual channel. The actual CMS account that the user authenticates with must be linked to the specified YouTube content owner.
      *     onBehalfOfContentOwner: 'placeholder-value',
-     *     // Convert the captions into this format. Supported options are
-     *     // sbv, srt, and vtt.
+     *     // Convert the captions into this format. Supported options are sbv, srt, and vtt.
      *     tfmt: 'placeholder-value',
-     *     // tlang is the language code; machine translate the captions into
-     *     // this language.
+     *     // tlang is the language code; machine translate the captions into this language.
      *     tlang: 'placeholder-value',
      *   });
      *   console.log(res.data);
@@ -4964,18 +4980,12 @@ export namespace youtube_v3 {
      *   throw e;
      * });
      *
-     * @alias youtube.captions.download
-     * @memberOf! ()
+     * ```
      *
-     * @param {object} params Parameters for request
-     * @param {string} params.id The ID of the caption track to download, required for One Platform.
-     * @param {string=} params.onBehalfOf ID of the Google+ Page for the channel that the request is be on behalf of
-     * @param {string=} params.onBehalfOfContentOwner <strong>Note:</strong> This parameter is intended exclusively for YouTube content partners.<br><br>The <code><strong>onBehalfOfContentOwner</strong></code> parameter indicates that the request's authorization credentials identify a YouTube CMS user who is acting on behalf of the content owner specified in the parameter value. This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and get access to all their video and channel data, without having to provide authentication credentials for each individual channel. The actual CMS account that the user authenticates with must be linked to the specified YouTube content owner.
-     * @param {string=} params.tfmt Convert the captions into this format. Supported options are sbv, srt, and vtt.
-     * @param {string=} params.tlang tlang is the language code; machine translate the captions into this language.
-     * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-     * @param {callback} callback The callback that handles the response.
-     * @return {object} Request object
+     * @param params - Parameters for request
+     * @param options - Optionally override request options, such as `url`, `method`, and `encoding`.
+     * @param callback - Optional callback that handles the response.
+     * @returns A promise if used with async/await, or void if used with a callback.
      */
     download(
       params: Params$Resource$Captions$Download,
@@ -4984,7 +4994,7 @@ export namespace youtube_v3 {
     download(
       params?: Params$Resource$Captions$Download,
       options?: MethodOptions
-    ): GaxiosPromise<void>;
+    ): GaxiosPromise<unknown>;
     download(
       params: Params$Resource$Captions$Download,
       options: StreamMethodOptions | BodyResponseCallback<Readable>,
@@ -4992,26 +5002,26 @@ export namespace youtube_v3 {
     ): void;
     download(
       params: Params$Resource$Captions$Download,
-      options: MethodOptions | BodyResponseCallback<void>,
-      callback: BodyResponseCallback<void>
+      options: MethodOptions | BodyResponseCallback<unknown>,
+      callback: BodyResponseCallback<unknown>
     ): void;
     download(
       params: Params$Resource$Captions$Download,
-      callback: BodyResponseCallback<void>
+      callback: BodyResponseCallback<unknown>
     ): void;
-    download(callback: BodyResponseCallback<void>): void;
+    download(callback: BodyResponseCallback<unknown>): void;
     download(
       paramsOrCallback?:
         | Params$Resource$Captions$Download
-        | BodyResponseCallback<void>
+        | BodyResponseCallback<unknown>
         | BodyResponseCallback<Readable>,
       optionsOrCallback?:
         | MethodOptions
         | StreamMethodOptions
-        | BodyResponseCallback<void>
+        | BodyResponseCallback<unknown>
         | BodyResponseCallback<Readable>,
-      callback?: BodyResponseCallback<void> | BodyResponseCallback<Readable>
-    ): void | GaxiosPromise<void> | GaxiosPromise<Readable> {
+      callback?: BodyResponseCallback<unknown> | BodyResponseCallback<Readable>
+    ): void | GaxiosPromise<unknown> | GaxiosPromise<Readable> {
       let params = (paramsOrCallback ||
         {}) as Params$Resource$Captions$Download;
       let options = (optionsOrCallback || {}) as MethodOptions;
@@ -5027,7 +5037,7 @@ export namespace youtube_v3 {
         options = {};
       }
 
-      const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+      const rootUrl = options.rootUrl || 'https://youtube.googleapis.com/';
       const parameters = {
         options: Object.assign(
           {
@@ -5045,19 +5055,19 @@ export namespace youtube_v3 {
         context: this.context,
       };
       if (callback) {
-        createAPIRequest<void>(
+        createAPIRequest<unknown>(
           parameters,
-          callback as BodyResponseCallback<{} | void>
+          callback as BodyResponseCallback<unknown>
         );
       } else {
-        return createAPIRequest<void>(parameters);
+        return createAPIRequest<unknown>(parameters);
       }
     }
 
     /**
-     * youtube.captions.insert
-     * @desc Inserts a new resource into this collection.
+     * Inserts a new resource into this collection.
      * @example
+     * ```js
      * // Before running the sample:
      * // - Enable the API at:
      * //   https://console.developers.google.com/apis/api/youtube.googleapis.com
@@ -5086,24 +5096,11 @@ export namespace youtube_v3 {
      *   const res = await youtube.captions.insert({
      *     // ID of the Google+ Page for the channel that the request is be on behalf of
      *     onBehalfOf: 'placeholder-value',
-     *     // <strong>Note:</strong> This parameter is intended exclusively for YouTube
-     *     // content partners.<br><br>The
-     *     // <code><strong>onBehalfOfContentOwner</strong></code> parameter indicates
-     *     // that the request's authorization credentials identify a YouTube CMS user
-     *     // who is acting on behalf of the content owner specified in the parameter
-     *     // value. This parameter is intended for YouTube content partners that own and
-     *     // manage many different YouTube channels. It allows content owners to
-     *     // authenticate once and get access to all their video and channel data,
-     *     // without having to provide authentication credentials for each individual
-     *     // channel. The actual CMS account that the user authenticates with must be
-     *     // linked to the specified YouTube content owner.
+     *     // *Note:* This parameter is intended exclusively for YouTube content partners. The *onBehalfOfContentOwner* parameter indicates that the request's authorization credentials identify a YouTube CMS user who is acting on behalf of the content owner specified in the parameter value. This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and get access to all their video and channel data, without having to provide authentication credentials for each individual channel. The actual CMS account that the user authenticates with must be linked to the specified YouTube content owner.
      *     onBehalfOfContentOwner: 'placeholder-value',
-     *     // The <code><strong>part</strong></code> parameter specifies the
-     *     // <code>caption</code> resource parts that the API response will include. Set
-     *     // the parameter value to <code>snippet</code>.
+     *     // The *part* parameter specifies the caption resource parts that the API response will include. Set the parameter value to snippet.
      *     part: 'placeholder-value',
-     *     // Extra parameter to allow automatically syncing the uploaded
-     *     // caption/transcript with the audio.
+     *     // Extra parameter to allow automatically syncing the uploaded caption/transcript with the audio.
      *     sync: 'placeholder-value',
      *
      *     // Request body metadata
@@ -5137,21 +5134,12 @@ export namespace youtube_v3 {
      *   throw e;
      * });
      *
-     * @alias youtube.captions.insert
-     * @memberOf! ()
+     * ```
      *
-     * @param {object} params Parameters for request
-     * @param {string=} params.onBehalfOf ID of the Google+ Page for the channel that the request is be on behalf of
-     * @param {string=} params.onBehalfOfContentOwner <strong>Note:</strong> This parameter is intended exclusively for YouTube content partners.<br><br>The <code><strong>onBehalfOfContentOwner</strong></code> parameter indicates that the request's authorization credentials identify a YouTube CMS user who is acting on behalf of the content owner specified in the parameter value. This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and get access to all their video and channel data, without having to provide authentication credentials for each individual channel. The actual CMS account that the user authenticates with must be linked to the specified YouTube content owner.
-     * @param {string} params.part The <code><strong>part</strong></code> parameter specifies the <code>caption</code> resource parts that the API response will include. Set the parameter value to <code>snippet</code>.
-     * @param {boolean=} params.sync Extra parameter to allow automatically syncing the uploaded caption/transcript with the audio.
-     * @param  {object} params.requestBody Media resource metadata
-     * @param {object} params.media Media object
-     * @param {string} params.media.mimeType Media mime-type
-     * @param {string|object} params.media.body Media body contents
-     * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-     * @param {callback} callback The callback that handles the response.
-     * @return {object} Request object
+     * @param params - Parameters for request
+     * @param options - Optionally override request options, such as `url`, `method`, and `encoding`.
+     * @param callback - Optional callback that handles the response.
+     * @returns A promise if used with async/await, or void if used with a callback.
      */
     insert(
       params: Params$Resource$Captions$Insert,
@@ -5204,7 +5192,7 @@ export namespace youtube_v3 {
         options = {};
       }
 
-      const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+      const rootUrl = options.rootUrl || 'https://youtube.googleapis.com/';
       const parameters = {
         options: Object.assign(
           {
@@ -5228,7 +5216,7 @@ export namespace youtube_v3 {
       if (callback) {
         createAPIRequest<Schema$Caption>(
           parameters,
-          callback as BodyResponseCallback<{} | void>
+          callback as BodyResponseCallback<unknown>
         );
       } else {
         return createAPIRequest<Schema$Caption>(parameters);
@@ -5236,9 +5224,9 @@ export namespace youtube_v3 {
     }
 
     /**
-     * youtube.captions.list
-     * @desc Retrieves a list of resources, possibly filtered.
+     * Retrieves a list of resources, possibly filtered.
      * @example
+     * ```js
      * // Before running the sample:
      * // - Enable the API at:
      * //   https://console.developers.google.com/apis/api/youtube.googleapis.com
@@ -5269,23 +5257,9 @@ export namespace youtube_v3 {
      *     id: 'placeholder-value',
      *     // ID of the Google+ Page for the channel that the request is on behalf of.
      *     onBehalfOf: 'placeholder-value',
-     *     // <strong>Note:</strong> This parameter is intended exclusively for YouTube
-     *     // content partners.<br><br>The
-     *     // <code><strong>onBehalfOfContentOwner</strong></code> parameter indicates
-     *     // that the request's authorization credentials identify a YouTube CMS user
-     *     // who is acting on behalf of the content owner specified in the parameter
-     *     // value. This parameter is intended for YouTube content partners that own and
-     *     // manage many different YouTube channels. It allows content owners to
-     *     // authenticate once and get access to all their video and channel data,
-     *     // without having to provide authentication credentials for each individual
-     *     // channel. The actual CMS account that the user authenticates with must be
-     *     // linked to the specified YouTube content owner.
+     *     // *Note:* This parameter is intended exclusively for YouTube content partners. The *onBehalfOfContentOwner* parameter indicates that the request's authorization credentials identify a YouTube CMS user who is acting on behalf of the content owner specified in the parameter value. This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and get access to all their video and channel data, without having to provide authentication credentials for each individual channel. The actual CMS account that the user authenticates with must be linked to the specified YouTube content owner.
      *     onBehalfOfContentOwner: 'placeholder-value',
-     *     // The <code><strong>part</strong></code> parameter specifies a
-     *     // comma-separated list of one or more <code>caption</code> resource parts
-     *     // that the API response will include. The <code>part</code> names that you
-     *     // can include in the parameter value are <code>id</code> and
-     *     // <code>snippet</code>.
+     *     // The *part* parameter specifies a comma-separated list of one or more caption resource parts that the API response will include. The part names that you can include in the parameter value are id and snippet.
      *     part: 'placeholder-value',
      *     // Returns the captions for the specified video.
      *     videoId: 'placeholder-value',
@@ -5307,18 +5281,12 @@ export namespace youtube_v3 {
      *   throw e;
      * });
      *
-     * @alias youtube.captions.list
-     * @memberOf! ()
+     * ```
      *
-     * @param {object} params Parameters for request
-     * @param {string=} params.id Returns the captions with the given IDs for Stubby or Apiary.
-     * @param {string=} params.onBehalfOf ID of the Google+ Page for the channel that the request is on behalf of.
-     * @param {string=} params.onBehalfOfContentOwner <strong>Note:</strong> This parameter is intended exclusively for YouTube content partners.<br><br>The <code><strong>onBehalfOfContentOwner</strong></code> parameter indicates that the request's authorization credentials identify a YouTube CMS user who is acting on behalf of the content owner specified in the parameter value. This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and get access to all their video and channel data, without having to provide authentication credentials for each individual channel. The actual CMS account that the user authenticates with must be linked to the specified YouTube content owner.
-     * @param {string} params.part The <code><strong>part</strong></code> parameter specifies a comma-separated list of one or more <code>caption</code> resource parts that the API response will include. The <code>part</code> names that you can include in the parameter value are <code>id</code> and <code>snippet</code>.
-     * @param {string} params.videoId Returns the captions for the specified video.
-     * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-     * @param {callback} callback The callback that handles the response.
-     * @return {object} Request object
+     * @param params - Parameters for request
+     * @param options - Optionally override request options, such as `url`, `method`, and `encoding`.
+     * @param callback - Optional callback that handles the response.
+     * @returns A promise if used with async/await, or void if used with a callback.
      */
     list(
       params: Params$Resource$Captions$List,
@@ -5374,7 +5342,7 @@ export namespace youtube_v3 {
         options = {};
       }
 
-      const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+      const rootUrl = options.rootUrl || 'https://youtube.googleapis.com/';
       const parameters = {
         options: Object.assign(
           {
@@ -5387,14 +5355,14 @@ export namespace youtube_v3 {
           options
         ),
         params,
-        requiredParams: ['videoId', 'part'],
+        requiredParams: ['part', 'videoId'],
         pathParams: [],
         context: this.context,
       };
       if (callback) {
         createAPIRequest<Schema$CaptionListResponse>(
           parameters,
-          callback as BodyResponseCallback<{} | void>
+          callback as BodyResponseCallback<unknown>
         );
       } else {
         return createAPIRequest<Schema$CaptionListResponse>(parameters);
@@ -5402,9 +5370,9 @@ export namespace youtube_v3 {
     }
 
     /**
-     * youtube.captions.update
-     * @desc Updates an existing resource.
+     * Updates an existing resource.
      * @example
+     * ```js
      * // Before running the sample:
      * // - Enable the API at:
      * //   https://console.developers.google.com/apis/api/youtube.googleapis.com
@@ -5433,26 +5401,11 @@ export namespace youtube_v3 {
      *   const res = await youtube.captions.update({
      *     // ID of the Google+ Page for the channel that the request is on behalf of.
      *     onBehalfOf: 'placeholder-value',
-     *     // <strong>Note:</strong> This parameter is intended exclusively for YouTube
-     *     // content partners.<br><br>The
-     *     // <code><strong>onBehalfOfContentOwner</strong></code> parameter indicates
-     *     // that the request's authorization credentials identify a YouTube CMS user
-     *     // who is acting on behalf of the content owner specified in the parameter
-     *     // value. This parameter is intended for YouTube content partners that own and
-     *     // manage many different YouTube channels. It allows content owners to
-     *     // authenticate once and get access to all their video and channel data,
-     *     // without having to provide authentication credentials for each individual
-     *     // channel. The actual CMS account that the user authenticates with must be
-     *     // linked to the specified YouTube content owner.
+     *     // *Note:* This parameter is intended exclusively for YouTube content partners. The *onBehalfOfContentOwner* parameter indicates that the request's authorization credentials identify a YouTube CMS user who is acting on behalf of the content owner specified in the parameter value. This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and get access to all their video and channel data, without having to provide authentication credentials for each individual channel. The actual CMS account that the user authenticates with must be linked to the specified YouTube content owner.
      *     onBehalfOfContentOwner: 'placeholder-value',
-     *     // The <code><strong>part</strong></code> parameter specifies a
-     *     // comma-separated list of one or more <code>caption</code> resource parts
-     *     // that the API response will include. The <code>part</code> names that you
-     *     // can include in the parameter value are <code>id</code> and
-     *     // <code>snippet</code>.
+     *     // The *part* parameter specifies a comma-separated list of one or more caption resource parts that the API response will include. The part names that you can include in the parameter value are id and snippet.
      *     part: 'placeholder-value',
-     *     // Extra parameter to allow automatically syncing the uploaded
-     *     // caption/transcript with the audio.
+     *     // Extra parameter to allow automatically syncing the uploaded caption/transcript with the audio.
      *     sync: 'placeholder-value',
      *
      *     // Request body metadata
@@ -5486,21 +5439,12 @@ export namespace youtube_v3 {
      *   throw e;
      * });
      *
-     * @alias youtube.captions.update
-     * @memberOf! ()
+     * ```
      *
-     * @param {object} params Parameters for request
-     * @param {string=} params.onBehalfOf ID of the Google+ Page for the channel that the request is on behalf of.
-     * @param {string=} params.onBehalfOfContentOwner <strong>Note:</strong> This parameter is intended exclusively for YouTube content partners.<br><br>The <code><strong>onBehalfOfContentOwner</strong></code> parameter indicates that the request's authorization credentials identify a YouTube CMS user who is acting on behalf of the content owner specified in the parameter value. This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and get access to all their video and channel data, without having to provide authentication credentials for each individual channel. The actual CMS account that the user authenticates with must be linked to the specified YouTube content owner.
-     * @param {string} params.part The <code><strong>part</strong></code> parameter specifies a comma-separated list of one or more <code>caption</code> resource parts that the API response will include. The <code>part</code> names that you can include in the parameter value are <code>id</code> and <code>snippet</code>.
-     * @param {boolean=} params.sync Extra parameter to allow automatically syncing the uploaded caption/transcript with the audio.
-     * @param  {object} params.requestBody Media resource metadata
-     * @param {object} params.media Media object
-     * @param {string} params.media.mimeType Media mime-type
-     * @param {string|object} params.media.body Media body contents
-     * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-     * @param {callback} callback The callback that handles the response.
-     * @return {object} Request object
+     * @param params - Parameters for request
+     * @param options - Optionally override request options, such as `url`, `method`, and `encoding`.
+     * @param callback - Optional callback that handles the response.
+     * @returns A promise if used with async/await, or void if used with a callback.
      */
     update(
       params: Params$Resource$Captions$Update,
@@ -5553,7 +5497,7 @@ export namespace youtube_v3 {
         options = {};
       }
 
-      const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+      const rootUrl = options.rootUrl || 'https://youtube.googleapis.com/';
       const parameters = {
         options: Object.assign(
           {
@@ -5577,7 +5521,7 @@ export namespace youtube_v3 {
       if (callback) {
         createAPIRequest<Schema$Caption>(
           parameters,
-          callback as BodyResponseCallback<{} | void>
+          callback as BodyResponseCallback<unknown>
         );
       } else {
         return createAPIRequest<Schema$Caption>(parameters);
@@ -5595,7 +5539,7 @@ export namespace youtube_v3 {
      */
     onBehalfOf?: string;
     /**
-     * <strong>Note:</strong> This parameter is intended exclusively for YouTube content partners.<br><br>The <code><strong>onBehalfOfContentOwner</strong></code> parameter indicates that the request's authorization credentials identify a YouTube CMS user who is acting on behalf of the content owner specified in the parameter value. This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and get access to all their video and channel data, without having to provide authentication credentials for each individual channel. The actual CMS account that the user authenticates with must be linked to the specified YouTube content owner.
+     * *Note:* This parameter is intended exclusively for YouTube content partners. The *onBehalfOfContentOwner* parameter indicates that the request's authorization credentials identify a YouTube CMS user who is acting on behalf of the content owner specified in the parameter value. This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and get access to all their video and channel data, without having to provide authentication credentials for each individual channel. The actual CMS account that the user authenticates with must be linked to the specified YouTube content owner.
      */
     onBehalfOfContentOwner?: string;
   }
@@ -5610,7 +5554,7 @@ export namespace youtube_v3 {
      */
     onBehalfOf?: string;
     /**
-     * <strong>Note:</strong> This parameter is intended exclusively for YouTube content partners.<br><br>The <code><strong>onBehalfOfContentOwner</strong></code> parameter indicates that the request's authorization credentials identify a YouTube CMS user who is acting on behalf of the content owner specified in the parameter value. This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and get access to all their video and channel data, without having to provide authentication credentials for each individual channel. The actual CMS account that the user authenticates with must be linked to the specified YouTube content owner.
+     * *Note:* This parameter is intended exclusively for YouTube content partners. The *onBehalfOfContentOwner* parameter indicates that the request's authorization credentials identify a YouTube CMS user who is acting on behalf of the content owner specified in the parameter value. This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and get access to all their video and channel data, without having to provide authentication credentials for each individual channel. The actual CMS account that the user authenticates with must be linked to the specified YouTube content owner.
      */
     onBehalfOfContentOwner?: string;
     /**
@@ -5628,11 +5572,11 @@ export namespace youtube_v3 {
      */
     onBehalfOf?: string;
     /**
-     * <strong>Note:</strong> This parameter is intended exclusively for YouTube content partners.<br><br>The <code><strong>onBehalfOfContentOwner</strong></code> parameter indicates that the request's authorization credentials identify a YouTube CMS user who is acting on behalf of the content owner specified in the parameter value. This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and get access to all their video and channel data, without having to provide authentication credentials for each individual channel. The actual CMS account that the user authenticates with must be linked to the specified YouTube content owner.
+     * *Note:* This parameter is intended exclusively for YouTube content partners. The *onBehalfOfContentOwner* parameter indicates that the request's authorization credentials identify a YouTube CMS user who is acting on behalf of the content owner specified in the parameter value. This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and get access to all their video and channel data, without having to provide authentication credentials for each individual channel. The actual CMS account that the user authenticates with must be linked to the specified YouTube content owner.
      */
     onBehalfOfContentOwner?: string;
     /**
-     * The <code><strong>part</strong></code> parameter specifies the <code>caption</code> resource parts that the API response will include. Set the parameter value to <code>snippet</code>.
+     * The *part* parameter specifies the caption resource parts that the API response will include. Set the parameter value to snippet.
      */
     part?: string[];
     /**
@@ -5670,11 +5614,11 @@ export namespace youtube_v3 {
      */
     onBehalfOf?: string;
     /**
-     * <strong>Note:</strong> This parameter is intended exclusively for YouTube content partners.<br><br>The <code><strong>onBehalfOfContentOwner</strong></code> parameter indicates that the request's authorization credentials identify a YouTube CMS user who is acting on behalf of the content owner specified in the parameter value. This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and get access to all their video and channel data, without having to provide authentication credentials for each individual channel. The actual CMS account that the user authenticates with must be linked to the specified YouTube content owner.
+     * *Note:* This parameter is intended exclusively for YouTube content partners. The *onBehalfOfContentOwner* parameter indicates that the request's authorization credentials identify a YouTube CMS user who is acting on behalf of the content owner specified in the parameter value. This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and get access to all their video and channel data, without having to provide authentication credentials for each individual channel. The actual CMS account that the user authenticates with must be linked to the specified YouTube content owner.
      */
     onBehalfOfContentOwner?: string;
     /**
-     * The <code><strong>part</strong></code> parameter specifies a comma-separated list of one or more <code>caption</code> resource parts that the API response will include. The <code>part</code> names that you can include in the parameter value are <code>id</code> and <code>snippet</code>.
+     * The *part* parameter specifies a comma-separated list of one or more caption resource parts that the API response will include. The part names that you can include in the parameter value are id and snippet.
      */
     part?: string[];
     /**
@@ -5688,11 +5632,11 @@ export namespace youtube_v3 {
      */
     onBehalfOf?: string;
     /**
-     * <strong>Note:</strong> This parameter is intended exclusively for YouTube content partners.<br><br>The <code><strong>onBehalfOfContentOwner</strong></code> parameter indicates that the request's authorization credentials identify a YouTube CMS user who is acting on behalf of the content owner specified in the parameter value. This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and get access to all their video and channel data, without having to provide authentication credentials for each individual channel. The actual CMS account that the user authenticates with must be linked to the specified YouTube content owner.
+     * *Note:* This parameter is intended exclusively for YouTube content partners. The *onBehalfOfContentOwner* parameter indicates that the request's authorization credentials identify a YouTube CMS user who is acting on behalf of the content owner specified in the parameter value. This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and get access to all their video and channel data, without having to provide authentication credentials for each individual channel. The actual CMS account that the user authenticates with must be linked to the specified YouTube content owner.
      */
     onBehalfOfContentOwner?: string;
     /**
-     * The <code><strong>part</strong></code> parameter specifies a comma-separated list of one or more <code>caption</code> resource parts that the API response will include. The <code>part</code> names that you can include in the parameter value are <code>id</code> and <code>snippet</code>.
+     * The *part* parameter specifies a comma-separated list of one or more caption resource parts that the API response will include. The part names that you can include in the parameter value are id and snippet.
      */
     part?: string[];
     /**
@@ -5728,9 +5672,9 @@ export namespace youtube_v3 {
     }
 
     /**
-     * youtube.channelBanners.insert
-     * @desc Inserts a new resource into this collection.
+     * Inserts a new resource into this collection.
      * @example
+     * ```js
      * // Before running the sample:
      * // - Enable the API at:
      * //   https://console.developers.google.com/apis/api/youtube.googleapis.com
@@ -5758,40 +5702,11 @@ export namespace youtube_v3 {
      *
      *   // Do the magic
      *   const res = await youtube.channelBanners.insert({
-     *     // Unused, channel_id is currently derived from the security context of the
-     *     // requestor.
+     *     // Unused, channel_id is currently derived from the security context of the requestor.
      *     channelId: 'placeholder-value',
-     *     // <strong>Note:</strong> This parameter is intended exclusively for YouTube
-     *     // content partners.<br><br>The
-     *     // <code><strong>onBehalfOfContentOwner</strong></code> parameter indicates
-     *     // that the request's authorization credentials identify a YouTube CMS user
-     *     // who is acting on behalf of the content owner specified in the parameter
-     *     // value. This parameter is intended for YouTube content partners that own and
-     *     // manage many different YouTube channels. It allows content owners to
-     *     // authenticate once and get access to all their video and channel data,
-     *     // without having to provide authentication credentials for each individual
-     *     // channel. The actual CMS account that the user authenticates with must be
-     *     // linked to the specified YouTube content owner.
+     *     // *Note:* This parameter is intended exclusively for YouTube content partners. The *onBehalfOfContentOwner* parameter indicates that the request's authorization credentials identify a YouTube CMS user who is acting on behalf of the content owner specified in the parameter value. This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and get access to all their video and channel data, without having to provide authentication credentials for each individual channel. The actual CMS account that the user authenticates with must be linked to the specified YouTube content owner.
      *     onBehalfOfContentOwner: 'placeholder-value',
-     *     // This parameter can only be used in a properly <a
-     *     // href="/youtube/v3/guides/authentication">authorized request</a>.
-     *     // <strong>Note:</strong> This parameter is intended exclusively for YouTube
-     *     // content partners.<br><br>The
-     *     // <code><strong>onBehalfOfContentOwnerChannel</strong></code> parameter
-     *     // specifies the YouTube channel ID of the channel to which a video is being
-     *     // added. This parameter is required when a request specifies a value for the
-     *     // <code>onBehalfOfContentOwner</code> parameter, and it can only be used in
-     *     // conjunction with that parameter. In addition, the request must be
-     *     // authorized using a CMS account that is linked to the content owner that the
-     *     // <code>onBehalfOfContentOwner</code> parameter specifies. Finally, the
-     *     // channel that the <code>onBehalfOfContentOwnerChannel</code> parameter value
-     *     // specifies must be linked to the content owner that the
-     *     // <code>onBehalfOfContentOwner</code> parameter specifies.<br><br>This
-     *     // parameter is intended for YouTube content partners that own and manage many
-     *     // different YouTube channels. It allows content owners to authenticate once
-     *     // and perform actions on behalf of the channel specified in the parameter
-     *     // value, without having to provide authentication credentials for each
-     *     // separate channel.
+     *     // This parameter can only be used in a properly authorized request. *Note:* This parameter is intended exclusively for YouTube content partners. The *onBehalfOfContentOwnerChannel* parameter specifies the YouTube channel ID of the channel to which a video is being added. This parameter is required when a request specifies a value for the onBehalfOfContentOwner parameter, and it can only be used in conjunction with that parameter. In addition, the request must be authorized using a CMS account that is linked to the content owner that the onBehalfOfContentOwner parameter specifies. Finally, the channel that the onBehalfOfContentOwnerChannel parameter value specifies must be linked to the content owner that the onBehalfOfContentOwner parameter specifies. This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and perform actions on behalf of the channel specified in the parameter value, without having to provide authentication credentials for each separate channel.
      *     onBehalfOfContentOwnerChannel: 'placeholder-value',
      *
      *     // Request body metadata
@@ -5823,20 +5738,12 @@ export namespace youtube_v3 {
      *   throw e;
      * });
      *
-     * @alias youtube.channelBanners.insert
-     * @memberOf! ()
+     * ```
      *
-     * @param {object} params Parameters for request
-     * @param {string=} params.channelId Unused, channel_id is currently derived from the security context of the requestor.
-     * @param {string=} params.onBehalfOfContentOwner <strong>Note:</strong> This parameter is intended exclusively for YouTube content partners.<br><br>The <code><strong>onBehalfOfContentOwner</strong></code> parameter indicates that the request's authorization credentials identify a YouTube CMS user who is acting on behalf of the content owner specified in the parameter value. This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and get access to all their video and channel data, without having to provide authentication credentials for each individual channel. The actual CMS account that the user authenticates with must be linked to the specified YouTube content owner.
-     * @param {string=} params.onBehalfOfContentOwnerChannel This parameter can only be used in a properly <a href="/youtube/v3/guides/authentication">authorized request</a>. <strong>Note:</strong> This parameter is intended exclusively for YouTube content partners.<br><br>The <code><strong>onBehalfOfContentOwnerChannel</strong></code> parameter specifies the YouTube channel ID of the channel to which a video is being added. This parameter is required when a request specifies a value for the <code>onBehalfOfContentOwner</code> parameter, and it can only be used in conjunction with that parameter. In addition, the request must be authorized using a CMS account that is linked to the content owner that the <code>onBehalfOfContentOwner</code> parameter specifies. Finally, the channel that the <code>onBehalfOfContentOwnerChannel</code> parameter value specifies must be linked to the content owner that the <code>onBehalfOfContentOwner</code> parameter specifies.<br><br>This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and perform actions on behalf of the channel specified in the parameter value, without having to provide authentication credentials for each separate channel.
-     * @param  {object} params.requestBody Media resource metadata
-     * @param {object} params.media Media object
-     * @param {string} params.media.mimeType Media mime-type
-     * @param {string|object} params.media.body Media body contents
-     * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-     * @param {callback} callback The callback that handles the response.
-     * @return {object} Request object
+     * @param params - Parameters for request
+     * @param options - Optionally override request options, such as `url`, `method`, and `encoding`.
+     * @param callback - Optional callback that handles the response.
+     * @returns A promise if used with async/await, or void if used with a callback.
      */
     insert(
       params: Params$Resource$Channelbanners$Insert,
@@ -5895,7 +5802,7 @@ export namespace youtube_v3 {
         options = {};
       }
 
-      const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+      const rootUrl = options.rootUrl || 'https://youtube.googleapis.com/';
       const parameters = {
         options: Object.assign(
           {
@@ -5918,7 +5825,7 @@ export namespace youtube_v3 {
       if (callback) {
         createAPIRequest<Schema$ChannelBannerResource>(
           parameters,
-          callback as BodyResponseCallback<{} | void>
+          callback as BodyResponseCallback<unknown>
         );
       } else {
         return createAPIRequest<Schema$ChannelBannerResource>(parameters);
@@ -5933,11 +5840,11 @@ export namespace youtube_v3 {
      */
     channelId?: string;
     /**
-     * <strong>Note:</strong> This parameter is intended exclusively for YouTube content partners.<br><br>The <code><strong>onBehalfOfContentOwner</strong></code> parameter indicates that the request's authorization credentials identify a YouTube CMS user who is acting on behalf of the content owner specified in the parameter value. This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and get access to all their video and channel data, without having to provide authentication credentials for each individual channel. The actual CMS account that the user authenticates with must be linked to the specified YouTube content owner.
+     * *Note:* This parameter is intended exclusively for YouTube content partners. The *onBehalfOfContentOwner* parameter indicates that the request's authorization credentials identify a YouTube CMS user who is acting on behalf of the content owner specified in the parameter value. This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and get access to all their video and channel data, without having to provide authentication credentials for each individual channel. The actual CMS account that the user authenticates with must be linked to the specified YouTube content owner.
      */
     onBehalfOfContentOwner?: string;
     /**
-     * This parameter can only be used in a properly <a href="/youtube/v3/guides/authentication">authorized request</a>. <strong>Note:</strong> This parameter is intended exclusively for YouTube content partners.<br><br>The <code><strong>onBehalfOfContentOwnerChannel</strong></code> parameter specifies the YouTube channel ID of the channel to which a video is being added. This parameter is required when a request specifies a value for the <code>onBehalfOfContentOwner</code> parameter, and it can only be used in conjunction with that parameter. In addition, the request must be authorized using a CMS account that is linked to the content owner that the <code>onBehalfOfContentOwner</code> parameter specifies. Finally, the channel that the <code>onBehalfOfContentOwnerChannel</code> parameter value specifies must be linked to the content owner that the <code>onBehalfOfContentOwner</code> parameter specifies.<br><br>This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and perform actions on behalf of the channel specified in the parameter value, without having to provide authentication credentials for each separate channel.
+     * This parameter can only be used in a properly authorized request. *Note:* This parameter is intended exclusively for YouTube content partners. The *onBehalfOfContentOwnerChannel* parameter specifies the YouTube channel ID of the channel to which a video is being added. This parameter is required when a request specifies a value for the onBehalfOfContentOwner parameter, and it can only be used in conjunction with that parameter. In addition, the request must be authorized using a CMS account that is linked to the content owner that the onBehalfOfContentOwner parameter specifies. Finally, the channel that the onBehalfOfContentOwnerChannel parameter value specifies must be linked to the content owner that the onBehalfOfContentOwner parameter specifies. This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and perform actions on behalf of the channel specified in the parameter value, without having to provide authentication credentials for each separate channel.
      */
     onBehalfOfContentOwnerChannel?: string;
 
@@ -5969,9 +5876,9 @@ export namespace youtube_v3 {
     }
 
     /**
-     * youtube.channels.list
-     * @desc Retrieves a list of resources, possibly filtered.
+     * Retrieves a list of resources, possibly filtered.
      * @example
+     * ```js
      * // Before running the sample:
      * // - Enable the API at:
      * //   https://console.developers.google.com/apis/api/youtube.googleapis.com
@@ -6005,50 +5912,23 @@ export namespace youtube_v3 {
      *     categoryId: 'placeholder-value',
      *     // Return the channel associated with a YouTube username.
      *     forUsername: 'placeholder-value',
-     *     // Stands for "host language". Specifies the localization language of the
-     *     // metadata to be filled into snippet.localized. The field is filled with the
-     *     // default metadata if there is no localization in the specified language.
-     *     // The parameter value must be a language code included in the list returned
-     *     // by the i18nLanguages.list method (e.g. en_US, es_MX).
+     *     // Stands for "host language". Specifies the localization language of the metadata to be filled into snippet.localized. The field is filled with the default metadata if there is no localization in the specified language. The parameter value must be a language code included in the list returned by the i18nLanguages.list method (e.g. en_US, es_MX).
      *     hl: 'placeholder-value',
      *     // Return the channels with the specified IDs.
      *     id: 'placeholder-value',
      *     // Return the channels managed by the authenticated user.
      *     managedByMe: 'placeholder-value',
-     *     // The <code><strong>maxResults</strong></code> parameter specifies the
-     *     // maximum number of items that should be returned in the result set.
+     *     // The *maxResults* parameter specifies the maximum number of items that should be returned in the result set.
      *     maxResults: 'placeholder-value',
      *     // Return the ids of channels owned by the authenticated user.
      *     mine: 'placeholder-value',
      *     // Return the channels subscribed to the authenticated user
      *     mySubscribers: 'placeholder-value',
-     *     // <strong>Note:</strong> This parameter is intended exclusively for YouTube
-     *     // content partners.<br><br>The
-     *     // <code><strong>onBehalfOfContentOwner</strong></code> parameter indicates
-     *     // that the
-     *     // request's authorization credentials identify a YouTube CMS user who is
-     *     // acting on behalf of the content owner specified in the parameter value.
-     *     // This parameter is intended for YouTube content partners that own and manage
-     *     // many different YouTube channels. It allows content owners to authenticate
-     *     // once and get access to all their video and channel data, without having to
-     *     // provide authentication credentials for each individual channel. The CMS
-     *     // account that the user authenticates with must be linked to the specified
-     *     // YouTube content owner.
+     *     // *Note:* This parameter is intended exclusively for YouTube content partners. The *onBehalfOfContentOwner* parameter indicates that the request's authorization credentials identify a YouTube CMS user who is acting on behalf of the content owner specified in the parameter value. This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and get access to all their video and channel data, without having to provide authentication credentials for each individual channel. The CMS account that the user authenticates with must be linked to the specified YouTube content owner.
      *     onBehalfOfContentOwner: 'placeholder-value',
-     *     // The <code><strong>pageToken</strong></code> parameter identifies a specific
-     *     // page in the result set that should be returned. In an API response, the
-     *     // <code>nextPageToken</code> and <code>prevPageToken</code> properties
-     *     // identify other pages that could be retrieved.
+     *     // The *pageToken* parameter identifies a specific page in the result set that should be returned. In an API response, the nextPageToken and prevPageToken properties identify other pages that could be retrieved.
      *     pageToken: 'placeholder-value',
-     *     // The <code><strong>part</strong></code> parameter specifies a
-     *     // comma-separated list of one or more <code>channel</code> resource
-     *     // properties that the API response will include.<br><br>If the parameter
-     *     // identifies a property that contains child properties, the child properties
-     *     // will be included in the response. For example, in a <code>channel</code>
-     *     // resource, the <code>contentDetails</code> property contains other
-     *     // properties, such as the <code>uploads</code> properties. As such, if you
-     *     // set <code><strong>part=contentDetails</strong></code>, the API response
-     *     // will also contain all of those nested properties.
+     *     // The *part* parameter specifies a comma-separated list of one or more channel resource properties that the API response will include. If the parameter identifies a property that contains child properties, the child properties will be included in the response. For example, in a channel resource, the contentDetails property contains other properties, such as the uploads properties. As such, if you set *part=contentDetails*, the API response will also contain all of those nested properties.
      *     part: 'placeholder-value',
      *   });
      *   console.log(res.data);
@@ -6072,24 +5952,12 @@ export namespace youtube_v3 {
      *   throw e;
      * });
      *
-     * @alias youtube.channels.list
-     * @memberOf! ()
+     * ```
      *
-     * @param {object} params Parameters for request
-     * @param {string=} params.categoryId Return the channels within the specified guide category ID.
-     * @param {string=} params.forUsername Return the channel associated with a YouTube username.
-     * @param {string=} params.hl Stands for "host language". Specifies the localization language of the metadata to be filled into snippet.localized. The field is filled with the default metadata if there is no localization in the specified language. The parameter value must be a language code included in the list returned by the i18nLanguages.list method (e.g. en_US, es_MX).
-     * @param {string=} params.id Return the channels with the specified IDs.
-     * @param {boolean=} params.managedByMe Return the channels managed by the authenticated user.
-     * @param {integer=} params.maxResults The <code><strong>maxResults</strong></code> parameter specifies the maximum number of items that should be returned in the result set.
-     * @param {boolean=} params.mine Return the ids of channels owned by the authenticated user.
-     * @param {boolean=} params.mySubscribers Return the channels subscribed to the authenticated user
-     * @param {string=} params.onBehalfOfContentOwner <strong>Note:</strong> This parameter is intended exclusively for YouTube content partners.<br><br>The <code><strong>onBehalfOfContentOwner</strong></code> parameter indicates that the request's authorization credentials identify a YouTube CMS user who is acting on behalf of the content owner specified in the parameter value. This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and get access to all their video and channel data, without having to provide authentication credentials for each individual channel. The CMS account that the user authenticates with must be linked to the specified YouTube content owner.
-     * @param {string=} params.pageToken The <code><strong>pageToken</strong></code> parameter identifies a specific page in the result set that should be returned. In an API response, the <code>nextPageToken</code> and <code>prevPageToken</code> properties identify other pages that could be retrieved.
-     * @param {string} params.part The <code><strong>part</strong></code> parameter specifies a comma-separated list of one or more <code>channel</code> resource properties that the API response will include.<br><br>If the parameter identifies a property that contains child properties, the child properties will be included in the response. For example, in a <code>channel</code> resource, the <code>contentDetails</code> property contains other properties, such as the <code>uploads</code> properties. As such, if you set <code><strong>part=contentDetails</strong></code>, the API response will also contain all of those nested properties.
-     * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-     * @param {callback} callback The callback that handles the response.
-     * @return {object} Request object
+     * @param params - Parameters for request
+     * @param options - Optionally override request options, such as `url`, `method`, and `encoding`.
+     * @param callback - Optional callback that handles the response.
+     * @returns A promise if used with async/await, or void if used with a callback.
      */
     list(
       params: Params$Resource$Channels$List,
@@ -6145,7 +6013,7 @@ export namespace youtube_v3 {
         options = {};
       }
 
-      const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+      const rootUrl = options.rootUrl || 'https://youtube.googleapis.com/';
       const parameters = {
         options: Object.assign(
           {
@@ -6165,7 +6033,7 @@ export namespace youtube_v3 {
       if (callback) {
         createAPIRequest<Schema$ChannelListResponse>(
           parameters,
-          callback as BodyResponseCallback<{} | void>
+          callback as BodyResponseCallback<unknown>
         );
       } else {
         return createAPIRequest<Schema$ChannelListResponse>(parameters);
@@ -6173,9 +6041,9 @@ export namespace youtube_v3 {
     }
 
     /**
-     * youtube.channels.update
-     * @desc Updates an existing resource.
+     * Updates an existing resource.
      * @example
+     * ```js
      * // Before running the sample:
      * // - Enable the API at:
      * //   https://console.developers.google.com/apis/api/youtube.googleapis.com
@@ -6203,25 +6071,9 @@ export namespace youtube_v3 {
      *
      *   // Do the magic
      *   const res = await youtube.channels.update({
-     *     // The <code><strong>onBehalfOfContentOwner</strong></code> parameter
-     *     // indicates that the authenticated user is acting on behalf of the content
-     *     // owner specified in the parameter value. This parameter is intended for
-     *     // YouTube content partners that own and manage many different YouTube
-     *     // channels. It allows content owners to authenticate once and get access to
-     *     // all their video and channel data, without having to provide authentication
-     *     // credentials for each individual channel. The actual CMS account that the
-     *     // user authenticates with needs to be linked to the specified YouTube content
-     *     // owner.
+     *     // The *onBehalfOfContentOwner* parameter indicates that the authenticated user is acting on behalf of the content owner specified in the parameter value. This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and get access to all their video and channel data, without having to provide authentication credentials for each individual channel. The actual CMS account that the user authenticates with needs to be linked to the specified YouTube content owner.
      *     onBehalfOfContentOwner: 'placeholder-value',
-     *     // The <code><strong>part</strong></code> parameter serves two purposes in
-     *     // this operation. It identifies the properties that the write operation will
-     *     // set as well as the properties that the API response will
-     *     // include.<br/><br/>The API currently only allows the parameter value to be
-     *     // set to either <code>brandingSettings</code> or
-     *     // <code>invideoPromotion</code>. (You cannot update both of those parts with
-     *     // a single request.)<br/><br/>Note that this method overrides the existing
-     *     // values for all of the mutable properties that are contained in any parts
-     *     // that the parameter value specifies.
+     *     // The *part* parameter serves two purposes in this operation. It identifies the properties that the write operation will set as well as the properties that the API response will include. The API currently only allows the parameter value to be set to either brandingSettings or invideoPromotion. (You cannot update both of those parts with a single request.) Note that this method overrides the existing values for all of the mutable properties that are contained in any parts that the parameter value specifies.
      *     part: 'placeholder-value',
      *
      *     // Request body metadata
@@ -6235,7 +6087,6 @@ export namespace youtube_v3 {
      *       //   "conversionPings": {},
      *       //   "etag": "my_etag",
      *       //   "id": "my_id",
-     *       //   "invideoPromotion": {},
      *       //   "kind": "my_kind",
      *       //   "localizations": {},
      *       //   "snippet": {},
@@ -6256,7 +6107,6 @@ export namespace youtube_v3 {
      *   //   "conversionPings": {},
      *   //   "etag": "my_etag",
      *   //   "id": "my_id",
-     *   //   "invideoPromotion": {},
      *   //   "kind": "my_kind",
      *   //   "localizations": {},
      *   //   "snippet": {},
@@ -6271,16 +6121,12 @@ export namespace youtube_v3 {
      *   throw e;
      * });
      *
-     * @alias youtube.channels.update
-     * @memberOf! ()
+     * ```
      *
-     * @param {object} params Parameters for request
-     * @param {string=} params.onBehalfOfContentOwner The <code><strong>onBehalfOfContentOwner</strong></code> parameter indicates that the authenticated user is acting on behalf of the content owner specified in the parameter value. This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and get access to all their video and channel data, without having to provide authentication credentials for each individual channel. The actual CMS account that the user authenticates with needs to be linked to the specified YouTube content owner.
-     * @param {string} params.part The <code><strong>part</strong></code> parameter serves two purposes in this operation. It identifies the properties that the write operation will set as well as the properties that the API response will include.<br/><br/>The API currently only allows the parameter value to be set to either <code>brandingSettings</code> or <code>invideoPromotion</code>. (You cannot update both of those parts with a single request.)<br/><br/>Note that this method overrides the existing values for all of the mutable properties that are contained in any parts that the parameter value specifies.
-     * @param {().Channel} params.requestBody Request body data
-     * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-     * @param {callback} callback The callback that handles the response.
-     * @return {object} Request object
+     * @param params - Parameters for request
+     * @param options - Optionally override request options, such as `url`, `method`, and `encoding`.
+     * @param callback - Optional callback that handles the response.
+     * @returns A promise if used with async/await, or void if used with a callback.
      */
     update(
       params: Params$Resource$Channels$Update,
@@ -6333,7 +6179,7 @@ export namespace youtube_v3 {
         options = {};
       }
 
-      const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+      const rootUrl = options.rootUrl || 'https://youtube.googleapis.com/';
       const parameters = {
         options: Object.assign(
           {
@@ -6353,7 +6199,7 @@ export namespace youtube_v3 {
       if (callback) {
         createAPIRequest<Schema$Channel>(
           parameters,
-          callback as BodyResponseCallback<{} | void>
+          callback as BodyResponseCallback<unknown>
         );
       } else {
         return createAPIRequest<Schema$Channel>(parameters);
@@ -6383,7 +6229,7 @@ export namespace youtube_v3 {
      */
     managedByMe?: boolean;
     /**
-     * The <code><strong>maxResults</strong></code> parameter specifies the maximum number of items that should be returned in the result set.
+     * The *maxResults* parameter specifies the maximum number of items that should be returned in the result set.
      */
     maxResults?: number;
     /**
@@ -6395,25 +6241,25 @@ export namespace youtube_v3 {
      */
     mySubscribers?: boolean;
     /**
-     * <strong>Note:</strong> This parameter is intended exclusively for YouTube content partners.<br><br>The <code><strong>onBehalfOfContentOwner</strong></code> parameter indicates that the request's authorization credentials identify a YouTube CMS user who is acting on behalf of the content owner specified in the parameter value. This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and get access to all their video and channel data, without having to provide authentication credentials for each individual channel. The CMS account that the user authenticates with must be linked to the specified YouTube content owner.
+     * *Note:* This parameter is intended exclusively for YouTube content partners. The *onBehalfOfContentOwner* parameter indicates that the request's authorization credentials identify a YouTube CMS user who is acting on behalf of the content owner specified in the parameter value. This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and get access to all their video and channel data, without having to provide authentication credentials for each individual channel. The CMS account that the user authenticates with must be linked to the specified YouTube content owner.
      */
     onBehalfOfContentOwner?: string;
     /**
-     * The <code><strong>pageToken</strong></code> parameter identifies a specific page in the result set that should be returned. In an API response, the <code>nextPageToken</code> and <code>prevPageToken</code> properties identify other pages that could be retrieved.
+     * The *pageToken* parameter identifies a specific page in the result set that should be returned. In an API response, the nextPageToken and prevPageToken properties identify other pages that could be retrieved.
      */
     pageToken?: string;
     /**
-     * The <code><strong>part</strong></code> parameter specifies a comma-separated list of one or more <code>channel</code> resource properties that the API response will include.<br><br>If the parameter identifies a property that contains child properties, the child properties will be included in the response. For example, in a <code>channel</code> resource, the <code>contentDetails</code> property contains other properties, such as the <code>uploads</code> properties. As such, if you set <code><strong>part=contentDetails</strong></code>, the API response will also contain all of those nested properties.
+     * The *part* parameter specifies a comma-separated list of one or more channel resource properties that the API response will include. If the parameter identifies a property that contains child properties, the child properties will be included in the response. For example, in a channel resource, the contentDetails property contains other properties, such as the uploads properties. As such, if you set *part=contentDetails*, the API response will also contain all of those nested properties.
      */
     part?: string[];
   }
   export interface Params$Resource$Channels$Update extends StandardParameters {
     /**
-     * The <code><strong>onBehalfOfContentOwner</strong></code> parameter indicates that the authenticated user is acting on behalf of the content owner specified in the parameter value. This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and get access to all their video and channel data, without having to provide authentication credentials for each individual channel. The actual CMS account that the user authenticates with needs to be linked to the specified YouTube content owner.
+     * The *onBehalfOfContentOwner* parameter indicates that the authenticated user is acting on behalf of the content owner specified in the parameter value. This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and get access to all their video and channel data, without having to provide authentication credentials for each individual channel. The actual CMS account that the user authenticates with needs to be linked to the specified YouTube content owner.
      */
     onBehalfOfContentOwner?: string;
     /**
-     * The <code><strong>part</strong></code> parameter serves two purposes in this operation. It identifies the properties that the write operation will set as well as the properties that the API response will include.<br/><br/>The API currently only allows the parameter value to be set to either <code>brandingSettings</code> or <code>invideoPromotion</code>. (You cannot update both of those parts with a single request.)<br/><br/>Note that this method overrides the existing values for all of the mutable properties that are contained in any parts that the parameter value specifies.
+     * The *part* parameter serves two purposes in this operation. It identifies the properties that the write operation will set as well as the properties that the API response will include. The API currently only allows the parameter value to be set to either brandingSettings or invideoPromotion. (You cannot update both of those parts with a single request.) Note that this method overrides the existing values for all of the mutable properties that are contained in any parts that the parameter value specifies.
      */
     part?: string[];
 
@@ -6430,9 +6276,9 @@ export namespace youtube_v3 {
     }
 
     /**
-     * youtube.channelSections.delete
-     * @desc Deletes a resource.
+     * Deletes a resource.
      * @example
+     * ```js
      * // Before running the sample:
      * // - Enable the API at:
      * //   https://console.developers.google.com/apis/api/youtube.googleapis.com
@@ -6461,18 +6307,7 @@ export namespace youtube_v3 {
      *   // Do the magic
      *   const res = await youtube.channelSections.delete({
      *     id: 'placeholder-value',
-     *     // <strong>Note:</strong> This parameter is intended exclusively for YouTube
-     *     // content partners.<br><br>The
-     *     // <code><strong>onBehalfOfContentOwner</strong></code> parameter indicates
-     *     // that the
-     *     // request's authorization credentials identify a YouTube CMS user who is
-     *     // acting on behalf of the content owner specified in the parameter value.
-     *     // This parameter is intended for YouTube content partners that own and manage
-     *     // many different YouTube channels. It allows content owners to authenticate
-     *     // once and get access to all their video and channel data, without having to
-     *     // provide authentication credentials for each individual channel. The CMS
-     *     // account that the user authenticates with must be linked to the specified
-     *     // YouTube content owner.
+     *     // *Note:* This parameter is intended exclusively for YouTube content partners. The *onBehalfOfContentOwner* parameter indicates that the request's authorization credentials identify a YouTube CMS user who is acting on behalf of the content owner specified in the parameter value. This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and get access to all their video and channel data, without having to provide authentication credentials for each individual channel. The CMS account that the user authenticates with must be linked to the specified YouTube content owner.
      *     onBehalfOfContentOwner: 'placeholder-value',
      *   });
      *   console.log(res.data);
@@ -6483,15 +6318,12 @@ export namespace youtube_v3 {
      *   throw e;
      * });
      *
-     * @alias youtube.channelSections.delete
-     * @memberOf! ()
+     * ```
      *
-     * @param {object} params Parameters for request
-     * @param {string} params.id
-     * @param {string=} params.onBehalfOfContentOwner <strong>Note:</strong> This parameter is intended exclusively for YouTube content partners.<br><br>The <code><strong>onBehalfOfContentOwner</strong></code> parameter indicates that the request's authorization credentials identify a YouTube CMS user who is acting on behalf of the content owner specified in the parameter value. This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and get access to all their video and channel data, without having to provide authentication credentials for each individual channel. The CMS account that the user authenticates with must be linked to the specified YouTube content owner.
-     * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-     * @param {callback} callback The callback that handles the response.
-     * @return {object} Request object
+     * @param params - Parameters for request
+     * @param options - Optionally override request options, such as `url`, `method`, and `encoding`.
+     * @param callback - Optional callback that handles the response.
+     * @returns A promise if used with async/await, or void if used with a callback.
      */
     delete(
       params: Params$Resource$Channelsections$Delete,
@@ -6543,7 +6375,7 @@ export namespace youtube_v3 {
         options = {};
       }
 
-      const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+      const rootUrl = options.rootUrl || 'https://youtube.googleapis.com/';
       const parameters = {
         options: Object.assign(
           {
@@ -6563,7 +6395,7 @@ export namespace youtube_v3 {
       if (callback) {
         createAPIRequest<void>(
           parameters,
-          callback as BodyResponseCallback<{} | void>
+          callback as BodyResponseCallback<unknown>
         );
       } else {
         return createAPIRequest<void>(parameters);
@@ -6571,9 +6403,9 @@ export namespace youtube_v3 {
     }
 
     /**
-     * youtube.channelSections.insert
-     * @desc Inserts a new resource into this collection.
+     * Inserts a new resource into this collection.
      * @example
+     * ```js
      * // Before running the sample:
      * // - Enable the API at:
      * //   https://console.developers.google.com/apis/api/youtube.googleapis.com
@@ -6601,44 +6433,11 @@ export namespace youtube_v3 {
      *
      *   // Do the magic
      *   const res = await youtube.channelSections.insert({
-     *     // <strong>Note:</strong> This parameter is intended exclusively for YouTube
-     *     // content partners.<br><br>The
-     *     // <code><strong>onBehalfOfContentOwner</strong></code> parameter indicates
-     *     // that the
-     *     // request's authorization credentials identify a YouTube CMS user who is
-     *     // acting on behalf of the content owner specified in the parameter value.
-     *     // This parameter is intended for YouTube content partners that own and manage
-     *     // many different YouTube channels. It allows content owners to authenticate
-     *     // once and get access to all their video and channel data, without having to
-     *     // provide authentication credentials for each individual channel. The CMS
-     *     // account that the user authenticates with must be linked to the specified
-     *     // YouTube content owner.
+     *     // *Note:* This parameter is intended exclusively for YouTube content partners. The *onBehalfOfContentOwner* parameter indicates that the request's authorization credentials identify a YouTube CMS user who is acting on behalf of the content owner specified in the parameter value. This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and get access to all their video and channel data, without having to provide authentication credentials for each individual channel. The CMS account that the user authenticates with must be linked to the specified YouTube content owner.
      *     onBehalfOfContentOwner: 'placeholder-value',
-     *     // This parameter can only be used in a properly <a
-     *     // href="/youtube/v3/guides/authentication">authorized request</a>.
-     *     // <strong>Note:</strong> This parameter is intended exclusively for YouTube
-     *     // content partners.<br><br>The
-     *     // <code><strong>onBehalfOfContentOwnerChannel</strong></code> parameter
-     *     // specifies the YouTube channel ID of the channel to which a video is being
-     *     // added. This parameter is required when a request specifies a value for the
-     *     // <code>onBehalfOfContentOwner</code> parameter, and it can only be used in
-     *     // conjunction with that parameter. In addition, the request must be
-     *     // authorized using a CMS account that is linked to the content owner that the
-     *     // <code>onBehalfOfContentOwner</code> parameter specifies. Finally, the
-     *     // channel that the <code>onBehalfOfContentOwnerChannel</code> parameter value
-     *     // specifies must be linked to the content owner that the
-     *     // <code>onBehalfOfContentOwner</code> parameter specifies.<br><br>This
-     *     // parameter is intended for YouTube content partners that own and manage many
-     *     // different YouTube channels. It allows content owners to authenticate once
-     *     // and perform actions on behalf of the channel specified in the parameter
-     *     // value, without having to provide authentication credentials for each
-     *     // separate channel.
+     *     // This parameter can only be used in a properly authorized request. *Note:* This parameter is intended exclusively for YouTube content partners. The *onBehalfOfContentOwnerChannel* parameter specifies the YouTube channel ID of the channel to which a video is being added. This parameter is required when a request specifies a value for the onBehalfOfContentOwner parameter, and it can only be used in conjunction with that parameter. In addition, the request must be authorized using a CMS account that is linked to the content owner that the onBehalfOfContentOwner parameter specifies. Finally, the channel that the onBehalfOfContentOwnerChannel parameter value specifies must be linked to the content owner that the onBehalfOfContentOwner parameter specifies. This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and perform actions on behalf of the channel specified in the parameter value, without having to provide authentication credentials for each separate channel.
      *     onBehalfOfContentOwnerChannel: 'placeholder-value',
-     *     // The <code><strong>part</strong></code> parameter serves two purposes in
-     *     // this operation. It identifies the properties that the write operation will
-     *     // set as well as the properties that the API response will
-     *     // include.<br/><br/>The <code>part</code> names that you can include in the
-     *     // parameter value are <code>snippet</code> and <code>contentDetails</code>.
+     *     // The *part* parameter serves two purposes in this operation. It identifies the properties that the write operation will set as well as the properties that the API response will include. The part names that you can include in the parameter value are snippet and contentDetails.
      *     part: 'placeholder-value',
      *
      *     // Request body metadata
@@ -6674,17 +6473,12 @@ export namespace youtube_v3 {
      *   throw e;
      * });
      *
-     * @alias youtube.channelSections.insert
-     * @memberOf! ()
+     * ```
      *
-     * @param {object} params Parameters for request
-     * @param {string=} params.onBehalfOfContentOwner <strong>Note:</strong> This parameter is intended exclusively for YouTube content partners.<br><br>The <code><strong>onBehalfOfContentOwner</strong></code> parameter indicates that the request's authorization credentials identify a YouTube CMS user who is acting on behalf of the content owner specified in the parameter value. This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and get access to all their video and channel data, without having to provide authentication credentials for each individual channel. The CMS account that the user authenticates with must be linked to the specified YouTube content owner.
-     * @param {string=} params.onBehalfOfContentOwnerChannel This parameter can only be used in a properly <a href="/youtube/v3/guides/authentication">authorized request</a>. <strong>Note:</strong> This parameter is intended exclusively for YouTube content partners.<br><br>The <code><strong>onBehalfOfContentOwnerChannel</strong></code> parameter specifies the YouTube channel ID of the channel to which a video is being added. This parameter is required when a request specifies a value for the <code>onBehalfOfContentOwner</code> parameter, and it can only be used in conjunction with that parameter. In addition, the request must be authorized using a CMS account that is linked to the content owner that the <code>onBehalfOfContentOwner</code> parameter specifies. Finally, the channel that the <code>onBehalfOfContentOwnerChannel</code> parameter value specifies must be linked to the content owner that the <code>onBehalfOfContentOwner</code> parameter specifies.<br><br>This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and perform actions on behalf of the channel specified in the parameter value, without having to provide authentication credentials for each separate channel.
-     * @param {string} params.part The <code><strong>part</strong></code> parameter serves two purposes in this operation. It identifies the properties that the write operation will set as well as the properties that the API response will include.<br/><br/>The <code>part</code> names that you can include in the parameter value are <code>snippet</code> and <code>contentDetails</code>.
-     * @param {().ChannelSection} params.requestBody Request body data
-     * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-     * @param {callback} callback The callback that handles the response.
-     * @return {object} Request object
+     * @param params - Parameters for request
+     * @param options - Optionally override request options, such as `url`, `method`, and `encoding`.
+     * @param callback - Optional callback that handles the response.
+     * @returns A promise if used with async/await, or void if used with a callback.
      */
     insert(
       params: Params$Resource$Channelsections$Insert,
@@ -6738,7 +6532,7 @@ export namespace youtube_v3 {
         options = {};
       }
 
-      const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+      const rootUrl = options.rootUrl || 'https://youtube.googleapis.com/';
       const parameters = {
         options: Object.assign(
           {
@@ -6758,7 +6552,7 @@ export namespace youtube_v3 {
       if (callback) {
         createAPIRequest<Schema$ChannelSection>(
           parameters,
-          callback as BodyResponseCallback<{} | void>
+          callback as BodyResponseCallback<unknown>
         );
       } else {
         return createAPIRequest<Schema$ChannelSection>(parameters);
@@ -6766,9 +6560,9 @@ export namespace youtube_v3 {
     }
 
     /**
-     * youtube.channelSections.list
-     * @desc Retrieves a list of resources, possibly filtered.
+     * Retrieves a list of resources, possibly filtered.
      * @example
+     * ```js
      * // Before running the sample:
      * // - Enable the API at:
      * //   https://console.developers.google.com/apis/api/youtube.googleapis.com
@@ -6805,30 +6599,9 @@ export namespace youtube_v3 {
      *     id: 'placeholder-value',
      *     // Return the ChannelSections owned by the authenticated user.
      *     mine: 'placeholder-value',
-     *     // <strong>Note:</strong> This parameter is intended exclusively for YouTube
-     *     // content partners.<br><br>The
-     *     // <code><strong>onBehalfOfContentOwner</strong></code> parameter indicates
-     *     // that the
-     *     // request's authorization credentials identify a YouTube CMS user who is
-     *     // acting on behalf of the content owner specified in the parameter value.
-     *     // This parameter is intended for YouTube content partners that own and manage
-     *     // many different YouTube channels. It allows content owners to authenticate
-     *     // once and get access to all their video and channel data, without having to
-     *     // provide authentication credentials for each individual channel. The CMS
-     *     // account that the user authenticates with must be linked to the specified
-     *     // YouTube content owner.
+     *     // *Note:* This parameter is intended exclusively for YouTube content partners. The *onBehalfOfContentOwner* parameter indicates that the request's authorization credentials identify a YouTube CMS user who is acting on behalf of the content owner specified in the parameter value. This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and get access to all their video and channel data, without having to provide authentication credentials for each individual channel. The CMS account that the user authenticates with must be linked to the specified YouTube content owner.
      *     onBehalfOfContentOwner: 'placeholder-value',
-     *     // The <code><strong>part</strong></code> parameter specifies a
-     *     // comma-separated list of one or more <code>channelSection</code> resource
-     *     // properties that the API response will include. The <code>part</code> names
-     *     // that you can include in the parameter value are <code>id</code>,
-     *     // <code>snippet</code>, and <code>contentDetails</code>.<br><br>If the
-     *     // parameter identifies a property that contains child properties, the child
-     *     // properties will be included in the response. For example, in a
-     *     // <code>channelSection</code> resource, the <code>snippet</code> property
-     *     // contains other properties, such as a display title for the channelSection.
-     *     // If you set <code><strong>part=snippet</strong></code>, the API response
-     *     // will also contain all of those nested properties.
+     *     // The *part* parameter specifies a comma-separated list of one or more channelSection resource properties that the API response will include. The part names that you can include in the parameter value are id, snippet, and contentDetails. If the parameter identifies a property that contains child properties, the child properties will be included in the response. For example, in a channelSection resource, the snippet property contains other properties, such as a display title for the channelSection. If you set *part=snippet*, the API response will also contain all of those nested properties.
      *     part: 'placeholder-value',
      *   });
      *   console.log(res.data);
@@ -6848,19 +6621,12 @@ export namespace youtube_v3 {
      *   throw e;
      * });
      *
-     * @alias youtube.channelSections.list
-     * @memberOf! ()
+     * ```
      *
-     * @param {object} params Parameters for request
-     * @param {string=} params.channelId Return the ChannelSections owned by the specified channel ID.
-     * @param {string=} params.hl Return content in specified language
-     * @param {string=} params.id Return the ChannelSections with the given IDs for Stubby or Apiary.
-     * @param {boolean=} params.mine Return the ChannelSections owned by the authenticated user.
-     * @param {string=} params.onBehalfOfContentOwner <strong>Note:</strong> This parameter is intended exclusively for YouTube content partners.<br><br>The <code><strong>onBehalfOfContentOwner</strong></code> parameter indicates that the request's authorization credentials identify a YouTube CMS user who is acting on behalf of the content owner specified in the parameter value. This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and get access to all their video and channel data, without having to provide authentication credentials for each individual channel. The CMS account that the user authenticates with must be linked to the specified YouTube content owner.
-     * @param {string} params.part The <code><strong>part</strong></code> parameter specifies a comma-separated list of one or more <code>channelSection</code> resource properties that the API response will include. The <code>part</code> names that you can include in the parameter value are <code>id</code>, <code>snippet</code>, and <code>contentDetails</code>.<br><br>If the parameter identifies a property that contains child properties, the child properties will be included in the response. For example, in a <code>channelSection</code> resource, the <code>snippet</code> property contains other properties, such as a display title for the channelSection. If you set <code><strong>part=snippet</strong></code>, the API response will also contain all of those nested properties.
-     * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-     * @param {callback} callback The callback that handles the response.
-     * @return {object} Request object
+     * @param params - Parameters for request
+     * @param options - Optionally override request options, such as `url`, `method`, and `encoding`.
+     * @param callback - Optional callback that handles the response.
+     * @returns A promise if used with async/await, or void if used with a callback.
      */
     list(
       params: Params$Resource$Channelsections$List,
@@ -6921,7 +6687,7 @@ export namespace youtube_v3 {
         options = {};
       }
 
-      const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+      const rootUrl = options.rootUrl || 'https://youtube.googleapis.com/';
       const parameters = {
         options: Object.assign(
           {
@@ -6941,7 +6707,7 @@ export namespace youtube_v3 {
       if (callback) {
         createAPIRequest<Schema$ChannelSectionListResponse>(
           parameters,
-          callback as BodyResponseCallback<{} | void>
+          callback as BodyResponseCallback<unknown>
         );
       } else {
         return createAPIRequest<Schema$ChannelSectionListResponse>(parameters);
@@ -6949,9 +6715,9 @@ export namespace youtube_v3 {
     }
 
     /**
-     * youtube.channelSections.update
-     * @desc Updates an existing resource.
+     * Updates an existing resource.
      * @example
+     * ```js
      * // Before running the sample:
      * // - Enable the API at:
      * //   https://console.developers.google.com/apis/api/youtube.googleapis.com
@@ -6979,24 +6745,9 @@ export namespace youtube_v3 {
      *
      *   // Do the magic
      *   const res = await youtube.channelSections.update({
-     *     // <strong>Note:</strong> This parameter is intended exclusively for YouTube
-     *     // content partners.<br><br>The
-     *     // <code><strong>onBehalfOfContentOwner</strong></code> parameter indicates
-     *     // that the
-     *     // request's authorization credentials identify a YouTube CMS user who is
-     *     // acting on behalf of the content owner specified in the parameter value.
-     *     // This parameter is intended for YouTube content partners that own and manage
-     *     // many different YouTube channels. It allows content owners to authenticate
-     *     // once and get access to all their video and channel data, without having to
-     *     // provide authentication credentials for each individual channel. The CMS
-     *     // account that the user authenticates with must be linked to the specified
-     *     // YouTube content owner.
+     *     // *Note:* This parameter is intended exclusively for YouTube content partners. The *onBehalfOfContentOwner* parameter indicates that the request's authorization credentials identify a YouTube CMS user who is acting on behalf of the content owner specified in the parameter value. This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and get access to all their video and channel data, without having to provide authentication credentials for each individual channel. The CMS account that the user authenticates with must be linked to the specified YouTube content owner.
      *     onBehalfOfContentOwner: 'placeholder-value',
-     *     // The <code><strong>part</strong></code> parameter serves two purposes in
-     *     // this operation. It identifies the properties that the write operation will
-     *     // set as well as the properties that the API response will
-     *     // include.<br/><br/>The <code>part</code> names that you can include in the
-     *     // parameter value are <code>snippet</code> and <code>contentDetails</code>.
+     *     // The *part* parameter serves two purposes in this operation. It identifies the properties that the write operation will set as well as the properties that the API response will include. The part names that you can include in the parameter value are snippet and contentDetails.
      *     part: 'placeholder-value',
      *
      *     // Request body metadata
@@ -7032,16 +6783,12 @@ export namespace youtube_v3 {
      *   throw e;
      * });
      *
-     * @alias youtube.channelSections.update
-     * @memberOf! ()
+     * ```
      *
-     * @param {object} params Parameters for request
-     * @param {string=} params.onBehalfOfContentOwner <strong>Note:</strong> This parameter is intended exclusively for YouTube content partners.<br><br>The <code><strong>onBehalfOfContentOwner</strong></code> parameter indicates that the request's authorization credentials identify a YouTube CMS user who is acting on behalf of the content owner specified in the parameter value. This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and get access to all their video and channel data, without having to provide authentication credentials for each individual channel. The CMS account that the user authenticates with must be linked to the specified YouTube content owner.
-     * @param {string} params.part The <code><strong>part</strong></code> parameter serves two purposes in this operation. It identifies the properties that the write operation will set as well as the properties that the API response will include.<br/><br/>The <code>part</code> names that you can include in the parameter value are <code>snippet</code> and <code>contentDetails</code>.
-     * @param {().ChannelSection} params.requestBody Request body data
-     * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-     * @param {callback} callback The callback that handles the response.
-     * @return {object} Request object
+     * @param params - Parameters for request
+     * @param options - Optionally override request options, such as `url`, `method`, and `encoding`.
+     * @param callback - Optional callback that handles the response.
+     * @returns A promise if used with async/await, or void if used with a callback.
      */
     update(
       params: Params$Resource$Channelsections$Update,
@@ -7095,7 +6842,7 @@ export namespace youtube_v3 {
         options = {};
       }
 
-      const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+      const rootUrl = options.rootUrl || 'https://youtube.googleapis.com/';
       const parameters = {
         options: Object.assign(
           {
@@ -7115,7 +6862,7 @@ export namespace youtube_v3 {
       if (callback) {
         createAPIRequest<Schema$ChannelSection>(
           parameters,
-          callback as BodyResponseCallback<{} | void>
+          callback as BodyResponseCallback<unknown>
         );
       } else {
         return createAPIRequest<Schema$ChannelSection>(parameters);
@@ -7130,22 +6877,22 @@ export namespace youtube_v3 {
      */
     id?: string;
     /**
-     * <strong>Note:</strong> This parameter is intended exclusively for YouTube content partners.<br><br>The <code><strong>onBehalfOfContentOwner</strong></code> parameter indicates that the request's authorization credentials identify a YouTube CMS user who is acting on behalf of the content owner specified in the parameter value. This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and get access to all their video and channel data, without having to provide authentication credentials for each individual channel. The CMS account that the user authenticates with must be linked to the specified YouTube content owner.
+     * *Note:* This parameter is intended exclusively for YouTube content partners. The *onBehalfOfContentOwner* parameter indicates that the request's authorization credentials identify a YouTube CMS user who is acting on behalf of the content owner specified in the parameter value. This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and get access to all their video and channel data, without having to provide authentication credentials for each individual channel. The CMS account that the user authenticates with must be linked to the specified YouTube content owner.
      */
     onBehalfOfContentOwner?: string;
   }
   export interface Params$Resource$Channelsections$Insert
     extends StandardParameters {
     /**
-     * <strong>Note:</strong> This parameter is intended exclusively for YouTube content partners.<br><br>The <code><strong>onBehalfOfContentOwner</strong></code> parameter indicates that the request's authorization credentials identify a YouTube CMS user who is acting on behalf of the content owner specified in the parameter value. This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and get access to all their video and channel data, without having to provide authentication credentials for each individual channel. The CMS account that the user authenticates with must be linked to the specified YouTube content owner.
+     * *Note:* This parameter is intended exclusively for YouTube content partners. The *onBehalfOfContentOwner* parameter indicates that the request's authorization credentials identify a YouTube CMS user who is acting on behalf of the content owner specified in the parameter value. This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and get access to all their video and channel data, without having to provide authentication credentials for each individual channel. The CMS account that the user authenticates with must be linked to the specified YouTube content owner.
      */
     onBehalfOfContentOwner?: string;
     /**
-     * This parameter can only be used in a properly <a href="/youtube/v3/guides/authentication">authorized request</a>. <strong>Note:</strong> This parameter is intended exclusively for YouTube content partners.<br><br>The <code><strong>onBehalfOfContentOwnerChannel</strong></code> parameter specifies the YouTube channel ID of the channel to which a video is being added. This parameter is required when a request specifies a value for the <code>onBehalfOfContentOwner</code> parameter, and it can only be used in conjunction with that parameter. In addition, the request must be authorized using a CMS account that is linked to the content owner that the <code>onBehalfOfContentOwner</code> parameter specifies. Finally, the channel that the <code>onBehalfOfContentOwnerChannel</code> parameter value specifies must be linked to the content owner that the <code>onBehalfOfContentOwner</code> parameter specifies.<br><br>This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and perform actions on behalf of the channel specified in the parameter value, without having to provide authentication credentials for each separate channel.
+     * This parameter can only be used in a properly authorized request. *Note:* This parameter is intended exclusively for YouTube content partners. The *onBehalfOfContentOwnerChannel* parameter specifies the YouTube channel ID of the channel to which a video is being added. This parameter is required when a request specifies a value for the onBehalfOfContentOwner parameter, and it can only be used in conjunction with that parameter. In addition, the request must be authorized using a CMS account that is linked to the content owner that the onBehalfOfContentOwner parameter specifies. Finally, the channel that the onBehalfOfContentOwnerChannel parameter value specifies must be linked to the content owner that the onBehalfOfContentOwner parameter specifies. This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and perform actions on behalf of the channel specified in the parameter value, without having to provide authentication credentials for each separate channel.
      */
     onBehalfOfContentOwnerChannel?: string;
     /**
-     * The <code><strong>part</strong></code> parameter serves two purposes in this operation. It identifies the properties that the write operation will set as well as the properties that the API response will include.<br/><br/>The <code>part</code> names that you can include in the parameter value are <code>snippet</code> and <code>contentDetails</code>.
+     * The *part* parameter serves two purposes in this operation. It identifies the properties that the write operation will set as well as the properties that the API response will include. The part names that you can include in the parameter value are snippet and contentDetails.
      */
     part?: string[];
 
@@ -7173,22 +6920,22 @@ export namespace youtube_v3 {
      */
     mine?: boolean;
     /**
-     * <strong>Note:</strong> This parameter is intended exclusively for YouTube content partners.<br><br>The <code><strong>onBehalfOfContentOwner</strong></code> parameter indicates that the request's authorization credentials identify a YouTube CMS user who is acting on behalf of the content owner specified in the parameter value. This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and get access to all their video and channel data, without having to provide authentication credentials for each individual channel. The CMS account that the user authenticates with must be linked to the specified YouTube content owner.
+     * *Note:* This parameter is intended exclusively for YouTube content partners. The *onBehalfOfContentOwner* parameter indicates that the request's authorization credentials identify a YouTube CMS user who is acting on behalf of the content owner specified in the parameter value. This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and get access to all their video and channel data, without having to provide authentication credentials for each individual channel. The CMS account that the user authenticates with must be linked to the specified YouTube content owner.
      */
     onBehalfOfContentOwner?: string;
     /**
-     * The <code><strong>part</strong></code> parameter specifies a comma-separated list of one or more <code>channelSection</code> resource properties that the API response will include. The <code>part</code> names that you can include in the parameter value are <code>id</code>, <code>snippet</code>, and <code>contentDetails</code>.<br><br>If the parameter identifies a property that contains child properties, the child properties will be included in the response. For example, in a <code>channelSection</code> resource, the <code>snippet</code> property contains other properties, such as a display title for the channelSection. If you set <code><strong>part=snippet</strong></code>, the API response will also contain all of those nested properties.
+     * The *part* parameter specifies a comma-separated list of one or more channelSection resource properties that the API response will include. The part names that you can include in the parameter value are id, snippet, and contentDetails. If the parameter identifies a property that contains child properties, the child properties will be included in the response. For example, in a channelSection resource, the snippet property contains other properties, such as a display title for the channelSection. If you set *part=snippet*, the API response will also contain all of those nested properties.
      */
     part?: string[];
   }
   export interface Params$Resource$Channelsections$Update
     extends StandardParameters {
     /**
-     * <strong>Note:</strong> This parameter is intended exclusively for YouTube content partners.<br><br>The <code><strong>onBehalfOfContentOwner</strong></code> parameter indicates that the request's authorization credentials identify a YouTube CMS user who is acting on behalf of the content owner specified in the parameter value. This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and get access to all their video and channel data, without having to provide authentication credentials for each individual channel. The CMS account that the user authenticates with must be linked to the specified YouTube content owner.
+     * *Note:* This parameter is intended exclusively for YouTube content partners. The *onBehalfOfContentOwner* parameter indicates that the request's authorization credentials identify a YouTube CMS user who is acting on behalf of the content owner specified in the parameter value. This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and get access to all their video and channel data, without having to provide authentication credentials for each individual channel. The CMS account that the user authenticates with must be linked to the specified YouTube content owner.
      */
     onBehalfOfContentOwner?: string;
     /**
-     * The <code><strong>part</strong></code> parameter serves two purposes in this operation. It identifies the properties that the write operation will set as well as the properties that the API response will include.<br/><br/>The <code>part</code> names that you can include in the parameter value are <code>snippet</code> and <code>contentDetails</code>.
+     * The *part* parameter serves two purposes in this operation. It identifies the properties that the write operation will set as well as the properties that the API response will include. The part names that you can include in the parameter value are snippet and contentDetails.
      */
     part?: string[];
 
@@ -7205,9 +6952,9 @@ export namespace youtube_v3 {
     }
 
     /**
-     * youtube.comments.delete
-     * @desc Deletes a resource.
+     * Deletes a resource.
      * @example
+     * ```js
      * // Before running the sample:
      * // - Enable the API at:
      * //   https://console.developers.google.com/apis/api/youtube.googleapis.com
@@ -7241,14 +6988,12 @@ export namespace youtube_v3 {
      *   throw e;
      * });
      *
-     * @alias youtube.comments.delete
-     * @memberOf! ()
+     * ```
      *
-     * @param {object} params Parameters for request
-     * @param {string} params.id
-     * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-     * @param {callback} callback The callback that handles the response.
-     * @return {object} Request object
+     * @param params - Parameters for request
+     * @param options - Optionally override request options, such as `url`, `method`, and `encoding`.
+     * @param callback - Optional callback that handles the response.
+     * @returns A promise if used with async/await, or void if used with a callback.
      */
     delete(
       params: Params$Resource$Comments$Delete,
@@ -7299,7 +7044,7 @@ export namespace youtube_v3 {
         options = {};
       }
 
-      const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+      const rootUrl = options.rootUrl || 'https://youtube.googleapis.com/';
       const parameters = {
         options: Object.assign(
           {
@@ -7319,7 +7064,7 @@ export namespace youtube_v3 {
       if (callback) {
         createAPIRequest<void>(
           parameters,
-          callback as BodyResponseCallback<{} | void>
+          callback as BodyResponseCallback<unknown>
         );
       } else {
         return createAPIRequest<void>(parameters);
@@ -7327,9 +7072,9 @@ export namespace youtube_v3 {
     }
 
     /**
-     * youtube.comments.insert
-     * @desc Inserts a new resource into this collection.
+     * Inserts a new resource into this collection.
      * @example
+     * ```js
      * // Before running the sample:
      * // - Enable the API at:
      * //   https://console.developers.google.com/apis/api/youtube.googleapis.com
@@ -7353,10 +7098,7 @@ export namespace youtube_v3 {
      *
      *   // Do the magic
      *   const res = await youtube.comments.insert({
-     *     // The <code><strong>part</strong></code> parameter identifies the properties
-     *     // that the API response will include. Set the parameter value to
-     *     // <code>snippet</code>. The <code>snippet</code> part has a quota cost of 2
-     *     // units.
+     *     // The *part* parameter identifies the properties that the API response will include. Set the parameter value to snippet. The snippet part has a quota cost of 2 units.
      *     part: 'placeholder-value',
      *
      *     // Request body metadata
@@ -7386,15 +7128,12 @@ export namespace youtube_v3 {
      *   throw e;
      * });
      *
-     * @alias youtube.comments.insert
-     * @memberOf! ()
+     * ```
      *
-     * @param {object} params Parameters for request
-     * @param {string} params.part The <code><strong>part</strong></code> parameter identifies the properties that the API response will include. Set the parameter value to <code>snippet</code>. The <code>snippet</code> part has a quota cost of 2 units.
-     * @param {().Comment} params.requestBody Request body data
-     * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-     * @param {callback} callback The callback that handles the response.
-     * @return {object} Request object
+     * @param params - Parameters for request
+     * @param options - Optionally override request options, such as `url`, `method`, and `encoding`.
+     * @param callback - Optional callback that handles the response.
+     * @returns A promise if used with async/await, or void if used with a callback.
      */
     insert(
       params: Params$Resource$Comments$Insert,
@@ -7447,7 +7186,7 @@ export namespace youtube_v3 {
         options = {};
       }
 
-      const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+      const rootUrl = options.rootUrl || 'https://youtube.googleapis.com/';
       const parameters = {
         options: Object.assign(
           {
@@ -7467,7 +7206,7 @@ export namespace youtube_v3 {
       if (callback) {
         createAPIRequest<Schema$Comment>(
           parameters,
-          callback as BodyResponseCallback<{} | void>
+          callback as BodyResponseCallback<unknown>
         );
       } else {
         return createAPIRequest<Schema$Comment>(parameters);
@@ -7475,9 +7214,9 @@ export namespace youtube_v3 {
     }
 
     /**
-     * youtube.comments.list
-     * @desc Retrieves a list of resources, possibly filtered.
+     * Retrieves a list of resources, possibly filtered.
      * @example
+     * ```js
      * // Before running the sample:
      * // - Enable the API at:
      * //   https://console.developers.google.com/apis/api/youtube.googleapis.com
@@ -7503,22 +7242,13 @@ export namespace youtube_v3 {
      *   const res = await youtube.comments.list({
      *     // Returns the comments with the given IDs for One Platform.
      *     id: 'placeholder-value',
-     *     // The <code><strong>maxResults</strong></code> parameter specifies the
-     *     // maximum number of items that should be returned in the result set.
+     *     // The *maxResults* parameter specifies the maximum number of items that should be returned in the result set.
      *     maxResults: 'placeholder-value',
-     *     // The <code><strong>pageToken</strong></code> parameter identifies a specific
-     *     // page in the result set that should be returned. In an API response, the
-     *     // <code>nextPageToken</code> and <code>prevPageToken</code> properties
-     *     // identify other pages that could be retrieved.
+     *     // The *pageToken* parameter identifies a specific page in the result set that should be returned. In an API response, the nextPageToken and prevPageToken properties identify other pages that could be retrieved.
      *     pageToken: 'placeholder-value',
-     *     // Returns replies to the specified comment.
-     *     // Note, currently YouTube features only one level of replies (ie replies
-     *     // to top level comments). However replies to replies may be supported in
-     *     // the future.
+     *     // Returns replies to the specified comment. Note, currently YouTube features only one level of replies (ie replies to top level comments). However replies to replies may be supported in the future.
      *     parentId: 'placeholder-value',
-     *     // The <code><strong>part</strong></code> parameter specifies a
-     *     // comma-separated list of one or more <code>comment</code> resource
-     *     // properties that the API response will include.
+     *     // The *part* parameter specifies a comma-separated list of one or more comment resource properties that the API response will include.
      *     part: 'placeholder-value',
      *     // The requested text format for the returned comments.
      *     textFormat: 'placeholder-value',
@@ -7543,19 +7273,12 @@ export namespace youtube_v3 {
      *   throw e;
      * });
      *
-     * @alias youtube.comments.list
-     * @memberOf! ()
+     * ```
      *
-     * @param {object} params Parameters for request
-     * @param {string=} params.id Returns the comments with the given IDs for One Platform.
-     * @param {integer=} params.maxResults The <code><strong>maxResults</strong></code> parameter specifies the maximum number of items that should be returned in the result set.
-     * @param {string=} params.pageToken The <code><strong>pageToken</strong></code> parameter identifies a specific page in the result set that should be returned. In an API response, the <code>nextPageToken</code> and <code>prevPageToken</code> properties identify other pages that could be retrieved.
-     * @param {string=} params.parentId Returns replies to the specified comment. Note, currently YouTube features only one level of replies (ie replies to top level comments). However replies to replies may be supported in the future.
-     * @param {string} params.part The <code><strong>part</strong></code> parameter specifies a comma-separated list of one or more <code>comment</code> resource properties that the API response will include.
-     * @param {string=} params.textFormat The requested text format for the returned comments.
-     * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-     * @param {callback} callback The callback that handles the response.
-     * @return {object} Request object
+     * @param params - Parameters for request
+     * @param options - Optionally override request options, such as `url`, `method`, and `encoding`.
+     * @param callback - Optional callback that handles the response.
+     * @returns A promise if used with async/await, or void if used with a callback.
      */
     list(
       params: Params$Resource$Comments$List,
@@ -7611,7 +7334,7 @@ export namespace youtube_v3 {
         options = {};
       }
 
-      const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+      const rootUrl = options.rootUrl || 'https://youtube.googleapis.com/';
       const parameters = {
         options: Object.assign(
           {
@@ -7631,7 +7354,7 @@ export namespace youtube_v3 {
       if (callback) {
         createAPIRequest<Schema$CommentListResponse>(
           parameters,
-          callback as BodyResponseCallback<{} | void>
+          callback as BodyResponseCallback<unknown>
         );
       } else {
         return createAPIRequest<Schema$CommentListResponse>(parameters);
@@ -7639,9 +7362,9 @@ export namespace youtube_v3 {
     }
 
     /**
-     * youtube.comments.markAsSpam
-     * @desc Expresses the caller's opinion that one or more comments should be flagged as spam.
+     * Expresses the caller's opinion that one or more comments should be flagged as spam.
      * @example
+     * ```js
      * // Before running the sample:
      * // - Enable the API at:
      * //   https://console.developers.google.com/apis/api/youtube.googleapis.com
@@ -7676,14 +7399,12 @@ export namespace youtube_v3 {
      *   throw e;
      * });
      *
-     * @alias youtube.comments.markAsSpam
-     * @memberOf! ()
+     * ```
      *
-     * @param {object} params Parameters for request
-     * @param {string} params.id Flags the comments with the given IDs as spam in the caller's opinion.
-     * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-     * @param {callback} callback The callback that handles the response.
-     * @return {object} Request object
+     * @param params - Parameters for request
+     * @param options - Optionally override request options, such as `url`, `method`, and `encoding`.
+     * @param callback - Optional callback that handles the response.
+     * @returns A promise if used with async/await, or void if used with a callback.
      */
     markAsSpam(
       params: Params$Resource$Comments$Markasspam,
@@ -7735,7 +7456,7 @@ export namespace youtube_v3 {
         options = {};
       }
 
-      const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+      const rootUrl = options.rootUrl || 'https://youtube.googleapis.com/';
       const parameters = {
         options: Object.assign(
           {
@@ -7755,7 +7476,7 @@ export namespace youtube_v3 {
       if (callback) {
         createAPIRequest<void>(
           parameters,
-          callback as BodyResponseCallback<{} | void>
+          callback as BodyResponseCallback<unknown>
         );
       } else {
         return createAPIRequest<void>(parameters);
@@ -7763,9 +7484,9 @@ export namespace youtube_v3 {
     }
 
     /**
-     * youtube.comments.setModerationStatus
-     * @desc Sets the moderation status of one or more comments.
+     * Sets the moderation status of one or more comments.
      * @example
+     * ```js
      * // Before running the sample:
      * // - Enable the API at:
      * //   https://console.developers.google.com/apis/api/youtube.googleapis.com
@@ -7789,18 +7510,11 @@ export namespace youtube_v3 {
      *
      *   // Do the magic
      *   const res = await youtube.comments.setModerationStatus({
-     *     // If set to true the author of the comment gets added to the ban list.
-     *     // This means all future comments of the author will autmomatically be
-     *     // rejected.
-     *     // Only valid in combination with STATUS_REJECTED.
+     *     // If set to true the author of the comment gets added to the ban list. This means all future comments of the author will autmomatically be rejected. Only valid in combination with STATUS_REJECTED.
      *     banAuthor: 'placeholder-value',
      *     // Modifies the moderation status of the comments with the given IDs
      *     id: 'placeholder-value',
-     *     // Specifies the requested moderation status. Note, comments can be in
-     *     // statuses, which are not available through this call. For example, this
-     *     // call does not allow to mark a comment as 'likely spam'.
-     *     // Valid values: MODERATION_STATUS_PUBLISHED,
-     *     // MODERATION_STATUS_HELD_FOR_REVIEW, MODERATION_STATUS_REJECTED.
+     *     // Specifies the requested moderation status. Note, comments can be in statuses, which are not available through this call. For example, this call does not allow to mark a comment as 'likely spam'. Valid values: MODERATION_STATUS_PUBLISHED, MODERATION_STATUS_HELD_FOR_REVIEW, MODERATION_STATUS_REJECTED.
      *     moderationStatus: 'placeholder-value',
      *   });
      *   console.log(res.data);
@@ -7811,16 +7525,12 @@ export namespace youtube_v3 {
      *   throw e;
      * });
      *
-     * @alias youtube.comments.setModerationStatus
-     * @memberOf! ()
+     * ```
      *
-     * @param {object} params Parameters for request
-     * @param {boolean=} params.banAuthor If set to true the author of the comment gets added to the ban list. This means all future comments of the author will autmomatically be rejected. Only valid in combination with STATUS_REJECTED.
-     * @param {string} params.id Modifies the moderation status of the comments with the given IDs
-     * @param {string} params.moderationStatus Specifies the requested moderation status. Note, comments can be in statuses, which are not available through this call. For example, this call does not allow to mark a comment as 'likely spam'. Valid values: MODERATION_STATUS_PUBLISHED, MODERATION_STATUS_HELD_FOR_REVIEW, MODERATION_STATUS_REJECTED.
-     * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-     * @param {callback} callback The callback that handles the response.
-     * @return {object} Request object
+     * @param params - Parameters for request
+     * @param options - Optionally override request options, such as `url`, `method`, and `encoding`.
+     * @param callback - Optional callback that handles the response.
+     * @returns A promise if used with async/await, or void if used with a callback.
      */
     setModerationStatus(
       params: Params$Resource$Comments$Setmoderationstatus,
@@ -7872,7 +7582,7 @@ export namespace youtube_v3 {
         options = {};
       }
 
-      const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+      const rootUrl = options.rootUrl || 'https://youtube.googleapis.com/';
       const parameters = {
         options: Object.assign(
           {
@@ -7892,7 +7602,7 @@ export namespace youtube_v3 {
       if (callback) {
         createAPIRequest<void>(
           parameters,
-          callback as BodyResponseCallback<{} | void>
+          callback as BodyResponseCallback<unknown>
         );
       } else {
         return createAPIRequest<void>(parameters);
@@ -7900,9 +7610,9 @@ export namespace youtube_v3 {
     }
 
     /**
-     * youtube.comments.update
-     * @desc Updates an existing resource.
+     * Updates an existing resource.
      * @example
+     * ```js
      * // Before running the sample:
      * // - Enable the API at:
      * //   https://console.developers.google.com/apis/api/youtube.googleapis.com
@@ -7926,10 +7636,7 @@ export namespace youtube_v3 {
      *
      *   // Do the magic
      *   const res = await youtube.comments.update({
-     *     // The <code><strong>part</strong></code> parameter identifies the properties
-     *     // that the API response will include. You must at least include the
-     *     // <code>snippet</code> part in the parameter value since that part contains
-     *     // all of the properties that the API request can update.
+     *     // The *part* parameter identifies the properties that the API response will include. You must at least include the snippet part in the parameter value since that part contains all of the properties that the API request can update.
      *     part: 'placeholder-value',
      *
      *     // Request body metadata
@@ -7959,15 +7666,12 @@ export namespace youtube_v3 {
      *   throw e;
      * });
      *
-     * @alias youtube.comments.update
-     * @memberOf! ()
+     * ```
      *
-     * @param {object} params Parameters for request
-     * @param {string} params.part The <code><strong>part</strong></code> parameter identifies the properties that the API response will include. You must at least include the <code>snippet</code> part in the parameter value since that part contains all of the properties that the API request can update.
-     * @param {().Comment} params.requestBody Request body data
-     * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-     * @param {callback} callback The callback that handles the response.
-     * @return {object} Request object
+     * @param params - Parameters for request
+     * @param options - Optionally override request options, such as `url`, `method`, and `encoding`.
+     * @param callback - Optional callback that handles the response.
+     * @returns A promise if used with async/await, or void if used with a callback.
      */
     update(
       params: Params$Resource$Comments$Update,
@@ -8020,7 +7724,7 @@ export namespace youtube_v3 {
         options = {};
       }
 
-      const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+      const rootUrl = options.rootUrl || 'https://youtube.googleapis.com/';
       const parameters = {
         options: Object.assign(
           {
@@ -8040,7 +7744,7 @@ export namespace youtube_v3 {
       if (callback) {
         createAPIRequest<Schema$Comment>(
           parameters,
-          callback as BodyResponseCallback<{} | void>
+          callback as BodyResponseCallback<unknown>
         );
       } else {
         return createAPIRequest<Schema$Comment>(parameters);
@@ -8056,7 +7760,7 @@ export namespace youtube_v3 {
   }
   export interface Params$Resource$Comments$Insert extends StandardParameters {
     /**
-     * The <code><strong>part</strong></code> parameter identifies the properties that the API response will include. Set the parameter value to <code>snippet</code>. The <code>snippet</code> part has a quota cost of 2 units.
+     * The *part* parameter identifies the properties that the API response will include. Set the parameter value to snippet. The snippet part has a quota cost of 2 units.
      */
     part?: string[];
 
@@ -8071,11 +7775,11 @@ export namespace youtube_v3 {
      */
     id?: string[];
     /**
-     * The <code><strong>maxResults</strong></code> parameter specifies the maximum number of items that should be returned in the result set.
+     * The *maxResults* parameter specifies the maximum number of items that should be returned in the result set.
      */
     maxResults?: number;
     /**
-     * The <code><strong>pageToken</strong></code> parameter identifies a specific page in the result set that should be returned. In an API response, the <code>nextPageToken</code> and <code>prevPageToken</code> properties identify other pages that could be retrieved.
+     * The *pageToken* parameter identifies a specific page in the result set that should be returned. In an API response, the nextPageToken and prevPageToken properties identify other pages that could be retrieved.
      */
     pageToken?: string;
     /**
@@ -8083,7 +7787,7 @@ export namespace youtube_v3 {
      */
     parentId?: string;
     /**
-     * The <code><strong>part</strong></code> parameter specifies a comma-separated list of one or more <code>comment</code> resource properties that the API response will include.
+     * The *part* parameter specifies a comma-separated list of one or more comment resource properties that the API response will include.
      */
     part?: string[];
     /**
@@ -8115,7 +7819,7 @@ export namespace youtube_v3 {
   }
   export interface Params$Resource$Comments$Update extends StandardParameters {
     /**
-     * The <code><strong>part</strong></code> parameter identifies the properties that the API response will include. You must at least include the <code>snippet</code> part in the parameter value since that part contains all of the properties that the API request can update.
+     * The *part* parameter identifies the properties that the API response will include. You must at least include the snippet part in the parameter value since that part contains all of the properties that the API request can update.
      */
     part?: string[];
 
@@ -8132,9 +7836,9 @@ export namespace youtube_v3 {
     }
 
     /**
-     * youtube.commentThreads.insert
-     * @desc Inserts a new resource into this collection.
+     * Inserts a new resource into this collection.
      * @example
+     * ```js
      * // Before running the sample:
      * // - Enable the API at:
      * //   https://console.developers.google.com/apis/api/youtube.googleapis.com
@@ -8158,10 +7862,7 @@ export namespace youtube_v3 {
      *
      *   // Do the magic
      *   const res = await youtube.commentThreads.insert({
-     *     // The <code><strong>part</strong></code> parameter identifies the properties
-     *     // that the API response will include. Set the parameter value to
-     *     // <code>snippet</code>. The <code>snippet</code> part has a quota cost of 2
-     *     // units.
+     *     // The *part* parameter identifies the properties that the API response will include. Set the parameter value to snippet. The snippet part has a quota cost of 2 units.
      *     part: 'placeholder-value',
      *
      *     // Request body metadata
@@ -8193,15 +7894,12 @@ export namespace youtube_v3 {
      *   throw e;
      * });
      *
-     * @alias youtube.commentThreads.insert
-     * @memberOf! ()
+     * ```
      *
-     * @param {object} params Parameters for request
-     * @param {string} params.part The <code><strong>part</strong></code> parameter identifies the properties that the API response will include. Set the parameter value to <code>snippet</code>. The <code>snippet</code> part has a quota cost of 2 units.
-     * @param {().CommentThread} params.requestBody Request body data
-     * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-     * @param {callback} callback The callback that handles the response.
-     * @return {object} Request object
+     * @param params - Parameters for request
+     * @param options - Optionally override request options, such as `url`, `method`, and `encoding`.
+     * @param callback - Optional callback that handles the response.
+     * @returns A promise if used with async/await, or void if used with a callback.
      */
     insert(
       params: Params$Resource$Commentthreads$Insert,
@@ -8255,7 +7953,7 @@ export namespace youtube_v3 {
         options = {};
       }
 
-      const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+      const rootUrl = options.rootUrl || 'https://youtube.googleapis.com/';
       const parameters = {
         options: Object.assign(
           {
@@ -8275,7 +7973,7 @@ export namespace youtube_v3 {
       if (callback) {
         createAPIRequest<Schema$CommentThread>(
           parameters,
-          callback as BodyResponseCallback<{} | void>
+          callback as BodyResponseCallback<unknown>
         );
       } else {
         return createAPIRequest<Schema$CommentThread>(parameters);
@@ -8283,9 +7981,9 @@ export namespace youtube_v3 {
     }
 
     /**
-     * youtube.commentThreads.list
-     * @desc Retrieves a list of resources, possibly filtered.
+     * Retrieves a list of resources, possibly filtered.
      * @example
+     * ```js
      * // Before running the sample:
      * // - Enable the API at:
      * //   https://console.developers.google.com/apis/api/youtube.googleapis.com
@@ -8309,34 +8007,23 @@ export namespace youtube_v3 {
      *
      *   // Do the magic
      *   const res = await youtube.commentThreads.list({
-     *     // Returns the comment threads of all videos of the channel and the
-     *     // channel comments as well.
+     *     // Returns the comment threads of all videos of the channel and the channel comments as well.
      *     allThreadsRelatedToChannelId: 'placeholder-value',
-     *     // Returns the comment threads for all the channel comments (ie does not
-     *     // include comments left on videos).
+     *     // Returns the comment threads for all the channel comments (ie does not include comments left on videos).
      *     channelId: 'placeholder-value',
      *     // Returns the comment threads with the given IDs for Stubby or Apiary.
      *     id: 'placeholder-value',
-     *     // The <code><strong>maxResults</strong></code> parameter specifies the
-     *     // maximum number of items that should be returned in the result set.
+     *     // The *maxResults* parameter specifies the maximum number of items that should be returned in the result set.
      *     maxResults: 'placeholder-value',
-     *     // Limits the returned comment threads to those with the specified
-     *     // moderation status. Not compatible with the 'id' filter.
-     *     // Valid values: published, heldForReview, likelySpam.
+     *     // Limits the returned comment threads to those with the specified moderation status. Not compatible with the 'id' filter. Valid values: published, heldForReview, likelySpam.
      *     moderationStatus: 'placeholder-value',
      *
      *     order: 'placeholder-value',
-     *     // The <code><strong>pageToken</strong></code> parameter identifies a specific
-     *     // page in the result set that should be returned. In an API response, the
-     *     // <code>nextPageToken</code> and <code>prevPageToken</code> properties
-     *     // identify other pages that could be retrieved.
+     *     // The *pageToken* parameter identifies a specific page in the result set that should be returned. In an API response, the nextPageToken and prevPageToken properties identify other pages that could be retrieved.
      *     pageToken: 'placeholder-value',
-     *     // The <code><strong>part</strong></code> parameter specifies a
-     *     // comma-separated list of one or more <code>commentThread</code> resource
-     *     // properties that the API response will include.
+     *     // The *part* parameter specifies a comma-separated list of one or more commentThread resource properties that the API response will include.
      *     part: 'placeholder-value',
-     *     // Limits the returned comment threads to those matching the specified
-     *     // key words. Not compatible with the 'id' filter.
+     *     // Limits the returned comment threads to those matching the specified key words. Not compatible with the 'id' filter.
      *     searchTerms: 'placeholder-value',
      *     // The requested text format for the returned comments.
      *     textFormat: 'placeholder-value',
@@ -8363,24 +8050,12 @@ export namespace youtube_v3 {
      *   throw e;
      * });
      *
-     * @alias youtube.commentThreads.list
-     * @memberOf! ()
+     * ```
      *
-     * @param {object} params Parameters for request
-     * @param {string=} params.allThreadsRelatedToChannelId Returns the comment threads of all videos of the channel and the channel comments as well.
-     * @param {string=} params.channelId Returns the comment threads for all the channel comments (ie does not include comments left on videos).
-     * @param {string=} params.id Returns the comment threads with the given IDs for Stubby or Apiary.
-     * @param {integer=} params.maxResults The <code><strong>maxResults</strong></code> parameter specifies the maximum number of items that should be returned in the result set.
-     * @param {string=} params.moderationStatus Limits the returned comment threads to those with the specified moderation status. Not compatible with the 'id' filter. Valid values: published, heldForReview, likelySpam.
-     * @param {string=} params.order
-     * @param {string=} params.pageToken The <code><strong>pageToken</strong></code> parameter identifies a specific page in the result set that should be returned. In an API response, the <code>nextPageToken</code> and <code>prevPageToken</code> properties identify other pages that could be retrieved.
-     * @param {string} params.part The <code><strong>part</strong></code> parameter specifies a comma-separated list of one or more <code>commentThread</code> resource properties that the API response will include.
-     * @param {string=} params.searchTerms Limits the returned comment threads to those matching the specified key words. Not compatible with the 'id' filter.
-     * @param {string=} params.textFormat The requested text format for the returned comments.
-     * @param {string=} params.videoId Returns the comment threads of the specified video.
-     * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-     * @param {callback} callback The callback that handles the response.
-     * @return {object} Request object
+     * @param params - Parameters for request
+     * @param options - Optionally override request options, such as `url`, `method`, and `encoding`.
+     * @param callback - Optional callback that handles the response.
+     * @returns A promise if used with async/await, or void if used with a callback.
      */
     list(
       params: Params$Resource$Commentthreads$List,
@@ -8441,7 +8116,7 @@ export namespace youtube_v3 {
         options = {};
       }
 
-      const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+      const rootUrl = options.rootUrl || 'https://youtube.googleapis.com/';
       const parameters = {
         options: Object.assign(
           {
@@ -8461,7 +8136,7 @@ export namespace youtube_v3 {
       if (callback) {
         createAPIRequest<Schema$CommentThreadListResponse>(
           parameters,
-          callback as BodyResponseCallback<{} | void>
+          callback as BodyResponseCallback<unknown>
         );
       } else {
         return createAPIRequest<Schema$CommentThreadListResponse>(parameters);
@@ -8469,9 +8144,9 @@ export namespace youtube_v3 {
     }
 
     /**
-     * youtube.commentThreads.update
-     * @desc Updates an existing resource.
+     * Updates an existing resource.
      * @example
+     * ```js
      * // Before running the sample:
      * // - Enable the API at:
      * //   https://console.developers.google.com/apis/api/youtube.googleapis.com
@@ -8495,11 +8170,7 @@ export namespace youtube_v3 {
      *
      *   // Do the magic
      *   const res = await youtube.commentThreads.update({
-     *     // The <code><strong>part</strong></code> parameter specifies a
-     *     // comma-separated list of <code>commentThread</code> resource properties that
-     *     // the API response will include. You must at least include the
-     *     // <code>snippet</code> part in the parameter value since that part contains
-     *     // all of the properties that the API request can update.
+     *     // The *part* parameter specifies a comma-separated list of commentThread resource properties that the API response will include. You must at least include the snippet part in the parameter value since that part contains all of the properties that the API request can update.
      *     part: 'placeholder-value',
      *
      *     // Request body metadata
@@ -8531,15 +8202,12 @@ export namespace youtube_v3 {
      *   throw e;
      * });
      *
-     * @alias youtube.commentThreads.update
-     * @memberOf! ()
+     * ```
      *
-     * @param {object} params Parameters for request
-     * @param {string} params.part The <code><strong>part</strong></code> parameter specifies a comma-separated list of <code>commentThread</code> resource properties that the API response will include. You must at least include the <code>snippet</code> part in the parameter value since that part contains all of the properties that the API request can update.
-     * @param {().CommentThread} params.requestBody Request body data
-     * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-     * @param {callback} callback The callback that handles the response.
-     * @return {object} Request object
+     * @param params - Parameters for request
+     * @param options - Optionally override request options, such as `url`, `method`, and `encoding`.
+     * @param callback - Optional callback that handles the response.
+     * @returns A promise if used with async/await, or void if used with a callback.
      */
     update(
       params: Params$Resource$Commentthreads$Update,
@@ -8593,7 +8261,7 @@ export namespace youtube_v3 {
         options = {};
       }
 
-      const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+      const rootUrl = options.rootUrl || 'https://youtube.googleapis.com/';
       const parameters = {
         options: Object.assign(
           {
@@ -8613,7 +8281,7 @@ export namespace youtube_v3 {
       if (callback) {
         createAPIRequest<Schema$CommentThread>(
           parameters,
-          callback as BodyResponseCallback<{} | void>
+          callback as BodyResponseCallback<unknown>
         );
       } else {
         return createAPIRequest<Schema$CommentThread>(parameters);
@@ -8624,7 +8292,7 @@ export namespace youtube_v3 {
   export interface Params$Resource$Commentthreads$Insert
     extends StandardParameters {
     /**
-     * The <code><strong>part</strong></code> parameter identifies the properties that the API response will include. Set the parameter value to <code>snippet</code>. The <code>snippet</code> part has a quota cost of 2 units.
+     * The *part* parameter identifies the properties that the API response will include. Set the parameter value to snippet. The snippet part has a quota cost of 2 units.
      */
     part?: string[];
 
@@ -8648,7 +8316,7 @@ export namespace youtube_v3 {
      */
     id?: string[];
     /**
-     * The <code><strong>maxResults</strong></code> parameter specifies the maximum number of items that should be returned in the result set.
+     * The *maxResults* parameter specifies the maximum number of items that should be returned in the result set.
      */
     maxResults?: number;
     /**
@@ -8660,11 +8328,11 @@ export namespace youtube_v3 {
      */
     order?: string;
     /**
-     * The <code><strong>pageToken</strong></code> parameter identifies a specific page in the result set that should be returned. In an API response, the <code>nextPageToken</code> and <code>prevPageToken</code> properties identify other pages that could be retrieved.
+     * The *pageToken* parameter identifies a specific page in the result set that should be returned. In an API response, the nextPageToken and prevPageToken properties identify other pages that could be retrieved.
      */
     pageToken?: string;
     /**
-     * The <code><strong>part</strong></code> parameter specifies a comma-separated list of one or more <code>commentThread</code> resource properties that the API response will include.
+     * The *part* parameter specifies a comma-separated list of one or more commentThread resource properties that the API response will include.
      */
     part?: string[];
     /**
@@ -8683,7 +8351,7 @@ export namespace youtube_v3 {
   export interface Params$Resource$Commentthreads$Update
     extends StandardParameters {
     /**
-     * The <code><strong>part</strong></code> parameter specifies a comma-separated list of <code>commentThread</code> resource properties that the API response will include. You must at least include the <code>snippet</code> part in the parameter value since that part contains all of the properties that the API request can update.
+     * The *part* parameter specifies a comma-separated list of commentThread resource properties that the API response will include. You must at least include the snippet part in the parameter value since that part contains all of the properties that the API request can update.
      */
     part?: string[];
 
@@ -8693,194 +8361,6 @@ export namespace youtube_v3 {
     requestBody?: Schema$CommentThread;
   }
 
-  export class Resource$Guidecategories {
-    context: APIRequestContext;
-    constructor(context: APIRequestContext) {
-      this.context = context;
-    }
-
-    /**
-     * youtube.guideCategories.list
-     * @desc Retrieves a list of guide categories.
-     * @example
-     * // Before running the sample:
-     * // - Enable the API at:
-     * //   https://console.developers.google.com/apis/api/youtube.googleapis.com
-     * // - Login into gcloud by running:
-     * //   `$ gcloud auth application-default login`
-     * // - Install the npm module by running:
-     * //   `$ npm install googleapis`
-     *
-     * const {google} = require('googleapis');
-     * const youtube = google.youtube('v3');
-     *
-     * async function main() {
-     *   const auth = new google.auth.GoogleAuth({
-     *     // Scopes can be specified either as an array or as a single, space-delimited string.
-     *     scopes: [
-     *       'https://www.googleapis.com/auth/youtube',
-     *       'https://www.googleapis.com/auth/youtube.force-ssl',
-     *       'https://www.googleapis.com/auth/youtube.readonly',
-     *       'https://www.googleapis.com/auth/youtubepartner',
-     *     ],
-     *   });
-     *
-     *   // Acquire an auth client, and bind it to all future calls
-     *   const authClient = await auth.getClient();
-     *   google.options({auth: authClient});
-     *
-     *   // Do the magic
-     *   const res = await youtube.guideCategories.list({
-     *     hl: 'placeholder-value',
-     *     // Return the guide categories with the given IDs.
-     *     id: 'placeholder-value',
-     *     // The <code><strong>part</strong></code> parameter specifies the
-     *     // <code>guideCategory</code> resource properties that the API response will
-     *     // include. Set the parameter value to <code>snippet</code>.
-     *     part: 'placeholder-value',
-     *     // Return all categories in the given region code.
-     *     regionCode: 'placeholder-value',
-     *   });
-     *   console.log(res.data);
-     *
-     *   // Example response
-     *   // {
-     *   //   "etag": "my_etag",
-     *   //   "eventId": "my_eventId",
-     *   //   "items": [],
-     *   //   "kind": "my_kind",
-     *   //   "nextPageToken": "my_nextPageToken",
-     *   //   "pageInfo": {},
-     *   //   "prevPageToken": "my_prevPageToken",
-     *   //   "tokenPagination": {},
-     *   //   "visitorId": "my_visitorId"
-     *   // }
-     * }
-     *
-     * main().catch(e => {
-     *   console.error(e);
-     *   throw e;
-     * });
-     *
-     * @alias youtube.guideCategories.list
-     * @memberOf! ()
-     *
-     * @param {object} params Parameters for request
-     * @param {string=} params.hl
-     * @param {string=} params.id Return the guide categories with the given IDs.
-     * @param {string} params.part The <code><strong>part</strong></code> parameter specifies the <code>guideCategory</code> resource properties that the API response will include. Set the parameter value to <code>snippet</code>.
-     * @param {string=} params.regionCode Return all categories in the given region code.
-     * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-     * @param {callback} callback The callback that handles the response.
-     * @return {object} Request object
-     */
-    list(
-      params: Params$Resource$Guidecategories$List,
-      options: StreamMethodOptions
-    ): GaxiosPromise<Readable>;
-    list(
-      params?: Params$Resource$Guidecategories$List,
-      options?: MethodOptions
-    ): GaxiosPromise<Schema$GuideCategoryListResponse>;
-    list(
-      params: Params$Resource$Guidecategories$List,
-      options: StreamMethodOptions | BodyResponseCallback<Readable>,
-      callback: BodyResponseCallback<Readable>
-    ): void;
-    list(
-      params: Params$Resource$Guidecategories$List,
-      options:
-        | MethodOptions
-        | BodyResponseCallback<Schema$GuideCategoryListResponse>,
-      callback: BodyResponseCallback<Schema$GuideCategoryListResponse>
-    ): void;
-    list(
-      params: Params$Resource$Guidecategories$List,
-      callback: BodyResponseCallback<Schema$GuideCategoryListResponse>
-    ): void;
-    list(
-      callback: BodyResponseCallback<Schema$GuideCategoryListResponse>
-    ): void;
-    list(
-      paramsOrCallback?:
-        | Params$Resource$Guidecategories$List
-        | BodyResponseCallback<Schema$GuideCategoryListResponse>
-        | BodyResponseCallback<Readable>,
-      optionsOrCallback?:
-        | MethodOptions
-        | StreamMethodOptions
-        | BodyResponseCallback<Schema$GuideCategoryListResponse>
-        | BodyResponseCallback<Readable>,
-      callback?:
-        | BodyResponseCallback<Schema$GuideCategoryListResponse>
-        | BodyResponseCallback<Readable>
-    ):
-      | void
-      | GaxiosPromise<Schema$GuideCategoryListResponse>
-      | GaxiosPromise<Readable> {
-      let params = (paramsOrCallback ||
-        {}) as Params$Resource$Guidecategories$List;
-      let options = (optionsOrCallback || {}) as MethodOptions;
-
-      if (typeof paramsOrCallback === 'function') {
-        callback = paramsOrCallback;
-        params = {} as Params$Resource$Guidecategories$List;
-        options = {};
-      }
-
-      if (typeof optionsOrCallback === 'function') {
-        callback = optionsOrCallback;
-        options = {};
-      }
-
-      const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
-      const parameters = {
-        options: Object.assign(
-          {
-            url: (rootUrl + '/youtube/v3/guideCategories').replace(
-              /([^:]\/)\/+/g,
-              '$1'
-            ),
-            method: 'GET',
-          },
-          options
-        ),
-        params,
-        requiredParams: ['part'],
-        pathParams: [],
-        context: this.context,
-      };
-      if (callback) {
-        createAPIRequest<Schema$GuideCategoryListResponse>(
-          parameters,
-          callback as BodyResponseCallback<{} | void>
-        );
-      } else {
-        return createAPIRequest<Schema$GuideCategoryListResponse>(parameters);
-      }
-    }
-  }
-
-  export interface Params$Resource$Guidecategories$List
-    extends StandardParameters {
-    /**
-     *
-     */
-    hl?: string;
-    /**
-     * Return the guide categories with the given IDs.
-     */
-    id?: string[];
-    /**
-     * The <code><strong>part</strong></code> parameter specifies the <code>guideCategory</code> resource properties that the API response will include. Set the parameter value to <code>snippet</code>.
-     */
-    part?: string[];
-    /**
-     * Return all categories in the given region code.
-     */
-    regionCode?: string;
-  }
-
   export class Resource$I18nlanguages {
     context: APIRequestContext;
     constructor(context: APIRequestContext) {
@@ -8888,9 +8368,9 @@ export namespace youtube_v3 {
     }
 
     /**
-     * youtube.i18nLanguages.list
-     * @desc Retrieves a list of resources, possibly filtered.
+     * Retrieves a list of resources, possibly filtered.
      * @example
+     * ```js
      * // Before running the sample:
      * // - Enable the API at:
      * //   https://console.developers.google.com/apis/api/youtube.googleapis.com
@@ -8920,9 +8400,7 @@ export namespace youtube_v3 {
      *   // Do the magic
      *   const res = await youtube.i18nLanguages.list({
      *     hl: 'placeholder-value',
-     *     // The <code><strong>part</strong></code> parameter specifies the
-     *     // <code>i18nLanguage</code> resource properties that the API response will
-     *     // include. Set the parameter value to <code>snippet</code>.
+     *     // The *part* parameter specifies the i18nLanguage resource properties that the API response will include. Set the parameter value to snippet.
      *     part: 'placeholder-value',
      *   });
      *   console.log(res.data);
@@ -8942,15 +8420,12 @@ export namespace youtube_v3 {
      *   throw e;
      * });
      *
-     * @alias youtube.i18nLanguages.list
-     * @memberOf! ()
+     * ```
      *
-     * @param {object} params Parameters for request
-     * @param {string=} params.hl
-     * @param {string} params.part The <code><strong>part</strong></code> parameter specifies the <code>i18nLanguage</code> resource properties that the API response will include. Set the parameter value to <code>snippet</code>.
-     * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-     * @param {callback} callback The callback that handles the response.
-     * @return {object} Request object
+     * @param params - Parameters for request
+     * @param options - Optionally override request options, such as `url`, `method`, and `encoding`.
+     * @param callback - Optional callback that handles the response.
+     * @returns A promise if used with async/await, or void if used with a callback.
      */
     list(
       params: Params$Resource$I18nlanguages$List,
@@ -9009,7 +8484,7 @@ export namespace youtube_v3 {
         options = {};
       }
 
-      const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+      const rootUrl = options.rootUrl || 'https://youtube.googleapis.com/';
       const parameters = {
         options: Object.assign(
           {
@@ -9029,7 +8504,7 @@ export namespace youtube_v3 {
       if (callback) {
         createAPIRequest<Schema$I18nLanguageListResponse>(
           parameters,
-          callback as BodyResponseCallback<{} | void>
+          callback as BodyResponseCallback<unknown>
         );
       } else {
         return createAPIRequest<Schema$I18nLanguageListResponse>(parameters);
@@ -9044,7 +8519,7 @@ export namespace youtube_v3 {
      */
     hl?: string;
     /**
-     * The <code><strong>part</strong></code> parameter specifies the <code>i18nLanguage</code> resource properties that the API response will include. Set the parameter value to <code>snippet</code>.
+     * The *part* parameter specifies the i18nLanguage resource properties that the API response will include. Set the parameter value to snippet.
      */
     part?: string[];
   }
@@ -9056,9 +8531,9 @@ export namespace youtube_v3 {
     }
 
     /**
-     * youtube.i18nRegions.list
-     * @desc Retrieves a list of resources, possibly filtered.
+     * Retrieves a list of resources, possibly filtered.
      * @example
+     * ```js
      * // Before running the sample:
      * // - Enable the API at:
      * //   https://console.developers.google.com/apis/api/youtube.googleapis.com
@@ -9088,9 +8563,7 @@ export namespace youtube_v3 {
      *   // Do the magic
      *   const res = await youtube.i18nRegions.list({
      *     hl: 'placeholder-value',
-     *     // The <code><strong>part</strong></code> parameter specifies the
-     *     // <code>i18nRegion</code> resource properties that the API response will
-     *     // include. Set the parameter value to <code>snippet</code>.
+     *     // The *part* parameter specifies the i18nRegion resource properties that the API response will include. Set the parameter value to snippet.
      *     part: 'placeholder-value',
      *   });
      *   console.log(res.data);
@@ -9110,15 +8583,12 @@ export namespace youtube_v3 {
      *   throw e;
      * });
      *
-     * @alias youtube.i18nRegions.list
-     * @memberOf! ()
+     * ```
      *
-     * @param {object} params Parameters for request
-     * @param {string=} params.hl
-     * @param {string} params.part The <code><strong>part</strong></code> parameter specifies the <code>i18nRegion</code> resource properties that the API response will include. Set the parameter value to <code>snippet</code>.
-     * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-     * @param {callback} callback The callback that handles the response.
-     * @return {object} Request object
+     * @param params - Parameters for request
+     * @param options - Optionally override request options, such as `url`, `method`, and `encoding`.
+     * @param callback - Optional callback that handles the response.
+     * @returns A promise if used with async/await, or void if used with a callback.
      */
     list(
       params: Params$Resource$I18nregions$List,
@@ -9176,7 +8646,7 @@ export namespace youtube_v3 {
         options = {};
       }
 
-      const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+      const rootUrl = options.rootUrl || 'https://youtube.googleapis.com/';
       const parameters = {
         options: Object.assign(
           {
@@ -9196,7 +8666,7 @@ export namespace youtube_v3 {
       if (callback) {
         createAPIRequest<Schema$I18nRegionListResponse>(
           parameters,
-          callback as BodyResponseCallback<{} | void>
+          callback as BodyResponseCallback<unknown>
         );
       } else {
         return createAPIRequest<Schema$I18nRegionListResponse>(parameters);
@@ -9210,7 +8680,7 @@ export namespace youtube_v3 {
      */
     hl?: string;
     /**
-     * The <code><strong>part</strong></code> parameter specifies the <code>i18nRegion</code> resource properties that the API response will include. Set the parameter value to <code>snippet</code>.
+     * The *part* parameter specifies the i18nRegion resource properties that the API response will include. Set the parameter value to snippet.
      */
     part?: string[];
   }
@@ -9222,9 +8692,9 @@ export namespace youtube_v3 {
     }
 
     /**
-     * youtube.liveBroadcasts.bind
-     * @desc Bind a broadcast to a stream.
+     * Bind a broadcast to a stream.
      * @example
+     * ```js
      * // Before running the sample:
      * // - Enable the API at:
      * //   https://console.developers.google.com/apis/api/youtube.googleapis.com
@@ -9253,44 +8723,11 @@ export namespace youtube_v3 {
      *   const res = await youtube.liveBroadcasts.bind({
      *     // Broadcast to bind to the stream
      *     id: 'placeholder-value',
-     *     // <strong>Note:</strong> This parameter is intended exclusively for YouTube
-     *     // content partners.<br><br>The
-     *     // <code><strong>onBehalfOfContentOwner</strong></code> parameter indicates
-     *     // that the
-     *     // request's authorization credentials identify a YouTube CMS user who is
-     *     // acting on behalf of the content owner specified in the parameter value.
-     *     // This parameter is intended for YouTube content partners that own and manage
-     *     // many different YouTube channels. It allows content owners to authenticate
-     *     // once and get access to all their video and channel data, without having to
-     *     // provide authentication credentials for each individual channel. The CMS
-     *     // account that the user authenticates with must be linked to the specified
-     *     // YouTube content owner.
+     *     // *Note:* This parameter is intended exclusively for YouTube content partners. The *onBehalfOfContentOwner* parameter indicates that the request's authorization credentials identify a YouTube CMS user who is acting on behalf of the content owner specified in the parameter value. This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and get access to all their video and channel data, without having to provide authentication credentials for each individual channel. The CMS account that the user authenticates with must be linked to the specified YouTube content owner.
      *     onBehalfOfContentOwner: 'placeholder-value',
-     *     // This parameter can only be used in a properly <a
-     *     // href="/youtube/v3/guides/authentication">authorized request</a>.
-     *     // <strong>Note:</strong> This parameter is intended exclusively for YouTube
-     *     // content partners.<br><br>The
-     *     // <code><strong>onBehalfOfContentOwnerChannel</strong></code> parameter
-     *     // specifies the YouTube channel ID of the channel to which a video is being
-     *     // added. This parameter is required when a request specifies a value for the
-     *     // <code>onBehalfOfContentOwner</code> parameter, and it can only be used in
-     *     // conjunction with that parameter. In addition, the request must be
-     *     // authorized using a CMS account that is linked to the content owner that the
-     *     // <code>onBehalfOfContentOwner</code> parameter specifies. Finally, the
-     *     // channel that the <code>onBehalfOfContentOwnerChannel</code> parameter value
-     *     // specifies must be linked to the content owner that the
-     *     // <code>onBehalfOfContentOwner</code> parameter specifies.<br><br>This
-     *     // parameter is intended for YouTube content partners that own and manage many
-     *     // different YouTube channels. It allows content owners to authenticate once
-     *     // and perform actions on behalf of the channel specified in the parameter
-     *     // value, without having to provide authentication credentials for each
-     *     // separate channel.
+     *     // This parameter can only be used in a properly authorized request. *Note:* This parameter is intended exclusively for YouTube content partners. The *onBehalfOfContentOwnerChannel* parameter specifies the YouTube channel ID of the channel to which a video is being added. This parameter is required when a request specifies a value for the onBehalfOfContentOwner parameter, and it can only be used in conjunction with that parameter. In addition, the request must be authorized using a CMS account that is linked to the content owner that the onBehalfOfContentOwner parameter specifies. Finally, the channel that the onBehalfOfContentOwnerChannel parameter value specifies must be linked to the content owner that the onBehalfOfContentOwner parameter specifies. This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and perform actions on behalf of the channel specified in the parameter value, without having to provide authentication credentials for each separate channel.
      *     onBehalfOfContentOwnerChannel: 'placeholder-value',
-     *     // The <code><strong>part</strong></code> parameter specifies a
-     *     // comma-separated list of one or more <code>liveBroadcast</code> resource
-     *     // properties that the API response will include. The <code>part</code> names
-     *     // that you can include in the parameter value are <code>id</code>,
-     *     // <code>snippet</code>, <code>contentDetails</code>, and <code>status</code>.
+     *     // The *part* parameter specifies a comma-separated list of one or more liveBroadcast resource properties that the API response will include. The part names that you can include in the parameter value are id, snippet, contentDetails, and status.
      *     part: 'placeholder-value',
      *     // Stream to bind, if not set unbind the current one.
      *     streamId: 'placeholder-value',
@@ -9314,18 +8751,12 @@ export namespace youtube_v3 {
      *   throw e;
      * });
      *
-     * @alias youtube.liveBroadcasts.bind
-     * @memberOf! ()
+     * ```
      *
-     * @param {object} params Parameters for request
-     * @param {string} params.id Broadcast to bind to the stream
-     * @param {string=} params.onBehalfOfContentOwner <strong>Note:</strong> This parameter is intended exclusively for YouTube content partners.<br><br>The <code><strong>onBehalfOfContentOwner</strong></code> parameter indicates that the request's authorization credentials identify a YouTube CMS user who is acting on behalf of the content owner specified in the parameter value. This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and get access to all their video and channel data, without having to provide authentication credentials for each individual channel. The CMS account that the user authenticates with must be linked to the specified YouTube content owner.
-     * @param {string=} params.onBehalfOfContentOwnerChannel This parameter can only be used in a properly <a href="/youtube/v3/guides/authentication">authorized request</a>. <strong>Note:</strong> This parameter is intended exclusively for YouTube content partners.<br><br>The <code><strong>onBehalfOfContentOwnerChannel</strong></code> parameter specifies the YouTube channel ID of the channel to which a video is being added. This parameter is required when a request specifies a value for the <code>onBehalfOfContentOwner</code> parameter, and it can only be used in conjunction with that parameter. In addition, the request must be authorized using a CMS account that is linked to the content owner that the <code>onBehalfOfContentOwner</code> parameter specifies. Finally, the channel that the <code>onBehalfOfContentOwnerChannel</code> parameter value specifies must be linked to the content owner that the <code>onBehalfOfContentOwner</code> parameter specifies.<br><br>This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and perform actions on behalf of the channel specified in the parameter value, without having to provide authentication credentials for each separate channel.
-     * @param {string} params.part The <code><strong>part</strong></code> parameter specifies a comma-separated list of one or more <code>liveBroadcast</code> resource properties that the API response will include. The <code>part</code> names that you can include in the parameter value are <code>id</code>, <code>snippet</code>, <code>contentDetails</code>, and <code>status</code>.
-     * @param {string=} params.streamId Stream to bind, if not set unbind the current one.
-     * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-     * @param {callback} callback The callback that handles the response.
-     * @return {object} Request object
+     * @param params - Parameters for request
+     * @param options - Optionally override request options, such as `url`, `method`, and `encoding`.
+     * @param callback - Optional callback that handles the response.
+     * @returns A promise if used with async/await, or void if used with a callback.
      */
     bind(
       params: Params$Resource$Livebroadcasts$Bind,
@@ -9379,7 +8810,7 @@ export namespace youtube_v3 {
         options = {};
       }
 
-      const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+      const rootUrl = options.rootUrl || 'https://youtube.googleapis.com/';
       const parameters = {
         options: Object.assign(
           {
@@ -9399,7 +8830,7 @@ export namespace youtube_v3 {
       if (callback) {
         createAPIRequest<Schema$LiveBroadcast>(
           parameters,
-          callback as BodyResponseCallback<{} | void>
+          callback as BodyResponseCallback<unknown>
         );
       } else {
         return createAPIRequest<Schema$LiveBroadcast>(parameters);
@@ -9407,205 +8838,9 @@ export namespace youtube_v3 {
     }
 
     /**
-     * youtube.liveBroadcasts.control
-     * @desc Slate and recording control of the live broadcast. Support actions: slate on/off, recording start/stop/pause/resume. Design doc: goto/yt-api-liveBroadcast-control
+     * Delete a given broadcast.
      * @example
-     * // Before running the sample:
-     * // - Enable the API at:
-     * //   https://console.developers.google.com/apis/api/youtube.googleapis.com
-     * // - Login into gcloud by running:
-     * //   `$ gcloud auth application-default login`
-     * // - Install the npm module by running:
-     * //   `$ npm install googleapis`
-     *
-     * const {google} = require('googleapis');
-     * const youtube = google.youtube('v3');
-     *
-     * async function main() {
-     *   const auth = new google.auth.GoogleAuth({
-     *     // Scopes can be specified either as an array or as a single, space-delimited string.
-     *     scopes: [
-     *       'https://www.googleapis.com/auth/youtube',
-     *       'https://www.googleapis.com/auth/youtube.force-ssl',
-     *     ],
-     *   });
-     *
-     *   // Acquire an auth client, and bind it to all future calls
-     *   const authClient = await auth.getClient();
-     *   google.options({auth: authClient});
-     *
-     *   // Do the magic
-     *   const res = await youtube.liveBroadcasts.control({
-     *     // Whether display or hide slate.
-     *     displaySlate: 'placeholder-value',
-     *     // Broadcast to operate.
-     *     id: 'placeholder-value',
-     *     // The exact time when the actions (e.g. slate on) are executed.
-     *     // It is an offset from the first frame of the monitor stream.
-     *     // If not set, it means "now" or ASAP.
-     *     // This field should not be set if the monitor stream is disabled,
-     *     // otherwise an error will be returned.
-     *     offsetTimeMs: 'placeholder-value',
-     *     // <strong>Note:</strong> This parameter is intended exclusively for YouTube
-     *     // content partners.<br><br>The
-     *     // <code><strong>onBehalfOfContentOwner</strong></code> parameter indicates
-     *     // that the
-     *     // request's authorization credentials identify a YouTube CMS user who is
-     *     // acting on behalf of the content owner specified in the parameter value.
-     *     // This parameter is intended for YouTube content partners that own and manage
-     *     // many different YouTube channels. It allows content owners to authenticate
-     *     // once and get access to all their video and channel data, without having to
-     *     // provide authentication credentials for each individual channel. The CMS
-     *     // account that the user authenticates with must be linked to the specified
-     *     // YouTube content owner.
-     *     onBehalfOfContentOwner: 'placeholder-value',
-     *     // This parameter can only be used in a properly <a
-     *     // href="/youtube/v3/guides/authentication">authorized request</a>.
-     *     // <strong>Note:</strong> This parameter is intended exclusively for YouTube
-     *     // content partners.<br><br>The
-     *     // <code><strong>onBehalfOfContentOwnerChannel</strong></code> parameter
-     *     // specifies the YouTube channel ID of the channel to which a video is being
-     *     // added. This parameter is required when a request specifies a value for the
-     *     // <code>onBehalfOfContentOwner</code> parameter, and it can only be used in
-     *     // conjunction with that parameter. In addition, the request must be
-     *     // authorized using a CMS account that is linked to the content owner that the
-     *     // <code>onBehalfOfContentOwner</code> parameter specifies. Finally, the
-     *     // channel that the <code>onBehalfOfContentOwnerChannel</code> parameter value
-     *     // specifies must be linked to the content owner that the
-     *     // <code>onBehalfOfContentOwner</code> parameter specifies.<br><br>This
-     *     // parameter is intended for YouTube content partners that own and manage many
-     *     // different YouTube channels. It allows content owners to authenticate once
-     *     // and perform actions on behalf of the channel specified in the parameter
-     *     // value, without having to provide authentication credentials for each
-     *     // separate channel.
-     *     onBehalfOfContentOwnerChannel: 'placeholder-value',
-     *     // The <code><strong>part</strong></code> parameter specifies a
-     *     // comma-separated list of one or more <code>liveBroadcast</code> resource
-     *     // properties that the API response will include. The <code>part</code> names
-     *     // that you can include in the parameter value are <code>id</code>,
-     *     // <code>snippet</code>, <code>contentDetails</code>, and <code>status</code>.
-     *     part: 'placeholder-value',
-     *     // The wall clock time at which the action should be executed.
-     *     // Only one of offset_time_ms and walltime may be set at a time.
-     *     walltime: 'placeholder-value',
-     *   });
-     *   console.log(res.data);
-     *
-     *   // Example response
-     *   // {
-     *   //   "contentDetails": {},
-     *   //   "etag": "my_etag",
-     *   //   "id": "my_id",
-     *   //   "kind": "my_kind",
-     *   //   "snippet": {},
-     *   //   "statistics": {},
-     *   //   "status": {}
-     *   // }
-     * }
-     *
-     * main().catch(e => {
-     *   console.error(e);
-     *   throw e;
-     * });
-     *
-     * @alias youtube.liveBroadcasts.control
-     * @memberOf! ()
-     *
-     * @param {object} params Parameters for request
-     * @param {boolean=} params.displaySlate Whether display or hide slate.
-     * @param {string} params.id Broadcast to operate.
-     * @param {string=} params.offsetTimeMs The exact time when the actions (e.g. slate on) are executed. It is an offset from the first frame of the monitor stream. If not set, it means "now" or ASAP. This field should not be set if the monitor stream is disabled, otherwise an error will be returned.
-     * @param {string=} params.onBehalfOfContentOwner <strong>Note:</strong> This parameter is intended exclusively for YouTube content partners.<br><br>The <code><strong>onBehalfOfContentOwner</strong></code> parameter indicates that the request's authorization credentials identify a YouTube CMS user who is acting on behalf of the content owner specified in the parameter value. This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and get access to all their video and channel data, without having to provide authentication credentials for each individual channel. The CMS account that the user authenticates with must be linked to the specified YouTube content owner.
-     * @param {string=} params.onBehalfOfContentOwnerChannel This parameter can only be used in a properly <a href="/youtube/v3/guides/authentication">authorized request</a>. <strong>Note:</strong> This parameter is intended exclusively for YouTube content partners.<br><br>The <code><strong>onBehalfOfContentOwnerChannel</strong></code> parameter specifies the YouTube channel ID of the channel to which a video is being added. This parameter is required when a request specifies a value for the <code>onBehalfOfContentOwner</code> parameter, and it can only be used in conjunction with that parameter. In addition, the request must be authorized using a CMS account that is linked to the content owner that the <code>onBehalfOfContentOwner</code> parameter specifies. Finally, the channel that the <code>onBehalfOfContentOwnerChannel</code> parameter value specifies must be linked to the content owner that the <code>onBehalfOfContentOwner</code> parameter specifies.<br><br>This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and perform actions on behalf of the channel specified in the parameter value, without having to provide authentication credentials for each separate channel.
-     * @param {string} params.part The <code><strong>part</strong></code> parameter specifies a comma-separated list of one or more <code>liveBroadcast</code> resource properties that the API response will include. The <code>part</code> names that you can include in the parameter value are <code>id</code>, <code>snippet</code>, <code>contentDetails</code>, and <code>status</code>.
-     * @param {string=} params.walltime The wall clock time at which the action should be executed. Only one of offset_time_ms and walltime may be set at a time.
-     * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-     * @param {callback} callback The callback that handles the response.
-     * @return {object} Request object
-     */
-    control(
-      params: Params$Resource$Livebroadcasts$Control,
-      options: StreamMethodOptions
-    ): GaxiosPromise<Readable>;
-    control(
-      params?: Params$Resource$Livebroadcasts$Control,
-      options?: MethodOptions
-    ): GaxiosPromise<Schema$LiveBroadcast>;
-    control(
-      params: Params$Resource$Livebroadcasts$Control,
-      options: StreamMethodOptions | BodyResponseCallback<Readable>,
-      callback: BodyResponseCallback<Readable>
-    ): void;
-    control(
-      params: Params$Resource$Livebroadcasts$Control,
-      options: MethodOptions | BodyResponseCallback<Schema$LiveBroadcast>,
-      callback: BodyResponseCallback<Schema$LiveBroadcast>
-    ): void;
-    control(
-      params: Params$Resource$Livebroadcasts$Control,
-      callback: BodyResponseCallback<Schema$LiveBroadcast>
-    ): void;
-    control(callback: BodyResponseCallback<Schema$LiveBroadcast>): void;
-    control(
-      paramsOrCallback?:
-        | Params$Resource$Livebroadcasts$Control
-        | BodyResponseCallback<Schema$LiveBroadcast>
-        | BodyResponseCallback<Readable>,
-      optionsOrCallback?:
-        | MethodOptions
-        | StreamMethodOptions
-        | BodyResponseCallback<Schema$LiveBroadcast>
-        | BodyResponseCallback<Readable>,
-      callback?:
-        | BodyResponseCallback<Schema$LiveBroadcast>
-        | BodyResponseCallback<Readable>
-    ): void | GaxiosPromise<Schema$LiveBroadcast> | GaxiosPromise<Readable> {
-      let params = (paramsOrCallback ||
-        {}) as Params$Resource$Livebroadcasts$Control;
-      let options = (optionsOrCallback || {}) as MethodOptions;
-
-      if (typeof paramsOrCallback === 'function') {
-        callback = paramsOrCallback;
-        params = {} as Params$Resource$Livebroadcasts$Control;
-        options = {};
-      }
-
-      if (typeof optionsOrCallback === 'function') {
-        callback = optionsOrCallback;
-        options = {};
-      }
-
-      const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
-      const parameters = {
-        options: Object.assign(
-          {
-            url: (rootUrl + '/youtube/v3/liveBroadcasts/control').replace(
-              /([^:]\/)\/+/g,
-              '$1'
-            ),
-            method: 'POST',
-          },
-          options
-        ),
-        params,
-        requiredParams: ['id', 'part'],
-        pathParams: [],
-        context: this.context,
-      };
-      if (callback) {
-        createAPIRequest<Schema$LiveBroadcast>(
-          parameters,
-          callback as BodyResponseCallback<{} | void>
-        );
-      } else {
-        return createAPIRequest<Schema$LiveBroadcast>(parameters);
-      }
-    }
-
-    /**
-     * youtube.liveBroadcasts.delete
-     * @desc Delete a given broadcast.
-     * @example
+     * ```js
      * // Before running the sample:
      * // - Enable the API at:
      * //   https://console.developers.google.com/apis/api/youtube.googleapis.com
@@ -9632,39 +8867,11 @@ export namespace youtube_v3 {
      *
      *   // Do the magic
      *   const res = await youtube.liveBroadcasts.delete({
+     *     // Broadcast to delete.
      *     id: 'placeholder-value',
-     *     // <strong>Note:</strong> This parameter is intended exclusively for YouTube
-     *     // content partners.<br><br>The
-     *     // <code><strong>onBehalfOfContentOwner</strong></code> parameter indicates
-     *     // that the
-     *     // request's authorization credentials identify a YouTube CMS user who is
-     *     // acting on behalf of the content owner specified in the parameter value.
-     *     // This parameter is intended for YouTube content partners that own and manage
-     *     // many different YouTube channels. It allows content owners to authenticate
-     *     // once and get access to all their video and channel data, without having to
-     *     // provide authentication credentials for each individual channel. The CMS
-     *     // account that the user authenticates with must be linked to the specified
-     *     // YouTube content owner.
+     *     // *Note:* This parameter is intended exclusively for YouTube content partners. The *onBehalfOfContentOwner* parameter indicates that the request's authorization credentials identify a YouTube CMS user who is acting on behalf of the content owner specified in the parameter value. This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and get access to all their video and channel data, without having to provide authentication credentials for each individual channel. The CMS account that the user authenticates with must be linked to the specified YouTube content owner.
      *     onBehalfOfContentOwner: 'placeholder-value',
-     *     // This parameter can only be used in a properly <a
-     *     // href="/youtube/v3/guides/authentication">authorized request</a>.
-     *     // <strong>Note:</strong> This parameter is intended exclusively for YouTube
-     *     // content partners.<br><br>The
-     *     // <code><strong>onBehalfOfContentOwnerChannel</strong></code> parameter
-     *     // specifies the YouTube channel ID of the channel to which a video is being
-     *     // added. This parameter is required when a request specifies a value for the
-     *     // <code>onBehalfOfContentOwner</code> parameter, and it can only be used in
-     *     // conjunction with that parameter. In addition, the request must be
-     *     // authorized using a CMS account that is linked to the content owner that the
-     *     // <code>onBehalfOfContentOwner</code> parameter specifies. Finally, the
-     *     // channel that the <code>onBehalfOfContentOwnerChannel</code> parameter value
-     *     // specifies must be linked to the content owner that the
-     *     // <code>onBehalfOfContentOwner</code> parameter specifies.<br><br>This
-     *     // parameter is intended for YouTube content partners that own and manage many
-     *     // different YouTube channels. It allows content owners to authenticate once
-     *     // and perform actions on behalf of the channel specified in the parameter
-     *     // value, without having to provide authentication credentials for each
-     *     // separate channel.
+     *     // This parameter can only be used in a properly authorized request. *Note:* This parameter is intended exclusively for YouTube content partners. The *onBehalfOfContentOwnerChannel* parameter specifies the YouTube channel ID of the channel to which a video is being added. This parameter is required when a request specifies a value for the onBehalfOfContentOwner parameter, and it can only be used in conjunction with that parameter. In addition, the request must be authorized using a CMS account that is linked to the content owner that the onBehalfOfContentOwner parameter specifies. Finally, the channel that the onBehalfOfContentOwnerChannel parameter value specifies must be linked to the content owner that the onBehalfOfContentOwner parameter specifies. This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and perform actions on behalf of the channel specified in the parameter value, without having to provide authentication credentials for each separate channel.
      *     onBehalfOfContentOwnerChannel: 'placeholder-value',
      *   });
      *   console.log(res.data);
@@ -9675,16 +8882,12 @@ export namespace youtube_v3 {
      *   throw e;
      * });
      *
-     * @alias youtube.liveBroadcasts.delete
-     * @memberOf! ()
+     * ```
      *
-     * @param {object} params Parameters for request
-     * @param {string} params.id
-     * @param {string=} params.onBehalfOfContentOwner <strong>Note:</strong> This parameter is intended exclusively for YouTube content partners.<br><br>The <code><strong>onBehalfOfContentOwner</strong></code> parameter indicates that the request's authorization credentials identify a YouTube CMS user who is acting on behalf of the content owner specified in the parameter value. This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and get access to all their video and channel data, without having to provide authentication credentials for each individual channel. The CMS account that the user authenticates with must be linked to the specified YouTube content owner.
-     * @param {string=} params.onBehalfOfContentOwnerChannel This parameter can only be used in a properly <a href="/youtube/v3/guides/authentication">authorized request</a>. <strong>Note:</strong> This parameter is intended exclusively for YouTube content partners.<br><br>The <code><strong>onBehalfOfContentOwnerChannel</strong></code> parameter specifies the YouTube channel ID of the channel to which a video is being added. This parameter is required when a request specifies a value for the <code>onBehalfOfContentOwner</code> parameter, and it can only be used in conjunction with that parameter. In addition, the request must be authorized using a CMS account that is linked to the content owner that the <code>onBehalfOfContentOwner</code> parameter specifies. Finally, the channel that the <code>onBehalfOfContentOwnerChannel</code> parameter value specifies must be linked to the content owner that the <code>onBehalfOfContentOwner</code> parameter specifies.<br><br>This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and perform actions on behalf of the channel specified in the parameter value, without having to provide authentication credentials for each separate channel.
-     * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-     * @param {callback} callback The callback that handles the response.
-     * @return {object} Request object
+     * @param params - Parameters for request
+     * @param options - Optionally override request options, such as `url`, `method`, and `encoding`.
+     * @param callback - Optional callback that handles the response.
+     * @returns A promise if used with async/await, or void if used with a callback.
      */
     delete(
       params: Params$Resource$Livebroadcasts$Delete,
@@ -9736,7 +8939,7 @@ export namespace youtube_v3 {
         options = {};
       }
 
-      const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+      const rootUrl = options.rootUrl || 'https://youtube.googleapis.com/';
       const parameters = {
         options: Object.assign(
           {
@@ -9756,7 +8959,7 @@ export namespace youtube_v3 {
       if (callback) {
         createAPIRequest<void>(
           parameters,
-          callback as BodyResponseCallback<{} | void>
+          callback as BodyResponseCallback<unknown>
         );
       } else {
         return createAPIRequest<void>(parameters);
@@ -9764,9 +8967,9 @@ export namespace youtube_v3 {
     }
 
     /**
-     * youtube.liveBroadcasts.insert
-     * @desc Inserts a new stream for the authenticated user.
+     * Inserts a new stream for the authenticated user.
      * @example
+     * ```js
      * // Before running the sample:
      * // - Enable the API at:
      * //   https://console.developers.google.com/apis/api/youtube.googleapis.com
@@ -9793,45 +8996,11 @@ export namespace youtube_v3 {
      *
      *   // Do the magic
      *   const res = await youtube.liveBroadcasts.insert({
-     *     // <strong>Note:</strong> This parameter is intended exclusively for YouTube
-     *     // content partners.<br><br>The
-     *     // <code><strong>onBehalfOfContentOwner</strong></code> parameter indicates
-     *     // that the
-     *     // request's authorization credentials identify a YouTube CMS user who is
-     *     // acting on behalf of the content owner specified in the parameter value.
-     *     // This parameter is intended for YouTube content partners that own and manage
-     *     // many different YouTube channels. It allows content owners to authenticate
-     *     // once and get access to all their video and channel data, without having to
-     *     // provide authentication credentials for each individual channel. The CMS
-     *     // account that the user authenticates with must be linked to the specified
-     *     // YouTube content owner.
+     *     // *Note:* This parameter is intended exclusively for YouTube content partners. The *onBehalfOfContentOwner* parameter indicates that the request's authorization credentials identify a YouTube CMS user who is acting on behalf of the content owner specified in the parameter value. This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and get access to all their video and channel data, without having to provide authentication credentials for each individual channel. The CMS account that the user authenticates with must be linked to the specified YouTube content owner.
      *     onBehalfOfContentOwner: 'placeholder-value',
-     *     // This parameter can only be used in a properly <a
-     *     // href="/youtube/v3/guides/authentication">authorized request</a>.
-     *     // <strong>Note:</strong> This parameter is intended exclusively for YouTube
-     *     // content partners.<br><br>The
-     *     // <code><strong>onBehalfOfContentOwnerChannel</strong></code> parameter
-     *     // specifies the YouTube channel ID of the channel to which a video is being
-     *     // added. This parameter is required when a request specifies a value for the
-     *     // <code>onBehalfOfContentOwner</code> parameter, and it can only be used in
-     *     // conjunction with that parameter. In addition, the request must be
-     *     // authorized using a CMS account that is linked to the content owner that the
-     *     // <code>onBehalfOfContentOwner</code> parameter specifies. Finally, the
-     *     // channel that the <code>onBehalfOfContentOwnerChannel</code> parameter value
-     *     // specifies must be linked to the content owner that the
-     *     // <code>onBehalfOfContentOwner</code> parameter specifies.<br><br>This
-     *     // parameter is intended for YouTube content partners that own and manage many
-     *     // different YouTube channels. It allows content owners to authenticate once
-     *     // and perform actions on behalf of the channel specified in the parameter
-     *     // value, without having to provide authentication credentials for each
-     *     // separate channel.
+     *     // This parameter can only be used in a properly authorized request. *Note:* This parameter is intended exclusively for YouTube content partners. The *onBehalfOfContentOwnerChannel* parameter specifies the YouTube channel ID of the channel to which a video is being added. This parameter is required when a request specifies a value for the onBehalfOfContentOwner parameter, and it can only be used in conjunction with that parameter. In addition, the request must be authorized using a CMS account that is linked to the content owner that the onBehalfOfContentOwner parameter specifies. Finally, the channel that the onBehalfOfContentOwnerChannel parameter value specifies must be linked to the content owner that the onBehalfOfContentOwner parameter specifies. This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and perform actions on behalf of the channel specified in the parameter value, without having to provide authentication credentials for each separate channel.
      *     onBehalfOfContentOwnerChannel: 'placeholder-value',
-     *     // The <code><strong>part</strong></code> parameter serves two purposes in
-     *     // this operation. It identifies the properties that the write operation will
-     *     // set as well as the properties that the API response will
-     *     // include.<br><br>The <code>part</code> properties that you can include in
-     *     // the parameter value are <code>id</code>, <code>snippet</code>,
-     *     // <code>contentDetails</code>, and <code>status</code>.
+     *     // The *part* parameter serves two purposes in this operation. It identifies the properties that the write operation will set as well as the properties that the API response will include. The part properties that you can include in the parameter value are id, snippet, contentDetails, and status.
      *     part: 'placeholder-value',
      *
      *     // Request body metadata
@@ -9867,17 +9036,12 @@ export namespace youtube_v3 {
      *   throw e;
      * });
      *
-     * @alias youtube.liveBroadcasts.insert
-     * @memberOf! ()
+     * ```
      *
-     * @param {object} params Parameters for request
-     * @param {string=} params.onBehalfOfContentOwner <strong>Note:</strong> This parameter is intended exclusively for YouTube content partners.<br><br>The <code><strong>onBehalfOfContentOwner</strong></code> parameter indicates that the request's authorization credentials identify a YouTube CMS user who is acting on behalf of the content owner specified in the parameter value. This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and get access to all their video and channel data, without having to provide authentication credentials for each individual channel. The CMS account that the user authenticates with must be linked to the specified YouTube content owner.
-     * @param {string=} params.onBehalfOfContentOwnerChannel This parameter can only be used in a properly <a href="/youtube/v3/guides/authentication">authorized request</a>. <strong>Note:</strong> This parameter is intended exclusively for YouTube content partners.<br><br>The <code><strong>onBehalfOfContentOwnerChannel</strong></code> parameter specifies the YouTube channel ID of the channel to which a video is being added. This parameter is required when a request specifies a value for the <code>onBehalfOfContentOwner</code> parameter, and it can only be used in conjunction with that parameter. In addition, the request must be authorized using a CMS account that is linked to the content owner that the <code>onBehalfOfContentOwner</code> parameter specifies. Finally, the channel that the <code>onBehalfOfContentOwnerChannel</code> parameter value specifies must be linked to the content owner that the <code>onBehalfOfContentOwner</code> parameter specifies.<br><br>This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and perform actions on behalf of the channel specified in the parameter value, without having to provide authentication credentials for each separate channel.
-     * @param {string} params.part The <code><strong>part</strong></code> parameter serves two purposes in this operation. It identifies the properties that the write operation will set as well as the properties that the API response will include.<br><br>The <code>part</code> properties that you can include in the parameter value are <code>id</code>, <code>snippet</code>, <code>contentDetails</code>, and <code>status</code>.
-     * @param {().LiveBroadcast} params.requestBody Request body data
-     * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-     * @param {callback} callback The callback that handles the response.
-     * @return {object} Request object
+     * @param params - Parameters for request
+     * @param options - Optionally override request options, such as `url`, `method`, and `encoding`.
+     * @param callback - Optional callback that handles the response.
+     * @returns A promise if used with async/await, or void if used with a callback.
      */
     insert(
       params: Params$Resource$Livebroadcasts$Insert,
@@ -9931,7 +9095,7 @@ export namespace youtube_v3 {
         options = {};
       }
 
-      const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+      const rootUrl = options.rootUrl || 'https://youtube.googleapis.com/';
       const parameters = {
         options: Object.assign(
           {
@@ -9951,7 +9115,7 @@ export namespace youtube_v3 {
       if (callback) {
         createAPIRequest<Schema$LiveBroadcast>(
           parameters,
-          callback as BodyResponseCallback<{} | void>
+          callback as BodyResponseCallback<unknown>
         );
       } else {
         return createAPIRequest<Schema$LiveBroadcast>(parameters);
@@ -9959,9 +9123,9 @@ export namespace youtube_v3 {
     }
 
     /**
-     * youtube.liveBroadcasts.list
-     * @desc Retrieve the list of broadcasts associated with the given channel.
+     * Retrieve the list of broadcasts associated with the given channel.
      * @example
+     * ```js
      * // Before running the sample:
      * // - Enable the API at:
      * //   https://console.developers.google.com/apis/api/youtube.googleapis.com
@@ -9995,54 +9159,17 @@ export namespace youtube_v3 {
      *     broadcastType: 'placeholder-value',
      *     // Return broadcasts with the given ids from Stubby or Apiary.
      *     id: 'placeholder-value',
-     *     // The <code><strong>maxResults</strong></code> parameter specifies the
-     *     // maximum number of items that should be returned in the result set.
+     *     // The *maxResults* parameter specifies the maximum number of items that should be returned in the result set.
      *     maxResults: 'placeholder-value',
      *
      *     mine: 'placeholder-value',
-     *     // <strong>Note:</strong> This parameter is intended exclusively for YouTube
-     *     // content partners.<br><br>The
-     *     // <code><strong>onBehalfOfContentOwner</strong></code> parameter indicates
-     *     // that the
-     *     // request's authorization credentials identify a YouTube CMS user who is
-     *     // acting on behalf of the content owner specified in the parameter value.
-     *     // This parameter is intended for YouTube content partners that own and manage
-     *     // many different YouTube channels. It allows content owners to authenticate
-     *     // once and get access to all their video and channel data, without having to
-     *     // provide authentication credentials for each individual channel. The CMS
-     *     // account that the user authenticates with must be linked to the specified
-     *     // YouTube content owner.
+     *     // *Note:* This parameter is intended exclusively for YouTube content partners. The *onBehalfOfContentOwner* parameter indicates that the request's authorization credentials identify a YouTube CMS user who is acting on behalf of the content owner specified in the parameter value. This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and get access to all their video and channel data, without having to provide authentication credentials for each individual channel. The CMS account that the user authenticates with must be linked to the specified YouTube content owner.
      *     onBehalfOfContentOwner: 'placeholder-value',
-     *     // This parameter can only be used in a properly <a
-     *     // href="/youtube/v3/guides/authentication">authorized request</a>.
-     *     // <strong>Note:</strong> This parameter is intended exclusively for YouTube
-     *     // content partners.<br><br>The
-     *     // <code><strong>onBehalfOfContentOwnerChannel</strong></code> parameter
-     *     // specifies the YouTube channel ID of the channel to which a video is being
-     *     // added. This parameter is required when a request specifies a value for the
-     *     // <code>onBehalfOfContentOwner</code> parameter, and it can only be used in
-     *     // conjunction with that parameter. In addition, the request must be
-     *     // authorized using a CMS account that is linked to the content owner that the
-     *     // <code>onBehalfOfContentOwner</code> parameter specifies. Finally, the
-     *     // channel that the <code>onBehalfOfContentOwnerChannel</code> parameter value
-     *     // specifies must be linked to the content owner that the
-     *     // <code>onBehalfOfContentOwner</code> parameter specifies.<br><br>This
-     *     // parameter is intended for YouTube content partners that own and manage many
-     *     // different YouTube channels. It allows content owners to authenticate once
-     *     // and perform actions on behalf of the channel specified in the parameter
-     *     // value, without having to provide authentication credentials for each
-     *     // separate channel.
+     *     // This parameter can only be used in a properly authorized request. *Note:* This parameter is intended exclusively for YouTube content partners. The *onBehalfOfContentOwnerChannel* parameter specifies the YouTube channel ID of the channel to which a video is being added. This parameter is required when a request specifies a value for the onBehalfOfContentOwner parameter, and it can only be used in conjunction with that parameter. In addition, the request must be authorized using a CMS account that is linked to the content owner that the onBehalfOfContentOwner parameter specifies. Finally, the channel that the onBehalfOfContentOwnerChannel parameter value specifies must be linked to the content owner that the onBehalfOfContentOwner parameter specifies. This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and perform actions on behalf of the channel specified in the parameter value, without having to provide authentication credentials for each separate channel.
      *     onBehalfOfContentOwnerChannel: 'placeholder-value',
-     *     // The <code><strong>pageToken</strong></code> parameter identifies a specific
-     *     // page in the result set that should be returned. In an API response, the
-     *     // <code>nextPageToken</code> and <code>prevPageToken</code> properties
-     *     // identify other pages that could be retrieved.
+     *     // The *pageToken* parameter identifies a specific page in the result set that should be returned. In an API response, the nextPageToken and prevPageToken properties identify other pages that could be retrieved.
      *     pageToken: 'placeholder-value',
-     *     // The <code><strong>part</strong></code> parameter specifies a
-     *     // comma-separated list of one or more <code>liveBroadcast</code> resource
-     *     // properties that the API response will include. The <code>part</code> names
-     *     // that you can include in the parameter value are <code>id</code>,
-     *     // <code>snippet</code>, <code>contentDetails</code>, and <code>status</code>.
+     *     // The *part* parameter specifies a comma-separated list of one or more liveBroadcast resource properties that the API response will include. The part names that you can include in the parameter value are id, snippet, contentDetails, status and statistics.
      *     part: 'placeholder-value',
      *   });
      *   console.log(res.data);
@@ -10066,22 +9193,12 @@ export namespace youtube_v3 {
      *   throw e;
      * });
      *
-     * @alias youtube.liveBroadcasts.list
-     * @memberOf! ()
+     * ```
      *
-     * @param {object} params Parameters for request
-     * @param {string=} params.broadcastStatus Return broadcasts with a certain status, e.g. active broadcasts.
-     * @param {string=} params.broadcastType Return only broadcasts with the selected type.
-     * @param {string=} params.id Return broadcasts with the given ids from Stubby or Apiary.
-     * @param {integer=} params.maxResults The <code><strong>maxResults</strong></code> parameter specifies the maximum number of items that should be returned in the result set.
-     * @param {boolean=} params.mine
-     * @param {string=} params.onBehalfOfContentOwner <strong>Note:</strong> This parameter is intended exclusively for YouTube content partners.<br><br>The <code><strong>onBehalfOfContentOwner</strong></code> parameter indicates that the request's authorization credentials identify a YouTube CMS user who is acting on behalf of the content owner specified in the parameter value. This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and get access to all their video and channel data, without having to provide authentication credentials for each individual channel. The CMS account that the user authenticates with must be linked to the specified YouTube content owner.
-     * @param {string=} params.onBehalfOfContentOwnerChannel This parameter can only be used in a properly <a href="/youtube/v3/guides/authentication">authorized request</a>. <strong>Note:</strong> This parameter is intended exclusively for YouTube content partners.<br><br>The <code><strong>onBehalfOfContentOwnerChannel</strong></code> parameter specifies the YouTube channel ID of the channel to which a video is being added. This parameter is required when a request specifies a value for the <code>onBehalfOfContentOwner</code> parameter, and it can only be used in conjunction with that parameter. In addition, the request must be authorized using a CMS account that is linked to the content owner that the <code>onBehalfOfContentOwner</code> parameter specifies. Finally, the channel that the <code>onBehalfOfContentOwnerChannel</code> parameter value specifies must be linked to the content owner that the <code>onBehalfOfContentOwner</code> parameter specifies.<br><br>This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and perform actions on behalf of the channel specified in the parameter value, without having to provide authentication credentials for each separate channel.
-     * @param {string=} params.pageToken The <code><strong>pageToken</strong></code> parameter identifies a specific page in the result set that should be returned. In an API response, the <code>nextPageToken</code> and <code>prevPageToken</code> properties identify other pages that could be retrieved.
-     * @param {string} params.part The <code><strong>part</strong></code> parameter specifies a comma-separated list of one or more <code>liveBroadcast</code> resource properties that the API response will include. The <code>part</code> names that you can include in the parameter value are <code>id</code>, <code>snippet</code>, <code>contentDetails</code>, and <code>status</code>.
-     * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-     * @param {callback} callback The callback that handles the response.
-     * @return {object} Request object
+     * @param params - Parameters for request
+     * @param options - Optionally override request options, such as `url`, `method`, and `encoding`.
+     * @param callback - Optional callback that handles the response.
+     * @returns A promise if used with async/await, or void if used with a callback.
      */
     list(
       params: Params$Resource$Livebroadcasts$List,
@@ -10142,7 +9259,7 @@ export namespace youtube_v3 {
         options = {};
       }
 
-      const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+      const rootUrl = options.rootUrl || 'https://youtube.googleapis.com/';
       const parameters = {
         options: Object.assign(
           {
@@ -10162,7 +9279,7 @@ export namespace youtube_v3 {
       if (callback) {
         createAPIRequest<Schema$LiveBroadcastListResponse>(
           parameters,
-          callback as BodyResponseCallback<{} | void>
+          callback as BodyResponseCallback<unknown>
         );
       } else {
         return createAPIRequest<Schema$LiveBroadcastListResponse>(parameters);
@@ -10170,9 +9287,9 @@ export namespace youtube_v3 {
     }
 
     /**
-     * youtube.liveBroadcasts.transition
-     * @desc Transition a broadcast to a given status.
+     * Transition a broadcast to a given status.
      * @example
+     * ```js
      * // Before running the sample:
      * // - Enable the API at:
      * //   https://console.developers.google.com/apis/api/youtube.googleapis.com
@@ -10203,44 +9320,11 @@ export namespace youtube_v3 {
      *     broadcastStatus: 'placeholder-value',
      *     // Broadcast to transition.
      *     id: 'placeholder-value',
-     *     // <strong>Note:</strong> This parameter is intended exclusively for YouTube
-     *     // content partners.<br><br>The
-     *     // <code><strong>onBehalfOfContentOwner</strong></code> parameter indicates
-     *     // that the
-     *     // request's authorization credentials identify a YouTube CMS user who is
-     *     // acting on behalf of the content owner specified in the parameter value.
-     *     // This parameter is intended for YouTube content partners that own and manage
-     *     // many different YouTube channels. It allows content owners to authenticate
-     *     // once and get access to all their video and channel data, without having to
-     *     // provide authentication credentials for each individual channel. The CMS
-     *     // account that the user authenticates with must be linked to the specified
-     *     // YouTube content owner.
+     *     // *Note:* This parameter is intended exclusively for YouTube content partners. The *onBehalfOfContentOwner* parameter indicates that the request's authorization credentials identify a YouTube CMS user who is acting on behalf of the content owner specified in the parameter value. This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and get access to all their video and channel data, without having to provide authentication credentials for each individual channel. The CMS account that the user authenticates with must be linked to the specified YouTube content owner.
      *     onBehalfOfContentOwner: 'placeholder-value',
-     *     // This parameter can only be used in a properly <a
-     *     // href="/youtube/v3/guides/authentication">authorized request</a>.
-     *     // <strong>Note:</strong> This parameter is intended exclusively for YouTube
-     *     // content partners.<br><br>The
-     *     // <code><strong>onBehalfOfContentOwnerChannel</strong></code> parameter
-     *     // specifies the YouTube channel ID of the channel to which a video is being
-     *     // added. This parameter is required when a request specifies a value for the
-     *     // <code>onBehalfOfContentOwner</code> parameter, and it can only be used in
-     *     // conjunction with that parameter. In addition, the request must be
-     *     // authorized using a CMS account that is linked to the content owner that the
-     *     // <code>onBehalfOfContentOwner</code> parameter specifies. Finally, the
-     *     // channel that the <code>onBehalfOfContentOwnerChannel</code> parameter value
-     *     // specifies must be linked to the content owner that the
-     *     // <code>onBehalfOfContentOwner</code> parameter specifies.<br><br>This
-     *     // parameter is intended for YouTube content partners that own and manage many
-     *     // different YouTube channels. It allows content owners to authenticate once
-     *     // and perform actions on behalf of the channel specified in the parameter
-     *     // value, without having to provide authentication credentials for each
-     *     // separate channel.
+     *     // This parameter can only be used in a properly authorized request. *Note:* This parameter is intended exclusively for YouTube content partners. The *onBehalfOfContentOwnerChannel* parameter specifies the YouTube channel ID of the channel to which a video is being added. This parameter is required when a request specifies a value for the onBehalfOfContentOwner parameter, and it can only be used in conjunction with that parameter. In addition, the request must be authorized using a CMS account that is linked to the content owner that the onBehalfOfContentOwner parameter specifies. Finally, the channel that the onBehalfOfContentOwnerChannel parameter value specifies must be linked to the content owner that the onBehalfOfContentOwner parameter specifies. This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and perform actions on behalf of the channel specified in the parameter value, without having to provide authentication credentials for each separate channel.
      *     onBehalfOfContentOwnerChannel: 'placeholder-value',
-     *     // The <code><strong>part</strong></code> parameter specifies a
-     *     // comma-separated list of one or more <code>liveBroadcast</code> resource
-     *     // properties that the API response will include. The <code>part</code> names
-     *     // that you can include in the parameter value are <code>id</code>,
-     *     // <code>snippet</code>, <code>contentDetails</code>, and <code>status</code>.
+     *     // The *part* parameter specifies a comma-separated list of one or more liveBroadcast resource properties that the API response will include. The part names that you can include in the parameter value are id, snippet, contentDetails, and status.
      *     part: 'placeholder-value',
      *   });
      *   console.log(res.data);
@@ -10262,18 +9346,12 @@ export namespace youtube_v3 {
      *   throw e;
      * });
      *
-     * @alias youtube.liveBroadcasts.transition
-     * @memberOf! ()
+     * ```
      *
-     * @param {object} params Parameters for request
-     * @param {string} params.broadcastStatus The status to which the broadcast is going to transition.
-     * @param {string} params.id Broadcast to transition.
-     * @param {string=} params.onBehalfOfContentOwner <strong>Note:</strong> This parameter is intended exclusively for YouTube content partners.<br><br>The <code><strong>onBehalfOfContentOwner</strong></code> parameter indicates that the request's authorization credentials identify a YouTube CMS user who is acting on behalf of the content owner specified in the parameter value. This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and get access to all their video and channel data, without having to provide authentication credentials for each individual channel. The CMS account that the user authenticates with must be linked to the specified YouTube content owner.
-     * @param {string=} params.onBehalfOfContentOwnerChannel This parameter can only be used in a properly <a href="/youtube/v3/guides/authentication">authorized request</a>. <strong>Note:</strong> This parameter is intended exclusively for YouTube content partners.<br><br>The <code><strong>onBehalfOfContentOwnerChannel</strong></code> parameter specifies the YouTube channel ID of the channel to which a video is being added. This parameter is required when a request specifies a value for the <code>onBehalfOfContentOwner</code> parameter, and it can only be used in conjunction with that parameter. In addition, the request must be authorized using a CMS account that is linked to the content owner that the <code>onBehalfOfContentOwner</code> parameter specifies. Finally, the channel that the <code>onBehalfOfContentOwnerChannel</code> parameter value specifies must be linked to the content owner that the <code>onBehalfOfContentOwner</code> parameter specifies.<br><br>This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and perform actions on behalf of the channel specified in the parameter value, without having to provide authentication credentials for each separate channel.
-     * @param {string} params.part The <code><strong>part</strong></code> parameter specifies a comma-separated list of one or more <code>liveBroadcast</code> resource properties that the API response will include. The <code>part</code> names that you can include in the parameter value are <code>id</code>, <code>snippet</code>, <code>contentDetails</code>, and <code>status</code>.
-     * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-     * @param {callback} callback The callback that handles the response.
-     * @return {object} Request object
+     * @param params - Parameters for request
+     * @param options - Optionally override request options, such as `url`, `method`, and `encoding`.
+     * @param callback - Optional callback that handles the response.
+     * @returns A promise if used with async/await, or void if used with a callback.
      */
     transition(
       params: Params$Resource$Livebroadcasts$Transition,
@@ -10327,7 +9405,7 @@ export namespace youtube_v3 {
         options = {};
       }
 
-      const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+      const rootUrl = options.rootUrl || 'https://youtube.googleapis.com/';
       const parameters = {
         options: Object.assign(
           {
@@ -10340,14 +9418,14 @@ export namespace youtube_v3 {
           options
         ),
         params,
-        requiredParams: ['id', 'broadcastStatus', 'part'],
+        requiredParams: ['broadcastStatus', 'id', 'part'],
         pathParams: [],
         context: this.context,
       };
       if (callback) {
         createAPIRequest<Schema$LiveBroadcast>(
           parameters,
-          callback as BodyResponseCallback<{} | void>
+          callback as BodyResponseCallback<unknown>
         );
       } else {
         return createAPIRequest<Schema$LiveBroadcast>(parameters);
@@ -10355,9 +9433,9 @@ export namespace youtube_v3 {
     }
 
     /**
-     * youtube.liveBroadcasts.update
-     * @desc Updates an existing broadcast for the authenticated user.
+     * Updates an existing broadcast for the authenticated user.
      * @example
+     * ```js
      * // Before running the sample:
      * // - Enable the API at:
      * //   https://console.developers.google.com/apis/api/youtube.googleapis.com
@@ -10384,55 +9462,11 @@ export namespace youtube_v3 {
      *
      *   // Do the magic
      *   const res = await youtube.liveBroadcasts.update({
-     *     // <strong>Note:</strong> This parameter is intended exclusively for YouTube
-     *     // content partners.<br><br>The
-     *     // <code><strong>onBehalfOfContentOwner</strong></code> parameter indicates
-     *     // that the
-     *     // request's authorization credentials identify a YouTube CMS user who is
-     *     // acting on behalf of the content owner specified in the parameter value.
-     *     // This parameter is intended for YouTube content partners that own and manage
-     *     // many different YouTube channels. It allows content owners to authenticate
-     *     // once and get access to all their video and channel data, without having to
-     *     // provide authentication credentials for each individual channel. The CMS
-     *     // account that the user authenticates with must be linked to the specified
-     *     // YouTube content owner.
+     *     // *Note:* This parameter is intended exclusively for YouTube content partners. The *onBehalfOfContentOwner* parameter indicates that the request's authorization credentials identify a YouTube CMS user who is acting on behalf of the content owner specified in the parameter value. This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and get access to all their video and channel data, without having to provide authentication credentials for each individual channel. The CMS account that the user authenticates with must be linked to the specified YouTube content owner.
      *     onBehalfOfContentOwner: 'placeholder-value',
-     *     // This parameter can only be used in a properly <a
-     *     // href="/youtube/v3/guides/authentication">authorized request</a>.
-     *     // <strong>Note:</strong> This parameter is intended exclusively for YouTube
-     *     // content partners.<br><br>The
-     *     // <code><strong>onBehalfOfContentOwnerChannel</strong></code> parameter
-     *     // specifies the YouTube channel ID of the channel to which a video is being
-     *     // added. This parameter is required when a request specifies a value for the
-     *     // <code>onBehalfOfContentOwner</code> parameter, and it can only be used in
-     *     // conjunction with that parameter. In addition, the request must be
-     *     // authorized using a CMS account that is linked to the content owner that the
-     *     // <code>onBehalfOfContentOwner</code> parameter specifies. Finally, the
-     *     // channel that the <code>onBehalfOfContentOwnerChannel</code> parameter value
-     *     // specifies must be linked to the content owner that the
-     *     // <code>onBehalfOfContentOwner</code> parameter specifies.<br><br>This
-     *     // parameter is intended for YouTube content partners that own and manage many
-     *     // different YouTube channels. It allows content owners to authenticate once
-     *     // and perform actions on behalf of the channel specified in the parameter
-     *     // value, without having to provide authentication credentials for each
-     *     // separate channel.
+     *     // This parameter can only be used in a properly authorized request. *Note:* This parameter is intended exclusively for YouTube content partners. The *onBehalfOfContentOwnerChannel* parameter specifies the YouTube channel ID of the channel to which a video is being added. This parameter is required when a request specifies a value for the onBehalfOfContentOwner parameter, and it can only be used in conjunction with that parameter. In addition, the request must be authorized using a CMS account that is linked to the content owner that the onBehalfOfContentOwner parameter specifies. Finally, the channel that the onBehalfOfContentOwnerChannel parameter value specifies must be linked to the content owner that the onBehalfOfContentOwner parameter specifies. This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and perform actions on behalf of the channel specified in the parameter value, without having to provide authentication credentials for each separate channel.
      *     onBehalfOfContentOwnerChannel: 'placeholder-value',
-     *     // The <code><strong>part</strong></code> parameter serves two purposes in
-     *     // this operation. It identifies the properties that the write operation will
-     *     // set as well as the properties that the API response will
-     *     // include.<br><br>The <code>part</code> properties that you can include in
-     *     // the parameter value are <code>id</code>, <code>snippet</code>,
-     *     // <code>contentDetails</code>, and <code>status</code>.<br><br>Note that this
-     *     // method will override the existing values for all of the mutable properties
-     *     // that are contained in any parts that the parameter value specifies. For
-     *     // example, a
-     *     // broadcast's privacy status is defined in the <code>status</code> part. As
-     *     // such, if your request is updating a private or unlisted broadcast, and the
-     *     // request's <code>part</code> parameter value includes the
-     *     // <code>status</code> part, the broadcast's privacy setting will be updated
-     *     // to whatever value the request body specifies. If the request body does not
-     *     // specify a value, the existing privacy setting will be removed and the
-     *     // broadcast will revert to the default privacy setting.
+     *     // The *part* parameter serves two purposes in this operation. It identifies the properties that the write operation will set as well as the properties that the API response will include. The part properties that you can include in the parameter value are id, snippet, contentDetails, and status. Note that this method will override the existing values for all of the mutable properties that are contained in any parts that the parameter value specifies. For example, a broadcast's privacy status is defined in the status part. As such, if your request is updating a private or unlisted broadcast, and the request's part parameter value includes the status part, the broadcast's privacy setting will be updated to whatever value the request body specifies. If the request body does not specify a value, the existing privacy setting will be removed and the broadcast will revert to the default privacy setting.
      *     part: 'placeholder-value',
      *
      *     // Request body metadata
@@ -10468,17 +9502,12 @@ export namespace youtube_v3 {
      *   throw e;
      * });
      *
-     * @alias youtube.liveBroadcasts.update
-     * @memberOf! ()
+     * ```
      *
-     * @param {object} params Parameters for request
-     * @param {string=} params.onBehalfOfContentOwner <strong>Note:</strong> This parameter is intended exclusively for YouTube content partners.<br><br>The <code><strong>onBehalfOfContentOwner</strong></code> parameter indicates that the request's authorization credentials identify a YouTube CMS user who is acting on behalf of the content owner specified in the parameter value. This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and get access to all their video and channel data, without having to provide authentication credentials for each individual channel. The CMS account that the user authenticates with must be linked to the specified YouTube content owner.
-     * @param {string=} params.onBehalfOfContentOwnerChannel This parameter can only be used in a properly <a href="/youtube/v3/guides/authentication">authorized request</a>. <strong>Note:</strong> This parameter is intended exclusively for YouTube content partners.<br><br>The <code><strong>onBehalfOfContentOwnerChannel</strong></code> parameter specifies the YouTube channel ID of the channel to which a video is being added. This parameter is required when a request specifies a value for the <code>onBehalfOfContentOwner</code> parameter, and it can only be used in conjunction with that parameter. In addition, the request must be authorized using a CMS account that is linked to the content owner that the <code>onBehalfOfContentOwner</code> parameter specifies. Finally, the channel that the <code>onBehalfOfContentOwnerChannel</code> parameter value specifies must be linked to the content owner that the <code>onBehalfOfContentOwner</code> parameter specifies.<br><br>This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and perform actions on behalf of the channel specified in the parameter value, without having to provide authentication credentials for each separate channel.
-     * @param {string} params.part The <code><strong>part</strong></code> parameter serves two purposes in this operation. It identifies the properties that the write operation will set as well as the properties that the API response will include.<br><br>The <code>part</code> properties that you can include in the parameter value are <code>id</code>, <code>snippet</code>, <code>contentDetails</code>, and <code>status</code>.<br><br>Note that this method will override the existing values for all of the mutable properties that are contained in any parts that the parameter value specifies. For example, a broadcast's privacy status is defined in the <code>status</code> part. As such, if your request is updating a private or unlisted broadcast, and the request's <code>part</code> parameter value includes the <code>status</code> part, the broadcast's privacy setting will be updated to whatever value the request body specifies. If the request body does not specify a value, the existing privacy setting will be removed and the broadcast will revert to the default privacy setting.
-     * @param {().LiveBroadcast} params.requestBody Request body data
-     * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-     * @param {callback} callback The callback that handles the response.
-     * @return {object} Request object
+     * @param params - Parameters for request
+     * @param options - Optionally override request options, such as `url`, `method`, and `encoding`.
+     * @param callback - Optional callback that handles the response.
+     * @returns A promise if used with async/await, or void if used with a callback.
      */
     update(
       params: Params$Resource$Livebroadcasts$Update,
@@ -10532,7 +9561,7 @@ export namespace youtube_v3 {
         options = {};
       }
 
-      const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+      const rootUrl = options.rootUrl || 'https://youtube.googleapis.com/';
       const parameters = {
         options: Object.assign(
           {
@@ -10552,7 +9581,7 @@ export namespace youtube_v3 {
       if (callback) {
         createAPIRequest<Schema$LiveBroadcast>(
           parameters,
-          callback as BodyResponseCallback<{} | void>
+          callback as BodyResponseCallback<unknown>
         );
       } else {
         return createAPIRequest<Schema$LiveBroadcast>(parameters);
@@ -10567,15 +9596,15 @@ export namespace youtube_v3 {
      */
     id?: string;
     /**
-     * <strong>Note:</strong> This parameter is intended exclusively for YouTube content partners.<br><br>The <code><strong>onBehalfOfContentOwner</strong></code> parameter indicates that the request's authorization credentials identify a YouTube CMS user who is acting on behalf of the content owner specified in the parameter value. This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and get access to all their video and channel data, without having to provide authentication credentials for each individual channel. The CMS account that the user authenticates with must be linked to the specified YouTube content owner.
+     * *Note:* This parameter is intended exclusively for YouTube content partners. The *onBehalfOfContentOwner* parameter indicates that the request's authorization credentials identify a YouTube CMS user who is acting on behalf of the content owner specified in the parameter value. This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and get access to all their video and channel data, without having to provide authentication credentials for each individual channel. The CMS account that the user authenticates with must be linked to the specified YouTube content owner.
      */
     onBehalfOfContentOwner?: string;
     /**
-     * This parameter can only be used in a properly <a href="/youtube/v3/guides/authentication">authorized request</a>. <strong>Note:</strong> This parameter is intended exclusively for YouTube content partners.<br><br>The <code><strong>onBehalfOfContentOwnerChannel</strong></code> parameter specifies the YouTube channel ID of the channel to which a video is being added. This parameter is required when a request specifies a value for the <code>onBehalfOfContentOwner</code> parameter, and it can only be used in conjunction with that parameter. In addition, the request must be authorized using a CMS account that is linked to the content owner that the <code>onBehalfOfContentOwner</code> parameter specifies. Finally, the channel that the <code>onBehalfOfContentOwnerChannel</code> parameter value specifies must be linked to the content owner that the <code>onBehalfOfContentOwner</code> parameter specifies.<br><br>This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and perform actions on behalf of the channel specified in the parameter value, without having to provide authentication credentials for each separate channel.
+     * This parameter can only be used in a properly authorized request. *Note:* This parameter is intended exclusively for YouTube content partners. The *onBehalfOfContentOwnerChannel* parameter specifies the YouTube channel ID of the channel to which a video is being added. This parameter is required when a request specifies a value for the onBehalfOfContentOwner parameter, and it can only be used in conjunction with that parameter. In addition, the request must be authorized using a CMS account that is linked to the content owner that the onBehalfOfContentOwner parameter specifies. Finally, the channel that the onBehalfOfContentOwnerChannel parameter value specifies must be linked to the content owner that the onBehalfOfContentOwner parameter specifies. This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and perform actions on behalf of the channel specified in the parameter value, without having to provide authentication credentials for each separate channel.
      */
     onBehalfOfContentOwnerChannel?: string;
     /**
-     * The <code><strong>part</strong></code> parameter specifies a comma-separated list of one or more <code>liveBroadcast</code> resource properties that the API response will include. The <code>part</code> names that you can include in the parameter value are <code>id</code>, <code>snippet</code>, <code>contentDetails</code>, and <code>status</code>.
+     * The *part* parameter specifies a comma-separated list of one or more liveBroadcast resource properties that the API response will include. The part names that you can include in the parameter value are id, snippet, contentDetails, and status.
      */
     part?: string[];
     /**
@@ -10583,64 +9612,33 @@ export namespace youtube_v3 {
      */
     streamId?: string;
   }
-  export interface Params$Resource$Livebroadcasts$Control
-    extends StandardParameters {
-    /**
-     * Whether display or hide slate.
-     */
-    displaySlate?: boolean;
-    /**
-     * Broadcast to operate.
-     */
-    id?: string;
-    /**
-     * The exact time when the actions (e.g. slate on) are executed. It is an offset from the first frame of the monitor stream. If not set, it means "now" or ASAP. This field should not be set if the monitor stream is disabled, otherwise an error will be returned.
-     */
-    offsetTimeMs?: string;
-    /**
-     * <strong>Note:</strong> This parameter is intended exclusively for YouTube content partners.<br><br>The <code><strong>onBehalfOfContentOwner</strong></code> parameter indicates that the request's authorization credentials identify a YouTube CMS user who is acting on behalf of the content owner specified in the parameter value. This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and get access to all their video and channel data, without having to provide authentication credentials for each individual channel. The CMS account that the user authenticates with must be linked to the specified YouTube content owner.
-     */
-    onBehalfOfContentOwner?: string;
-    /**
-     * This parameter can only be used in a properly <a href="/youtube/v3/guides/authentication">authorized request</a>. <strong>Note:</strong> This parameter is intended exclusively for YouTube content partners.<br><br>The <code><strong>onBehalfOfContentOwnerChannel</strong></code> parameter specifies the YouTube channel ID of the channel to which a video is being added. This parameter is required when a request specifies a value for the <code>onBehalfOfContentOwner</code> parameter, and it can only be used in conjunction with that parameter. In addition, the request must be authorized using a CMS account that is linked to the content owner that the <code>onBehalfOfContentOwner</code> parameter specifies. Finally, the channel that the <code>onBehalfOfContentOwnerChannel</code> parameter value specifies must be linked to the content owner that the <code>onBehalfOfContentOwner</code> parameter specifies.<br><br>This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and perform actions on behalf of the channel specified in the parameter value, without having to provide authentication credentials for each separate channel.
-     */
-    onBehalfOfContentOwnerChannel?: string;
-    /**
-     * The <code><strong>part</strong></code> parameter specifies a comma-separated list of one or more <code>liveBroadcast</code> resource properties that the API response will include. The <code>part</code> names that you can include in the parameter value are <code>id</code>, <code>snippet</code>, <code>contentDetails</code>, and <code>status</code>.
-     */
-    part?: string[];
-    /**
-     * The wall clock time at which the action should be executed. Only one of offset_time_ms and walltime may be set at a time.
-     */
-    walltime?: string;
-  }
   export interface Params$Resource$Livebroadcasts$Delete
     extends StandardParameters {
     /**
-     *
+     * Broadcast to delete.
      */
     id?: string;
     /**
-     * <strong>Note:</strong> This parameter is intended exclusively for YouTube content partners.<br><br>The <code><strong>onBehalfOfContentOwner</strong></code> parameter indicates that the request's authorization credentials identify a YouTube CMS user who is acting on behalf of the content owner specified in the parameter value. This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and get access to all their video and channel data, without having to provide authentication credentials for each individual channel. The CMS account that the user authenticates with must be linked to the specified YouTube content owner.
+     * *Note:* This parameter is intended exclusively for YouTube content partners. The *onBehalfOfContentOwner* parameter indicates that the request's authorization credentials identify a YouTube CMS user who is acting on behalf of the content owner specified in the parameter value. This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and get access to all their video and channel data, without having to provide authentication credentials for each individual channel. The CMS account that the user authenticates with must be linked to the specified YouTube content owner.
      */
     onBehalfOfContentOwner?: string;
     /**
-     * This parameter can only be used in a properly <a href="/youtube/v3/guides/authentication">authorized request</a>. <strong>Note:</strong> This parameter is intended exclusively for YouTube content partners.<br><br>The <code><strong>onBehalfOfContentOwnerChannel</strong></code> parameter specifies the YouTube channel ID of the channel to which a video is being added. This parameter is required when a request specifies a value for the <code>onBehalfOfContentOwner</code> parameter, and it can only be used in conjunction with that parameter. In addition, the request must be authorized using a CMS account that is linked to the content owner that the <code>onBehalfOfContentOwner</code> parameter specifies. Finally, the channel that the <code>onBehalfOfContentOwnerChannel</code> parameter value specifies must be linked to the content owner that the <code>onBehalfOfContentOwner</code> parameter specifies.<br><br>This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and perform actions on behalf of the channel specified in the parameter value, without having to provide authentication credentials for each separate channel.
+     * This parameter can only be used in a properly authorized request. *Note:* This parameter is intended exclusively for YouTube content partners. The *onBehalfOfContentOwnerChannel* parameter specifies the YouTube channel ID of the channel to which a video is being added. This parameter is required when a request specifies a value for the onBehalfOfContentOwner parameter, and it can only be used in conjunction with that parameter. In addition, the request must be authorized using a CMS account that is linked to the content owner that the onBehalfOfContentOwner parameter specifies. Finally, the channel that the onBehalfOfContentOwnerChannel parameter value specifies must be linked to the content owner that the onBehalfOfContentOwner parameter specifies. This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and perform actions on behalf of the channel specified in the parameter value, without having to provide authentication credentials for each separate channel.
      */
     onBehalfOfContentOwnerChannel?: string;
   }
   export interface Params$Resource$Livebroadcasts$Insert
     extends StandardParameters {
     /**
-     * <strong>Note:</strong> This parameter is intended exclusively for YouTube content partners.<br><br>The <code><strong>onBehalfOfContentOwner</strong></code> parameter indicates that the request's authorization credentials identify a YouTube CMS user who is acting on behalf of the content owner specified in the parameter value. This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and get access to all their video and channel data, without having to provide authentication credentials for each individual channel. The CMS account that the user authenticates with must be linked to the specified YouTube content owner.
+     * *Note:* This parameter is intended exclusively for YouTube content partners. The *onBehalfOfContentOwner* parameter indicates that the request's authorization credentials identify a YouTube CMS user who is acting on behalf of the content owner specified in the parameter value. This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and get access to all their video and channel data, without having to provide authentication credentials for each individual channel. The CMS account that the user authenticates with must be linked to the specified YouTube content owner.
      */
     onBehalfOfContentOwner?: string;
     /**
-     * This parameter can only be used in a properly <a href="/youtube/v3/guides/authentication">authorized request</a>. <strong>Note:</strong> This parameter is intended exclusively for YouTube content partners.<br><br>The <code><strong>onBehalfOfContentOwnerChannel</strong></code> parameter specifies the YouTube channel ID of the channel to which a video is being added. This parameter is required when a request specifies a value for the <code>onBehalfOfContentOwner</code> parameter, and it can only be used in conjunction with that parameter. In addition, the request must be authorized using a CMS account that is linked to the content owner that the <code>onBehalfOfContentOwner</code> parameter specifies. Finally, the channel that the <code>onBehalfOfContentOwnerChannel</code> parameter value specifies must be linked to the content owner that the <code>onBehalfOfContentOwner</code> parameter specifies.<br><br>This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and perform actions on behalf of the channel specified in the parameter value, without having to provide authentication credentials for each separate channel.
+     * This parameter can only be used in a properly authorized request. *Note:* This parameter is intended exclusively for YouTube content partners. The *onBehalfOfContentOwnerChannel* parameter specifies the YouTube channel ID of the channel to which a video is being added. This parameter is required when a request specifies a value for the onBehalfOfContentOwner parameter, and it can only be used in conjunction with that parameter. In addition, the request must be authorized using a CMS account that is linked to the content owner that the onBehalfOfContentOwner parameter specifies. Finally, the channel that the onBehalfOfContentOwnerChannel parameter value specifies must be linked to the content owner that the onBehalfOfContentOwner parameter specifies. This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and perform actions on behalf of the channel specified in the parameter value, without having to provide authentication credentials for each separate channel.
      */
     onBehalfOfContentOwnerChannel?: string;
     /**
-     * The <code><strong>part</strong></code> parameter serves two purposes in this operation. It identifies the properties that the write operation will set as well as the properties that the API response will include.<br><br>The <code>part</code> properties that you can include in the parameter value are <code>id</code>, <code>snippet</code>, <code>contentDetails</code>, and <code>status</code>.
+     * The *part* parameter serves two purposes in this operation. It identifies the properties that the write operation will set as well as the properties that the API response will include. The part properties that you can include in the parameter value are id, snippet, contentDetails, and status.
      */
     part?: string[];
 
@@ -10664,7 +9662,7 @@ export namespace youtube_v3 {
      */
     id?: string[];
     /**
-     * The <code><strong>maxResults</strong></code> parameter specifies the maximum number of items that should be returned in the result set.
+     * The *maxResults* parameter specifies the maximum number of items that should be returned in the result set.
      */
     maxResults?: number;
     /**
@@ -10672,19 +9670,19 @@ export namespace youtube_v3 {
      */
     mine?: boolean;
     /**
-     * <strong>Note:</strong> This parameter is intended exclusively for YouTube content partners.<br><br>The <code><strong>onBehalfOfContentOwner</strong></code> parameter indicates that the request's authorization credentials identify a YouTube CMS user who is acting on behalf of the content owner specified in the parameter value. This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and get access to all their video and channel data, without having to provide authentication credentials for each individual channel. The CMS account that the user authenticates with must be linked to the specified YouTube content owner.
+     * *Note:* This parameter is intended exclusively for YouTube content partners. The *onBehalfOfContentOwner* parameter indicates that the request's authorization credentials identify a YouTube CMS user who is acting on behalf of the content owner specified in the parameter value. This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and get access to all their video and channel data, without having to provide authentication credentials for each individual channel. The CMS account that the user authenticates with must be linked to the specified YouTube content owner.
      */
     onBehalfOfContentOwner?: string;
     /**
-     * This parameter can only be used in a properly <a href="/youtube/v3/guides/authentication">authorized request</a>. <strong>Note:</strong> This parameter is intended exclusively for YouTube content partners.<br><br>The <code><strong>onBehalfOfContentOwnerChannel</strong></code> parameter specifies the YouTube channel ID of the channel to which a video is being added. This parameter is required when a request specifies a value for the <code>onBehalfOfContentOwner</code> parameter, and it can only be used in conjunction with that parameter. In addition, the request must be authorized using a CMS account that is linked to the content owner that the <code>onBehalfOfContentOwner</code> parameter specifies. Finally, the channel that the <code>onBehalfOfContentOwnerChannel</code> parameter value specifies must be linked to the content owner that the <code>onBehalfOfContentOwner</code> parameter specifies.<br><br>This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and perform actions on behalf of the channel specified in the parameter value, without having to provide authentication credentials for each separate channel.
+     * This parameter can only be used in a properly authorized request. *Note:* This parameter is intended exclusively for YouTube content partners. The *onBehalfOfContentOwnerChannel* parameter specifies the YouTube channel ID of the channel to which a video is being added. This parameter is required when a request specifies a value for the onBehalfOfContentOwner parameter, and it can only be used in conjunction with that parameter. In addition, the request must be authorized using a CMS account that is linked to the content owner that the onBehalfOfContentOwner parameter specifies. Finally, the channel that the onBehalfOfContentOwnerChannel parameter value specifies must be linked to the content owner that the onBehalfOfContentOwner parameter specifies. This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and perform actions on behalf of the channel specified in the parameter value, without having to provide authentication credentials for each separate channel.
      */
     onBehalfOfContentOwnerChannel?: string;
     /**
-     * The <code><strong>pageToken</strong></code> parameter identifies a specific page in the result set that should be returned. In an API response, the <code>nextPageToken</code> and <code>prevPageToken</code> properties identify other pages that could be retrieved.
+     * The *pageToken* parameter identifies a specific page in the result set that should be returned. In an API response, the nextPageToken and prevPageToken properties identify other pages that could be retrieved.
      */
     pageToken?: string;
     /**
-     * The <code><strong>part</strong></code> parameter specifies a comma-separated list of one or more <code>liveBroadcast</code> resource properties that the API response will include. The <code>part</code> names that you can include in the parameter value are <code>id</code>, <code>snippet</code>, <code>contentDetails</code>, and <code>status</code>.
+     * The *part* parameter specifies a comma-separated list of one or more liveBroadcast resource properties that the API response will include. The part names that you can include in the parameter value are id, snippet, contentDetails, status and statistics.
      */
     part?: string[];
   }
@@ -10699,30 +9697,30 @@ export namespace youtube_v3 {
      */
     id?: string;
     /**
-     * <strong>Note:</strong> This parameter is intended exclusively for YouTube content partners.<br><br>The <code><strong>onBehalfOfContentOwner</strong></code> parameter indicates that the request's authorization credentials identify a YouTube CMS user who is acting on behalf of the content owner specified in the parameter value. This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and get access to all their video and channel data, without having to provide authentication credentials for each individual channel. The CMS account that the user authenticates with must be linked to the specified YouTube content owner.
+     * *Note:* This parameter is intended exclusively for YouTube content partners. The *onBehalfOfContentOwner* parameter indicates that the request's authorization credentials identify a YouTube CMS user who is acting on behalf of the content owner specified in the parameter value. This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and get access to all their video and channel data, without having to provide authentication credentials for each individual channel. The CMS account that the user authenticates with must be linked to the specified YouTube content owner.
      */
     onBehalfOfContentOwner?: string;
     /**
-     * This parameter can only be used in a properly <a href="/youtube/v3/guides/authentication">authorized request</a>. <strong>Note:</strong> This parameter is intended exclusively for YouTube content partners.<br><br>The <code><strong>onBehalfOfContentOwnerChannel</strong></code> parameter specifies the YouTube channel ID of the channel to which a video is being added. This parameter is required when a request specifies a value for the <code>onBehalfOfContentOwner</code> parameter, and it can only be used in conjunction with that parameter. In addition, the request must be authorized using a CMS account that is linked to the content owner that the <code>onBehalfOfContentOwner</code> parameter specifies. Finally, the channel that the <code>onBehalfOfContentOwnerChannel</code> parameter value specifies must be linked to the content owner that the <code>onBehalfOfContentOwner</code> parameter specifies.<br><br>This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and perform actions on behalf of the channel specified in the parameter value, without having to provide authentication credentials for each separate channel.
+     * This parameter can only be used in a properly authorized request. *Note:* This parameter is intended exclusively for YouTube content partners. The *onBehalfOfContentOwnerChannel* parameter specifies the YouTube channel ID of the channel to which a video is being added. This parameter is required when a request specifies a value for the onBehalfOfContentOwner parameter, and it can only be used in conjunction with that parameter. In addition, the request must be authorized using a CMS account that is linked to the content owner that the onBehalfOfContentOwner parameter specifies. Finally, the channel that the onBehalfOfContentOwnerChannel parameter value specifies must be linked to the content owner that the onBehalfOfContentOwner parameter specifies. This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and perform actions on behalf of the channel specified in the parameter value, without having to provide authentication credentials for each separate channel.
      */
     onBehalfOfContentOwnerChannel?: string;
     /**
-     * The <code><strong>part</strong></code> parameter specifies a comma-separated list of one or more <code>liveBroadcast</code> resource properties that the API response will include. The <code>part</code> names that you can include in the parameter value are <code>id</code>, <code>snippet</code>, <code>contentDetails</code>, and <code>status</code>.
+     * The *part* parameter specifies a comma-separated list of one or more liveBroadcast resource properties that the API response will include. The part names that you can include in the parameter value are id, snippet, contentDetails, and status.
      */
     part?: string[];
   }
   export interface Params$Resource$Livebroadcasts$Update
     extends StandardParameters {
     /**
-     * <strong>Note:</strong> This parameter is intended exclusively for YouTube content partners.<br><br>The <code><strong>onBehalfOfContentOwner</strong></code> parameter indicates that the request's authorization credentials identify a YouTube CMS user who is acting on behalf of the content owner specified in the parameter value. This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and get access to all their video and channel data, without having to provide authentication credentials for each individual channel. The CMS account that the user authenticates with must be linked to the specified YouTube content owner.
+     * *Note:* This parameter is intended exclusively for YouTube content partners. The *onBehalfOfContentOwner* parameter indicates that the request's authorization credentials identify a YouTube CMS user who is acting on behalf of the content owner specified in the parameter value. This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and get access to all their video and channel data, without having to provide authentication credentials for each individual channel. The CMS account that the user authenticates with must be linked to the specified YouTube content owner.
      */
     onBehalfOfContentOwner?: string;
     /**
-     * This parameter can only be used in a properly <a href="/youtube/v3/guides/authentication">authorized request</a>. <strong>Note:</strong> This parameter is intended exclusively for YouTube content partners.<br><br>The <code><strong>onBehalfOfContentOwnerChannel</strong></code> parameter specifies the YouTube channel ID of the channel to which a video is being added. This parameter is required when a request specifies a value for the <code>onBehalfOfContentOwner</code> parameter, and it can only be used in conjunction with that parameter. In addition, the request must be authorized using a CMS account that is linked to the content owner that the <code>onBehalfOfContentOwner</code> parameter specifies. Finally, the channel that the <code>onBehalfOfContentOwnerChannel</code> parameter value specifies must be linked to the content owner that the <code>onBehalfOfContentOwner</code> parameter specifies.<br><br>This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and perform actions on behalf of the channel specified in the parameter value, without having to provide authentication credentials for each separate channel.
+     * This parameter can only be used in a properly authorized request. *Note:* This parameter is intended exclusively for YouTube content partners. The *onBehalfOfContentOwnerChannel* parameter specifies the YouTube channel ID of the channel to which a video is being added. This parameter is required when a request specifies a value for the onBehalfOfContentOwner parameter, and it can only be used in conjunction with that parameter. In addition, the request must be authorized using a CMS account that is linked to the content owner that the onBehalfOfContentOwner parameter specifies. Finally, the channel that the onBehalfOfContentOwnerChannel parameter value specifies must be linked to the content owner that the onBehalfOfContentOwner parameter specifies. This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and perform actions on behalf of the channel specified in the parameter value, without having to provide authentication credentials for each separate channel.
      */
     onBehalfOfContentOwnerChannel?: string;
     /**
-     * The <code><strong>part</strong></code> parameter serves two purposes in this operation. It identifies the properties that the write operation will set as well as the properties that the API response will include.<br><br>The <code>part</code> properties that you can include in the parameter value are <code>id</code>, <code>snippet</code>, <code>contentDetails</code>, and <code>status</code>.<br><br>Note that this method will override the existing values for all of the mutable properties that are contained in any parts that the parameter value specifies. For example, a broadcast's privacy status is defined in the <code>status</code> part. As such, if your request is updating a private or unlisted broadcast, and the request's <code>part</code> parameter value includes the <code>status</code> part, the broadcast's privacy setting will be updated to whatever value the request body specifies. If the request body does not specify a value, the existing privacy setting will be removed and the broadcast will revert to the default privacy setting.
+     * The *part* parameter serves two purposes in this operation. It identifies the properties that the write operation will set as well as the properties that the API response will include. The part properties that you can include in the parameter value are id, snippet, contentDetails, and status. Note that this method will override the existing values for all of the mutable properties that are contained in any parts that the parameter value specifies. For example, a broadcast's privacy status is defined in the status part. As such, if your request is updating a private or unlisted broadcast, and the request's part parameter value includes the status part, the broadcast's privacy setting will be updated to whatever value the request body specifies. If the request body does not specify a value, the existing privacy setting will be removed and the broadcast will revert to the default privacy setting.
      */
     part?: string[];
 
@@ -10739,9 +9737,9 @@ export namespace youtube_v3 {
     }
 
     /**
-     * youtube.liveChatBans.delete
-     * @desc Deletes a chat ban.
+     * Deletes a chat ban.
      * @example
+     * ```js
      * // Before running the sample:
      * // - Enable the API at:
      * //   https://console.developers.google.com/apis/api/youtube.googleapis.com
@@ -10778,14 +9776,12 @@ export namespace youtube_v3 {
      *   throw e;
      * });
      *
-     * @alias youtube.liveChatBans.delete
-     * @memberOf! ()
+     * ```
      *
-     * @param {object} params Parameters for request
-     * @param {string} params.id
-     * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-     * @param {callback} callback The callback that handles the response.
-     * @return {object} Request object
+     * @param params - Parameters for request
+     * @param options - Optionally override request options, such as `url`, `method`, and `encoding`.
+     * @param callback - Optional callback that handles the response.
+     * @returns A promise if used with async/await, or void if used with a callback.
      */
     delete(
       params: Params$Resource$Livechatbans$Delete,
@@ -10837,7 +9833,7 @@ export namespace youtube_v3 {
         options = {};
       }
 
-      const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+      const rootUrl = options.rootUrl || 'https://youtube.googleapis.com/';
       const parameters = {
         options: Object.assign(
           {
@@ -10857,7 +9853,7 @@ export namespace youtube_v3 {
       if (callback) {
         createAPIRequest<void>(
           parameters,
-          callback as BodyResponseCallback<{} | void>
+          callback as BodyResponseCallback<unknown>
         );
       } else {
         return createAPIRequest<void>(parameters);
@@ -10865,9 +9861,9 @@ export namespace youtube_v3 {
     }
 
     /**
-     * youtube.liveChatBans.insert
-     * @desc Inserts a new resource into this collection.
+     * Inserts a new resource into this collection.
      * @example
+     * ```js
      * // Before running the sample:
      * // - Enable the API at:
      * //   https://console.developers.google.com/apis/api/youtube.googleapis.com
@@ -10894,10 +9890,7 @@ export namespace youtube_v3 {
      *
      *   // Do the magic
      *   const res = await youtube.liveChatBans.insert({
-     *     // The <code><strong>part</strong></code> parameter serves two purposes in
-     *     // this operation. It identifies the properties that the write operation will
-     *     // set as well as the properties that the API response returns. Set the
-     *     // parameter value to <code>snippet</code>.
+     *     // The *part* parameter serves two purposes in this operation. It identifies the properties that the write operation will set as well as the properties that the API response returns. Set the parameter value to snippet.
      *     part: 'placeholder-value',
      *
      *     // Request body metadata
@@ -10927,15 +9920,12 @@ export namespace youtube_v3 {
      *   throw e;
      * });
      *
-     * @alias youtube.liveChatBans.insert
-     * @memberOf! ()
+     * ```
      *
-     * @param {object} params Parameters for request
-     * @param {string} params.part The <code><strong>part</strong></code> parameter serves two purposes in this operation. It identifies the properties that the write operation will set as well as the properties that the API response returns. Set the parameter value to <code>snippet</code>.
-     * @param {().LiveChatBan} params.requestBody Request body data
-     * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-     * @param {callback} callback The callback that handles the response.
-     * @return {object} Request object
+     * @param params - Parameters for request
+     * @param options - Optionally override request options, such as `url`, `method`, and `encoding`.
+     * @param callback - Optional callback that handles the response.
+     * @returns A promise if used with async/await, or void if used with a callback.
      */
     insert(
       params: Params$Resource$Livechatbans$Insert,
@@ -10989,7 +9979,7 @@ export namespace youtube_v3 {
         options = {};
       }
 
-      const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+      const rootUrl = options.rootUrl || 'https://youtube.googleapis.com/';
       const parameters = {
         options: Object.assign(
           {
@@ -11009,7 +9999,7 @@ export namespace youtube_v3 {
       if (callback) {
         createAPIRequest<Schema$LiveChatBan>(
           parameters,
-          callback as BodyResponseCallback<{} | void>
+          callback as BodyResponseCallback<unknown>
         );
       } else {
         return createAPIRequest<Schema$LiveChatBan>(parameters);
@@ -11027,7 +10017,7 @@ export namespace youtube_v3 {
   export interface Params$Resource$Livechatbans$Insert
     extends StandardParameters {
     /**
-     * The <code><strong>part</strong></code> parameter serves two purposes in this operation. It identifies the properties that the write operation will set as well as the properties that the API response returns. Set the parameter value to <code>snippet</code>.
+     * The *part* parameter serves two purposes in this operation. It identifies the properties that the write operation will set as well as the properties that the API response returns. Set the parameter value to snippet.
      */
     part?: string[];
 
@@ -11044,9 +10034,9 @@ export namespace youtube_v3 {
     }
 
     /**
-     * youtube.liveChatMessages.delete
-     * @desc Deletes a chat message.
+     * Deletes a chat message.
      * @example
+     * ```js
      * // Before running the sample:
      * // - Enable the API at:
      * //   https://console.developers.google.com/apis/api/youtube.googleapis.com
@@ -11083,14 +10073,12 @@ export namespace youtube_v3 {
      *   throw e;
      * });
      *
-     * @alias youtube.liveChatMessages.delete
-     * @memberOf! ()
+     * ```
      *
-     * @param {object} params Parameters for request
-     * @param {string} params.id
-     * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-     * @param {callback} callback The callback that handles the response.
-     * @return {object} Request object
+     * @param params - Parameters for request
+     * @param options - Optionally override request options, such as `url`, `method`, and `encoding`.
+     * @param callback - Optional callback that handles the response.
+     * @returns A promise if used with async/await, or void if used with a callback.
      */
     delete(
       params: Params$Resource$Livechatmessages$Delete,
@@ -11142,7 +10130,7 @@ export namespace youtube_v3 {
         options = {};
       }
 
-      const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+      const rootUrl = options.rootUrl || 'https://youtube.googleapis.com/';
       const parameters = {
         options: Object.assign(
           {
@@ -11162,7 +10150,7 @@ export namespace youtube_v3 {
       if (callback) {
         createAPIRequest<void>(
           parameters,
-          callback as BodyResponseCallback<{} | void>
+          callback as BodyResponseCallback<unknown>
         );
       } else {
         return createAPIRequest<void>(parameters);
@@ -11170,9 +10158,9 @@ export namespace youtube_v3 {
     }
 
     /**
-     * youtube.liveChatMessages.insert
-     * @desc Inserts a new resource into this collection.
+     * Inserts a new resource into this collection.
      * @example
+     * ```js
      * // Before running the sample:
      * // - Enable the API at:
      * //   https://console.developers.google.com/apis/api/youtube.googleapis.com
@@ -11199,10 +10187,7 @@ export namespace youtube_v3 {
      *
      *   // Do the magic
      *   const res = await youtube.liveChatMessages.insert({
-     *     // The <code><strong>part</strong></code> parameter serves two purposes. It
-     *     // identifies the properties that the write operation will set as well as the
-     *     // properties that the API response will include. Set the parameter value to
-     *     // <code>snippet</code>.
+     *     // The *part* parameter serves two purposes. It identifies the properties that the write operation will set as well as the properties that the API response will include. Set the parameter value to snippet.
      *     part: 'placeholder-value',
      *
      *     // Request body metadata
@@ -11234,15 +10219,12 @@ export namespace youtube_v3 {
      *   throw e;
      * });
      *
-     * @alias youtube.liveChatMessages.insert
-     * @memberOf! ()
+     * ```
      *
-     * @param {object} params Parameters for request
-     * @param {string} params.part The <code><strong>part</strong></code> parameter serves two purposes. It identifies the properties that the write operation will set as well as the properties that the API response will include. Set the parameter value to <code>snippet</code>.
-     * @param {().LiveChatMessage} params.requestBody Request body data
-     * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-     * @param {callback} callback The callback that handles the response.
-     * @return {object} Request object
+     * @param params - Parameters for request
+     * @param options - Optionally override request options, such as `url`, `method`, and `encoding`.
+     * @param callback - Optional callback that handles the response.
+     * @returns A promise if used with async/await, or void if used with a callback.
      */
     insert(
       params: Params$Resource$Livechatmessages$Insert,
@@ -11296,7 +10278,7 @@ export namespace youtube_v3 {
         options = {};
       }
 
-      const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+      const rootUrl = options.rootUrl || 'https://youtube.googleapis.com/';
       const parameters = {
         options: Object.assign(
           {
@@ -11316,7 +10298,7 @@ export namespace youtube_v3 {
       if (callback) {
         createAPIRequest<Schema$LiveChatMessage>(
           parameters,
-          callback as BodyResponseCallback<{} | void>
+          callback as BodyResponseCallback<unknown>
         );
       } else {
         return createAPIRequest<Schema$LiveChatMessage>(parameters);
@@ -11324,9 +10306,9 @@ export namespace youtube_v3 {
     }
 
     /**
-     * youtube.liveChatMessages.list
-     * @desc Retrieves a list of resources, possibly filtered.
+     * Retrieves a list of resources, possibly filtered.
      * @example
+     * ```js
      * // Before running the sample:
      * // - Enable the API at:
      * //   https://console.developers.google.com/apis/api/youtube.googleapis.com
@@ -11354,25 +10336,17 @@ export namespace youtube_v3 {
      *
      *   // Do the magic
      *   const res = await youtube.liveChatMessages.list({
-     *     // Specifies the localization language in which the system messages
-     *     // should be returned.
+     *     // Specifies the localization language in which the system messages should be returned.
      *     hl: 'placeholder-value',
      *     // The id of the live chat for which comments should be returned.
      *     liveChatId: 'placeholder-value',
-     *     // The <code><strong>maxResults</strong></code> parameter specifies the
-     *     // maximum number of items that should be returned in the result set.
+     *     // The *maxResults* parameter specifies the maximum number of items that should be returned in the result set.
      *     maxResults: 'placeholder-value',
-     *     // The <code><strong>pageToken</strong></code> parameter identifies a specific
-     *     // page in the result set that should be returned. In an API response, the
-     *     // <code>nextPageToken</code> property identify other pages that could be
-     *     // retrieved.
+     *     // The *pageToken* parameter identifies a specific page in the result set that should be returned. In an API response, the nextPageToken property identify other pages that could be retrieved.
      *     pageToken: 'placeholder-value',
-     *     // The <code><strong>part</strong></code> parameter specifies the
-     *     // <code>liveChatComment</code> resource parts that the API response will
-     *     // include. Supported values are <code>id</code> and <code>snippet</code>.
+     *     // The *part* parameter specifies the liveChatComment resource parts that the API response will include. Supported values are id and snippet.
      *     part: 'placeholder-value',
-     *     // Specifies the size of the profile image that should be
-     *     // returned for each user.
+     *     // Specifies the size of the profile image that should be returned for each user.
      *     profileImageSize: 'placeholder-value',
      *   });
      *   console.log(res.data);
@@ -11397,19 +10371,12 @@ export namespace youtube_v3 {
      *   throw e;
      * });
      *
-     * @alias youtube.liveChatMessages.list
-     * @memberOf! ()
+     * ```
      *
-     * @param {object} params Parameters for request
-     * @param {string=} params.hl Specifies the localization language in which the system messages should be returned.
-     * @param {string} params.liveChatId The id of the live chat for which comments should be returned.
-     * @param {integer=} params.maxResults The <code><strong>maxResults</strong></code> parameter specifies the maximum number of items that should be returned in the result set.
-     * @param {string=} params.pageToken The <code><strong>pageToken</strong></code> parameter identifies a specific page in the result set that should be returned. In an API response, the <code>nextPageToken</code> property identify other pages that could be retrieved.
-     * @param {string} params.part The <code><strong>part</strong></code> parameter specifies the <code>liveChatComment</code> resource parts that the API response will include. Supported values are <code>id</code> and <code>snippet</code>.
-     * @param {integer=} params.profileImageSize Specifies the size of the profile image that should be returned for each user.
-     * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-     * @param {callback} callback The callback that handles the response.
-     * @return {object} Request object
+     * @param params - Parameters for request
+     * @param options - Optionally override request options, such as `url`, `method`, and `encoding`.
+     * @param callback - Optional callback that handles the response.
+     * @returns A promise if used with async/await, or void if used with a callback.
      */
     list(
       params: Params$Resource$Livechatmessages$List,
@@ -11470,7 +10437,7 @@ export namespace youtube_v3 {
         options = {};
       }
 
-      const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+      const rootUrl = options.rootUrl || 'https://youtube.googleapis.com/';
       const parameters = {
         options: Object.assign(
           {
@@ -11490,7 +10457,7 @@ export namespace youtube_v3 {
       if (callback) {
         createAPIRequest<Schema$LiveChatMessageListResponse>(
           parameters,
-          callback as BodyResponseCallback<{} | void>
+          callback as BodyResponseCallback<unknown>
         );
       } else {
         return createAPIRequest<Schema$LiveChatMessageListResponse>(parameters);
@@ -11508,7 +10475,7 @@ export namespace youtube_v3 {
   export interface Params$Resource$Livechatmessages$Insert
     extends StandardParameters {
     /**
-     * The <code><strong>part</strong></code> parameter serves two purposes. It identifies the properties that the write operation will set as well as the properties that the API response will include. Set the parameter value to <code>snippet</code>.
+     * The *part* parameter serves two purposes. It identifies the properties that the write operation will set as well as the properties that the API response will include. Set the parameter value to snippet.
      */
     part?: string[];
 
@@ -11528,15 +10495,15 @@ export namespace youtube_v3 {
      */
     liveChatId?: string;
     /**
-     * The <code><strong>maxResults</strong></code> parameter specifies the maximum number of items that should be returned in the result set.
+     * The *maxResults* parameter specifies the maximum number of items that should be returned in the result set.
      */
     maxResults?: number;
     /**
-     * The <code><strong>pageToken</strong></code> parameter identifies a specific page in the result set that should be returned. In an API response, the <code>nextPageToken</code> property identify other pages that could be retrieved.
+     * The *pageToken* parameter identifies a specific page in the result set that should be returned. In an API response, the nextPageToken property identify other pages that could be retrieved.
      */
     pageToken?: string;
     /**
-     * The <code><strong>part</strong></code> parameter specifies the <code>liveChatComment</code> resource parts that the API response will include. Supported values are <code>id</code> and <code>snippet</code>.
+     * The *part* parameter specifies the liveChatComment resource parts that the API response will include. Supported values are id and snippet.
      */
     part?: string[];
     /**
@@ -11552,9 +10519,9 @@ export namespace youtube_v3 {
     }
 
     /**
-     * youtube.liveChatModerators.delete
-     * @desc Deletes a chat moderator.
+     * Deletes a chat moderator.
      * @example
+     * ```js
      * // Before running the sample:
      * // - Enable the API at:
      * //   https://console.developers.google.com/apis/api/youtube.googleapis.com
@@ -11591,14 +10558,12 @@ export namespace youtube_v3 {
      *   throw e;
      * });
      *
-     * @alias youtube.liveChatModerators.delete
-     * @memberOf! ()
+     * ```
      *
-     * @param {object} params Parameters for request
-     * @param {string} params.id
-     * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-     * @param {callback} callback The callback that handles the response.
-     * @return {object} Request object
+     * @param params - Parameters for request
+     * @param options - Optionally override request options, such as `url`, `method`, and `encoding`.
+     * @param callback - Optional callback that handles the response.
+     * @returns A promise if used with async/await, or void if used with a callback.
      */
     delete(
       params: Params$Resource$Livechatmoderators$Delete,
@@ -11650,7 +10615,7 @@ export namespace youtube_v3 {
         options = {};
       }
 
-      const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+      const rootUrl = options.rootUrl || 'https://youtube.googleapis.com/';
       const parameters = {
         options: Object.assign(
           {
@@ -11670,7 +10635,7 @@ export namespace youtube_v3 {
       if (callback) {
         createAPIRequest<void>(
           parameters,
-          callback as BodyResponseCallback<{} | void>
+          callback as BodyResponseCallback<unknown>
         );
       } else {
         return createAPIRequest<void>(parameters);
@@ -11678,9 +10643,9 @@ export namespace youtube_v3 {
     }
 
     /**
-     * youtube.liveChatModerators.insert
-     * @desc Inserts a new resource into this collection.
+     * Inserts a new resource into this collection.
      * @example
+     * ```js
      * // Before running the sample:
      * // - Enable the API at:
      * //   https://console.developers.google.com/apis/api/youtube.googleapis.com
@@ -11707,10 +10672,7 @@ export namespace youtube_v3 {
      *
      *   // Do the magic
      *   const res = await youtube.liveChatModerators.insert({
-     *     // The <code><strong>part</strong></code> parameter serves two purposes in
-     *     // this operation. It identifies the properties that the write operation will
-     *     // set as well as the properties that the API response returns. Set the
-     *     // parameter value to <code>snippet</code>.
+     *     // The *part* parameter serves two purposes in this operation. It identifies the properties that the write operation will set as well as the properties that the API response returns. Set the parameter value to snippet.
      *     part: 'placeholder-value',
      *
      *     // Request body metadata
@@ -11740,15 +10702,12 @@ export namespace youtube_v3 {
      *   throw e;
      * });
      *
-     * @alias youtube.liveChatModerators.insert
-     * @memberOf! ()
+     * ```
      *
-     * @param {object} params Parameters for request
-     * @param {string} params.part The <code><strong>part</strong></code> parameter serves two purposes in this operation. It identifies the properties that the write operation will set as well as the properties that the API response returns. Set the parameter value to <code>snippet</code>.
-     * @param {().LiveChatModerator} params.requestBody Request body data
-     * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-     * @param {callback} callback The callback that handles the response.
-     * @return {object} Request object
+     * @param params - Parameters for request
+     * @param options - Optionally override request options, such as `url`, `method`, and `encoding`.
+     * @param callback - Optional callback that handles the response.
+     * @returns A promise if used with async/await, or void if used with a callback.
      */
     insert(
       params: Params$Resource$Livechatmoderators$Insert,
@@ -11805,7 +10764,7 @@ export namespace youtube_v3 {
         options = {};
       }
 
-      const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+      const rootUrl = options.rootUrl || 'https://youtube.googleapis.com/';
       const parameters = {
         options: Object.assign(
           {
@@ -11825,7 +10784,7 @@ export namespace youtube_v3 {
       if (callback) {
         createAPIRequest<Schema$LiveChatModerator>(
           parameters,
-          callback as BodyResponseCallback<{} | void>
+          callback as BodyResponseCallback<unknown>
         );
       } else {
         return createAPIRequest<Schema$LiveChatModerator>(parameters);
@@ -11833,9 +10792,9 @@ export namespace youtube_v3 {
     }
 
     /**
-     * youtube.liveChatModerators.list
-     * @desc Retrieves a list of resources, possibly filtered.
+     * Retrieves a list of resources, possibly filtered.
      * @example
+     * ```js
      * // Before running the sample:
      * // - Enable the API at:
      * //   https://console.developers.google.com/apis/api/youtube.googleapis.com
@@ -11865,17 +10824,11 @@ export namespace youtube_v3 {
      *   const res = await youtube.liveChatModerators.list({
      *     // The id of the live chat for which moderators should be returned.
      *     liveChatId: 'placeholder-value',
-     *     // The <code><strong>maxResults</strong></code> parameter specifies the
-     *     // maximum number of items that should be returned in the result set.
+     *     // The *maxResults* parameter specifies the maximum number of items that should be returned in the result set.
      *     maxResults: 'placeholder-value',
-     *     // The <code><strong>pageToken</strong></code> parameter identifies a specific
-     *     // page in the result set that should be returned. In an API response, the
-     *     // <code>nextPageToken</code> and <code>prevPageToken</code> properties
-     *     // identify other pages that could be retrieved.
+     *     // The *pageToken* parameter identifies a specific page in the result set that should be returned. In an API response, the nextPageToken and prevPageToken properties identify other pages that could be retrieved.
      *     pageToken: 'placeholder-value',
-     *     // The <code><strong>part</strong></code> parameter specifies the
-     *     // <code>liveChatModerator</code> resource parts that the API response will
-     *     // include. Supported values are <code>id</code> and <code>snippet</code>.
+     *     // The *part* parameter specifies the liveChatModerator resource parts that the API response will include. Supported values are id and snippet.
      *     part: 'placeholder-value',
      *   });
      *   console.log(res.data);
@@ -11899,17 +10852,12 @@ export namespace youtube_v3 {
      *   throw e;
      * });
      *
-     * @alias youtube.liveChatModerators.list
-     * @memberOf! ()
+     * ```
      *
-     * @param {object} params Parameters for request
-     * @param {string} params.liveChatId The id of the live chat for which moderators should be returned.
-     * @param {integer=} params.maxResults The <code><strong>maxResults</strong></code> parameter specifies the maximum number of items that should be returned in the result set.
-     * @param {string=} params.pageToken The <code><strong>pageToken</strong></code> parameter identifies a specific page in the result set that should be returned. In an API response, the <code>nextPageToken</code> and <code>prevPageToken</code> properties identify other pages that could be retrieved.
-     * @param {string} params.part The <code><strong>part</strong></code> parameter specifies the <code>liveChatModerator</code> resource parts that the API response will include. Supported values are <code>id</code> and <code>snippet</code>.
-     * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-     * @param {callback} callback The callback that handles the response.
-     * @return {object} Request object
+     * @param params - Parameters for request
+     * @param options - Optionally override request options, such as `url`, `method`, and `encoding`.
+     * @param callback - Optional callback that handles the response.
+     * @returns A promise if used with async/await, or void if used with a callback.
      */
     list(
       params: Params$Resource$Livechatmoderators$List,
@@ -11970,7 +10918,7 @@ export namespace youtube_v3 {
         options = {};
       }
 
-      const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+      const rootUrl = options.rootUrl || 'https://youtube.googleapis.com/';
       const parameters = {
         options: Object.assign(
           {
@@ -11990,7 +10938,7 @@ export namespace youtube_v3 {
       if (callback) {
         createAPIRequest<Schema$LiveChatModeratorListResponse>(
           parameters,
-          callback as BodyResponseCallback<{} | void>
+          callback as BodyResponseCallback<unknown>
         );
       } else {
         return createAPIRequest<Schema$LiveChatModeratorListResponse>(
@@ -12010,7 +10958,7 @@ export namespace youtube_v3 {
   export interface Params$Resource$Livechatmoderators$Insert
     extends StandardParameters {
     /**
-     * The <code><strong>part</strong></code> parameter serves two purposes in this operation. It identifies the properties that the write operation will set as well as the properties that the API response returns. Set the parameter value to <code>snippet</code>.
+     * The *part* parameter serves two purposes in this operation. It identifies the properties that the write operation will set as well as the properties that the API response returns. Set the parameter value to snippet.
      */
     part?: string[];
 
@@ -12026,15 +10974,15 @@ export namespace youtube_v3 {
      */
     liveChatId?: string;
     /**
-     * The <code><strong>maxResults</strong></code> parameter specifies the maximum number of items that should be returned in the result set.
+     * The *maxResults* parameter specifies the maximum number of items that should be returned in the result set.
      */
     maxResults?: number;
     /**
-     * The <code><strong>pageToken</strong></code> parameter identifies a specific page in the result set that should be returned. In an API response, the <code>nextPageToken</code> and <code>prevPageToken</code> properties identify other pages that could be retrieved.
+     * The *pageToken* parameter identifies a specific page in the result set that should be returned. In an API response, the nextPageToken and prevPageToken properties identify other pages that could be retrieved.
      */
     pageToken?: string;
     /**
-     * The <code><strong>part</strong></code> parameter specifies the <code>liveChatModerator</code> resource parts that the API response will include. Supported values are <code>id</code> and <code>snippet</code>.
+     * The *part* parameter specifies the liveChatModerator resource parts that the API response will include. Supported values are id and snippet.
      */
     part?: string[];
   }
@@ -12046,9 +10994,9 @@ export namespace youtube_v3 {
     }
 
     /**
-     * youtube.liveStreams.delete
-     * @desc Deletes an existing stream for the authenticated user.
+     * Deletes an existing stream for the authenticated user.
      * @example
+     * ```js
      * // Before running the sample:
      * // - Enable the API at:
      * //   https://console.developers.google.com/apis/api/youtube.googleapis.com
@@ -12076,38 +11024,9 @@ export namespace youtube_v3 {
      *   // Do the magic
      *   const res = await youtube.liveStreams.delete({
      *     id: 'placeholder-value',
-     *     // <strong>Note:</strong> This parameter is intended exclusively for YouTube
-     *     // content partners.<br><br>The
-     *     // <code><strong>onBehalfOfContentOwner</strong></code> parameter indicates
-     *     // that the
-     *     // request's authorization credentials identify a YouTube CMS user who is
-     *     // acting on behalf of the content owner specified in the parameter value.
-     *     // This parameter is intended for YouTube content partners that own and manage
-     *     // many different YouTube channels. It allows content owners to authenticate
-     *     // once and get access to all their video and channel data, without having to
-     *     // provide authentication credentials for each individual channel. The CMS
-     *     // account that the user authenticates with must be linked to the specified
-     *     // YouTube content owner.
+     *     // *Note:* This parameter is intended exclusively for YouTube content partners. The *onBehalfOfContentOwner* parameter indicates that the request's authorization credentials identify a YouTube CMS user who is acting on behalf of the content owner specified in the parameter value. This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and get access to all their video and channel data, without having to provide authentication credentials for each individual channel. The CMS account that the user authenticates with must be linked to the specified YouTube content owner.
      *     onBehalfOfContentOwner: 'placeholder-value',
-     *     // This parameter can only be used in a properly <a
-     *     // href="/youtube/v3/guides/authentication">authorized request</a>.
-     *     // <strong>Note:</strong> This parameter is intended exclusively for YouTube
-     *     // content partners.<br><br>The
-     *     // <code><strong>onBehalfOfContentOwnerChannel</strong></code> parameter
-     *     // specifies the YouTube channel ID of the channel to which a video is being
-     *     // added. This parameter is required when a request specifies a value for the
-     *     // <code>onBehalfOfContentOwner</code> parameter, and it can only be used in
-     *     // conjunction with that parameter. In addition, the request must be
-     *     // authorized using a CMS account that is linked to the content owner that the
-     *     // <code>onBehalfOfContentOwner</code> parameter specifies. Finally, the
-     *     // channel that the <code>onBehalfOfContentOwnerChannel</code> parameter value
-     *     // specifies must be linked to the content owner that the
-     *     // <code>onBehalfOfContentOwner</code> parameter specifies.<br><br>This
-     *     // parameter is intended for YouTube content partners that own and manage many
-     *     // different YouTube channels. It allows content owners to authenticate once
-     *     // and perform actions on behalf of the channel specified in the parameter
-     *     // value, without having to provide authentication credentials for each
-     *     // separate channel.
+     *     // This parameter can only be used in a properly authorized request. *Note:* This parameter is intended exclusively for YouTube content partners. The *onBehalfOfContentOwnerChannel* parameter specifies the YouTube channel ID of the channel to which a video is being added. This parameter is required when a request specifies a value for the onBehalfOfContentOwner parameter, and it can only be used in conjunction with that parameter. In addition, the request must be authorized using a CMS account that is linked to the content owner that the onBehalfOfContentOwner parameter specifies. Finally, the channel that the onBehalfOfContentOwnerChannel parameter value specifies must be linked to the content owner that the onBehalfOfContentOwner parameter specifies. This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and perform actions on behalf of the channel specified in the parameter value, without having to provide authentication credentials for each separate channel.
      *     onBehalfOfContentOwnerChannel: 'placeholder-value',
      *   });
      *   console.log(res.data);
@@ -12118,16 +11037,12 @@ export namespace youtube_v3 {
      *   throw e;
      * });
      *
-     * @alias youtube.liveStreams.delete
-     * @memberOf! ()
+     * ```
      *
-     * @param {object} params Parameters for request
-     * @param {string} params.id
-     * @param {string=} params.onBehalfOfContentOwner <strong>Note:</strong> This parameter is intended exclusively for YouTube content partners.<br><br>The <code><strong>onBehalfOfContentOwner</strong></code> parameter indicates that the request's authorization credentials identify a YouTube CMS user who is acting on behalf of the content owner specified in the parameter value. This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and get access to all their video and channel data, without having to provide authentication credentials for each individual channel. The CMS account that the user authenticates with must be linked to the specified YouTube content owner.
-     * @param {string=} params.onBehalfOfContentOwnerChannel This parameter can only be used in a properly <a href="/youtube/v3/guides/authentication">authorized request</a>. <strong>Note:</strong> This parameter is intended exclusively for YouTube content partners.<br><br>The <code><strong>onBehalfOfContentOwnerChannel</strong></code> parameter specifies the YouTube channel ID of the channel to which a video is being added. This parameter is required when a request specifies a value for the <code>onBehalfOfContentOwner</code> parameter, and it can only be used in conjunction with that parameter. In addition, the request must be authorized using a CMS account that is linked to the content owner that the <code>onBehalfOfContentOwner</code> parameter specifies. Finally, the channel that the <code>onBehalfOfContentOwnerChannel</code> parameter value specifies must be linked to the content owner that the <code>onBehalfOfContentOwner</code> parameter specifies.<br><br>This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and perform actions on behalf of the channel specified in the parameter value, without having to provide authentication credentials for each separate channel.
-     * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-     * @param {callback} callback The callback that handles the response.
-     * @return {object} Request object
+     * @param params - Parameters for request
+     * @param options - Optionally override request options, such as `url`, `method`, and `encoding`.
+     * @param callback - Optional callback that handles the response.
+     * @returns A promise if used with async/await, or void if used with a callback.
      */
     delete(
       params: Params$Resource$Livestreams$Delete,
@@ -12179,7 +11094,7 @@ export namespace youtube_v3 {
         options = {};
       }
 
-      const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+      const rootUrl = options.rootUrl || 'https://youtube.googleapis.com/';
       const parameters = {
         options: Object.assign(
           {
@@ -12199,7 +11114,7 @@ export namespace youtube_v3 {
       if (callback) {
         createAPIRequest<void>(
           parameters,
-          callback as BodyResponseCallback<{} | void>
+          callback as BodyResponseCallback<unknown>
         );
       } else {
         return createAPIRequest<void>(parameters);
@@ -12207,9 +11122,9 @@ export namespace youtube_v3 {
     }
 
     /**
-     * youtube.liveStreams.insert
-     * @desc Inserts a new stream for the authenticated user.
+     * Inserts a new stream for the authenticated user.
      * @example
+     * ```js
      * // Before running the sample:
      * // - Enable the API at:
      * //   https://console.developers.google.com/apis/api/youtube.googleapis.com
@@ -12236,45 +11151,11 @@ export namespace youtube_v3 {
      *
      *   // Do the magic
      *   const res = await youtube.liveStreams.insert({
-     *     // <strong>Note:</strong> This parameter is intended exclusively for YouTube
-     *     // content partners.<br><br>The
-     *     // <code><strong>onBehalfOfContentOwner</strong></code> parameter indicates
-     *     // that the
-     *     // request's authorization credentials identify a YouTube CMS user who is
-     *     // acting on behalf of the content owner specified in the parameter value.
-     *     // This parameter is intended for YouTube content partners that own and manage
-     *     // many different YouTube channels. It allows content owners to authenticate
-     *     // once and get access to all their video and channel data, without having to
-     *     // provide authentication credentials for each individual channel. The CMS
-     *     // account that the user authenticates with must be linked to the specified
-     *     // YouTube content owner.
+     *     // *Note:* This parameter is intended exclusively for YouTube content partners. The *onBehalfOfContentOwner* parameter indicates that the request's authorization credentials identify a YouTube CMS user who is acting on behalf of the content owner specified in the parameter value. This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and get access to all their video and channel data, without having to provide authentication credentials for each individual channel. The CMS account that the user authenticates with must be linked to the specified YouTube content owner.
      *     onBehalfOfContentOwner: 'placeholder-value',
-     *     // This parameter can only be used in a properly <a
-     *     // href="/youtube/v3/guides/authentication">authorized request</a>.
-     *     // <strong>Note:</strong> This parameter is intended exclusively for YouTube
-     *     // content partners.<br><br>The
-     *     // <code><strong>onBehalfOfContentOwnerChannel</strong></code> parameter
-     *     // specifies the YouTube channel ID of the channel to which a video is being
-     *     // added. This parameter is required when a request specifies a value for the
-     *     // <code>onBehalfOfContentOwner</code> parameter, and it can only be used in
-     *     // conjunction with that parameter. In addition, the request must be
-     *     // authorized using a CMS account that is linked to the content owner that the
-     *     // <code>onBehalfOfContentOwner</code> parameter specifies. Finally, the
-     *     // channel that the <code>onBehalfOfContentOwnerChannel</code> parameter value
-     *     // specifies must be linked to the content owner that the
-     *     // <code>onBehalfOfContentOwner</code> parameter specifies.<br><br>This
-     *     // parameter is intended for YouTube content partners that own and manage many
-     *     // different YouTube channels. It allows content owners to authenticate once
-     *     // and perform actions on behalf of the channel specified in the parameter
-     *     // value, without having to provide authentication credentials for each
-     *     // separate channel.
+     *     // This parameter can only be used in a properly authorized request. *Note:* This parameter is intended exclusively for YouTube content partners. The *onBehalfOfContentOwnerChannel* parameter specifies the YouTube channel ID of the channel to which a video is being added. This parameter is required when a request specifies a value for the onBehalfOfContentOwner parameter, and it can only be used in conjunction with that parameter. In addition, the request must be authorized using a CMS account that is linked to the content owner that the onBehalfOfContentOwner parameter specifies. Finally, the channel that the onBehalfOfContentOwnerChannel parameter value specifies must be linked to the content owner that the onBehalfOfContentOwner parameter specifies. This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and perform actions on behalf of the channel specified in the parameter value, without having to provide authentication credentials for each separate channel.
      *     onBehalfOfContentOwnerChannel: 'placeholder-value',
-     *     // The <code><strong>part</strong></code> parameter serves two purposes in
-     *     // this operation. It identifies the properties that the write operation will
-     *     // set as well as the properties that the API response will
-     *     // include.<br><br>The <code>part</code> properties that you can include in
-     *     // the parameter value are <code>id</code>, <code>snippet</code>,
-     *     // <code>cdn</code>, and <code>status</code>.
+     *     // The *part* parameter serves two purposes in this operation. It identifies the properties that the write operation will set as well as the properties that the API response will include. The part properties that you can include in the parameter value are id, snippet, cdn, content_details, and status.
      *     part: 'placeholder-value',
      *
      *     // Request body metadata
@@ -12310,17 +11191,12 @@ export namespace youtube_v3 {
      *   throw e;
      * });
      *
-     * @alias youtube.liveStreams.insert
-     * @memberOf! ()
+     * ```
      *
-     * @param {object} params Parameters for request
-     * @param {string=} params.onBehalfOfContentOwner <strong>Note:</strong> This parameter is intended exclusively for YouTube content partners.<br><br>The <code><strong>onBehalfOfContentOwner</strong></code> parameter indicates that the request's authorization credentials identify a YouTube CMS user who is acting on behalf of the content owner specified in the parameter value. This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and get access to all their video and channel data, without having to provide authentication credentials for each individual channel. The CMS account that the user authenticates with must be linked to the specified YouTube content owner.
-     * @param {string=} params.onBehalfOfContentOwnerChannel This parameter can only be used in a properly <a href="/youtube/v3/guides/authentication">authorized request</a>. <strong>Note:</strong> This parameter is intended exclusively for YouTube content partners.<br><br>The <code><strong>onBehalfOfContentOwnerChannel</strong></code> parameter specifies the YouTube channel ID of the channel to which a video is being added. This parameter is required when a request specifies a value for the <code>onBehalfOfContentOwner</code> parameter, and it can only be used in conjunction with that parameter. In addition, the request must be authorized using a CMS account that is linked to the content owner that the <code>onBehalfOfContentOwner</code> parameter specifies. Finally, the channel that the <code>onBehalfOfContentOwnerChannel</code> parameter value specifies must be linked to the content owner that the <code>onBehalfOfContentOwner</code> parameter specifies.<br><br>This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and perform actions on behalf of the channel specified in the parameter value, without having to provide authentication credentials for each separate channel.
-     * @param {string} params.part The <code><strong>part</strong></code> parameter serves two purposes in this operation. It identifies the properties that the write operation will set as well as the properties that the API response will include.<br><br>The <code>part</code> properties that you can include in the parameter value are <code>id</code>, <code>snippet</code>, <code>cdn</code>, and <code>status</code>.
-     * @param {().LiveStream} params.requestBody Request body data
-     * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-     * @param {callback} callback The callback that handles the response.
-     * @return {object} Request object
+     * @param params - Parameters for request
+     * @param options - Optionally override request options, such as `url`, `method`, and `encoding`.
+     * @param callback - Optional callback that handles the response.
+     * @returns A promise if used with async/await, or void if used with a callback.
      */
     insert(
       params: Params$Resource$Livestreams$Insert,
@@ -12374,7 +11250,7 @@ export namespace youtube_v3 {
         options = {};
       }
 
-      const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+      const rootUrl = options.rootUrl || 'https://youtube.googleapis.com/';
       const parameters = {
         options: Object.assign(
           {
@@ -12394,7 +11270,7 @@ export namespace youtube_v3 {
       if (callback) {
         createAPIRequest<Schema$LiveStream>(
           parameters,
-          callback as BodyResponseCallback<{} | void>
+          callback as BodyResponseCallback<unknown>
         );
       } else {
         return createAPIRequest<Schema$LiveStream>(parameters);
@@ -12402,9 +11278,9 @@ export namespace youtube_v3 {
     }
 
     /**
-     * youtube.liveStreams.list
-     * @desc Retrieve the list of streams associated with the given channel. --
+     * Retrieve the list of streams associated with the given channel. --
      * @example
+     * ```js
      * // Before running the sample:
      * // - Enable the API at:
      * //   https://console.developers.google.com/apis/api/youtube.googleapis.com
@@ -12434,54 +11310,17 @@ export namespace youtube_v3 {
      *   const res = await youtube.liveStreams.list({
      *     // Return LiveStreams with the given ids from Stubby or Apiary.
      *     id: 'placeholder-value',
-     *     // The <code><strong>maxResults</strong></code> parameter specifies the
-     *     // maximum number of items that should be returned in the result set.
+     *     // The *maxResults* parameter specifies the maximum number of items that should be returned in the result set.
      *     maxResults: 'placeholder-value',
      *
      *     mine: 'placeholder-value',
-     *     // <strong>Note:</strong> This parameter is intended exclusively for YouTube
-     *     // content partners.<br><br>The
-     *     // <code><strong>onBehalfOfContentOwner</strong></code> parameter indicates
-     *     // that the
-     *     // request's authorization credentials identify a YouTube CMS user who is
-     *     // acting on behalf of the content owner specified in the parameter value.
-     *     // This parameter is intended for YouTube content partners that own and manage
-     *     // many different YouTube channels. It allows content owners to authenticate
-     *     // once and get access to all their video and channel data, without having to
-     *     // provide authentication credentials for each individual channel. The CMS
-     *     // account that the user authenticates with must be linked to the specified
-     *     // YouTube content owner.
+     *     // *Note:* This parameter is intended exclusively for YouTube content partners. The *onBehalfOfContentOwner* parameter indicates that the request's authorization credentials identify a YouTube CMS user who is acting on behalf of the content owner specified in the parameter value. This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and get access to all their video and channel data, without having to provide authentication credentials for each individual channel. The CMS account that the user authenticates with must be linked to the specified YouTube content owner.
      *     onBehalfOfContentOwner: 'placeholder-value',
-     *     // This parameter can only be used in a properly <a
-     *     // href="/youtube/v3/guides/authentication">authorized request</a>.
-     *     // <strong>Note:</strong> This parameter is intended exclusively for YouTube
-     *     // content partners.<br><br>The
-     *     // <code><strong>onBehalfOfContentOwnerChannel</strong></code> parameter
-     *     // specifies the YouTube channel ID of the channel to which a video is being
-     *     // added. This parameter is required when a request specifies a value for the
-     *     // <code>onBehalfOfContentOwner</code> parameter, and it can only be used in
-     *     // conjunction with that parameter. In addition, the request must be
-     *     // authorized using a CMS account that is linked to the content owner that the
-     *     // <code>onBehalfOfContentOwner</code> parameter specifies. Finally, the
-     *     // channel that the <code>onBehalfOfContentOwnerChannel</code> parameter value
-     *     // specifies must be linked to the content owner that the
-     *     // <code>onBehalfOfContentOwner</code> parameter specifies.<br><br>This
-     *     // parameter is intended for YouTube content partners that own and manage many
-     *     // different YouTube channels. It allows content owners to authenticate once
-     *     // and perform actions on behalf of the channel specified in the parameter
-     *     // value, without having to provide authentication credentials for each
-     *     // separate channel.
+     *     // This parameter can only be used in a properly authorized request. *Note:* This parameter is intended exclusively for YouTube content partners. The *onBehalfOfContentOwnerChannel* parameter specifies the YouTube channel ID of the channel to which a video is being added. This parameter is required when a request specifies a value for the onBehalfOfContentOwner parameter, and it can only be used in conjunction with that parameter. In addition, the request must be authorized using a CMS account that is linked to the content owner that the onBehalfOfContentOwner parameter specifies. Finally, the channel that the onBehalfOfContentOwnerChannel parameter value specifies must be linked to the content owner that the onBehalfOfContentOwner parameter specifies. This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and perform actions on behalf of the channel specified in the parameter value, without having to provide authentication credentials for each separate channel.
      *     onBehalfOfContentOwnerChannel: 'placeholder-value',
-     *     // The <code><strong>pageToken</strong></code> parameter identifies a specific
-     *     // page in the result set that should be returned. In an API response, the
-     *     // <code>nextPageToken</code> and <code>prevPageToken</code> properties
-     *     // identify other pages that could be retrieved.
+     *     // The *pageToken* parameter identifies a specific page in the result set that should be returned. In an API response, the nextPageToken and prevPageToken properties identify other pages that could be retrieved.
      *     pageToken: 'placeholder-value',
-     *     // The <code><strong>part</strong></code> parameter specifies a
-     *     // comma-separated list of one or more <code>liveStream</code> resource
-     *     // properties that the API response will include. The <code>part</code> names
-     *     // that you can include in the parameter value are <code>id</code>,
-     *     // <code>snippet</code>, <code>cdn</code>, and <code>status</code>.
+     *     // The *part* parameter specifies a comma-separated list of one or more liveStream resource properties that the API response will include. The part names that you can include in the parameter value are id, snippet, cdn, and status.
      *     part: 'placeholder-value',
      *   });
      *   console.log(res.data);
@@ -12505,20 +11344,12 @@ export namespace youtube_v3 {
      *   throw e;
      * });
      *
-     * @alias youtube.liveStreams.list
-     * @memberOf! ()
+     * ```
      *
-     * @param {object} params Parameters for request
-     * @param {string=} params.id Return LiveStreams with the given ids from Stubby or Apiary.
-     * @param {integer=} params.maxResults The <code><strong>maxResults</strong></code> parameter specifies the maximum number of items that should be returned in the result set.
-     * @param {boolean=} params.mine
-     * @param {string=} params.onBehalfOfContentOwner <strong>Note:</strong> This parameter is intended exclusively for YouTube content partners.<br><br>The <code><strong>onBehalfOfContentOwner</strong></code> parameter indicates that the request's authorization credentials identify a YouTube CMS user who is acting on behalf of the content owner specified in the parameter value. This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and get access to all their video and channel data, without having to provide authentication credentials for each individual channel. The CMS account that the user authenticates with must be linked to the specified YouTube content owner.
-     * @param {string=} params.onBehalfOfContentOwnerChannel This parameter can only be used in a properly <a href="/youtube/v3/guides/authentication">authorized request</a>. <strong>Note:</strong> This parameter is intended exclusively for YouTube content partners.<br><br>The <code><strong>onBehalfOfContentOwnerChannel</strong></code> parameter specifies the YouTube channel ID of the channel to which a video is being added. This parameter is required when a request specifies a value for the <code>onBehalfOfContentOwner</code> parameter, and it can only be used in conjunction with that parameter. In addition, the request must be authorized using a CMS account that is linked to the content owner that the <code>onBehalfOfContentOwner</code> parameter specifies. Finally, the channel that the <code>onBehalfOfContentOwnerChannel</code> parameter value specifies must be linked to the content owner that the <code>onBehalfOfContentOwner</code> parameter specifies.<br><br>This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and perform actions on behalf of the channel specified in the parameter value, without having to provide authentication credentials for each separate channel.
-     * @param {string=} params.pageToken The <code><strong>pageToken</strong></code> parameter identifies a specific page in the result set that should be returned. In an API response, the <code>nextPageToken</code> and <code>prevPageToken</code> properties identify other pages that could be retrieved.
-     * @param {string} params.part The <code><strong>part</strong></code> parameter specifies a comma-separated list of one or more <code>liveStream</code> resource properties that the API response will include. The <code>part</code> names that you can include in the parameter value are <code>id</code>, <code>snippet</code>, <code>cdn</code>, and <code>status</code>.
-     * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-     * @param {callback} callback The callback that handles the response.
-     * @return {object} Request object
+     * @param params - Parameters for request
+     * @param options - Optionally override request options, such as `url`, `method`, and `encoding`.
+     * @param callback - Optional callback that handles the response.
+     * @returns A promise if used with async/await, or void if used with a callback.
      */
     list(
       params: Params$Resource$Livestreams$List,
@@ -12576,7 +11407,7 @@ export namespace youtube_v3 {
         options = {};
       }
 
-      const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+      const rootUrl = options.rootUrl || 'https://youtube.googleapis.com/';
       const parameters = {
         options: Object.assign(
           {
@@ -12596,7 +11427,7 @@ export namespace youtube_v3 {
       if (callback) {
         createAPIRequest<Schema$LiveStreamListResponse>(
           parameters,
-          callback as BodyResponseCallback<{} | void>
+          callback as BodyResponseCallback<unknown>
         );
       } else {
         return createAPIRequest<Schema$LiveStreamListResponse>(parameters);
@@ -12604,9 +11435,9 @@ export namespace youtube_v3 {
     }
 
     /**
-     * youtube.liveStreams.update
-     * @desc Updates an existing stream for the authenticated user.
+     * Updates an existing stream for the authenticated user.
      * @example
+     * ```js
      * // Before running the sample:
      * // - Enable the API at:
      * //   https://console.developers.google.com/apis/api/youtube.googleapis.com
@@ -12633,49 +11464,11 @@ export namespace youtube_v3 {
      *
      *   // Do the magic
      *   const res = await youtube.liveStreams.update({
-     *     // <strong>Note:</strong> This parameter is intended exclusively for YouTube
-     *     // content partners.<br><br>The
-     *     // <code><strong>onBehalfOfContentOwner</strong></code> parameter indicates
-     *     // that the
-     *     // request's authorization credentials identify a YouTube CMS user who is
-     *     // acting on behalf of the content owner specified in the parameter value.
-     *     // This parameter is intended for YouTube content partners that own and manage
-     *     // many different YouTube channels. It allows content owners to authenticate
-     *     // once and get access to all their video and channel data, without having to
-     *     // provide authentication credentials for each individual channel. The CMS
-     *     // account that the user authenticates with must be linked to the specified
-     *     // YouTube content owner.
+     *     // *Note:* This parameter is intended exclusively for YouTube content partners. The *onBehalfOfContentOwner* parameter indicates that the request's authorization credentials identify a YouTube CMS user who is acting on behalf of the content owner specified in the parameter value. This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and get access to all their video and channel data, without having to provide authentication credentials for each individual channel. The CMS account that the user authenticates with must be linked to the specified YouTube content owner.
      *     onBehalfOfContentOwner: 'placeholder-value',
-     *     // This parameter can only be used in a properly <a
-     *     // href="/youtube/v3/guides/authentication">authorized request</a>.
-     *     // <strong>Note:</strong> This parameter is intended exclusively for YouTube
-     *     // content partners.<br><br>The
-     *     // <code><strong>onBehalfOfContentOwnerChannel</strong></code> parameter
-     *     // specifies the YouTube channel ID of the channel to which a video is being
-     *     // added. This parameter is required when a request specifies a value for the
-     *     // <code>onBehalfOfContentOwner</code> parameter, and it can only be used in
-     *     // conjunction with that parameter. In addition, the request must be
-     *     // authorized using a CMS account that is linked to the content owner that the
-     *     // <code>onBehalfOfContentOwner</code> parameter specifies. Finally, the
-     *     // channel that the <code>onBehalfOfContentOwnerChannel</code> parameter value
-     *     // specifies must be linked to the content owner that the
-     *     // <code>onBehalfOfContentOwner</code> parameter specifies.<br><br>This
-     *     // parameter is intended for YouTube content partners that own and manage many
-     *     // different YouTube channels. It allows content owners to authenticate once
-     *     // and perform actions on behalf of the channel specified in the parameter
-     *     // value, without having to provide authentication credentials for each
-     *     // separate channel.
+     *     // This parameter can only be used in a properly authorized request. *Note:* This parameter is intended exclusively for YouTube content partners. The *onBehalfOfContentOwnerChannel* parameter specifies the YouTube channel ID of the channel to which a video is being added. This parameter is required when a request specifies a value for the onBehalfOfContentOwner parameter, and it can only be used in conjunction with that parameter. In addition, the request must be authorized using a CMS account that is linked to the content owner that the onBehalfOfContentOwner parameter specifies. Finally, the channel that the onBehalfOfContentOwnerChannel parameter value specifies must be linked to the content owner that the onBehalfOfContentOwner parameter specifies. This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and perform actions on behalf of the channel specified in the parameter value, without having to provide authentication credentials for each separate channel.
      *     onBehalfOfContentOwnerChannel: 'placeholder-value',
-     *     // The <code><strong>part</strong></code> parameter serves two purposes in
-     *     // this operation. It identifies the properties that the write operation will
-     *     // set as well as the properties that the API response will
-     *     // include.<br><br>The <code>part</code> properties that you can include in
-     *     // the parameter value are <code>id</code>, <code>snippet</code>,
-     *     // <code>cdn</code>, and <code>status</code>.<br><br>Note that this method
-     *     // will override the existing values for all of the mutable properties that
-     *     // are contained in any parts that the parameter value specifies. If the
-     *     // request body does not specify a value for a mutable property, the existing
-     *     // value for that property will be removed.
+     *     // The *part* parameter serves two purposes in this operation. It identifies the properties that the write operation will set as well as the properties that the API response will include. The part properties that you can include in the parameter value are id, snippet, cdn, and status. Note that this method will override the existing values for all of the mutable properties that are contained in any parts that the parameter value specifies. If the request body does not specify a value for a mutable property, the existing value for that property will be removed.
      *     part: 'placeholder-value',
      *
      *     // Request body metadata
@@ -12711,17 +11504,12 @@ export namespace youtube_v3 {
      *   throw e;
      * });
      *
-     * @alias youtube.liveStreams.update
-     * @memberOf! ()
+     * ```
      *
-     * @param {object} params Parameters for request
-     * @param {string=} params.onBehalfOfContentOwner <strong>Note:</strong> This parameter is intended exclusively for YouTube content partners.<br><br>The <code><strong>onBehalfOfContentOwner</strong></code> parameter indicates that the request's authorization credentials identify a YouTube CMS user who is acting on behalf of the content owner specified in the parameter value. This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and get access to all their video and channel data, without having to provide authentication credentials for each individual channel. The CMS account that the user authenticates with must be linked to the specified YouTube content owner.
-     * @param {string=} params.onBehalfOfContentOwnerChannel This parameter can only be used in a properly <a href="/youtube/v3/guides/authentication">authorized request</a>. <strong>Note:</strong> This parameter is intended exclusively for YouTube content partners.<br><br>The <code><strong>onBehalfOfContentOwnerChannel</strong></code> parameter specifies the YouTube channel ID of the channel to which a video is being added. This parameter is required when a request specifies a value for the <code>onBehalfOfContentOwner</code> parameter, and it can only be used in conjunction with that parameter. In addition, the request must be authorized using a CMS account that is linked to the content owner that the <code>onBehalfOfContentOwner</code> parameter specifies. Finally, the channel that the <code>onBehalfOfContentOwnerChannel</code> parameter value specifies must be linked to the content owner that the <code>onBehalfOfContentOwner</code> parameter specifies.<br><br>This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and perform actions on behalf of the channel specified in the parameter value, without having to provide authentication credentials for each separate channel.
-     * @param {string} params.part The <code><strong>part</strong></code> parameter serves two purposes in this operation. It identifies the properties that the write operation will set as well as the properties that the API response will include.<br><br>The <code>part</code> properties that you can include in the parameter value are <code>id</code>, <code>snippet</code>, <code>cdn</code>, and <code>status</code>.<br><br>Note that this method will override the existing values for all of the mutable properties that are contained in any parts that the parameter value specifies. If the request body does not specify a value for a mutable property, the existing value for that property will be removed.
-     * @param {().LiveStream} params.requestBody Request body data
-     * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-     * @param {callback} callback The callback that handles the response.
-     * @return {object} Request object
+     * @param params - Parameters for request
+     * @param options - Optionally override request options, such as `url`, `method`, and `encoding`.
+     * @param callback - Optional callback that handles the response.
+     * @returns A promise if used with async/await, or void if used with a callback.
      */
     update(
       params: Params$Resource$Livestreams$Update,
@@ -12775,7 +11563,7 @@ export namespace youtube_v3 {
         options = {};
       }
 
-      const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+      const rootUrl = options.rootUrl || 'https://youtube.googleapis.com/';
       const parameters = {
         options: Object.assign(
           {
@@ -12795,7 +11583,7 @@ export namespace youtube_v3 {
       if (callback) {
         createAPIRequest<Schema$LiveStream>(
           parameters,
-          callback as BodyResponseCallback<{} | void>
+          callback as BodyResponseCallback<unknown>
         );
       } else {
         return createAPIRequest<Schema$LiveStream>(parameters);
@@ -12810,26 +11598,26 @@ export namespace youtube_v3 {
      */
     id?: string;
     /**
-     * <strong>Note:</strong> This parameter is intended exclusively for YouTube content partners.<br><br>The <code><strong>onBehalfOfContentOwner</strong></code> parameter indicates that the request's authorization credentials identify a YouTube CMS user who is acting on behalf of the content owner specified in the parameter value. This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and get access to all their video and channel data, without having to provide authentication credentials for each individual channel. The CMS account that the user authenticates with must be linked to the specified YouTube content owner.
+     * *Note:* This parameter is intended exclusively for YouTube content partners. The *onBehalfOfContentOwner* parameter indicates that the request's authorization credentials identify a YouTube CMS user who is acting on behalf of the content owner specified in the parameter value. This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and get access to all their video and channel data, without having to provide authentication credentials for each individual channel. The CMS account that the user authenticates with must be linked to the specified YouTube content owner.
      */
     onBehalfOfContentOwner?: string;
     /**
-     * This parameter can only be used in a properly <a href="/youtube/v3/guides/authentication">authorized request</a>. <strong>Note:</strong> This parameter is intended exclusively for YouTube content partners.<br><br>The <code><strong>onBehalfOfContentOwnerChannel</strong></code> parameter specifies the YouTube channel ID of the channel to which a video is being added. This parameter is required when a request specifies a value for the <code>onBehalfOfContentOwner</code> parameter, and it can only be used in conjunction with that parameter. In addition, the request must be authorized using a CMS account that is linked to the content owner that the <code>onBehalfOfContentOwner</code> parameter specifies. Finally, the channel that the <code>onBehalfOfContentOwnerChannel</code> parameter value specifies must be linked to the content owner that the <code>onBehalfOfContentOwner</code> parameter specifies.<br><br>This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and perform actions on behalf of the channel specified in the parameter value, without having to provide authentication credentials for each separate channel.
+     * This parameter can only be used in a properly authorized request. *Note:* This parameter is intended exclusively for YouTube content partners. The *onBehalfOfContentOwnerChannel* parameter specifies the YouTube channel ID of the channel to which a video is being added. This parameter is required when a request specifies a value for the onBehalfOfContentOwner parameter, and it can only be used in conjunction with that parameter. In addition, the request must be authorized using a CMS account that is linked to the content owner that the onBehalfOfContentOwner parameter specifies. Finally, the channel that the onBehalfOfContentOwnerChannel parameter value specifies must be linked to the content owner that the onBehalfOfContentOwner parameter specifies. This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and perform actions on behalf of the channel specified in the parameter value, without having to provide authentication credentials for each separate channel.
      */
     onBehalfOfContentOwnerChannel?: string;
   }
   export interface Params$Resource$Livestreams$Insert
     extends StandardParameters {
     /**
-     * <strong>Note:</strong> This parameter is intended exclusively for YouTube content partners.<br><br>The <code><strong>onBehalfOfContentOwner</strong></code> parameter indicates that the request's authorization credentials identify a YouTube CMS user who is acting on behalf of the content owner specified in the parameter value. This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and get access to all their video and channel data, without having to provide authentication credentials for each individual channel. The CMS account that the user authenticates with must be linked to the specified YouTube content owner.
+     * *Note:* This parameter is intended exclusively for YouTube content partners. The *onBehalfOfContentOwner* parameter indicates that the request's authorization credentials identify a YouTube CMS user who is acting on behalf of the content owner specified in the parameter value. This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and get access to all their video and channel data, without having to provide authentication credentials for each individual channel. The CMS account that the user authenticates with must be linked to the specified YouTube content owner.
      */
     onBehalfOfContentOwner?: string;
     /**
-     * This parameter can only be used in a properly <a href="/youtube/v3/guides/authentication">authorized request</a>. <strong>Note:</strong> This parameter is intended exclusively for YouTube content partners.<br><br>The <code><strong>onBehalfOfContentOwnerChannel</strong></code> parameter specifies the YouTube channel ID of the channel to which a video is being added. This parameter is required when a request specifies a value for the <code>onBehalfOfContentOwner</code> parameter, and it can only be used in conjunction with that parameter. In addition, the request must be authorized using a CMS account that is linked to the content owner that the <code>onBehalfOfContentOwner</code> parameter specifies. Finally, the channel that the <code>onBehalfOfContentOwnerChannel</code> parameter value specifies must be linked to the content owner that the <code>onBehalfOfContentOwner</code> parameter specifies.<br><br>This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and perform actions on behalf of the channel specified in the parameter value, without having to provide authentication credentials for each separate channel.
+     * This parameter can only be used in a properly authorized request. *Note:* This parameter is intended exclusively for YouTube content partners. The *onBehalfOfContentOwnerChannel* parameter specifies the YouTube channel ID of the channel to which a video is being added. This parameter is required when a request specifies a value for the onBehalfOfContentOwner parameter, and it can only be used in conjunction with that parameter. In addition, the request must be authorized using a CMS account that is linked to the content owner that the onBehalfOfContentOwner parameter specifies. Finally, the channel that the onBehalfOfContentOwnerChannel parameter value specifies must be linked to the content owner that the onBehalfOfContentOwner parameter specifies. This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and perform actions on behalf of the channel specified in the parameter value, without having to provide authentication credentials for each separate channel.
      */
     onBehalfOfContentOwnerChannel?: string;
     /**
-     * The <code><strong>part</strong></code> parameter serves two purposes in this operation. It identifies the properties that the write operation will set as well as the properties that the API response will include.<br><br>The <code>part</code> properties that you can include in the parameter value are <code>id</code>, <code>snippet</code>, <code>cdn</code>, and <code>status</code>.
+     * The *part* parameter serves two purposes in this operation. It identifies the properties that the write operation will set as well as the properties that the API response will include. The part properties that you can include in the parameter value are id, snippet, cdn, content_details, and status.
      */
     part?: string[];
 
@@ -12844,7 +11632,7 @@ export namespace youtube_v3 {
      */
     id?: string[];
     /**
-     * The <code><strong>maxResults</strong></code> parameter specifies the maximum number of items that should be returned in the result set.
+     * The *maxResults* parameter specifies the maximum number of items that should be returned in the result set.
      */
     maxResults?: number;
     /**
@@ -12852,34 +11640,34 @@ export namespace youtube_v3 {
      */
     mine?: boolean;
     /**
-     * <strong>Note:</strong> This parameter is intended exclusively for YouTube content partners.<br><br>The <code><strong>onBehalfOfContentOwner</strong></code> parameter indicates that the request's authorization credentials identify a YouTube CMS user who is acting on behalf of the content owner specified in the parameter value. This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and get access to all their video and channel data, without having to provide authentication credentials for each individual channel. The CMS account that the user authenticates with must be linked to the specified YouTube content owner.
+     * *Note:* This parameter is intended exclusively for YouTube content partners. The *onBehalfOfContentOwner* parameter indicates that the request's authorization credentials identify a YouTube CMS user who is acting on behalf of the content owner specified in the parameter value. This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and get access to all their video and channel data, without having to provide authentication credentials for each individual channel. The CMS account that the user authenticates with must be linked to the specified YouTube content owner.
      */
     onBehalfOfContentOwner?: string;
     /**
-     * This parameter can only be used in a properly <a href="/youtube/v3/guides/authentication">authorized request</a>. <strong>Note:</strong> This parameter is intended exclusively for YouTube content partners.<br><br>The <code><strong>onBehalfOfContentOwnerChannel</strong></code> parameter specifies the YouTube channel ID of the channel to which a video is being added. This parameter is required when a request specifies a value for the <code>onBehalfOfContentOwner</code> parameter, and it can only be used in conjunction with that parameter. In addition, the request must be authorized using a CMS account that is linked to the content owner that the <code>onBehalfOfContentOwner</code> parameter specifies. Finally, the channel that the <code>onBehalfOfContentOwnerChannel</code> parameter value specifies must be linked to the content owner that the <code>onBehalfOfContentOwner</code> parameter specifies.<br><br>This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and perform actions on behalf of the channel specified in the parameter value, without having to provide authentication credentials for each separate channel.
+     * This parameter can only be used in a properly authorized request. *Note:* This parameter is intended exclusively for YouTube content partners. The *onBehalfOfContentOwnerChannel* parameter specifies the YouTube channel ID of the channel to which a video is being added. This parameter is required when a request specifies a value for the onBehalfOfContentOwner parameter, and it can only be used in conjunction with that parameter. In addition, the request must be authorized using a CMS account that is linked to the content owner that the onBehalfOfContentOwner parameter specifies. Finally, the channel that the onBehalfOfContentOwnerChannel parameter value specifies must be linked to the content owner that the onBehalfOfContentOwner parameter specifies. This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and perform actions on behalf of the channel specified in the parameter value, without having to provide authentication credentials for each separate channel.
      */
     onBehalfOfContentOwnerChannel?: string;
     /**
-     * The <code><strong>pageToken</strong></code> parameter identifies a specific page in the result set that should be returned. In an API response, the <code>nextPageToken</code> and <code>prevPageToken</code> properties identify other pages that could be retrieved.
+     * The *pageToken* parameter identifies a specific page in the result set that should be returned. In an API response, the nextPageToken and prevPageToken properties identify other pages that could be retrieved.
      */
     pageToken?: string;
     /**
-     * The <code><strong>part</strong></code> parameter specifies a comma-separated list of one or more <code>liveStream</code> resource properties that the API response will include. The <code>part</code> names that you can include in the parameter value are <code>id</code>, <code>snippet</code>, <code>cdn</code>, and <code>status</code>.
+     * The *part* parameter specifies a comma-separated list of one or more liveStream resource properties that the API response will include. The part names that you can include in the parameter value are id, snippet, cdn, and status.
      */
     part?: string[];
   }
   export interface Params$Resource$Livestreams$Update
     extends StandardParameters {
     /**
-     * <strong>Note:</strong> This parameter is intended exclusively for YouTube content partners.<br><br>The <code><strong>onBehalfOfContentOwner</strong></code> parameter indicates that the request's authorization credentials identify a YouTube CMS user who is acting on behalf of the content owner specified in the parameter value. This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and get access to all their video and channel data, without having to provide authentication credentials for each individual channel. The CMS account that the user authenticates with must be linked to the specified YouTube content owner.
+     * *Note:* This parameter is intended exclusively for YouTube content partners. The *onBehalfOfContentOwner* parameter indicates that the request's authorization credentials identify a YouTube CMS user who is acting on behalf of the content owner specified in the parameter value. This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and get access to all their video and channel data, without having to provide authentication credentials for each individual channel. The CMS account that the user authenticates with must be linked to the specified YouTube content owner.
      */
     onBehalfOfContentOwner?: string;
     /**
-     * This parameter can only be used in a properly <a href="/youtube/v3/guides/authentication">authorized request</a>. <strong>Note:</strong> This parameter is intended exclusively for YouTube content partners.<br><br>The <code><strong>onBehalfOfContentOwnerChannel</strong></code> parameter specifies the YouTube channel ID of the channel to which a video is being added. This parameter is required when a request specifies a value for the <code>onBehalfOfContentOwner</code> parameter, and it can only be used in conjunction with that parameter. In addition, the request must be authorized using a CMS account that is linked to the content owner that the <code>onBehalfOfContentOwner</code> parameter specifies. Finally, the channel that the <code>onBehalfOfContentOwnerChannel</code> parameter value specifies must be linked to the content owner that the <code>onBehalfOfContentOwner</code> parameter specifies.<br><br>This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and perform actions on behalf of the channel specified in the parameter value, without having to provide authentication credentials for each separate channel.
+     * This parameter can only be used in a properly authorized request. *Note:* This parameter is intended exclusively for YouTube content partners. The *onBehalfOfContentOwnerChannel* parameter specifies the YouTube channel ID of the channel to which a video is being added. This parameter is required when a request specifies a value for the onBehalfOfContentOwner parameter, and it can only be used in conjunction with that parameter. In addition, the request must be authorized using a CMS account that is linked to the content owner that the onBehalfOfContentOwner parameter specifies. Finally, the channel that the onBehalfOfContentOwnerChannel parameter value specifies must be linked to the content owner that the onBehalfOfContentOwner parameter specifies. This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and perform actions on behalf of the channel specified in the parameter value, without having to provide authentication credentials for each separate channel.
      */
     onBehalfOfContentOwnerChannel?: string;
     /**
-     * The <code><strong>part</strong></code> parameter serves two purposes in this operation. It identifies the properties that the write operation will set as well as the properties that the API response will include.<br><br>The <code>part</code> properties that you can include in the parameter value are <code>id</code>, <code>snippet</code>, <code>cdn</code>, and <code>status</code>.<br><br>Note that this method will override the existing values for all of the mutable properties that are contained in any parts that the parameter value specifies. If the request body does not specify a value for a mutable property, the existing value for that property will be removed.
+     * The *part* parameter serves two purposes in this operation. It identifies the properties that the write operation will set as well as the properties that the API response will include. The part properties that you can include in the parameter value are id, snippet, cdn, and status. Note that this method will override the existing values for all of the mutable properties that are contained in any parts that the parameter value specifies. If the request body does not specify a value for a mutable property, the existing value for that property will be removed.
      */
     part?: string[];
 
@@ -12896,9 +11684,9 @@ export namespace youtube_v3 {
     }
 
     /**
-     * youtube.members.list
-     * @desc Retrieves a list of members that match the request criteria for a channel.
+     * Retrieves a list of members that match the request criteria for a channel.
      * @example
+     * ```js
      * // Before running the sample:
      * // - Enable the API at:
      * //   https://console.developers.google.com/apis/api/youtube.googleapis.com
@@ -12914,11 +11702,7 @@ export namespace youtube_v3 {
      *   const auth = new google.auth.GoogleAuth({
      *     // Scopes can be specified either as an array or as a single, space-delimited string.
      *     scopes: [
-     *       'https://www.googleapis.com/auth/youtube',
      *       'https://www.googleapis.com/auth/youtube.channel-memberships.creator',
-     *       'https://www.googleapis.com/auth/youtube.force-ssl',
-     *       'https://www.googleapis.com/auth/youtube.readonly',
-     *       'https://www.googleapis.com/auth/youtubepartner',
      *     ],
      *   });
      *
@@ -12928,24 +11712,17 @@ export namespace youtube_v3 {
      *
      *   // Do the magic
      *   const res = await youtube.members.list({
-     *     // Comma separated list of channel IDs. Only data about members that are part
-     *     // of this list will be included in the response.
+     *     // Comma separated list of channel IDs. Only data about members that are part of this list will be included in the response.
      *     filterByMemberChannelId: 'placeholder-value',
      *     // Filter members in the results set to the ones that have access to a level.
      *     hasAccessToLevel: 'placeholder-value',
-     *     // The <code><strong>maxResults</strong></code> parameter specifies the
-     *     // maximum number of items that should be returned in the result set.
+     *     // The *maxResults* parameter specifies the maximum number of items that should be returned in the result set.
      *     maxResults: 'placeholder-value',
      *     // Parameter that specifies which channel members to return.
      *     mode: 'placeholder-value',
-     *     // The <code><strong>pageToken</strong></code> parameter identifies a specific
-     *     // page in the result set that should be returned. In an API response, the
-     *     // <code>nextPageToken</code> and <code>prevPageToken</code> properties
-     *     // identify other pages that could be retrieved.
+     *     // The *pageToken* parameter identifies a specific page in the result set that should be returned. In an API response, the nextPageToken and prevPageToken properties identify other pages that could be retrieved.
      *     pageToken: 'placeholder-value',
-     *     // The <code><strong>part</strong></code> parameter specifies the
-     *     // <code>member</code> resource parts that the API response will include. Set
-     *     // the parameter value to <code>snippet</code>.
+     *     // The *part* parameter specifies the member resource parts that the API response will include. Set the parameter value to snippet.
      *     part: 'placeholder-value',
      *   });
      *   console.log(res.data);
@@ -12968,19 +11745,12 @@ export namespace youtube_v3 {
      *   throw e;
      * });
      *
-     * @alias youtube.members.list
-     * @memberOf! ()
+     * ```
      *
-     * @param {object} params Parameters for request
-     * @param {string=} params.filterByMemberChannelId Comma separated list of channel IDs. Only data about members that are part of this list will be included in the response.
-     * @param {string=} params.hasAccessToLevel Filter members in the results set to the ones that have access to a level.
-     * @param {integer=} params.maxResults The <code><strong>maxResults</strong></code> parameter specifies the maximum number of items that should be returned in the result set.
-     * @param {string=} params.mode Parameter that specifies which channel members to return.
-     * @param {string=} params.pageToken The <code><strong>pageToken</strong></code> parameter identifies a specific page in the result set that should be returned. In an API response, the <code>nextPageToken</code> and <code>prevPageToken</code> properties identify other pages that could be retrieved.
-     * @param {string} params.part The <code><strong>part</strong></code> parameter specifies the <code>member</code> resource parts that the API response will include. Set the parameter value to <code>snippet</code>.
-     * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-     * @param {callback} callback The callback that handles the response.
-     * @return {object} Request object
+     * @param params - Parameters for request
+     * @param options - Optionally override request options, such as `url`, `method`, and `encoding`.
+     * @param callback - Optional callback that handles the response.
+     * @returns A promise if used with async/await, or void if used with a callback.
      */
     list(
       params: Params$Resource$Members$List,
@@ -13036,7 +11806,7 @@ export namespace youtube_v3 {
         options = {};
       }
 
-      const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+      const rootUrl = options.rootUrl || 'https://youtube.googleapis.com/';
       const parameters = {
         options: Object.assign(
           {
@@ -13056,7 +11826,7 @@ export namespace youtube_v3 {
       if (callback) {
         createAPIRequest<Schema$MemberListResponse>(
           parameters,
-          callback as BodyResponseCallback<{} | void>
+          callback as BodyResponseCallback<unknown>
         );
       } else {
         return createAPIRequest<Schema$MemberListResponse>(parameters);
@@ -13074,7 +11844,7 @@ export namespace youtube_v3 {
      */
     hasAccessToLevel?: string;
     /**
-     * The <code><strong>maxResults</strong></code> parameter specifies the maximum number of items that should be returned in the result set.
+     * The *maxResults* parameter specifies the maximum number of items that should be returned in the result set.
      */
     maxResults?: number;
     /**
@@ -13082,11 +11852,11 @@ export namespace youtube_v3 {
      */
     mode?: string;
     /**
-     * The <code><strong>pageToken</strong></code> parameter identifies a specific page in the result set that should be returned. In an API response, the <code>nextPageToken</code> and <code>prevPageToken</code> properties identify other pages that could be retrieved.
+     * The *pageToken* parameter identifies a specific page in the result set that should be returned. In an API response, the nextPageToken and prevPageToken properties identify other pages that could be retrieved.
      */
     pageToken?: string;
     /**
-     * The <code><strong>part</strong></code> parameter specifies the <code>member</code> resource parts that the API response will include. Set the parameter value to <code>snippet</code>.
+     * The *part* parameter specifies the member resource parts that the API response will include. Set the parameter value to snippet.
      */
     part?: string[];
   }
@@ -13098,9 +11868,9 @@ export namespace youtube_v3 {
     }
 
     /**
-     * youtube.membershipsLevels.list
-     * @desc Retrieves a list of all pricing levels offered by a creator to the fans.
+     * Retrieves a list of all pricing levels offered by a creator to the fans.
      * @example
+     * ```js
      * // Before running the sample:
      * // - Enable the API at:
      * //   https://console.developers.google.com/apis/api/youtube.googleapis.com
@@ -13116,11 +11886,7 @@ export namespace youtube_v3 {
      *   const auth = new google.auth.GoogleAuth({
      *     // Scopes can be specified either as an array or as a single, space-delimited string.
      *     scopes: [
-     *       'https://www.googleapis.com/auth/youtube',
      *       'https://www.googleapis.com/auth/youtube.channel-memberships.creator',
-     *       'https://www.googleapis.com/auth/youtube.force-ssl',
-     *       'https://www.googleapis.com/auth/youtube.readonly',
-     *       'https://www.googleapis.com/auth/youtubepartner',
      *     ],
      *   });
      *
@@ -13130,9 +11896,7 @@ export namespace youtube_v3 {
      *
      *   // Do the magic
      *   const res = await youtube.membershipsLevels.list({
-     *     // The <code><strong>part</strong></code> parameter specifies the
-     *     // <code>membershipsLevel</code> resource parts that the API response will
-     *     // include. Supported values are <code>id</code> and <code>snippet</code>.
+     *     // The *part* parameter specifies the membershipsLevel resource parts that the API response will include. Supported values are id and snippet.
      *     part: 'placeholder-value',
      *   });
      *   console.log(res.data);
@@ -13152,14 +11916,12 @@ export namespace youtube_v3 {
      *   throw e;
      * });
      *
-     * @alias youtube.membershipsLevels.list
-     * @memberOf! ()
+     * ```
      *
-     * @param {object} params Parameters for request
-     * @param {string} params.part The <code><strong>part</strong></code> parameter specifies the <code>membershipsLevel</code> resource parts that the API response will include. Supported values are <code>id</code> and <code>snippet</code>.
-     * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-     * @param {callback} callback The callback that handles the response.
-     * @return {object} Request object
+     * @param params - Parameters for request
+     * @param options - Optionally override request options, such as `url`, `method`, and `encoding`.
+     * @param callback - Optional callback that handles the response.
+     * @returns A promise if used with async/await, or void if used with a callback.
      */
     list(
       params: Params$Resource$Membershipslevels$List,
@@ -13220,7 +11982,7 @@ export namespace youtube_v3 {
         options = {};
       }
 
-      const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+      const rootUrl = options.rootUrl || 'https://youtube.googleapis.com/';
       const parameters = {
         options: Object.assign(
           {
@@ -13240,7 +12002,7 @@ export namespace youtube_v3 {
       if (callback) {
         createAPIRequest<Schema$MembershipsLevelListResponse>(
           parameters,
-          callback as BodyResponseCallback<{} | void>
+          callback as BodyResponseCallback<unknown>
         );
       } else {
         return createAPIRequest<Schema$MembershipsLevelListResponse>(
@@ -13253,7 +12015,7 @@ export namespace youtube_v3 {
   export interface Params$Resource$Membershipslevels$List
     extends StandardParameters {
     /**
-     * The <code><strong>part</strong></code> parameter specifies the <code>membershipsLevel</code> resource parts that the API response will include. Supported values are <code>id</code> and <code>snippet</code>.
+     * The *part* parameter specifies the membershipsLevel resource parts that the API response will include. Supported values are id and snippet.
      */
     part?: string[];
   }
@@ -13265,9 +12027,9 @@ export namespace youtube_v3 {
     }
 
     /**
-     * youtube.playlistItems.delete
-     * @desc Deletes a resource.
+     * Deletes a resource.
      * @example
+     * ```js
      * // Before running the sample:
      * // - Enable the API at:
      * //   https://console.developers.google.com/apis/api/youtube.googleapis.com
@@ -13296,18 +12058,7 @@ export namespace youtube_v3 {
      *   // Do the magic
      *   const res = await youtube.playlistItems.delete({
      *     id: 'placeholder-value',
-     *     // <strong>Note:</strong> This parameter is intended exclusively for YouTube
-     *     // content partners.<br><br>The
-     *     // <code><strong>onBehalfOfContentOwner</strong></code> parameter indicates
-     *     // that the
-     *     // request's authorization credentials identify a YouTube CMS user who is
-     *     // acting on behalf of the content owner specified in the parameter value.
-     *     // This parameter is intended for YouTube content partners that own and manage
-     *     // many different YouTube channels. It allows content owners to authenticate
-     *     // once and get access to all their video and channel data, without having to
-     *     // provide authentication credentials for each individual channel. The CMS
-     *     // account that the user authenticates with must be linked to the specified
-     *     // YouTube content owner.
+     *     // *Note:* This parameter is intended exclusively for YouTube content partners. The *onBehalfOfContentOwner* parameter indicates that the request's authorization credentials identify a YouTube CMS user who is acting on behalf of the content owner specified in the parameter value. This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and get access to all their video and channel data, without having to provide authentication credentials for each individual channel. The CMS account that the user authenticates with must be linked to the specified YouTube content owner.
      *     onBehalfOfContentOwner: 'placeholder-value',
      *   });
      *   console.log(res.data);
@@ -13318,15 +12069,12 @@ export namespace youtube_v3 {
      *   throw e;
      * });
      *
-     * @alias youtube.playlistItems.delete
-     * @memberOf! ()
+     * ```
      *
-     * @param {object} params Parameters for request
-     * @param {string} params.id
-     * @param {string=} params.onBehalfOfContentOwner <strong>Note:</strong> This parameter is intended exclusively for YouTube content partners.<br><br>The <code><strong>onBehalfOfContentOwner</strong></code> parameter indicates that the request's authorization credentials identify a YouTube CMS user who is acting on behalf of the content owner specified in the parameter value. This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and get access to all their video and channel data, without having to provide authentication credentials for each individual channel. The CMS account that the user authenticates with must be linked to the specified YouTube content owner.
-     * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-     * @param {callback} callback The callback that handles the response.
-     * @return {object} Request object
+     * @param params - Parameters for request
+     * @param options - Optionally override request options, such as `url`, `method`, and `encoding`.
+     * @param callback - Optional callback that handles the response.
+     * @returns A promise if used with async/await, or void if used with a callback.
      */
     delete(
       params: Params$Resource$Playlistitems$Delete,
@@ -13378,7 +12126,7 @@ export namespace youtube_v3 {
         options = {};
       }
 
-      const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+      const rootUrl = options.rootUrl || 'https://youtube.googleapis.com/';
       const parameters = {
         options: Object.assign(
           {
@@ -13398,7 +12146,7 @@ export namespace youtube_v3 {
       if (callback) {
         createAPIRequest<void>(
           parameters,
-          callback as BodyResponseCallback<{} | void>
+          callback as BodyResponseCallback<unknown>
         );
       } else {
         return createAPIRequest<void>(parameters);
@@ -13406,9 +12154,9 @@ export namespace youtube_v3 {
     }
 
     /**
-     * youtube.playlistItems.insert
-     * @desc Inserts a new resource into this collection.
+     * Inserts a new resource into this collection.
      * @example
+     * ```js
      * // Before running the sample:
      * // - Enable the API at:
      * //   https://console.developers.google.com/apis/api/youtube.googleapis.com
@@ -13436,22 +12184,9 @@ export namespace youtube_v3 {
      *
      *   // Do the magic
      *   const res = await youtube.playlistItems.insert({
-     *     // <strong>Note:</strong> This parameter is intended exclusively for YouTube
-     *     // content partners.<br><br>The
-     *     // <code><strong>onBehalfOfContentOwner</strong></code> parameter indicates
-     *     // that the
-     *     // request's authorization credentials identify a YouTube CMS user who is
-     *     // acting on behalf of the content owner specified in the parameter value.
-     *     // This parameter is intended for YouTube content partners that own and manage
-     *     // many different YouTube channels. It allows content owners to authenticate
-     *     // once and get access to all their video and channel data, without having to
-     *     // provide authentication credentials for each individual channel. The CMS
-     *     // account that the user authenticates with must be linked to the specified
-     *     // YouTube content owner.
+     *     // *Note:* This parameter is intended exclusively for YouTube content partners. The *onBehalfOfContentOwner* parameter indicates that the request's authorization credentials identify a YouTube CMS user who is acting on behalf of the content owner specified in the parameter value. This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and get access to all their video and channel data, without having to provide authentication credentials for each individual channel. The CMS account that the user authenticates with must be linked to the specified YouTube content owner.
      *     onBehalfOfContentOwner: 'placeholder-value',
-     *     // The <code><strong>part</strong></code> parameter serves two purposes in
-     *     // this operation. It identifies the properties that the write operation will
-     *     // set as well as the properties that the API response will include.
+     *     // The *part* parameter serves two purposes in this operation. It identifies the properties that the write operation will set as well as the properties that the API response will include.
      *     part: 'placeholder-value',
      *
      *     // Request body metadata
@@ -13485,16 +12220,12 @@ export namespace youtube_v3 {
      *   throw e;
      * });
      *
-     * @alias youtube.playlistItems.insert
-     * @memberOf! ()
+     * ```
      *
-     * @param {object} params Parameters for request
-     * @param {string=} params.onBehalfOfContentOwner <strong>Note:</strong> This parameter is intended exclusively for YouTube content partners.<br><br>The <code><strong>onBehalfOfContentOwner</strong></code> parameter indicates that the request's authorization credentials identify a YouTube CMS user who is acting on behalf of the content owner specified in the parameter value. This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and get access to all their video and channel data, without having to provide authentication credentials for each individual channel. The CMS account that the user authenticates with must be linked to the specified YouTube content owner.
-     * @param {string} params.part The <code><strong>part</strong></code> parameter serves two purposes in this operation. It identifies the properties that the write operation will set as well as the properties that the API response will include.
-     * @param {().PlaylistItem} params.requestBody Request body data
-     * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-     * @param {callback} callback The callback that handles the response.
-     * @return {object} Request object
+     * @param params - Parameters for request
+     * @param options - Optionally override request options, such as `url`, `method`, and `encoding`.
+     * @param callback - Optional callback that handles the response.
+     * @returns A promise if used with async/await, or void if used with a callback.
      */
     insert(
       params: Params$Resource$Playlistitems$Insert,
@@ -13548,7 +12279,7 @@ export namespace youtube_v3 {
         options = {};
       }
 
-      const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+      const rootUrl = options.rootUrl || 'https://youtube.googleapis.com/';
       const parameters = {
         options: Object.assign(
           {
@@ -13568,7 +12299,7 @@ export namespace youtube_v3 {
       if (callback) {
         createAPIRequest<Schema$PlaylistItem>(
           parameters,
-          callback as BodyResponseCallback<{} | void>
+          callback as BodyResponseCallback<unknown>
         );
       } else {
         return createAPIRequest<Schema$PlaylistItem>(parameters);
@@ -13576,9 +12307,9 @@ export namespace youtube_v3 {
     }
 
     /**
-     * youtube.playlistItems.list
-     * @desc Retrieves a list of resources, possibly filtered.
+     * Retrieves a list of resources, possibly filtered.
      * @example
+     * ```js
      * // Before running the sample:
      * // - Enable the API at:
      * //   https://console.developers.google.com/apis/api/youtube.googleapis.com
@@ -13608,38 +12339,13 @@ export namespace youtube_v3 {
      *   // Do the magic
      *   const res = await youtube.playlistItems.list({
      *     id: 'placeholder-value',
-     *     // The <code><strong>maxResults</strong></code> parameter specifies the
-     *     // maximum number of items that should be returned in the result set.
+     *     // The *maxResults* parameter specifies the maximum number of items that should be returned in the result set.
      *     maxResults: 'placeholder-value',
-     *     // <strong>Note:</strong> This parameter is intended exclusively for YouTube
-     *     // content partners.<br><br>The
-     *     // <code><strong>onBehalfOfContentOwner</strong></code> parameter indicates
-     *     // that the
-     *     // request's authorization credentials identify a YouTube CMS user who is
-     *     // acting on behalf of the content owner specified in the parameter value.
-     *     // This parameter is intended for YouTube content partners that own and manage
-     *     // many different YouTube channels. It allows content owners to authenticate
-     *     // once and get access to all their video and channel data, without having to
-     *     // provide authentication credentials for each individual channel. The CMS
-     *     // account that the user authenticates with must be linked to the specified
-     *     // YouTube content owner.
+     *     // *Note:* This parameter is intended exclusively for YouTube content partners. The *onBehalfOfContentOwner* parameter indicates that the request's authorization credentials identify a YouTube CMS user who is acting on behalf of the content owner specified in the parameter value. This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and get access to all their video and channel data, without having to provide authentication credentials for each individual channel. The CMS account that the user authenticates with must be linked to the specified YouTube content owner.
      *     onBehalfOfContentOwner: 'placeholder-value',
-     *     // The <code><strong>pageToken</strong></code> parameter identifies a specific
-     *     // page in the result set that should be returned. In an API response, the
-     *     // <code>nextPageToken</code> and <code>prevPageToken</code> properties
-     *     // identify other pages that could be retrieved.
+     *     // The *pageToken* parameter identifies a specific page in the result set that should be returned. In an API response, the nextPageToken and prevPageToken properties identify other pages that could be retrieved.
      *     pageToken: 'placeholder-value',
-     *     // The <code><strong>part</strong></code> parameter specifies a
-     *     // comma-separated list of one or more <code>playlistItem</code> resource
-     *     // properties that the API response will include.<br><br>If the parameter
-     *     // identifies a property that contains child properties, the child properties
-     *     // will be included in the response. For example, in a
-     *     // <code>playlistItem</code> resource, the <code>snippet</code> property
-     *     // contains numerous fields, including the <code>title</code>,
-     *     // <code>description</code>, <code>position</code>, and
-     *     // <code>resourceId</code> properties. As such, if you set
-     *     // <code><strong>part=snippet</strong></code>, the API response will contain
-     *     // all of those properties.
+     *     // The *part* parameter specifies a comma-separated list of one or more playlistItem resource properties that the API response will include. If the parameter identifies a property that contains child properties, the child properties will be included in the response. For example, in a playlistItem resource, the snippet property contains numerous fields, including the title, description, position, and resourceId properties. As such, if you set *part=snippet*, the API response will contain all of those properties.
      *     part: 'placeholder-value',
      *     // Return the playlist items within the given playlist.
      *     playlistId: 'placeholder-value',
@@ -13667,20 +12373,12 @@ export namespace youtube_v3 {
      *   throw e;
      * });
      *
-     * @alias youtube.playlistItems.list
-     * @memberOf! ()
+     * ```
      *
-     * @param {object} params Parameters for request
-     * @param {string=} params.id
-     * @param {integer=} params.maxResults The <code><strong>maxResults</strong></code> parameter specifies the maximum number of items that should be returned in the result set.
-     * @param {string=} params.onBehalfOfContentOwner <strong>Note:</strong> This parameter is intended exclusively for YouTube content partners.<br><br>The <code><strong>onBehalfOfContentOwner</strong></code> parameter indicates that the request's authorization credentials identify a YouTube CMS user who is acting on behalf of the content owner specified in the parameter value. This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and get access to all their video and channel data, without having to provide authentication credentials for each individual channel. The CMS account that the user authenticates with must be linked to the specified YouTube content owner.
-     * @param {string=} params.pageToken The <code><strong>pageToken</strong></code> parameter identifies a specific page in the result set that should be returned. In an API response, the <code>nextPageToken</code> and <code>prevPageToken</code> properties identify other pages that could be retrieved.
-     * @param {string} params.part The <code><strong>part</strong></code> parameter specifies a comma-separated list of one or more <code>playlistItem</code> resource properties that the API response will include.<br><br>If the parameter identifies a property that contains child properties, the child properties will be included in the response. For example, in a <code>playlistItem</code> resource, the <code>snippet</code> property contains numerous fields, including the <code>title</code>, <code>description</code>, <code>position</code>, and <code>resourceId</code> properties. As such, if you set <code><strong>part=snippet</strong></code>, the API response will contain all of those properties.
-     * @param {string=} params.playlistId Return the playlist items within the given playlist.
-     * @param {string=} params.videoId Return the playlist items associated with the given video ID.
-     * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-     * @param {callback} callback The callback that handles the response.
-     * @return {object} Request object
+     * @param params - Parameters for request
+     * @param options - Optionally override request options, such as `url`, `method`, and `encoding`.
+     * @param callback - Optional callback that handles the response.
+     * @returns A promise if used with async/await, or void if used with a callback.
      */
     list(
       params: Params$Resource$Playlistitems$List,
@@ -13739,7 +12437,7 @@ export namespace youtube_v3 {
         options = {};
       }
 
-      const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+      const rootUrl = options.rootUrl || 'https://youtube.googleapis.com/';
       const parameters = {
         options: Object.assign(
           {
@@ -13759,7 +12457,7 @@ export namespace youtube_v3 {
       if (callback) {
         createAPIRequest<Schema$PlaylistItemListResponse>(
           parameters,
-          callback as BodyResponseCallback<{} | void>
+          callback as BodyResponseCallback<unknown>
         );
       } else {
         return createAPIRequest<Schema$PlaylistItemListResponse>(parameters);
@@ -13767,9 +12465,9 @@ export namespace youtube_v3 {
     }
 
     /**
-     * youtube.playlistItems.update
-     * @desc Updates an existing resource.
+     * Updates an existing resource.
      * @example
+     * ```js
      * // Before running the sample:
      * // - Enable the API at:
      * //   https://console.developers.google.com/apis/api/youtube.googleapis.com
@@ -13797,33 +12495,9 @@ export namespace youtube_v3 {
      *
      *   // Do the magic
      *   const res = await youtube.playlistItems.update({
-     *     // <strong>Note:</strong> This parameter is intended exclusively for YouTube
-     *     // content partners.<br><br>The
-     *     // <code><strong>onBehalfOfContentOwner</strong></code> parameter indicates
-     *     // that the
-     *     // request's authorization credentials identify a YouTube CMS user who is
-     *     // acting on behalf of the content owner specified in the parameter value.
-     *     // This parameter is intended for YouTube content partners that own and manage
-     *     // many different YouTube channels. It allows content owners to authenticate
-     *     // once and get access to all their video and channel data, without having to
-     *     // provide authentication credentials for each individual channel. The CMS
-     *     // account that the user authenticates with must be linked to the specified
-     *     // YouTube content owner.
+     *     // *Note:* This parameter is intended exclusively for YouTube content partners. The *onBehalfOfContentOwner* parameter indicates that the request's authorization credentials identify a YouTube CMS user who is acting on behalf of the content owner specified in the parameter value. This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and get access to all their video and channel data, without having to provide authentication credentials for each individual channel. The CMS account that the user authenticates with must be linked to the specified YouTube content owner.
      *     onBehalfOfContentOwner: 'placeholder-value',
-     *     // The <code><strong>part</strong></code> parameter serves two purposes in
-     *     // this operation. It identifies the properties that the write operation will
-     *     // set as well as the properties that the API response will
-     *     // include.<br/><br/>Note that this method will override the existing values
-     *     // for all of the mutable properties that are contained in any parts that the
-     *     // parameter value specifies. For example, a playlist item can specify a start
-     *     // time and end time, which identify the times portion of the video that
-     *     // should play when users watch the video in the playlist. If your request is
-     *     // updating a playlist item that sets these values, and the
-     *     // request's <code>part</code> parameter value includes the
-     *     // <code>contentDetails</code> part, the playlist item's start and end times
-     *     // will be updated to whatever value the request body specifies. If the
-     *     // request body does not specify values, the existing start and end times will
-     *     // be removed and replaced with the default settings.
+     *     // The *part* parameter serves two purposes in this operation. It identifies the properties that the write operation will set as well as the properties that the API response will include. Note that this method will override the existing values for all of the mutable properties that are contained in any parts that the parameter value specifies. For example, a playlist item can specify a start time and end time, which identify the times portion of the video that should play when users watch the video in the playlist. If your request is updating a playlist item that sets these values, and the request's part parameter value includes the contentDetails part, the playlist item's start and end times will be updated to whatever value the request body specifies. If the request body does not specify values, the existing start and end times will be removed and replaced with the default settings.
      *     part: 'placeholder-value',
      *
      *     // Request body metadata
@@ -13857,16 +12531,12 @@ export namespace youtube_v3 {
      *   throw e;
      * });
      *
-     * @alias youtube.playlistItems.update
-     * @memberOf! ()
+     * ```
      *
-     * @param {object} params Parameters for request
-     * @param {string=} params.onBehalfOfContentOwner <strong>Note:</strong> This parameter is intended exclusively for YouTube content partners.<br><br>The <code><strong>onBehalfOfContentOwner</strong></code> parameter indicates that the request's authorization credentials identify a YouTube CMS user who is acting on behalf of the content owner specified in the parameter value. This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and get access to all their video and channel data, without having to provide authentication credentials for each individual channel. The CMS account that the user authenticates with must be linked to the specified YouTube content owner.
-     * @param {string} params.part The <code><strong>part</strong></code> parameter serves two purposes in this operation. It identifies the properties that the write operation will set as well as the properties that the API response will include.<br/><br/>Note that this method will override the existing values for all of the mutable properties that are contained in any parts that the parameter value specifies. For example, a playlist item can specify a start time and end time, which identify the times portion of the video that should play when users watch the video in the playlist. If your request is updating a playlist item that sets these values, and the request's <code>part</code> parameter value includes the <code>contentDetails</code> part, the playlist item's start and end times will be updated to whatever value the request body specifies. If the request body does not specify values, the existing start and end times will be removed and replaced with the default settings.
-     * @param {().PlaylistItem} params.requestBody Request body data
-     * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-     * @param {callback} callback The callback that handles the response.
-     * @return {object} Request object
+     * @param params - Parameters for request
+     * @param options - Optionally override request options, such as `url`, `method`, and `encoding`.
+     * @param callback - Optional callback that handles the response.
+     * @returns A promise if used with async/await, or void if used with a callback.
      */
     update(
       params: Params$Resource$Playlistitems$Update,
@@ -13920,7 +12590,7 @@ export namespace youtube_v3 {
         options = {};
       }
 
-      const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+      const rootUrl = options.rootUrl || 'https://youtube.googleapis.com/';
       const parameters = {
         options: Object.assign(
           {
@@ -13940,7 +12610,7 @@ export namespace youtube_v3 {
       if (callback) {
         createAPIRequest<Schema$PlaylistItem>(
           parameters,
-          callback as BodyResponseCallback<{} | void>
+          callback as BodyResponseCallback<unknown>
         );
       } else {
         return createAPIRequest<Schema$PlaylistItem>(parameters);
@@ -13955,18 +12625,18 @@ export namespace youtube_v3 {
      */
     id?: string;
     /**
-     * <strong>Note:</strong> This parameter is intended exclusively for YouTube content partners.<br><br>The <code><strong>onBehalfOfContentOwner</strong></code> parameter indicates that the request's authorization credentials identify a YouTube CMS user who is acting on behalf of the content owner specified in the parameter value. This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and get access to all their video and channel data, without having to provide authentication credentials for each individual channel. The CMS account that the user authenticates with must be linked to the specified YouTube content owner.
+     * *Note:* This parameter is intended exclusively for YouTube content partners. The *onBehalfOfContentOwner* parameter indicates that the request's authorization credentials identify a YouTube CMS user who is acting on behalf of the content owner specified in the parameter value. This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and get access to all their video and channel data, without having to provide authentication credentials for each individual channel. The CMS account that the user authenticates with must be linked to the specified YouTube content owner.
      */
     onBehalfOfContentOwner?: string;
   }
   export interface Params$Resource$Playlistitems$Insert
     extends StandardParameters {
     /**
-     * <strong>Note:</strong> This parameter is intended exclusively for YouTube content partners.<br><br>The <code><strong>onBehalfOfContentOwner</strong></code> parameter indicates that the request's authorization credentials identify a YouTube CMS user who is acting on behalf of the content owner specified in the parameter value. This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and get access to all their video and channel data, without having to provide authentication credentials for each individual channel. The CMS account that the user authenticates with must be linked to the specified YouTube content owner.
+     * *Note:* This parameter is intended exclusively for YouTube content partners. The *onBehalfOfContentOwner* parameter indicates that the request's authorization credentials identify a YouTube CMS user who is acting on behalf of the content owner specified in the parameter value. This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and get access to all their video and channel data, without having to provide authentication credentials for each individual channel. The CMS account that the user authenticates with must be linked to the specified YouTube content owner.
      */
     onBehalfOfContentOwner?: string;
     /**
-     * The <code><strong>part</strong></code> parameter serves two purposes in this operation. It identifies the properties that the write operation will set as well as the properties that the API response will include.
+     * The *part* parameter serves two purposes in this operation. It identifies the properties that the write operation will set as well as the properties that the API response will include.
      */
     part?: string[];
 
@@ -13982,19 +12652,19 @@ export namespace youtube_v3 {
      */
     id?: string[];
     /**
-     * The <code><strong>maxResults</strong></code> parameter specifies the maximum number of items that should be returned in the result set.
+     * The *maxResults* parameter specifies the maximum number of items that should be returned in the result set.
      */
     maxResults?: number;
     /**
-     * <strong>Note:</strong> This parameter is intended exclusively for YouTube content partners.<br><br>The <code><strong>onBehalfOfContentOwner</strong></code> parameter indicates that the request's authorization credentials identify a YouTube CMS user who is acting on behalf of the content owner specified in the parameter value. This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and get access to all their video and channel data, without having to provide authentication credentials for each individual channel. The CMS account that the user authenticates with must be linked to the specified YouTube content owner.
+     * *Note:* This parameter is intended exclusively for YouTube content partners. The *onBehalfOfContentOwner* parameter indicates that the request's authorization credentials identify a YouTube CMS user who is acting on behalf of the content owner specified in the parameter value. This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and get access to all their video and channel data, without having to provide authentication credentials for each individual channel. The CMS account that the user authenticates with must be linked to the specified YouTube content owner.
      */
     onBehalfOfContentOwner?: string;
     /**
-     * The <code><strong>pageToken</strong></code> parameter identifies a specific page in the result set that should be returned. In an API response, the <code>nextPageToken</code> and <code>prevPageToken</code> properties identify other pages that could be retrieved.
+     * The *pageToken* parameter identifies a specific page in the result set that should be returned. In an API response, the nextPageToken and prevPageToken properties identify other pages that could be retrieved.
      */
     pageToken?: string;
     /**
-     * The <code><strong>part</strong></code> parameter specifies a comma-separated list of one or more <code>playlistItem</code> resource properties that the API response will include.<br><br>If the parameter identifies a property that contains child properties, the child properties will be included in the response. For example, in a <code>playlistItem</code> resource, the <code>snippet</code> property contains numerous fields, including the <code>title</code>, <code>description</code>, <code>position</code>, and <code>resourceId</code> properties. As such, if you set <code><strong>part=snippet</strong></code>, the API response will contain all of those properties.
+     * The *part* parameter specifies a comma-separated list of one or more playlistItem resource properties that the API response will include. If the parameter identifies a property that contains child properties, the child properties will be included in the response. For example, in a playlistItem resource, the snippet property contains numerous fields, including the title, description, position, and resourceId properties. As such, if you set *part=snippet*, the API response will contain all of those properties.
      */
     part?: string[];
     /**
@@ -14009,11 +12679,11 @@ export namespace youtube_v3 {
   export interface Params$Resource$Playlistitems$Update
     extends StandardParameters {
     /**
-     * <strong>Note:</strong> This parameter is intended exclusively for YouTube content partners.<br><br>The <code><strong>onBehalfOfContentOwner</strong></code> parameter indicates that the request's authorization credentials identify a YouTube CMS user who is acting on behalf of the content owner specified in the parameter value. This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and get access to all their video and channel data, without having to provide authentication credentials for each individual channel. The CMS account that the user authenticates with must be linked to the specified YouTube content owner.
+     * *Note:* This parameter is intended exclusively for YouTube content partners. The *onBehalfOfContentOwner* parameter indicates that the request's authorization credentials identify a YouTube CMS user who is acting on behalf of the content owner specified in the parameter value. This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and get access to all their video and channel data, without having to provide authentication credentials for each individual channel. The CMS account that the user authenticates with must be linked to the specified YouTube content owner.
      */
     onBehalfOfContentOwner?: string;
     /**
-     * The <code><strong>part</strong></code> parameter serves two purposes in this operation. It identifies the properties that the write operation will set as well as the properties that the API response will include.<br/><br/>Note that this method will override the existing values for all of the mutable properties that are contained in any parts that the parameter value specifies. For example, a playlist item can specify a start time and end time, which identify the times portion of the video that should play when users watch the video in the playlist. If your request is updating a playlist item that sets these values, and the request's <code>part</code> parameter value includes the <code>contentDetails</code> part, the playlist item's start and end times will be updated to whatever value the request body specifies. If the request body does not specify values, the existing start and end times will be removed and replaced with the default settings.
+     * The *part* parameter serves two purposes in this operation. It identifies the properties that the write operation will set as well as the properties that the API response will include. Note that this method will override the existing values for all of the mutable properties that are contained in any parts that the parameter value specifies. For example, a playlist item can specify a start time and end time, which identify the times portion of the video that should play when users watch the video in the playlist. If your request is updating a playlist item that sets these values, and the request's part parameter value includes the contentDetails part, the playlist item's start and end times will be updated to whatever value the request body specifies. If the request body does not specify values, the existing start and end times will be removed and replaced with the default settings.
      */
     part?: string[];
 
@@ -14030,9 +12700,9 @@ export namespace youtube_v3 {
     }
 
     /**
-     * youtube.playlists.delete
-     * @desc Deletes a resource.
+     * Deletes a resource.
      * @example
+     * ```js
      * // Before running the sample:
      * // - Enable the API at:
      * //   https://console.developers.google.com/apis/api/youtube.googleapis.com
@@ -14061,18 +12731,7 @@ export namespace youtube_v3 {
      *   // Do the magic
      *   const res = await youtube.playlists.delete({
      *     id: 'placeholder-value',
-     *     // <strong>Note:</strong> This parameter is intended exclusively for YouTube
-     *     // content partners.<br><br>The
-     *     // <code><strong>onBehalfOfContentOwner</strong></code> parameter indicates
-     *     // that the
-     *     // request's authorization credentials identify a YouTube CMS user who is
-     *     // acting on behalf of the content owner specified in the parameter value.
-     *     // This parameter is intended for YouTube content partners that own and manage
-     *     // many different YouTube channels. It allows content owners to authenticate
-     *     // once and get access to all their video and channel data, without having to
-     *     // provide authentication credentials for each individual channel. The CMS
-     *     // account that the user authenticates with must be linked to the specified
-     *     // YouTube content owner.
+     *     // *Note:* This parameter is intended exclusively for YouTube content partners. The *onBehalfOfContentOwner* parameter indicates that the request's authorization credentials identify a YouTube CMS user who is acting on behalf of the content owner specified in the parameter value. This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and get access to all their video and channel data, without having to provide authentication credentials for each individual channel. The CMS account that the user authenticates with must be linked to the specified YouTube content owner.
      *     onBehalfOfContentOwner: 'placeholder-value',
      *   });
      *   console.log(res.data);
@@ -14083,15 +12742,12 @@ export namespace youtube_v3 {
      *   throw e;
      * });
      *
-     * @alias youtube.playlists.delete
-     * @memberOf! ()
+     * ```
      *
-     * @param {object} params Parameters for request
-     * @param {string} params.id
-     * @param {string=} params.onBehalfOfContentOwner <strong>Note:</strong> This parameter is intended exclusively for YouTube content partners.<br><br>The <code><strong>onBehalfOfContentOwner</strong></code> parameter indicates that the request's authorization credentials identify a YouTube CMS user who is acting on behalf of the content owner specified in the parameter value. This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and get access to all their video and channel data, without having to provide authentication credentials for each individual channel. The CMS account that the user authenticates with must be linked to the specified YouTube content owner.
-     * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-     * @param {callback} callback The callback that handles the response.
-     * @return {object} Request object
+     * @param params - Parameters for request
+     * @param options - Optionally override request options, such as `url`, `method`, and `encoding`.
+     * @param callback - Optional callback that handles the response.
+     * @returns A promise if used with async/await, or void if used with a callback.
      */
     delete(
       params: Params$Resource$Playlists$Delete,
@@ -14142,7 +12798,7 @@ export namespace youtube_v3 {
         options = {};
       }
 
-      const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+      const rootUrl = options.rootUrl || 'https://youtube.googleapis.com/';
       const parameters = {
         options: Object.assign(
           {
@@ -14162,7 +12818,7 @@ export namespace youtube_v3 {
       if (callback) {
         createAPIRequest<void>(
           parameters,
-          callback as BodyResponseCallback<{} | void>
+          callback as BodyResponseCallback<unknown>
         );
       } else {
         return createAPIRequest<void>(parameters);
@@ -14170,9 +12826,9 @@ export namespace youtube_v3 {
     }
 
     /**
-     * youtube.playlists.insert
-     * @desc Inserts a new resource into this collection.
+     * Inserts a new resource into this collection.
      * @example
+     * ```js
      * // Before running the sample:
      * // - Enable the API at:
      * //   https://console.developers.google.com/apis/api/youtube.googleapis.com
@@ -14200,42 +12856,11 @@ export namespace youtube_v3 {
      *
      *   // Do the magic
      *   const res = await youtube.playlists.insert({
-     *     // <strong>Note:</strong> This parameter is intended exclusively for YouTube
-     *     // content partners.<br><br>The
-     *     // <code><strong>onBehalfOfContentOwner</strong></code> parameter indicates
-     *     // that the
-     *     // request's authorization credentials identify a YouTube CMS user who is
-     *     // acting on behalf of the content owner specified in the parameter value.
-     *     // This parameter is intended for YouTube content partners that own and manage
-     *     // many different YouTube channels. It allows content owners to authenticate
-     *     // once and get access to all their video and channel data, without having to
-     *     // provide authentication credentials for each individual channel. The CMS
-     *     // account that the user authenticates with must be linked to the specified
-     *     // YouTube content owner.
+     *     // *Note:* This parameter is intended exclusively for YouTube content partners. The *onBehalfOfContentOwner* parameter indicates that the request's authorization credentials identify a YouTube CMS user who is acting on behalf of the content owner specified in the parameter value. This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and get access to all their video and channel data, without having to provide authentication credentials for each individual channel. The CMS account that the user authenticates with must be linked to the specified YouTube content owner.
      *     onBehalfOfContentOwner: 'placeholder-value',
-     *     // This parameter can only be used in a properly <a
-     *     // href="/youtube/v3/guides/authentication">authorized request</a>.
-     *     // <strong>Note:</strong> This parameter is intended exclusively for YouTube
-     *     // content partners.<br><br>The
-     *     // <code><strong>onBehalfOfContentOwnerChannel</strong></code> parameter
-     *     // specifies the YouTube channel ID of the channel to which a video is being
-     *     // added. This parameter is required when a request specifies a value for the
-     *     // <code>onBehalfOfContentOwner</code> parameter, and it can only be used in
-     *     // conjunction with that parameter. In addition, the request must be
-     *     // authorized using a CMS account that is linked to the content owner that the
-     *     // <code>onBehalfOfContentOwner</code> parameter specifies. Finally, the
-     *     // channel that the <code>onBehalfOfContentOwnerChannel</code> parameter value
-     *     // specifies must be linked to the content owner that the
-     *     // <code>onBehalfOfContentOwner</code> parameter specifies.<br><br>This
-     *     // parameter is intended for YouTube content partners that own and manage many
-     *     // different YouTube channels. It allows content owners to authenticate once
-     *     // and perform actions on behalf of the channel specified in the parameter
-     *     // value, without having to provide authentication credentials for each
-     *     // separate channel.
+     *     // This parameter can only be used in a properly authorized request. *Note:* This parameter is intended exclusively for YouTube content partners. The *onBehalfOfContentOwnerChannel* parameter specifies the YouTube channel ID of the channel to which a video is being added. This parameter is required when a request specifies a value for the onBehalfOfContentOwner parameter, and it can only be used in conjunction with that parameter. In addition, the request must be authorized using a CMS account that is linked to the content owner that the onBehalfOfContentOwner parameter specifies. Finally, the channel that the onBehalfOfContentOwnerChannel parameter value specifies must be linked to the content owner that the onBehalfOfContentOwner parameter specifies. This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and perform actions on behalf of the channel specified in the parameter value, without having to provide authentication credentials for each separate channel.
      *     onBehalfOfContentOwnerChannel: 'placeholder-value',
-     *     // The <code><strong>part</strong></code> parameter serves two purposes in
-     *     // this operation. It identifies the properties that the write operation will
-     *     // set as well as the properties that the API response will include.
+     *     // The *part* parameter serves two purposes in this operation. It identifies the properties that the write operation will set as well as the properties that the API response will include.
      *     part: 'placeholder-value',
      *
      *     // Request body metadata
@@ -14273,17 +12898,12 @@ export namespace youtube_v3 {
      *   throw e;
      * });
      *
-     * @alias youtube.playlists.insert
-     * @memberOf! ()
+     * ```
      *
-     * @param {object} params Parameters for request
-     * @param {string=} params.onBehalfOfContentOwner <strong>Note:</strong> This parameter is intended exclusively for YouTube content partners.<br><br>The <code><strong>onBehalfOfContentOwner</strong></code> parameter indicates that the request's authorization credentials identify a YouTube CMS user who is acting on behalf of the content owner specified in the parameter value. This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and get access to all their video and channel data, without having to provide authentication credentials for each individual channel. The CMS account that the user authenticates with must be linked to the specified YouTube content owner.
-     * @param {string=} params.onBehalfOfContentOwnerChannel This parameter can only be used in a properly <a href="/youtube/v3/guides/authentication">authorized request</a>. <strong>Note:</strong> This parameter is intended exclusively for YouTube content partners.<br><br>The <code><strong>onBehalfOfContentOwnerChannel</strong></code> parameter specifies the YouTube channel ID of the channel to which a video is being added. This parameter is required when a request specifies a value for the <code>onBehalfOfContentOwner</code> parameter, and it can only be used in conjunction with that parameter. In addition, the request must be authorized using a CMS account that is linked to the content owner that the <code>onBehalfOfContentOwner</code> parameter specifies. Finally, the channel that the <code>onBehalfOfContentOwnerChannel</code> parameter value specifies must be linked to the content owner that the <code>onBehalfOfContentOwner</code> parameter specifies.<br><br>This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and perform actions on behalf of the channel specified in the parameter value, without having to provide authentication credentials for each separate channel.
-     * @param {string} params.part The <code><strong>part</strong></code> parameter serves two purposes in this operation. It identifies the properties that the write operation will set as well as the properties that the API response will include.
-     * @param {().Playlist} params.requestBody Request body data
-     * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-     * @param {callback} callback The callback that handles the response.
-     * @return {object} Request object
+     * @param params - Parameters for request
+     * @param options - Optionally override request options, such as `url`, `method`, and `encoding`.
+     * @param callback - Optional callback that handles the response.
+     * @returns A promise if used with async/await, or void if used with a callback.
      */
     insert(
       params: Params$Resource$Playlists$Insert,
@@ -14336,7 +12956,7 @@ export namespace youtube_v3 {
         options = {};
       }
 
-      const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+      const rootUrl = options.rootUrl || 'https://youtube.googleapis.com/';
       const parameters = {
         options: Object.assign(
           {
@@ -14356,7 +12976,7 @@ export namespace youtube_v3 {
       if (callback) {
         createAPIRequest<Schema$Playlist>(
           parameters,
-          callback as BodyResponseCallback<{} | void>
+          callback as BodyResponseCallback<unknown>
         );
       } else {
         return createAPIRequest<Schema$Playlist>(parameters);
@@ -14364,9 +12984,9 @@ export namespace youtube_v3 {
     }
 
     /**
-     * youtube.playlists.list
-     * @desc Retrieves a list of resources, possibly filtered.
+     * Retrieves a list of resources, possibly filtered.
      * @example
+     * ```js
      * // Before running the sample:
      * // - Enable the API at:
      * //   https://console.developers.google.com/apis/api/youtube.googleapis.com
@@ -14401,59 +13021,17 @@ export namespace youtube_v3 {
      *     hl: 'placeholder-value',
      *     // Return the playlists with the given IDs for Stubby or Apiary.
      *     id: 'placeholder-value',
-     *     // The <code><strong>maxResults</strong></code> parameter specifies the
-     *     // maximum number of items that should be returned in the result set.
+     *     // The *maxResults* parameter specifies the maximum number of items that should be returned in the result set.
      *     maxResults: 'placeholder-value',
      *     // Return the playlists owned by the authenticated user.
      *     mine: 'placeholder-value',
-     *     // <strong>Note:</strong> This parameter is intended exclusively for YouTube
-     *     // content partners.<br><br>The
-     *     // <code><strong>onBehalfOfContentOwner</strong></code> parameter indicates
-     *     // that the
-     *     // request's authorization credentials identify a YouTube CMS user who is
-     *     // acting on behalf of the content owner specified in the parameter value.
-     *     // This parameter is intended for YouTube content partners that own and manage
-     *     // many different YouTube channels. It allows content owners to authenticate
-     *     // once and get access to all their video and channel data, without having to
-     *     // provide authentication credentials for each individual channel. The CMS
-     *     // account that the user authenticates with must be linked to the specified
-     *     // YouTube content owner.
+     *     // *Note:* This parameter is intended exclusively for YouTube content partners. The *onBehalfOfContentOwner* parameter indicates that the request's authorization credentials identify a YouTube CMS user who is acting on behalf of the content owner specified in the parameter value. This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and get access to all their video and channel data, without having to provide authentication credentials for each individual channel. The CMS account that the user authenticates with must be linked to the specified YouTube content owner.
      *     onBehalfOfContentOwner: 'placeholder-value',
-     *     // This parameter can only be used in a properly <a
-     *     // href="/youtube/v3/guides/authentication">authorized request</a>.
-     *     // <strong>Note:</strong> This parameter is intended exclusively for YouTube
-     *     // content partners.<br><br>The
-     *     // <code><strong>onBehalfOfContentOwnerChannel</strong></code> parameter
-     *     // specifies the YouTube channel ID of the channel to which a video is being
-     *     // added. This parameter is required when a request specifies a value for the
-     *     // <code>onBehalfOfContentOwner</code> parameter, and it can only be used in
-     *     // conjunction with that parameter. In addition, the request must be
-     *     // authorized using a CMS account that is linked to the content owner that the
-     *     // <code>onBehalfOfContentOwner</code> parameter specifies. Finally, the
-     *     // channel that the <code>onBehalfOfContentOwnerChannel</code> parameter value
-     *     // specifies must be linked to the content owner that the
-     *     // <code>onBehalfOfContentOwner</code> parameter specifies.<br><br>This
-     *     // parameter is intended for YouTube content partners that own and manage many
-     *     // different YouTube channels. It allows content owners to authenticate once
-     *     // and perform actions on behalf of the channel specified in the parameter
-     *     // value, without having to provide authentication credentials for each
-     *     // separate channel.
+     *     // This parameter can only be used in a properly authorized request. *Note:* This parameter is intended exclusively for YouTube content partners. The *onBehalfOfContentOwnerChannel* parameter specifies the YouTube channel ID of the channel to which a video is being added. This parameter is required when a request specifies a value for the onBehalfOfContentOwner parameter, and it can only be used in conjunction with that parameter. In addition, the request must be authorized using a CMS account that is linked to the content owner that the onBehalfOfContentOwner parameter specifies. Finally, the channel that the onBehalfOfContentOwnerChannel parameter value specifies must be linked to the content owner that the onBehalfOfContentOwner parameter specifies. This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and perform actions on behalf of the channel specified in the parameter value, without having to provide authentication credentials for each separate channel.
      *     onBehalfOfContentOwnerChannel: 'placeholder-value',
-     *     // The <code><strong>pageToken</strong></code> parameter identifies a specific
-     *     // page in the result set that should be returned. In an API response, the
-     *     // <code>nextPageToken</code> and <code>prevPageToken</code> properties
-     *     // identify other pages that could be retrieved.
+     *     // The *pageToken* parameter identifies a specific page in the result set that should be returned. In an API response, the nextPageToken and prevPageToken properties identify other pages that could be retrieved.
      *     pageToken: 'placeholder-value',
-     *     // The <code><strong>part</strong></code> parameter specifies a
-     *     // comma-separated list of one or more <code>playlist</code> resource
-     *     // properties that the API response will include.<br><br>If the parameter
-     *     // identifies a property that contains child properties, the child properties
-     *     // will be included in the response. For example, in a <code>playlist</code>
-     *     // resource, the <code>snippet</code> property contains properties like
-     *     // <code>author</code>, <code>title</code>, <code>description</code>,
-     *     // <code>tags</code>, and <code>timeCreated</code>. As such, if you set
-     *     // <code><strong>part=snippet</strong></code>, the API response will contain
-     *     // all of those properties.
+     *     // The *part* parameter specifies a comma-separated list of one or more playlist resource properties that the API response will include. If the parameter identifies a property that contains child properties, the child properties will be included in the response. For example, in a playlist resource, the snippet property contains properties like author, title, description, tags, and timeCreated. As such, if you set *part=snippet*, the API response will contain all of those properties.
      *     part: 'placeholder-value',
      *   });
      *   console.log(res.data);
@@ -14477,22 +13055,12 @@ export namespace youtube_v3 {
      *   throw e;
      * });
      *
-     * @alias youtube.playlists.list
-     * @memberOf! ()
+     * ```
      *
-     * @param {object} params Parameters for request
-     * @param {string=} params.channelId Return the playlists owned by the specified channel ID.
-     * @param {string=} params.hl Returen content in specified language
-     * @param {string=} params.id Return the playlists with the given IDs for Stubby or Apiary.
-     * @param {integer=} params.maxResults The <code><strong>maxResults</strong></code> parameter specifies the maximum number of items that should be returned in the result set.
-     * @param {boolean=} params.mine Return the playlists owned by the authenticated user.
-     * @param {string=} params.onBehalfOfContentOwner <strong>Note:</strong> This parameter is intended exclusively for YouTube content partners.<br><br>The <code><strong>onBehalfOfContentOwner</strong></code> parameter indicates that the request's authorization credentials identify a YouTube CMS user who is acting on behalf of the content owner specified in the parameter value. This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and get access to all their video and channel data, without having to provide authentication credentials for each individual channel. The CMS account that the user authenticates with must be linked to the specified YouTube content owner.
-     * @param {string=} params.onBehalfOfContentOwnerChannel This parameter can only be used in a properly <a href="/youtube/v3/guides/authentication">authorized request</a>. <strong>Note:</strong> This parameter is intended exclusively for YouTube content partners.<br><br>The <code><strong>onBehalfOfContentOwnerChannel</strong></code> parameter specifies the YouTube channel ID of the channel to which a video is being added. This parameter is required when a request specifies a value for the <code>onBehalfOfContentOwner</code> parameter, and it can only be used in conjunction with that parameter. In addition, the request must be authorized using a CMS account that is linked to the content owner that the <code>onBehalfOfContentOwner</code> parameter specifies. Finally, the channel that the <code>onBehalfOfContentOwnerChannel</code> parameter value specifies must be linked to the content owner that the <code>onBehalfOfContentOwner</code> parameter specifies.<br><br>This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and perform actions on behalf of the channel specified in the parameter value, without having to provide authentication credentials for each separate channel.
-     * @param {string=} params.pageToken The <code><strong>pageToken</strong></code> parameter identifies a specific page in the result set that should be returned. In an API response, the <code>nextPageToken</code> and <code>prevPageToken</code> properties identify other pages that could be retrieved.
-     * @param {string} params.part The <code><strong>part</strong></code> parameter specifies a comma-separated list of one or more <code>playlist</code> resource properties that the API response will include.<br><br>If the parameter identifies a property that contains child properties, the child properties will be included in the response. For example, in a <code>playlist</code> resource, the <code>snippet</code> property contains properties like <code>author</code>, <code>title</code>, <code>description</code>, <code>tags</code>, and <code>timeCreated</code>. As such, if you set <code><strong>part=snippet</strong></code>, the API response will contain all of those properties.
-     * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-     * @param {callback} callback The callback that handles the response.
-     * @return {object} Request object
+     * @param params - Parameters for request
+     * @param options - Optionally override request options, such as `url`, `method`, and `encoding`.
+     * @param callback - Optional callback that handles the response.
+     * @returns A promise if used with async/await, or void if used with a callback.
      */
     list(
       params: Params$Resource$Playlists$List,
@@ -14550,7 +13118,7 @@ export namespace youtube_v3 {
         options = {};
       }
 
-      const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+      const rootUrl = options.rootUrl || 'https://youtube.googleapis.com/';
       const parameters = {
         options: Object.assign(
           {
@@ -14570,7 +13138,7 @@ export namespace youtube_v3 {
       if (callback) {
         createAPIRequest<Schema$PlaylistListResponse>(
           parameters,
-          callback as BodyResponseCallback<{} | void>
+          callback as BodyResponseCallback<unknown>
         );
       } else {
         return createAPIRequest<Schema$PlaylistListResponse>(parameters);
@@ -14578,9 +13146,9 @@ export namespace youtube_v3 {
     }
 
     /**
-     * youtube.playlists.update
-     * @desc Updates an existing resource.
+     * Updates an existing resource.
      * @example
+     * ```js
      * // Before running the sample:
      * // - Enable the API at:
      * //   https://console.developers.google.com/apis/api/youtube.googleapis.com
@@ -14608,29 +13176,9 @@ export namespace youtube_v3 {
      *
      *   // Do the magic
      *   const res = await youtube.playlists.update({
-     *     // <strong>Note:</strong> This parameter is intended exclusively for YouTube
-     *     // content partners.<br><br>The
-     *     // <code><strong>onBehalfOfContentOwner</strong></code> parameter indicates
-     *     // that the
-     *     // request's authorization credentials identify a YouTube CMS user who is
-     *     // acting on behalf of the content owner specified in the parameter value.
-     *     // This parameter is intended for YouTube content partners that own and manage
-     *     // many different YouTube channels. It allows content owners to authenticate
-     *     // once and get access to all their video and channel data, without having to
-     *     // provide authentication credentials for each individual channel. The CMS
-     *     // account that the user authenticates with must be linked to the specified
-     *     // YouTube content owner.
+     *     // *Note:* This parameter is intended exclusively for YouTube content partners. The *onBehalfOfContentOwner* parameter indicates that the request's authorization credentials identify a YouTube CMS user who is acting on behalf of the content owner specified in the parameter value. This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and get access to all their video and channel data, without having to provide authentication credentials for each individual channel. The CMS account that the user authenticates with must be linked to the specified YouTube content owner.
      *     onBehalfOfContentOwner: 'placeholder-value',
-     *     // The <code><strong>part</strong></code> parameter serves two purposes in
-     *     // this operation. It identifies the properties that the write operation will
-     *     // set as well as the properties that the API response will
-     *     // include.<br/><br/>Note that this method will override the existing values
-     *     // for mutable properties that are contained in any parts that the request
-     *     // body specifies. For example, a
-     *     // playlist's description is contained in the <code>snippet</code> part, which
-     *     // must be included in the request body. If the request does not specify a
-     *     // value for the <code>snippet.description</code> property, the playlist's
-     *     // existing description will be deleted.
+     *     // The *part* parameter serves two purposes in this operation. It identifies the properties that the write operation will set as well as the properties that the API response will include. Note that this method will override the existing values for mutable properties that are contained in any parts that the request body specifies. For example, a playlist's description is contained in the snippet part, which must be included in the request body. If the request does not specify a value for the snippet.description property, the playlist's existing description will be deleted.
      *     part: 'placeholder-value',
      *
      *     // Request body metadata
@@ -14668,16 +13216,12 @@ export namespace youtube_v3 {
      *   throw e;
      * });
      *
-     * @alias youtube.playlists.update
-     * @memberOf! ()
+     * ```
      *
-     * @param {object} params Parameters for request
-     * @param {string=} params.onBehalfOfContentOwner <strong>Note:</strong> This parameter is intended exclusively for YouTube content partners.<br><br>The <code><strong>onBehalfOfContentOwner</strong></code> parameter indicates that the request's authorization credentials identify a YouTube CMS user who is acting on behalf of the content owner specified in the parameter value. This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and get access to all their video and channel data, without having to provide authentication credentials for each individual channel. The CMS account that the user authenticates with must be linked to the specified YouTube content owner.
-     * @param {string} params.part The <code><strong>part</strong></code> parameter serves two purposes in this operation. It identifies the properties that the write operation will set as well as the properties that the API response will include.<br/><br/>Note that this method will override the existing values for mutable properties that are contained in any parts that the request body specifies. For example, a playlist's description is contained in the <code>snippet</code> part, which must be included in the request body. If the request does not specify a value for the <code>snippet.description</code> property, the playlist's existing description will be deleted.
-     * @param {().Playlist} params.requestBody Request body data
-     * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-     * @param {callback} callback The callback that handles the response.
-     * @return {object} Request object
+     * @param params - Parameters for request
+     * @param options - Optionally override request options, such as `url`, `method`, and `encoding`.
+     * @param callback - Optional callback that handles the response.
+     * @returns A promise if used with async/await, or void if used with a callback.
      */
     update(
       params: Params$Resource$Playlists$Update,
@@ -14730,7 +13274,7 @@ export namespace youtube_v3 {
         options = {};
       }
 
-      const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+      const rootUrl = options.rootUrl || 'https://youtube.googleapis.com/';
       const parameters = {
         options: Object.assign(
           {
@@ -14750,7 +13294,7 @@ export namespace youtube_v3 {
       if (callback) {
         createAPIRequest<Schema$Playlist>(
           parameters,
-          callback as BodyResponseCallback<{} | void>
+          callback as BodyResponseCallback<unknown>
         );
       } else {
         return createAPIRequest<Schema$Playlist>(parameters);
@@ -14764,21 +13308,21 @@ export namespace youtube_v3 {
      */
     id?: string;
     /**
-     * <strong>Note:</strong> This parameter is intended exclusively for YouTube content partners.<br><br>The <code><strong>onBehalfOfContentOwner</strong></code> parameter indicates that the request's authorization credentials identify a YouTube CMS user who is acting on behalf of the content owner specified in the parameter value. This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and get access to all their video and channel data, without having to provide authentication credentials for each individual channel. The CMS account that the user authenticates with must be linked to the specified YouTube content owner.
+     * *Note:* This parameter is intended exclusively for YouTube content partners. The *onBehalfOfContentOwner* parameter indicates that the request's authorization credentials identify a YouTube CMS user who is acting on behalf of the content owner specified in the parameter value. This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and get access to all their video and channel data, without having to provide authentication credentials for each individual channel. The CMS account that the user authenticates with must be linked to the specified YouTube content owner.
      */
     onBehalfOfContentOwner?: string;
   }
   export interface Params$Resource$Playlists$Insert extends StandardParameters {
     /**
-     * <strong>Note:</strong> This parameter is intended exclusively for YouTube content partners.<br><br>The <code><strong>onBehalfOfContentOwner</strong></code> parameter indicates that the request's authorization credentials identify a YouTube CMS user who is acting on behalf of the content owner specified in the parameter value. This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and get access to all their video and channel data, without having to provide authentication credentials for each individual channel. The CMS account that the user authenticates with must be linked to the specified YouTube content owner.
+     * *Note:* This parameter is intended exclusively for YouTube content partners. The *onBehalfOfContentOwner* parameter indicates that the request's authorization credentials identify a YouTube CMS user who is acting on behalf of the content owner specified in the parameter value. This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and get access to all their video and channel data, without having to provide authentication credentials for each individual channel. The CMS account that the user authenticates with must be linked to the specified YouTube content owner.
      */
     onBehalfOfContentOwner?: string;
     /**
-     * This parameter can only be used in a properly <a href="/youtube/v3/guides/authentication">authorized request</a>. <strong>Note:</strong> This parameter is intended exclusively for YouTube content partners.<br><br>The <code><strong>onBehalfOfContentOwnerChannel</strong></code> parameter specifies the YouTube channel ID of the channel to which a video is being added. This parameter is required when a request specifies a value for the <code>onBehalfOfContentOwner</code> parameter, and it can only be used in conjunction with that parameter. In addition, the request must be authorized using a CMS account that is linked to the content owner that the <code>onBehalfOfContentOwner</code> parameter specifies. Finally, the channel that the <code>onBehalfOfContentOwnerChannel</code> parameter value specifies must be linked to the content owner that the <code>onBehalfOfContentOwner</code> parameter specifies.<br><br>This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and perform actions on behalf of the channel specified in the parameter value, without having to provide authentication credentials for each separate channel.
+     * This parameter can only be used in a properly authorized request. *Note:* This parameter is intended exclusively for YouTube content partners. The *onBehalfOfContentOwnerChannel* parameter specifies the YouTube channel ID of the channel to which a video is being added. This parameter is required when a request specifies a value for the onBehalfOfContentOwner parameter, and it can only be used in conjunction with that parameter. In addition, the request must be authorized using a CMS account that is linked to the content owner that the onBehalfOfContentOwner parameter specifies. Finally, the channel that the onBehalfOfContentOwnerChannel parameter value specifies must be linked to the content owner that the onBehalfOfContentOwner parameter specifies. This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and perform actions on behalf of the channel specified in the parameter value, without having to provide authentication credentials for each separate channel.
      */
     onBehalfOfContentOwnerChannel?: string;
     /**
-     * The <code><strong>part</strong></code> parameter serves two purposes in this operation. It identifies the properties that the write operation will set as well as the properties that the API response will include.
+     * The *part* parameter serves two purposes in this operation. It identifies the properties that the write operation will set as well as the properties that the API response will include.
      */
     part?: string[];
 
@@ -14801,7 +13345,7 @@ export namespace youtube_v3 {
      */
     id?: string[];
     /**
-     * The <code><strong>maxResults</strong></code> parameter specifies the maximum number of items that should be returned in the result set.
+     * The *maxResults* parameter specifies the maximum number of items that should be returned in the result set.
      */
     maxResults?: number;
     /**
@@ -14809,29 +13353,29 @@ export namespace youtube_v3 {
      */
     mine?: boolean;
     /**
-     * <strong>Note:</strong> This parameter is intended exclusively for YouTube content partners.<br><br>The <code><strong>onBehalfOfContentOwner</strong></code> parameter indicates that the request's authorization credentials identify a YouTube CMS user who is acting on behalf of the content owner specified in the parameter value. This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and get access to all their video and channel data, without having to provide authentication credentials for each individual channel. The CMS account that the user authenticates with must be linked to the specified YouTube content owner.
+     * *Note:* This parameter is intended exclusively for YouTube content partners. The *onBehalfOfContentOwner* parameter indicates that the request's authorization credentials identify a YouTube CMS user who is acting on behalf of the content owner specified in the parameter value. This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and get access to all their video and channel data, without having to provide authentication credentials for each individual channel. The CMS account that the user authenticates with must be linked to the specified YouTube content owner.
      */
     onBehalfOfContentOwner?: string;
     /**
-     * This parameter can only be used in a properly <a href="/youtube/v3/guides/authentication">authorized request</a>. <strong>Note:</strong> This parameter is intended exclusively for YouTube content partners.<br><br>The <code><strong>onBehalfOfContentOwnerChannel</strong></code> parameter specifies the YouTube channel ID of the channel to which a video is being added. This parameter is required when a request specifies a value for the <code>onBehalfOfContentOwner</code> parameter, and it can only be used in conjunction with that parameter. In addition, the request must be authorized using a CMS account that is linked to the content owner that the <code>onBehalfOfContentOwner</code> parameter specifies. Finally, the channel that the <code>onBehalfOfContentOwnerChannel</code> parameter value specifies must be linked to the content owner that the <code>onBehalfOfContentOwner</code> parameter specifies.<br><br>This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and perform actions on behalf of the channel specified in the parameter value, without having to provide authentication credentials for each separate channel.
+     * This parameter can only be used in a properly authorized request. *Note:* This parameter is intended exclusively for YouTube content partners. The *onBehalfOfContentOwnerChannel* parameter specifies the YouTube channel ID of the channel to which a video is being added. This parameter is required when a request specifies a value for the onBehalfOfContentOwner parameter, and it can only be used in conjunction with that parameter. In addition, the request must be authorized using a CMS account that is linked to the content owner that the onBehalfOfContentOwner parameter specifies. Finally, the channel that the onBehalfOfContentOwnerChannel parameter value specifies must be linked to the content owner that the onBehalfOfContentOwner parameter specifies. This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and perform actions on behalf of the channel specified in the parameter value, without having to provide authentication credentials for each separate channel.
      */
     onBehalfOfContentOwnerChannel?: string;
     /**
-     * The <code><strong>pageToken</strong></code> parameter identifies a specific page in the result set that should be returned. In an API response, the <code>nextPageToken</code> and <code>prevPageToken</code> properties identify other pages that could be retrieved.
+     * The *pageToken* parameter identifies a specific page in the result set that should be returned. In an API response, the nextPageToken and prevPageToken properties identify other pages that could be retrieved.
      */
     pageToken?: string;
     /**
-     * The <code><strong>part</strong></code> parameter specifies a comma-separated list of one or more <code>playlist</code> resource properties that the API response will include.<br><br>If the parameter identifies a property that contains child properties, the child properties will be included in the response. For example, in a <code>playlist</code> resource, the <code>snippet</code> property contains properties like <code>author</code>, <code>title</code>, <code>description</code>, <code>tags</code>, and <code>timeCreated</code>. As such, if you set <code><strong>part=snippet</strong></code>, the API response will contain all of those properties.
+     * The *part* parameter specifies a comma-separated list of one or more playlist resource properties that the API response will include. If the parameter identifies a property that contains child properties, the child properties will be included in the response. For example, in a playlist resource, the snippet property contains properties like author, title, description, tags, and timeCreated. As such, if you set *part=snippet*, the API response will contain all of those properties.
      */
     part?: string[];
   }
   export interface Params$Resource$Playlists$Update extends StandardParameters {
     /**
-     * <strong>Note:</strong> This parameter is intended exclusively for YouTube content partners.<br><br>The <code><strong>onBehalfOfContentOwner</strong></code> parameter indicates that the request's authorization credentials identify a YouTube CMS user who is acting on behalf of the content owner specified in the parameter value. This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and get access to all their video and channel data, without having to provide authentication credentials for each individual channel. The CMS account that the user authenticates with must be linked to the specified YouTube content owner.
+     * *Note:* This parameter is intended exclusively for YouTube content partners. The *onBehalfOfContentOwner* parameter indicates that the request's authorization credentials identify a YouTube CMS user who is acting on behalf of the content owner specified in the parameter value. This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and get access to all their video and channel data, without having to provide authentication credentials for each individual channel. The CMS account that the user authenticates with must be linked to the specified YouTube content owner.
      */
     onBehalfOfContentOwner?: string;
     /**
-     * The <code><strong>part</strong></code> parameter serves two purposes in this operation. It identifies the properties that the write operation will set as well as the properties that the API response will include.<br/><br/>Note that this method will override the existing values for mutable properties that are contained in any parts that the request body specifies. For example, a playlist's description is contained in the <code>snippet</code> part, which must be included in the request body. If the request does not specify a value for the <code>snippet.description</code> property, the playlist's existing description will be deleted.
+     * The *part* parameter serves two purposes in this operation. It identifies the properties that the write operation will set as well as the properties that the API response will include. Note that this method will override the existing values for mutable properties that are contained in any parts that the request body specifies. For example, a playlist's description is contained in the snippet part, which must be included in the request body. If the request does not specify a value for the snippet.description property, the playlist's existing description will be deleted.
      */
     part?: string[];
 
@@ -14848,9 +13392,9 @@ export namespace youtube_v3 {
     }
 
     /**
-     * youtube.search.list
-     * @desc Retrieves a list of search resources
+     * Retrieves a list of search resources
      * @example
+     * ```js
      * // Before running the sample:
      * // - Enable the API at:
      * //   https://console.developers.google.com/apis/api/youtube.googleapis.com
@@ -14887,8 +13431,7 @@ export namespace youtube_v3 {
      *     eventType: 'placeholder-value',
      *     // Search owned by a content owner.
      *     forContentOwner: 'placeholder-value',
-     *     // Restrict the search to only retrieve videos uploaded using the project id
-     *     // of the authenticated user.
+     *     // Restrict the search to only retrieve videos uploaded using the project id of the authenticated user.
      *     forDeveloper: 'placeholder-value',
      *     // Search for the private videos of the authenticated user.
      *     forMine: 'placeholder-value',
@@ -14896,33 +13439,15 @@ export namespace youtube_v3 {
      *     location: 'placeholder-value',
      *     // Filter on distance from the location (specified above).
      *     locationRadius: 'placeholder-value',
-     *     // The <code><strong>maxResults</strong></code> parameter specifies the
-     *     // maximum number of items that should be returned in the result set.
+     *     // The *maxResults* parameter specifies the maximum number of items that should be returned in the result set.
      *     maxResults: 'placeholder-value',
-     *     // <strong>Note:</strong> This parameter is intended exclusively for YouTube
-     *     // content partners.<br><br>The
-     *     // <code><strong>onBehalfOfContentOwner</strong></code> parameter indicates
-     *     // that the
-     *     // request's authorization credentials identify a YouTube CMS user who is
-     *     // acting on behalf of the content owner specified in the parameter value.
-     *     // This parameter is intended for YouTube content partners that own and manage
-     *     // many different YouTube channels. It allows content owners to authenticate
-     *     // once and get access to all their video and channel data, without having to
-     *     // provide authentication credentials for each individual channel. The CMS
-     *     // account that the user authenticates with must be linked to the specified
-     *     // YouTube content owner.
+     *     // *Note:* This parameter is intended exclusively for YouTube content partners. The *onBehalfOfContentOwner* parameter indicates that the request's authorization credentials identify a YouTube CMS user who is acting on behalf of the content owner specified in the parameter value. This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and get access to all their video and channel data, without having to provide authentication credentials for each individual channel. The CMS account that the user authenticates with must be linked to the specified YouTube content owner.
      *     onBehalfOfContentOwner: 'placeholder-value',
      *     // Sort order of the results.
      *     order: 'placeholder-value',
-     *     // The <code><strong>pageToken</strong></code> parameter identifies a specific
-     *     // page in the result set that should be returned. In an API response, the
-     *     // <code>nextPageToken</code> and <code>prevPageToken</code> properties
-     *     // identify other pages that could be retrieved.
+     *     // The *pageToken* parameter identifies a specific page in the result set that should be returned. In an API response, the nextPageToken and prevPageToken properties identify other pages that could be retrieved.
      *     pageToken: 'placeholder-value',
-     *     // The <code><strong>part</strong></code> parameter specifies a
-     *     // comma-separated list of one or more <code>search</code> resource properties
-     *     // that the API response will include. Set the parameter value to
-     *     // <code>snippet</code>.
+     *     // The *part* parameter specifies a comma-separated list of one or more search resource properties that the API response will include. Set the parameter value to snippet.
      *     part: 'placeholder-value',
      *     // Filter on resources published after this date.
      *     publishedAfter: 'placeholder-value',
@@ -14936,8 +13461,7 @@ export namespace youtube_v3 {
      *     relatedToVideoId: 'placeholder-value',
      *     // Return results relevant to this language.
      *     relevanceLanguage: 'placeholder-value',
-     *     // Indicates whether the search results should include restricted content as
-     *     // well as standard content.
+     *     // Indicates whether the search results should include restricted content as well as standard content.
      *     safeSearch: 'placeholder-value',
      *     // Restrict results to a particular topic.
      *     topicId: 'placeholder-value',
@@ -14984,44 +13508,12 @@ export namespace youtube_v3 {
      *   throw e;
      * });
      *
-     * @alias youtube.search.list
-     * @memberOf! ()
+     * ```
      *
-     * @param {object} params Parameters for request
-     * @param {string=} params.channelId Filter on resources belonging to this channelId.
-     * @param {string=} params.channelType Add a filter on the channel search.
-     * @param {string=} params.eventType Filter on the livestream status of the videos.
-     * @param {boolean=} params.forContentOwner Search owned by a content owner.
-     * @param {boolean=} params.forDeveloper Restrict the search to only retrieve videos uploaded using the project id of the authenticated user.
-     * @param {boolean=} params.forMine Search for the private videos of the authenticated user.
-     * @param {string=} params.location Filter on location of the video
-     * @param {string=} params.locationRadius Filter on distance from the location (specified above).
-     * @param {integer=} params.maxResults The <code><strong>maxResults</strong></code> parameter specifies the maximum number of items that should be returned in the result set.
-     * @param {string=} params.onBehalfOfContentOwner <strong>Note:</strong> This parameter is intended exclusively for YouTube content partners.<br><br>The <code><strong>onBehalfOfContentOwner</strong></code> parameter indicates that the request's authorization credentials identify a YouTube CMS user who is acting on behalf of the content owner specified in the parameter value. This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and get access to all their video and channel data, without having to provide authentication credentials for each individual channel. The CMS account that the user authenticates with must be linked to the specified YouTube content owner.
-     * @param {string=} params.order Sort order of the results.
-     * @param {string=} params.pageToken The <code><strong>pageToken</strong></code> parameter identifies a specific page in the result set that should be returned. In an API response, the <code>nextPageToken</code> and <code>prevPageToken</code> properties identify other pages that could be retrieved.
-     * @param {string} params.part The <code><strong>part</strong></code> parameter specifies a comma-separated list of one or more <code>search</code> resource properties that the API response will include. Set the parameter value to <code>snippet</code>.
-     * @param {string=} params.publishedAfter Filter on resources published after this date.
-     * @param {string=} params.publishedBefore Filter on resources published before this date.
-     * @param {string=} params.q Textual search terms to match.
-     * @param {string=} params.regionCode Display the content as seen by viewers in this country.
-     * @param {string=} params.relatedToVideoId Search related to a resource.
-     * @param {string=} params.relevanceLanguage Return results relevant to this language.
-     * @param {string=} params.safeSearch Indicates whether the search results should include restricted content as well as standard content.
-     * @param {string=} params.topicId Restrict results to a particular topic.
-     * @param {string=} params.type Restrict results to a particular set of resource types from One Platform.
-     * @param {string=} params.videoCaption Filter on the presence of captions on the videos.
-     * @param {string=} params.videoCategoryId Filter on videos in a specific category.
-     * @param {string=} params.videoDefinition Filter on the definition of the videos.
-     * @param {string=} params.videoDimension Filter on 3d videos.
-     * @param {string=} params.videoDuration Filter on the duration of the videos.
-     * @param {string=} params.videoEmbeddable Filter on embeddable videos.
-     * @param {string=} params.videoLicense Filter on the license of the videos.
-     * @param {string=} params.videoSyndicated Filter on syndicated videos.
-     * @param {string=} params.videoType Filter on videos of a specific type.
-     * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-     * @param {callback} callback The callback that handles the response.
-     * @return {object} Request object
+     * @param params - Parameters for request
+     * @param options - Optionally override request options, such as `url`, `method`, and `encoding`.
+     * @param callback - Optional callback that handles the response.
+     * @returns A promise if used with async/await, or void if used with a callback.
      */
     list(
       params: Params$Resource$Search$List,
@@ -15077,7 +13569,7 @@ export namespace youtube_v3 {
         options = {};
       }
 
-      const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+      const rootUrl = options.rootUrl || 'https://youtube.googleapis.com/';
       const parameters = {
         options: Object.assign(
           {
@@ -15094,7 +13586,7 @@ export namespace youtube_v3 {
       if (callback) {
         createAPIRequest<Schema$SearchListResponse>(
           parameters,
-          callback as BodyResponseCallback<{} | void>
+          callback as BodyResponseCallback<unknown>
         );
       } else {
         return createAPIRequest<Schema$SearchListResponse>(parameters);
@@ -15136,11 +13628,11 @@ export namespace youtube_v3 {
      */
     locationRadius?: string;
     /**
-     * The <code><strong>maxResults</strong></code> parameter specifies the maximum number of items that should be returned in the result set.
+     * The *maxResults* parameter specifies the maximum number of items that should be returned in the result set.
      */
     maxResults?: number;
     /**
-     * <strong>Note:</strong> This parameter is intended exclusively for YouTube content partners.<br><br>The <code><strong>onBehalfOfContentOwner</strong></code> parameter indicates that the request's authorization credentials identify a YouTube CMS user who is acting on behalf of the content owner specified in the parameter value. This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and get access to all their video and channel data, without having to provide authentication credentials for each individual channel. The CMS account that the user authenticates with must be linked to the specified YouTube content owner.
+     * *Note:* This parameter is intended exclusively for YouTube content partners. The *onBehalfOfContentOwner* parameter indicates that the request's authorization credentials identify a YouTube CMS user who is acting on behalf of the content owner specified in the parameter value. This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and get access to all their video and channel data, without having to provide authentication credentials for each individual channel. The CMS account that the user authenticates with must be linked to the specified YouTube content owner.
      */
     onBehalfOfContentOwner?: string;
     /**
@@ -15148,11 +13640,11 @@ export namespace youtube_v3 {
      */
     order?: string;
     /**
-     * The <code><strong>pageToken</strong></code> parameter identifies a specific page in the result set that should be returned. In an API response, the <code>nextPageToken</code> and <code>prevPageToken</code> properties identify other pages that could be retrieved.
+     * The *pageToken* parameter identifies a specific page in the result set that should be returned. In an API response, the nextPageToken and prevPageToken properties identify other pages that could be retrieved.
      */
     pageToken?: string;
     /**
-     * The <code><strong>part</strong></code> parameter specifies a comma-separated list of one or more <code>search</code> resource properties that the API response will include. Set the parameter value to <code>snippet</code>.
+     * The *part* parameter specifies a comma-separated list of one or more search resource properties that the API response will include. Set the parameter value to snippet.
      */
     part?: string[];
     /**
@@ -15229,191 +13721,6 @@ export namespace youtube_v3 {
     videoType?: string;
   }
 
-  export class Resource$Sponsors {
-    context: APIRequestContext;
-    constructor(context: APIRequestContext) {
-      this.context = context;
-    }
-
-    /**
-     * youtube.sponsors.list
-     * @desc Retrieves a list of sponsors that match the request criteria for a channel.
-     * @example
-     * // Before running the sample:
-     * // - Enable the API at:
-     * //   https://console.developers.google.com/apis/api/youtube.googleapis.com
-     * // - Login into gcloud by running:
-     * //   `$ gcloud auth application-default login`
-     * // - Install the npm module by running:
-     * //   `$ npm install googleapis`
-     *
-     * const {google} = require('googleapis');
-     * const youtube = google.youtube('v3');
-     *
-     * async function main() {
-     *   const auth = new google.auth.GoogleAuth({
-     *     // Scopes can be specified either as an array or as a single, space-delimited string.
-     *     scopes: [
-     *       'https://www.googleapis.com/auth/youtube',
-     *       'https://www.googleapis.com/auth/youtube.force-ssl',
-     *       'https://www.googleapis.com/auth/youtube.readonly',
-     *     ],
-     *   });
-     *
-     *   // Acquire an auth client, and bind it to all future calls
-     *   const authClient = await auth.getClient();
-     *   google.options({auth: authClient});
-     *
-     *   // Do the magic
-     *   const res = await youtube.sponsors.list({
-     *     // Parameter that specifies which channel sponsors to return.
-     *     filter: 'placeholder-value',
-     *     // The <code><strong>maxResults</strong></code> parameter specifies the
-     *     // maximum number of items that should be returned in the result set.
-     *     maxResults: 'placeholder-value',
-     *     // The <code><strong>pageToken</strong></code> parameter identifies a specific
-     *     // page in the result set that should be returned. In an API response, the
-     *     // <code>nextPageToken</code> and <code>prevPageToken</code> properties
-     *     // identify other pages that could be retrieved.
-     *     pageToken: 'placeholder-value',
-     *     // The <code><strong>part</strong></code> parameter specifies the
-     *     // <code>sponsor</code> resource parts that the API response will include.
-     *     // Supported values are <code>id</code> and <code>snippet</code>.
-     *     part: 'placeholder-value',
-     *   });
-     *   console.log(res.data);
-     *
-     *   // Example response
-     *   // {
-     *   //   "etag": "my_etag",
-     *   //   "eventId": "my_eventId",
-     *   //   "items": [],
-     *   //   "kind": "my_kind",
-     *   //   "nextPageToken": "my_nextPageToken",
-     *   //   "pageInfo": {},
-     *   //   "tokenPagination": {},
-     *   //   "visitorId": "my_visitorId"
-     *   // }
-     * }
-     *
-     * main().catch(e => {
-     *   console.error(e);
-     *   throw e;
-     * });
-     *
-     * @alias youtube.sponsors.list
-     * @memberOf! ()
-     *
-     * @param {object} params Parameters for request
-     * @param {string=} params.filter Parameter that specifies which channel sponsors to return.
-     * @param {integer=} params.maxResults The <code><strong>maxResults</strong></code> parameter specifies the maximum number of items that should be returned in the result set.
-     * @param {string=} params.pageToken The <code><strong>pageToken</strong></code> parameter identifies a specific page in the result set that should be returned. In an API response, the <code>nextPageToken</code> and <code>prevPageToken</code> properties identify other pages that could be retrieved.
-     * @param {string} params.part The <code><strong>part</strong></code> parameter specifies the <code>sponsor</code> resource parts that the API response will include. Supported values are <code>id</code> and <code>snippet</code>.
-     * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-     * @param {callback} callback The callback that handles the response.
-     * @return {object} Request object
-     */
-    list(
-      params: Params$Resource$Sponsors$List,
-      options: StreamMethodOptions
-    ): GaxiosPromise<Readable>;
-    list(
-      params?: Params$Resource$Sponsors$List,
-      options?: MethodOptions
-    ): GaxiosPromise<Schema$SponsorListResponse>;
-    list(
-      params: Params$Resource$Sponsors$List,
-      options: StreamMethodOptions | BodyResponseCallback<Readable>,
-      callback: BodyResponseCallback<Readable>
-    ): void;
-    list(
-      params: Params$Resource$Sponsors$List,
-      options: MethodOptions | BodyResponseCallback<Schema$SponsorListResponse>,
-      callback: BodyResponseCallback<Schema$SponsorListResponse>
-    ): void;
-    list(
-      params: Params$Resource$Sponsors$List,
-      callback: BodyResponseCallback<Schema$SponsorListResponse>
-    ): void;
-    list(callback: BodyResponseCallback<Schema$SponsorListResponse>): void;
-    list(
-      paramsOrCallback?:
-        | Params$Resource$Sponsors$List
-        | BodyResponseCallback<Schema$SponsorListResponse>
-        | BodyResponseCallback<Readable>,
-      optionsOrCallback?:
-        | MethodOptions
-        | StreamMethodOptions
-        | BodyResponseCallback<Schema$SponsorListResponse>
-        | BodyResponseCallback<Readable>,
-      callback?:
-        | BodyResponseCallback<Schema$SponsorListResponse>
-        | BodyResponseCallback<Readable>
-    ):
-      | void
-      | GaxiosPromise<Schema$SponsorListResponse>
-      | GaxiosPromise<Readable> {
-      let params = (paramsOrCallback || {}) as Params$Resource$Sponsors$List;
-      let options = (optionsOrCallback || {}) as MethodOptions;
-
-      if (typeof paramsOrCallback === 'function') {
-        callback = paramsOrCallback;
-        params = {} as Params$Resource$Sponsors$List;
-        options = {};
-      }
-
-      if (typeof optionsOrCallback === 'function') {
-        callback = optionsOrCallback;
-        options = {};
-      }
-
-      const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
-      const parameters = {
-        options: Object.assign(
-          {
-            url: (rootUrl + '/youtube/v3/sponsors').replace(
-              /([^:]\/)\/+/g,
-              '$1'
-            ),
-            method: 'GET',
-          },
-          options
-        ),
-        params,
-        requiredParams: ['part'],
-        pathParams: [],
-        context: this.context,
-      };
-      if (callback) {
-        createAPIRequest<Schema$SponsorListResponse>(
-          parameters,
-          callback as BodyResponseCallback<{} | void>
-        );
-      } else {
-        return createAPIRequest<Schema$SponsorListResponse>(parameters);
-      }
-    }
-  }
-
-  export interface Params$Resource$Sponsors$List extends StandardParameters {
-    /**
-     * Parameter that specifies which channel sponsors to return.
-     */
-    filter?: string;
-    /**
-     * The <code><strong>maxResults</strong></code> parameter specifies the maximum number of items that should be returned in the result set.
-     */
-    maxResults?: number;
-    /**
-     * The <code><strong>pageToken</strong></code> parameter identifies a specific page in the result set that should be returned. In an API response, the <code>nextPageToken</code> and <code>prevPageToken</code> properties identify other pages that could be retrieved.
-     */
-    pageToken?: string;
-    /**
-     * The <code><strong>part</strong></code> parameter specifies the <code>sponsor</code> resource parts that the API response will include. Supported values are <code>id</code> and <code>snippet</code>.
-     */
-    part?: string[];
-  }
-
   export class Resource$Subscriptions {
     context: APIRequestContext;
     constructor(context: APIRequestContext) {
@@ -15421,9 +13728,9 @@ export namespace youtube_v3 {
     }
 
     /**
-     * youtube.subscriptions.delete
-     * @desc Deletes a resource.
+     * Deletes a resource.
      * @example
+     * ```js
      * // Before running the sample:
      * // - Enable the API at:
      * //   https://console.developers.google.com/apis/api/youtube.googleapis.com
@@ -15461,14 +13768,12 @@ export namespace youtube_v3 {
      *   throw e;
      * });
      *
-     * @alias youtube.subscriptions.delete
-     * @memberOf! ()
+     * ```
      *
-     * @param {object} params Parameters for request
-     * @param {string} params.id
-     * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-     * @param {callback} callback The callback that handles the response.
-     * @return {object} Request object
+     * @param params - Parameters for request
+     * @param options - Optionally override request options, such as `url`, `method`, and `encoding`.
+     * @param callback - Optional callback that handles the response.
+     * @returns A promise if used with async/await, or void if used with a callback.
      */
     delete(
       params: Params$Resource$Subscriptions$Delete,
@@ -15520,7 +13825,7 @@ export namespace youtube_v3 {
         options = {};
       }
 
-      const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+      const rootUrl = options.rootUrl || 'https://youtube.googleapis.com/';
       const parameters = {
         options: Object.assign(
           {
@@ -15540,7 +13845,7 @@ export namespace youtube_v3 {
       if (callback) {
         createAPIRequest<void>(
           parameters,
-          callback as BodyResponseCallback<{} | void>
+          callback as BodyResponseCallback<unknown>
         );
       } else {
         return createAPIRequest<void>(parameters);
@@ -15548,9 +13853,9 @@ export namespace youtube_v3 {
     }
 
     /**
-     * youtube.subscriptions.insert
-     * @desc Inserts a new resource into this collection.
+     * Inserts a new resource into this collection.
      * @example
+     * ```js
      * // Before running the sample:
      * // - Enable the API at:
      * //   https://console.developers.google.com/apis/api/youtube.googleapis.com
@@ -15578,9 +13883,7 @@ export namespace youtube_v3 {
      *
      *   // Do the magic
      *   const res = await youtube.subscriptions.insert({
-     *     // The <code><strong>part</strong></code> parameter serves two purposes in
-     *     // this operation. It identifies the properties that the write operation will
-     *     // set as well as the properties that the API response will include.
+     *     // The *part* parameter serves two purposes in this operation. It identifies the properties that the write operation will set as well as the properties that the API response will include.
      *     part: 'placeholder-value',
      *
      *     // Request body metadata
@@ -15614,15 +13917,12 @@ export namespace youtube_v3 {
      *   throw e;
      * });
      *
-     * @alias youtube.subscriptions.insert
-     * @memberOf! ()
+     * ```
      *
-     * @param {object} params Parameters for request
-     * @param {string} params.part The <code><strong>part</strong></code> parameter serves two purposes in this operation. It identifies the properties that the write operation will set as well as the properties that the API response will include.
-     * @param {().Subscription} params.requestBody Request body data
-     * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-     * @param {callback} callback The callback that handles the response.
-     * @return {object} Request object
+     * @param params - Parameters for request
+     * @param options - Optionally override request options, such as `url`, `method`, and `encoding`.
+     * @param callback - Optional callback that handles the response.
+     * @returns A promise if used with async/await, or void if used with a callback.
      */
     insert(
       params: Params$Resource$Subscriptions$Insert,
@@ -15676,7 +13976,7 @@ export namespace youtube_v3 {
         options = {};
       }
 
-      const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+      const rootUrl = options.rootUrl || 'https://youtube.googleapis.com/';
       const parameters = {
         options: Object.assign(
           {
@@ -15696,7 +13996,7 @@ export namespace youtube_v3 {
       if (callback) {
         createAPIRequest<Schema$Subscription>(
           parameters,
-          callback as BodyResponseCallback<{} | void>
+          callback as BodyResponseCallback<unknown>
         );
       } else {
         return createAPIRequest<Schema$Subscription>(parameters);
@@ -15704,9 +14004,9 @@ export namespace youtube_v3 {
     }
 
     /**
-     * youtube.subscriptions.list
-     * @desc Retrieves a list of resources, possibly filtered.
+     * Retrieves a list of resources, possibly filtered.
      * @example
+     * ```js
      * // Before running the sample:
      * // - Enable the API at:
      * //   https://console.developers.google.com/apis/api/youtube.googleapis.com
@@ -15737,13 +14037,11 @@ export namespace youtube_v3 {
      *   const res = await youtube.subscriptions.list({
      *     // Return the subscriptions of the given channel owner.
      *     channelId: 'placeholder-value',
-     *     // Return the subscriptions to the subset of these channels that the
-     *     // authenticated user is subscribed to.
+     *     // Return the subscriptions to the subset of these channels that the authenticated user is subscribed to.
      *     forChannelId: 'placeholder-value',
      *     // Return the subscriptions with the given IDs for Stubby or Apiary.
      *     id: 'placeholder-value',
-     *     // The <code><strong>maxResults</strong></code> parameter specifies the
-     *     // maximum number of items that should be returned in the result set.
+     *     // The *maxResults* parameter specifies the maximum number of items that should be returned in the result set.
      *     maxResults: 'placeholder-value',
      *     // Flag for returning the subscriptions of the authenticated user.
      *     mine: 'placeholder-value',
@@ -15751,55 +14049,15 @@ export namespace youtube_v3 {
      *     myRecentSubscribers: 'placeholder-value',
      *     // Return the subscribers of the given channel owner.
      *     mySubscribers: 'placeholder-value',
-     *     // <strong>Note:</strong> This parameter is intended exclusively for YouTube
-     *     // content partners.<br><br>The
-     *     // <code><strong>onBehalfOfContentOwner</strong></code> parameter indicates
-     *     // that the
-     *     // request's authorization credentials identify a YouTube CMS user who is
-     *     // acting on behalf of the content owner specified in the parameter value.
-     *     // This parameter is intended for YouTube content partners that own and manage
-     *     // many different YouTube channels. It allows content owners to authenticate
-     *     // once and get access to all their video and channel data, without having to
-     *     // provide authentication credentials for each individual channel. The CMS
-     *     // account that the user authenticates with must be linked to the specified
-     *     // YouTube content owner.
+     *     // *Note:* This parameter is intended exclusively for YouTube content partners. The *onBehalfOfContentOwner* parameter indicates that the request's authorization credentials identify a YouTube CMS user who is acting on behalf of the content owner specified in the parameter value. This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and get access to all their video and channel data, without having to provide authentication credentials for each individual channel. The CMS account that the user authenticates with must be linked to the specified YouTube content owner.
      *     onBehalfOfContentOwner: 'placeholder-value',
-     *     // This parameter can only be used in a properly <a
-     *     // href="/youtube/v3/guides/authentication">authorized request</a>.
-     *     // <strong>Note:</strong> This parameter is intended exclusively for YouTube
-     *     // content partners.<br><br>The
-     *     // <code><strong>onBehalfOfContentOwnerChannel</strong></code> parameter
-     *     // specifies the YouTube channel ID of the channel to which a video is being
-     *     // added. This parameter is required when a request specifies a value for the
-     *     // <code>onBehalfOfContentOwner</code> parameter, and it can only be used in
-     *     // conjunction with that parameter. In addition, the request must be
-     *     // authorized using a CMS account that is linked to the content owner that the
-     *     // <code>onBehalfOfContentOwner</code> parameter specifies. Finally, the
-     *     // channel that the <code>onBehalfOfContentOwnerChannel</code> parameter value
-     *     // specifies must be linked to the content owner that the
-     *     // <code>onBehalfOfContentOwner</code> parameter specifies.<br><br>This
-     *     // parameter is intended for YouTube content partners that own and manage many
-     *     // different YouTube channels. It allows content owners to authenticate once
-     *     // and perform actions on behalf of the channel specified in the parameter
-     *     // value, without having to provide authentication credentials for each
-     *     // separate channel.
+     *     // This parameter can only be used in a properly authorized request. *Note:* This parameter is intended exclusively for YouTube content partners. The *onBehalfOfContentOwnerChannel* parameter specifies the YouTube channel ID of the channel to which a video is being added. This parameter is required when a request specifies a value for the onBehalfOfContentOwner parameter, and it can only be used in conjunction with that parameter. In addition, the request must be authorized using a CMS account that is linked to the content owner that the onBehalfOfContentOwner parameter specifies. Finally, the channel that the onBehalfOfContentOwnerChannel parameter value specifies must be linked to the content owner that the onBehalfOfContentOwner parameter specifies. This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and perform actions on behalf of the channel specified in the parameter value, without having to provide authentication credentials for each separate channel.
      *     onBehalfOfContentOwnerChannel: 'placeholder-value',
      *     // The order of the returned subscriptions
      *     order: 'placeholder-value',
-     *     // The <code><strong>pageToken</strong></code> parameter identifies a specific
-     *     // page in the result set that should be returned. In an API response, the
-     *     // <code>nextPageToken</code> and <code>prevPageToken</code> properties
-     *     // identify other pages that could be retrieved.
+     *     // The *pageToken* parameter identifies a specific page in the result set that should be returned. In an API response, the nextPageToken and prevPageToken properties identify other pages that could be retrieved.
      *     pageToken: 'placeholder-value',
-     *     // The <code><strong>part</strong></code> parameter specifies a
-     *     // comma-separated list of one or more <code>subscription</code> resource
-     *     // properties that the API response will include.<br><br>If the parameter
-     *     // identifies a property that contains child properties, the child properties
-     *     // will be included in the response. For example, in a
-     *     // <code>subscription</code> resource, the <code>snippet</code> property
-     *     // contains other properties, such as a display title for the subscription. If
-     *     // you set <code><strong>part=snippet</strong></code>, the API response will
-     *     // also contain all of those nested properties.
+     *     // The *part* parameter specifies a comma-separated list of one or more subscription resource properties that the API response will include. If the parameter identifies a property that contains child properties, the child properties will be included in the response. For example, in a subscription resource, the snippet property contains other properties, such as a display title for the subscription. If you set *part=snippet*, the API response will also contain all of those nested properties.
      *     part: 'placeholder-value',
      *   });
      *   console.log(res.data);
@@ -15823,25 +14081,12 @@ export namespace youtube_v3 {
      *   throw e;
      * });
      *
-     * @alias youtube.subscriptions.list
-     * @memberOf! ()
+     * ```
      *
-     * @param {object} params Parameters for request
-     * @param {string=} params.channelId Return the subscriptions of the given channel owner.
-     * @param {string=} params.forChannelId Return the subscriptions to the subset of these channels that the authenticated user is subscribed to.
-     * @param {string=} params.id Return the subscriptions with the given IDs for Stubby or Apiary.
-     * @param {integer=} params.maxResults The <code><strong>maxResults</strong></code> parameter specifies the maximum number of items that should be returned in the result set.
-     * @param {boolean=} params.mine Flag for returning the subscriptions of the authenticated user.
-     * @param {boolean=} params.myRecentSubscribers
-     * @param {boolean=} params.mySubscribers Return the subscribers of the given channel owner.
-     * @param {string=} params.onBehalfOfContentOwner <strong>Note:</strong> This parameter is intended exclusively for YouTube content partners.<br><br>The <code><strong>onBehalfOfContentOwner</strong></code> parameter indicates that the request's authorization credentials identify a YouTube CMS user who is acting on behalf of the content owner specified in the parameter value. This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and get access to all their video and channel data, without having to provide authentication credentials for each individual channel. The CMS account that the user authenticates with must be linked to the specified YouTube content owner.
-     * @param {string=} params.onBehalfOfContentOwnerChannel This parameter can only be used in a properly <a href="/youtube/v3/guides/authentication">authorized request</a>. <strong>Note:</strong> This parameter is intended exclusively for YouTube content partners.<br><br>The <code><strong>onBehalfOfContentOwnerChannel</strong></code> parameter specifies the YouTube channel ID of the channel to which a video is being added. This parameter is required when a request specifies a value for the <code>onBehalfOfContentOwner</code> parameter, and it can only be used in conjunction with that parameter. In addition, the request must be authorized using a CMS account that is linked to the content owner that the <code>onBehalfOfContentOwner</code> parameter specifies. Finally, the channel that the <code>onBehalfOfContentOwnerChannel</code> parameter value specifies must be linked to the content owner that the <code>onBehalfOfContentOwner</code> parameter specifies.<br><br>This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and perform actions on behalf of the channel specified in the parameter value, without having to provide authentication credentials for each separate channel.
-     * @param {string=} params.order The order of the returned subscriptions
-     * @param {string=} params.pageToken The <code><strong>pageToken</strong></code> parameter identifies a specific page in the result set that should be returned. In an API response, the <code>nextPageToken</code> and <code>prevPageToken</code> properties identify other pages that could be retrieved.
-     * @param {string} params.part The <code><strong>part</strong></code> parameter specifies a comma-separated list of one or more <code>subscription</code> resource properties that the API response will include.<br><br>If the parameter identifies a property that contains child properties, the child properties will be included in the response. For example, in a <code>subscription</code> resource, the <code>snippet</code> property contains other properties, such as a display title for the subscription. If you set <code><strong>part=snippet</strong></code>, the API response will also contain all of those nested properties.
-     * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-     * @param {callback} callback The callback that handles the response.
-     * @return {object} Request object
+     * @param params - Parameters for request
+     * @param options - Optionally override request options, such as `url`, `method`, and `encoding`.
+     * @param callback - Optional callback that handles the response.
+     * @returns A promise if used with async/await, or void if used with a callback.
      */
     list(
       params: Params$Resource$Subscriptions$List,
@@ -15900,7 +14145,7 @@ export namespace youtube_v3 {
         options = {};
       }
 
-      const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+      const rootUrl = options.rootUrl || 'https://youtube.googleapis.com/';
       const parameters = {
         options: Object.assign(
           {
@@ -15920,7 +14165,7 @@ export namespace youtube_v3 {
       if (callback) {
         createAPIRequest<Schema$SubscriptionListResponse>(
           parameters,
-          callback as BodyResponseCallback<{} | void>
+          callback as BodyResponseCallback<unknown>
         );
       } else {
         return createAPIRequest<Schema$SubscriptionListResponse>(parameters);
@@ -15938,7 +14183,7 @@ export namespace youtube_v3 {
   export interface Params$Resource$Subscriptions$Insert
     extends StandardParameters {
     /**
-     * The <code><strong>part</strong></code> parameter serves two purposes in this operation. It identifies the properties that the write operation will set as well as the properties that the API response will include.
+     * The *part* parameter serves two purposes in this operation. It identifies the properties that the write operation will set as well as the properties that the API response will include.
      */
     part?: string[];
 
@@ -15962,7 +14207,7 @@ export namespace youtube_v3 {
      */
     id?: string[];
     /**
-     * The <code><strong>maxResults</strong></code> parameter specifies the maximum number of items that should be returned in the result set.
+     * The *maxResults* parameter specifies the maximum number of items that should be returned in the result set.
      */
     maxResults?: number;
     /**
@@ -15978,11 +14223,11 @@ export namespace youtube_v3 {
      */
     mySubscribers?: boolean;
     /**
-     * <strong>Note:</strong> This parameter is intended exclusively for YouTube content partners.<br><br>The <code><strong>onBehalfOfContentOwner</strong></code> parameter indicates that the request's authorization credentials identify a YouTube CMS user who is acting on behalf of the content owner specified in the parameter value. This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and get access to all their video and channel data, without having to provide authentication credentials for each individual channel. The CMS account that the user authenticates with must be linked to the specified YouTube content owner.
+     * *Note:* This parameter is intended exclusively for YouTube content partners. The *onBehalfOfContentOwner* parameter indicates that the request's authorization credentials identify a YouTube CMS user who is acting on behalf of the content owner specified in the parameter value. This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and get access to all their video and channel data, without having to provide authentication credentials for each individual channel. The CMS account that the user authenticates with must be linked to the specified YouTube content owner.
      */
     onBehalfOfContentOwner?: string;
     /**
-     * This parameter can only be used in a properly <a href="/youtube/v3/guides/authentication">authorized request</a>. <strong>Note:</strong> This parameter is intended exclusively for YouTube content partners.<br><br>The <code><strong>onBehalfOfContentOwnerChannel</strong></code> parameter specifies the YouTube channel ID of the channel to which a video is being added. This parameter is required when a request specifies a value for the <code>onBehalfOfContentOwner</code> parameter, and it can only be used in conjunction with that parameter. In addition, the request must be authorized using a CMS account that is linked to the content owner that the <code>onBehalfOfContentOwner</code> parameter specifies. Finally, the channel that the <code>onBehalfOfContentOwnerChannel</code> parameter value specifies must be linked to the content owner that the <code>onBehalfOfContentOwner</code> parameter specifies.<br><br>This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and perform actions on behalf of the channel specified in the parameter value, without having to provide authentication credentials for each separate channel.
+     * This parameter can only be used in a properly authorized request. *Note:* This parameter is intended exclusively for YouTube content partners. The *onBehalfOfContentOwnerChannel* parameter specifies the YouTube channel ID of the channel to which a video is being added. This parameter is required when a request specifies a value for the onBehalfOfContentOwner parameter, and it can only be used in conjunction with that parameter. In addition, the request must be authorized using a CMS account that is linked to the content owner that the onBehalfOfContentOwner parameter specifies. Finally, the channel that the onBehalfOfContentOwnerChannel parameter value specifies must be linked to the content owner that the onBehalfOfContentOwner parameter specifies. This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and perform actions on behalf of the channel specified in the parameter value, without having to provide authentication credentials for each separate channel.
      */
     onBehalfOfContentOwnerChannel?: string;
     /**
@@ -15990,11 +14235,11 @@ export namespace youtube_v3 {
      */
     order?: string;
     /**
-     * The <code><strong>pageToken</strong></code> parameter identifies a specific page in the result set that should be returned. In an API response, the <code>nextPageToken</code> and <code>prevPageToken</code> properties identify other pages that could be retrieved.
+     * The *pageToken* parameter identifies a specific page in the result set that should be returned. In an API response, the nextPageToken and prevPageToken properties identify other pages that could be retrieved.
      */
     pageToken?: string;
     /**
-     * The <code><strong>part</strong></code> parameter specifies a comma-separated list of one or more <code>subscription</code> resource properties that the API response will include.<br><br>If the parameter identifies a property that contains child properties, the child properties will be included in the response. For example, in a <code>subscription</code> resource, the <code>snippet</code> property contains other properties, such as a display title for the subscription. If you set <code><strong>part=snippet</strong></code>, the API response will also contain all of those nested properties.
+     * The *part* parameter specifies a comma-separated list of one or more subscription resource properties that the API response will include. If the parameter identifies a property that contains child properties, the child properties will be included in the response. For example, in a subscription resource, the snippet property contains other properties, such as a display title for the subscription. If you set *part=snippet*, the API response will also contain all of those nested properties.
      */
     part?: string[];
   }
@@ -16006,9 +14251,9 @@ export namespace youtube_v3 {
     }
 
     /**
-     * youtube.superChatEvents.list
-     * @desc Retrieves a list of resources, possibly filtered.
+     * Retrieves a list of resources, possibly filtered.
      * @example
+     * ```js
      * // Before running the sample:
      * // - Enable the API at:
      * //   https://console.developers.google.com/apis/api/youtube.googleapis.com
@@ -16038,17 +14283,11 @@ export namespace youtube_v3 {
      *   const res = await youtube.superChatEvents.list({
      *     // Return rendered funding amounts in specified language.
      *     hl: 'placeholder-value',
-     *     // The <code><strong>maxResults</strong></code> parameter specifies the
-     *     // maximum number of items that should be returned in the result set.
+     *     // The *maxResults* parameter specifies the maximum number of items that should be returned in the result set.
      *     maxResults: 'placeholder-value',
-     *     // The <code><strong>pageToken</strong></code> parameter identifies a specific
-     *     // page in the result set that should be returned. In an API response, the
-     *     // <code>nextPageToken</code> and <code>prevPageToken</code> properties
-     *     // identify other pages that could be retrieved.
+     *     // The *pageToken* parameter identifies a specific page in the result set that should be returned. In an API response, the nextPageToken and prevPageToken properties identify other pages that could be retrieved.
      *     pageToken: 'placeholder-value',
-     *     // The <code><strong>part</strong></code> parameter specifies the
-     *     // <code>superChatEvent</code> resource parts that the API response will
-     *     // include. Supported values are <code>id</code> and <code>snippet</code>.
+     *     // The *part* parameter specifies the superChatEvent resource parts that the API response will include. Supported values are id and snippet.
      *     part: 'placeholder-value',
      *   });
      *   console.log(res.data);
@@ -16071,17 +14310,12 @@ export namespace youtube_v3 {
      *   throw e;
      * });
      *
-     * @alias youtube.superChatEvents.list
-     * @memberOf! ()
+     * ```
      *
-     * @param {object} params Parameters for request
-     * @param {string=} params.hl Return rendered funding amounts in specified language.
-     * @param {integer=} params.maxResults The <code><strong>maxResults</strong></code> parameter specifies the maximum number of items that should be returned in the result set.
-     * @param {string=} params.pageToken The <code><strong>pageToken</strong></code> parameter identifies a specific page in the result set that should be returned. In an API response, the <code>nextPageToken</code> and <code>prevPageToken</code> properties identify other pages that could be retrieved.
-     * @param {string} params.part The <code><strong>part</strong></code> parameter specifies the <code>superChatEvent</code> resource parts that the API response will include. Supported values are <code>id</code> and <code>snippet</code>.
-     * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-     * @param {callback} callback The callback that handles the response.
-     * @return {object} Request object
+     * @param params - Parameters for request
+     * @param options - Optionally override request options, such as `url`, `method`, and `encoding`.
+     * @param callback - Optional callback that handles the response.
+     * @returns A promise if used with async/await, or void if used with a callback.
      */
     list(
       params: Params$Resource$Superchatevents$List,
@@ -16142,7 +14376,7 @@ export namespace youtube_v3 {
         options = {};
       }
 
-      const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+      const rootUrl = options.rootUrl || 'https://youtube.googleapis.com/';
       const parameters = {
         options: Object.assign(
           {
@@ -16162,7 +14396,7 @@ export namespace youtube_v3 {
       if (callback) {
         createAPIRequest<Schema$SuperChatEventListResponse>(
           parameters,
-          callback as BodyResponseCallback<{} | void>
+          callback as BodyResponseCallback<unknown>
         );
       } else {
         return createAPIRequest<Schema$SuperChatEventListResponse>(parameters);
@@ -16177,17 +14411,787 @@ export namespace youtube_v3 {
      */
     hl?: string;
     /**
-     * The <code><strong>maxResults</strong></code> parameter specifies the maximum number of items that should be returned in the result set.
+     * The *maxResults* parameter specifies the maximum number of items that should be returned in the result set.
      */
     maxResults?: number;
     /**
-     * The <code><strong>pageToken</strong></code> parameter identifies a specific page in the result set that should be returned. In an API response, the <code>nextPageToken</code> and <code>prevPageToken</code> properties identify other pages that could be retrieved.
+     * The *pageToken* parameter identifies a specific page in the result set that should be returned. In an API response, the nextPageToken and prevPageToken properties identify other pages that could be retrieved.
      */
     pageToken?: string;
     /**
-     * The <code><strong>part</strong></code> parameter specifies the <code>superChatEvent</code> resource parts that the API response will include. Supported values are <code>id</code> and <code>snippet</code>.
+     * The *part* parameter specifies the superChatEvent resource parts that the API response will include. Supported values are id and snippet.
      */
     part?: string[];
+  }
+
+  export class Resource$Tests {
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
+
+    /**
+     * POST method.
+     * @example
+     * ```js
+     * // Before running the sample:
+     * // - Enable the API at:
+     * //   https://console.developers.google.com/apis/api/youtube.googleapis.com
+     * // - Login into gcloud by running:
+     * //   `$ gcloud auth application-default login`
+     * // - Install the npm module by running:
+     * //   `$ npm install googleapis`
+     *
+     * const {google} = require('googleapis');
+     * const youtube = google.youtube('v3');
+     *
+     * async function main() {
+     *   const auth = new google.auth.GoogleAuth({
+     *     // Scopes can be specified either as an array or as a single, space-delimited string.
+     *     scopes: ['https://www.googleapis.com/auth/youtube.readonly'],
+     *   });
+     *
+     *   // Acquire an auth client, and bind it to all future calls
+     *   const authClient = await auth.getClient();
+     *   google.options({auth: authClient});
+     *
+     *   // Do the magic
+     *   const res = await youtube.tests.insert({
+     *     part: 'placeholder-value',
+     *
+     *     // Request body metadata
+     *     requestBody: {
+     *       // request body parameters
+     *       // {
+     *       //   "gaia": "my_gaia",
+     *       //   "id": "my_id",
+     *       //   "snippet": {}
+     *       // }
+     *     },
+     *   });
+     *   console.log(res.data);
+     *
+     *   // Example response
+     *   // {
+     *   //   "gaia": "my_gaia",
+     *   //   "id": "my_id",
+     *   //   "snippet": {}
+     *   // }
+     * }
+     *
+     * main().catch(e => {
+     *   console.error(e);
+     *   throw e;
+     * });
+     *
+     * ```
+     *
+     * @param params - Parameters for request
+     * @param options - Optionally override request options, such as `url`, `method`, and `encoding`.
+     * @param callback - Optional callback that handles the response.
+     * @returns A promise if used with async/await, or void if used with a callback.
+     */
+    insert(
+      params: Params$Resource$Tests$Insert,
+      options: StreamMethodOptions
+    ): GaxiosPromise<Readable>;
+    insert(
+      params?: Params$Resource$Tests$Insert,
+      options?: MethodOptions
+    ): GaxiosPromise<Schema$TestItem>;
+    insert(
+      params: Params$Resource$Tests$Insert,
+      options: StreamMethodOptions | BodyResponseCallback<Readable>,
+      callback: BodyResponseCallback<Readable>
+    ): void;
+    insert(
+      params: Params$Resource$Tests$Insert,
+      options: MethodOptions | BodyResponseCallback<Schema$TestItem>,
+      callback: BodyResponseCallback<Schema$TestItem>
+    ): void;
+    insert(
+      params: Params$Resource$Tests$Insert,
+      callback: BodyResponseCallback<Schema$TestItem>
+    ): void;
+    insert(callback: BodyResponseCallback<Schema$TestItem>): void;
+    insert(
+      paramsOrCallback?:
+        | Params$Resource$Tests$Insert
+        | BodyResponseCallback<Schema$TestItem>
+        | BodyResponseCallback<Readable>,
+      optionsOrCallback?:
+        | MethodOptions
+        | StreamMethodOptions
+        | BodyResponseCallback<Schema$TestItem>
+        | BodyResponseCallback<Readable>,
+      callback?:
+        | BodyResponseCallback<Schema$TestItem>
+        | BodyResponseCallback<Readable>
+    ): void | GaxiosPromise<Schema$TestItem> | GaxiosPromise<Readable> {
+      let params = (paramsOrCallback || {}) as Params$Resource$Tests$Insert;
+      let options = (optionsOrCallback || {}) as MethodOptions;
+
+      if (typeof paramsOrCallback === 'function') {
+        callback = paramsOrCallback;
+        params = {} as Params$Resource$Tests$Insert;
+        options = {};
+      }
+
+      if (typeof optionsOrCallback === 'function') {
+        callback = optionsOrCallback;
+        options = {};
+      }
+
+      const rootUrl = options.rootUrl || 'https://youtube.googleapis.com/';
+      const parameters = {
+        options: Object.assign(
+          {
+            url: (rootUrl + '/youtube/v3/tests').replace(/([^:]\/)\/+/g, '$1'),
+            method: 'POST',
+          },
+          options
+        ),
+        params,
+        requiredParams: ['part'],
+        pathParams: [],
+        context: this.context,
+      };
+      if (callback) {
+        createAPIRequest<Schema$TestItem>(
+          parameters,
+          callback as BodyResponseCallback<unknown>
+        );
+      } else {
+        return createAPIRequest<Schema$TestItem>(parameters);
+      }
+    }
+  }
+
+  export interface Params$Resource$Tests$Insert extends StandardParameters {
+    /**
+     *
+     */
+    part?: string[];
+
+    /**
+     * Request body metadata
+     */
+    requestBody?: Schema$TestItem;
+  }
+
+  export class Resource$Thirdpartylinks {
+    context: APIRequestContext;
+    constructor(context: APIRequestContext) {
+      this.context = context;
+    }
+
+    /**
+     * Deletes a resource.
+     * @example
+     * ```js
+     * // Before running the sample:
+     * // - Enable the API at:
+     * //   https://console.developers.google.com/apis/api/youtube.googleapis.com
+     * // - Login into gcloud by running:
+     * //   `$ gcloud auth application-default login`
+     * // - Install the npm module by running:
+     * //   `$ npm install googleapis`
+     *
+     * const {google} = require('googleapis');
+     * const youtube = google.youtube('v3');
+     *
+     * async function main() {
+     *   const auth = new google.auth.GoogleAuth({
+     *     // Scopes can be specified either as an array or as a single, space-delimited string.
+     *     scopes: [],
+     *   });
+     *
+     *   // Acquire an auth client, and bind it to all future calls
+     *   const authClient = await auth.getClient();
+     *   google.options({auth: authClient});
+     *
+     *   // Do the magic
+     *   const res = await youtube.thirdPartyLinks.delete({
+     *     // Delete the partner links with the given linking token.
+     *     linkingToken: 'placeholder-value',
+     *     // Do not use. Required for compatibility.
+     *     part: 'placeholder-value',
+     *     // Type of the link to be deleted.
+     *     type: 'placeholder-value',
+     *   });
+     *   console.log(res.data);
+     * }
+     *
+     * main().catch(e => {
+     *   console.error(e);
+     *   throw e;
+     * });
+     *
+     * ```
+     *
+     * @param params - Parameters for request
+     * @param options - Optionally override request options, such as `url`, `method`, and `encoding`.
+     * @param callback - Optional callback that handles the response.
+     * @returns A promise if used with async/await, or void if used with a callback.
+     */
+    delete(
+      params: Params$Resource$Thirdpartylinks$Delete,
+      options: StreamMethodOptions
+    ): GaxiosPromise<Readable>;
+    delete(
+      params?: Params$Resource$Thirdpartylinks$Delete,
+      options?: MethodOptions
+    ): GaxiosPromise<void>;
+    delete(
+      params: Params$Resource$Thirdpartylinks$Delete,
+      options: StreamMethodOptions | BodyResponseCallback<Readable>,
+      callback: BodyResponseCallback<Readable>
+    ): void;
+    delete(
+      params: Params$Resource$Thirdpartylinks$Delete,
+      options: MethodOptions | BodyResponseCallback<void>,
+      callback: BodyResponseCallback<void>
+    ): void;
+    delete(
+      params: Params$Resource$Thirdpartylinks$Delete,
+      callback: BodyResponseCallback<void>
+    ): void;
+    delete(callback: BodyResponseCallback<void>): void;
+    delete(
+      paramsOrCallback?:
+        | Params$Resource$Thirdpartylinks$Delete
+        | BodyResponseCallback<void>
+        | BodyResponseCallback<Readable>,
+      optionsOrCallback?:
+        | MethodOptions
+        | StreamMethodOptions
+        | BodyResponseCallback<void>
+        | BodyResponseCallback<Readable>,
+      callback?: BodyResponseCallback<void> | BodyResponseCallback<Readable>
+    ): void | GaxiosPromise<void> | GaxiosPromise<Readable> {
+      let params = (paramsOrCallback ||
+        {}) as Params$Resource$Thirdpartylinks$Delete;
+      let options = (optionsOrCallback || {}) as MethodOptions;
+
+      if (typeof paramsOrCallback === 'function') {
+        callback = paramsOrCallback;
+        params = {} as Params$Resource$Thirdpartylinks$Delete;
+        options = {};
+      }
+
+      if (typeof optionsOrCallback === 'function') {
+        callback = optionsOrCallback;
+        options = {};
+      }
+
+      const rootUrl = options.rootUrl || 'https://youtube.googleapis.com/';
+      const parameters = {
+        options: Object.assign(
+          {
+            url: (rootUrl + '/youtube/v3/thirdPartyLinks').replace(
+              /([^:]\/)\/+/g,
+              '$1'
+            ),
+            method: 'DELETE',
+          },
+          options
+        ),
+        params,
+        requiredParams: ['linkingToken', 'type'],
+        pathParams: [],
+        context: this.context,
+      };
+      if (callback) {
+        createAPIRequest<void>(
+          parameters,
+          callback as BodyResponseCallback<unknown>
+        );
+      } else {
+        return createAPIRequest<void>(parameters);
+      }
+    }
+
+    /**
+     * Inserts a new resource into this collection.
+     * @example
+     * ```js
+     * // Before running the sample:
+     * // - Enable the API at:
+     * //   https://console.developers.google.com/apis/api/youtube.googleapis.com
+     * // - Login into gcloud by running:
+     * //   `$ gcloud auth application-default login`
+     * // - Install the npm module by running:
+     * //   `$ npm install googleapis`
+     *
+     * const {google} = require('googleapis');
+     * const youtube = google.youtube('v3');
+     *
+     * async function main() {
+     *   const auth = new google.auth.GoogleAuth({
+     *     // Scopes can be specified either as an array or as a single, space-delimited string.
+     *     scopes: [],
+     *   });
+     *
+     *   // Acquire an auth client, and bind it to all future calls
+     *   const authClient = await auth.getClient();
+     *   google.options({auth: authClient});
+     *
+     *   // Do the magic
+     *   const res = await youtube.thirdPartyLinks.insert({
+     *     // The *part* parameter specifies the thirdPartyLink resource parts that the API request and response will include. Supported values are linkingToken, status, and snippet.
+     *     part: 'placeholder-value',
+     *
+     *     // Request body metadata
+     *     requestBody: {
+     *       // request body parameters
+     *       // {
+     *       //   "etag": "my_etag",
+     *       //   "kind": "my_kind",
+     *       //   "linkingToken": "my_linkingToken",
+     *       //   "snippet": {},
+     *       //   "status": {}
+     *       // }
+     *     },
+     *   });
+     *   console.log(res.data);
+     *
+     *   // Example response
+     *   // {
+     *   //   "etag": "my_etag",
+     *   //   "kind": "my_kind",
+     *   //   "linkingToken": "my_linkingToken",
+     *   //   "snippet": {},
+     *   //   "status": {}
+     *   // }
+     * }
+     *
+     * main().catch(e => {
+     *   console.error(e);
+     *   throw e;
+     * });
+     *
+     * ```
+     *
+     * @param params - Parameters for request
+     * @param options - Optionally override request options, such as `url`, `method`, and `encoding`.
+     * @param callback - Optional callback that handles the response.
+     * @returns A promise if used with async/await, or void if used with a callback.
+     */
+    insert(
+      params: Params$Resource$Thirdpartylinks$Insert,
+      options: StreamMethodOptions
+    ): GaxiosPromise<Readable>;
+    insert(
+      params?: Params$Resource$Thirdpartylinks$Insert,
+      options?: MethodOptions
+    ): GaxiosPromise<Schema$ThirdPartyLink>;
+    insert(
+      params: Params$Resource$Thirdpartylinks$Insert,
+      options: StreamMethodOptions | BodyResponseCallback<Readable>,
+      callback: BodyResponseCallback<Readable>
+    ): void;
+    insert(
+      params: Params$Resource$Thirdpartylinks$Insert,
+      options: MethodOptions | BodyResponseCallback<Schema$ThirdPartyLink>,
+      callback: BodyResponseCallback<Schema$ThirdPartyLink>
+    ): void;
+    insert(
+      params: Params$Resource$Thirdpartylinks$Insert,
+      callback: BodyResponseCallback<Schema$ThirdPartyLink>
+    ): void;
+    insert(callback: BodyResponseCallback<Schema$ThirdPartyLink>): void;
+    insert(
+      paramsOrCallback?:
+        | Params$Resource$Thirdpartylinks$Insert
+        | BodyResponseCallback<Schema$ThirdPartyLink>
+        | BodyResponseCallback<Readable>,
+      optionsOrCallback?:
+        | MethodOptions
+        | StreamMethodOptions
+        | BodyResponseCallback<Schema$ThirdPartyLink>
+        | BodyResponseCallback<Readable>,
+      callback?:
+        | BodyResponseCallback<Schema$ThirdPartyLink>
+        | BodyResponseCallback<Readable>
+    ): void | GaxiosPromise<Schema$ThirdPartyLink> | GaxiosPromise<Readable> {
+      let params = (paramsOrCallback ||
+        {}) as Params$Resource$Thirdpartylinks$Insert;
+      let options = (optionsOrCallback || {}) as MethodOptions;
+
+      if (typeof paramsOrCallback === 'function') {
+        callback = paramsOrCallback;
+        params = {} as Params$Resource$Thirdpartylinks$Insert;
+        options = {};
+      }
+
+      if (typeof optionsOrCallback === 'function') {
+        callback = optionsOrCallback;
+        options = {};
+      }
+
+      const rootUrl = options.rootUrl || 'https://youtube.googleapis.com/';
+      const parameters = {
+        options: Object.assign(
+          {
+            url: (rootUrl + '/youtube/v3/thirdPartyLinks').replace(
+              /([^:]\/)\/+/g,
+              '$1'
+            ),
+            method: 'POST',
+          },
+          options
+        ),
+        params,
+        requiredParams: ['part'],
+        pathParams: [],
+        context: this.context,
+      };
+      if (callback) {
+        createAPIRequest<Schema$ThirdPartyLink>(
+          parameters,
+          callback as BodyResponseCallback<unknown>
+        );
+      } else {
+        return createAPIRequest<Schema$ThirdPartyLink>(parameters);
+      }
+    }
+
+    /**
+     * Retrieves a list of resources, possibly filtered.
+     * @example
+     * ```js
+     * // Before running the sample:
+     * // - Enable the API at:
+     * //   https://console.developers.google.com/apis/api/youtube.googleapis.com
+     * // - Login into gcloud by running:
+     * //   `$ gcloud auth application-default login`
+     * // - Install the npm module by running:
+     * //   `$ npm install googleapis`
+     *
+     * const {google} = require('googleapis');
+     * const youtube = google.youtube('v3');
+     *
+     * async function main() {
+     *   const auth = new google.auth.GoogleAuth({
+     *     // Scopes can be specified either as an array or as a single, space-delimited string.
+     *     scopes: [],
+     *   });
+     *
+     *   // Acquire an auth client, and bind it to all future calls
+     *   const authClient = await auth.getClient();
+     *   google.options({auth: authClient});
+     *
+     *   // Do the magic
+     *   const res = await youtube.thirdPartyLinks.list({
+     *     // Get a third party link with the given linking token.
+     *     linkingToken: 'placeholder-value',
+     *     // The *part* parameter specifies the thirdPartyLink resource parts that the API response will include. Supported values are linkingToken, status, and snippet.
+     *     part: 'placeholder-value',
+     *     // Get a third party link of the given type.
+     *     type: 'placeholder-value',
+     *   });
+     *   console.log(res.data);
+     *
+     *   // Example response
+     *   // {
+     *   //   "etag": "my_etag",
+     *   //   "kind": "my_kind",
+     *   //   "linkingToken": "my_linkingToken",
+     *   //   "snippet": {},
+     *   //   "status": {}
+     *   // }
+     * }
+     *
+     * main().catch(e => {
+     *   console.error(e);
+     *   throw e;
+     * });
+     *
+     * ```
+     *
+     * @param params - Parameters for request
+     * @param options - Optionally override request options, such as `url`, `method`, and `encoding`.
+     * @param callback - Optional callback that handles the response.
+     * @returns A promise if used with async/await, or void if used with a callback.
+     */
+    list(
+      params: Params$Resource$Thirdpartylinks$List,
+      options: StreamMethodOptions
+    ): GaxiosPromise<Readable>;
+    list(
+      params?: Params$Resource$Thirdpartylinks$List,
+      options?: MethodOptions
+    ): GaxiosPromise<Schema$ThirdPartyLink>;
+    list(
+      params: Params$Resource$Thirdpartylinks$List,
+      options: StreamMethodOptions | BodyResponseCallback<Readable>,
+      callback: BodyResponseCallback<Readable>
+    ): void;
+    list(
+      params: Params$Resource$Thirdpartylinks$List,
+      options: MethodOptions | BodyResponseCallback<Schema$ThirdPartyLink>,
+      callback: BodyResponseCallback<Schema$ThirdPartyLink>
+    ): void;
+    list(
+      params: Params$Resource$Thirdpartylinks$List,
+      callback: BodyResponseCallback<Schema$ThirdPartyLink>
+    ): void;
+    list(callback: BodyResponseCallback<Schema$ThirdPartyLink>): void;
+    list(
+      paramsOrCallback?:
+        | Params$Resource$Thirdpartylinks$List
+        | BodyResponseCallback<Schema$ThirdPartyLink>
+        | BodyResponseCallback<Readable>,
+      optionsOrCallback?:
+        | MethodOptions
+        | StreamMethodOptions
+        | BodyResponseCallback<Schema$ThirdPartyLink>
+        | BodyResponseCallback<Readable>,
+      callback?:
+        | BodyResponseCallback<Schema$ThirdPartyLink>
+        | BodyResponseCallback<Readable>
+    ): void | GaxiosPromise<Schema$ThirdPartyLink> | GaxiosPromise<Readable> {
+      let params = (paramsOrCallback ||
+        {}) as Params$Resource$Thirdpartylinks$List;
+      let options = (optionsOrCallback || {}) as MethodOptions;
+
+      if (typeof paramsOrCallback === 'function') {
+        callback = paramsOrCallback;
+        params = {} as Params$Resource$Thirdpartylinks$List;
+        options = {};
+      }
+
+      if (typeof optionsOrCallback === 'function') {
+        callback = optionsOrCallback;
+        options = {};
+      }
+
+      const rootUrl = options.rootUrl || 'https://youtube.googleapis.com/';
+      const parameters = {
+        options: Object.assign(
+          {
+            url: (rootUrl + '/youtube/v3/thirdPartyLinks').replace(
+              /([^:]\/)\/+/g,
+              '$1'
+            ),
+            method: 'GET',
+          },
+          options
+        ),
+        params,
+        requiredParams: ['part'],
+        pathParams: [],
+        context: this.context,
+      };
+      if (callback) {
+        createAPIRequest<Schema$ThirdPartyLink>(
+          parameters,
+          callback as BodyResponseCallback<unknown>
+        );
+      } else {
+        return createAPIRequest<Schema$ThirdPartyLink>(parameters);
+      }
+    }
+
+    /**
+     * Updates an existing resource.
+     * @example
+     * ```js
+     * // Before running the sample:
+     * // - Enable the API at:
+     * //   https://console.developers.google.com/apis/api/youtube.googleapis.com
+     * // - Login into gcloud by running:
+     * //   `$ gcloud auth application-default login`
+     * // - Install the npm module by running:
+     * //   `$ npm install googleapis`
+     *
+     * const {google} = require('googleapis');
+     * const youtube = google.youtube('v3');
+     *
+     * async function main() {
+     *   const auth = new google.auth.GoogleAuth({
+     *     // Scopes can be specified either as an array or as a single, space-delimited string.
+     *     scopes: [],
+     *   });
+     *
+     *   // Acquire an auth client, and bind it to all future calls
+     *   const authClient = await auth.getClient();
+     *   google.options({auth: authClient});
+     *
+     *   // Do the magic
+     *   const res = await youtube.thirdPartyLinks.update({
+     *     // The *part* parameter specifies the thirdPartyLink resource parts that the API request and response will include. Supported values are linkingToken, status, and snippet.
+     *     part: 'placeholder-value',
+     *
+     *     // Request body metadata
+     *     requestBody: {
+     *       // request body parameters
+     *       // {
+     *       //   "etag": "my_etag",
+     *       //   "kind": "my_kind",
+     *       //   "linkingToken": "my_linkingToken",
+     *       //   "snippet": {},
+     *       //   "status": {}
+     *       // }
+     *     },
+     *   });
+     *   console.log(res.data);
+     *
+     *   // Example response
+     *   // {
+     *   //   "etag": "my_etag",
+     *   //   "kind": "my_kind",
+     *   //   "linkingToken": "my_linkingToken",
+     *   //   "snippet": {},
+     *   //   "status": {}
+     *   // }
+     * }
+     *
+     * main().catch(e => {
+     *   console.error(e);
+     *   throw e;
+     * });
+     *
+     * ```
+     *
+     * @param params - Parameters for request
+     * @param options - Optionally override request options, such as `url`, `method`, and `encoding`.
+     * @param callback - Optional callback that handles the response.
+     * @returns A promise if used with async/await, or void if used with a callback.
+     */
+    update(
+      params: Params$Resource$Thirdpartylinks$Update,
+      options: StreamMethodOptions
+    ): GaxiosPromise<Readable>;
+    update(
+      params?: Params$Resource$Thirdpartylinks$Update,
+      options?: MethodOptions
+    ): GaxiosPromise<Schema$ThirdPartyLink>;
+    update(
+      params: Params$Resource$Thirdpartylinks$Update,
+      options: StreamMethodOptions | BodyResponseCallback<Readable>,
+      callback: BodyResponseCallback<Readable>
+    ): void;
+    update(
+      params: Params$Resource$Thirdpartylinks$Update,
+      options: MethodOptions | BodyResponseCallback<Schema$ThirdPartyLink>,
+      callback: BodyResponseCallback<Schema$ThirdPartyLink>
+    ): void;
+    update(
+      params: Params$Resource$Thirdpartylinks$Update,
+      callback: BodyResponseCallback<Schema$ThirdPartyLink>
+    ): void;
+    update(callback: BodyResponseCallback<Schema$ThirdPartyLink>): void;
+    update(
+      paramsOrCallback?:
+        | Params$Resource$Thirdpartylinks$Update
+        | BodyResponseCallback<Schema$ThirdPartyLink>
+        | BodyResponseCallback<Readable>,
+      optionsOrCallback?:
+        | MethodOptions
+        | StreamMethodOptions
+        | BodyResponseCallback<Schema$ThirdPartyLink>
+        | BodyResponseCallback<Readable>,
+      callback?:
+        | BodyResponseCallback<Schema$ThirdPartyLink>
+        | BodyResponseCallback<Readable>
+    ): void | GaxiosPromise<Schema$ThirdPartyLink> | GaxiosPromise<Readable> {
+      let params = (paramsOrCallback ||
+        {}) as Params$Resource$Thirdpartylinks$Update;
+      let options = (optionsOrCallback || {}) as MethodOptions;
+
+      if (typeof paramsOrCallback === 'function') {
+        callback = paramsOrCallback;
+        params = {} as Params$Resource$Thirdpartylinks$Update;
+        options = {};
+      }
+
+      if (typeof optionsOrCallback === 'function') {
+        callback = optionsOrCallback;
+        options = {};
+      }
+
+      const rootUrl = options.rootUrl || 'https://youtube.googleapis.com/';
+      const parameters = {
+        options: Object.assign(
+          {
+            url: (rootUrl + '/youtube/v3/thirdPartyLinks').replace(
+              /([^:]\/)\/+/g,
+              '$1'
+            ),
+            method: 'PUT',
+          },
+          options
+        ),
+        params,
+        requiredParams: ['part'],
+        pathParams: [],
+        context: this.context,
+      };
+      if (callback) {
+        createAPIRequest<Schema$ThirdPartyLink>(
+          parameters,
+          callback as BodyResponseCallback<unknown>
+        );
+      } else {
+        return createAPIRequest<Schema$ThirdPartyLink>(parameters);
+      }
+    }
+  }
+
+  export interface Params$Resource$Thirdpartylinks$Delete
+    extends StandardParameters {
+    /**
+     * Delete the partner links with the given linking token.
+     */
+    linkingToken?: string;
+    /**
+     * Do not use. Required for compatibility.
+     */
+    part?: string[];
+    /**
+     * Type of the link to be deleted.
+     */
+    type?: string;
+  }
+  export interface Params$Resource$Thirdpartylinks$Insert
+    extends StandardParameters {
+    /**
+     * The *part* parameter specifies the thirdPartyLink resource parts that the API request and response will include. Supported values are linkingToken, status, and snippet.
+     */
+    part?: string[];
+
+    /**
+     * Request body metadata
+     */
+    requestBody?: Schema$ThirdPartyLink;
+  }
+  export interface Params$Resource$Thirdpartylinks$List
+    extends StandardParameters {
+    /**
+     * Get a third party link with the given linking token.
+     */
+    linkingToken?: string;
+    /**
+     * The *part* parameter specifies the thirdPartyLink resource parts that the API response will include. Supported values are linkingToken, status, and snippet.
+     */
+    part?: string[];
+    /**
+     * Get a third party link of the given type.
+     */
+    type?: string;
+  }
+  export interface Params$Resource$Thirdpartylinks$Update
+    extends StandardParameters {
+    /**
+     * The *part* parameter specifies the thirdPartyLink resource parts that the API request and response will include. Supported values are linkingToken, status, and snippet.
+     */
+    part?: string[];
+
+    /**
+     * Request body metadata
+     */
+    requestBody?: Schema$ThirdPartyLink;
   }
 
   export class Resource$Thumbnails {
@@ -16197,9 +15201,9 @@ export namespace youtube_v3 {
     }
 
     /**
-     * youtube.thumbnails.set
-     * @desc As this is not an insert in a strict sense (it supports uploading/setting of a thumbnail for multiple videos, which doesn't result in creation of a single resource), I use a custom verb here.
+     * As this is not an insert in a strict sense (it supports uploading/setting of a thumbnail for multiple videos, which doesn't result in creation of a single resource), I use a custom verb here.
      * @example
+     * ```js
      * // Before running the sample:
      * // - Enable the API at:
      * //   https://console.developers.google.com/apis/api/youtube.googleapis.com
@@ -16228,18 +15232,7 @@ export namespace youtube_v3 {
      *
      *   // Do the magic
      *   const res = await youtube.thumbnails.set({
-     *     // <strong>Note:</strong> This parameter is intended exclusively for YouTube
-     *     // content partners.<br><br>The
-     *     // <code><strong>onBehalfOfContentOwner</strong></code> parameter indicates
-     *     // that the
-     *     // request's authorization credentials identify a YouTube CMS user who is
-     *     // acting on behalf of the content owner specified in the parameter value.
-     *     // This parameter is intended for YouTube content partners that own and manage
-     *     // many different YouTube channels. It allows content owners to authenticate
-     *     // once and get access to all their video and channel data, without having to
-     *     // provide authentication credentials for each individual channel. The actual
-     *     // CMS account that the user authenticates with must be linked to the
-     *     // specified YouTube content owner.
+     *     // *Note:* This parameter is intended exclusively for YouTube content partners. The *onBehalfOfContentOwner* parameter indicates that the request's authorization credentials identify a YouTube CMS user who is acting on behalf of the content owner specified in the parameter value. This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and get access to all their video and channel data, without having to provide authentication credentials for each individual channel. The actual CMS account that the user authenticates with must be linked to the specified YouTube content owner.
      *     onBehalfOfContentOwner: 'placeholder-value',
      *     // Returns the Thumbnail with the given video IDs for Stubby or Apiary.
      *     videoId: 'placeholder-value',
@@ -16269,18 +15262,12 @@ export namespace youtube_v3 {
      *   throw e;
      * });
      *
-     * @alias youtube.thumbnails.set
-     * @memberOf! ()
+     * ```
      *
-     * @param {object} params Parameters for request
-     * @param {string=} params.onBehalfOfContentOwner <strong>Note:</strong> This parameter is intended exclusively for YouTube content partners.<br><br>The <code><strong>onBehalfOfContentOwner</strong></code> parameter indicates that the request's authorization credentials identify a YouTube CMS user who is acting on behalf of the content owner specified in the parameter value. This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and get access to all their video and channel data, without having to provide authentication credentials for each individual channel. The actual CMS account that the user authenticates with must be linked to the specified YouTube content owner.
-     * @param {string} params.videoId Returns the Thumbnail with the given video IDs for Stubby or Apiary.
-     * @param {object} params.media Media object
-     * @param {string} params.media.mimeType Media mime-type
-     * @param {string|object} params.media.body Media body contents
-     * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-     * @param {callback} callback The callback that handles the response.
-     * @return {object} Request object
+     * @param params - Parameters for request
+     * @param options - Optionally override request options, such as `url`, `method`, and `encoding`.
+     * @param callback - Optional callback that handles the response.
+     * @returns A promise if used with async/await, or void if used with a callback.
      */
     set(
       params: Params$Resource$Thumbnails$Set,
@@ -16338,7 +15325,7 @@ export namespace youtube_v3 {
         options = {};
       }
 
-      const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+      const rootUrl = options.rootUrl || 'https://youtube.googleapis.com/';
       const parameters = {
         options: Object.assign(
           {
@@ -16362,7 +15349,7 @@ export namespace youtube_v3 {
       if (callback) {
         createAPIRequest<Schema$ThumbnailSetResponse>(
           parameters,
-          callback as BodyResponseCallback<{} | void>
+          callback as BodyResponseCallback<unknown>
         );
       } else {
         return createAPIRequest<Schema$ThumbnailSetResponse>(parameters);
@@ -16372,7 +15359,7 @@ export namespace youtube_v3 {
 
   export interface Params$Resource$Thumbnails$Set extends StandardParameters {
     /**
-     * <strong>Note:</strong> This parameter is intended exclusively for YouTube content partners.<br><br>The <code><strong>onBehalfOfContentOwner</strong></code> parameter indicates that the request's authorization credentials identify a YouTube CMS user who is acting on behalf of the content owner specified in the parameter value. This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and get access to all their video and channel data, without having to provide authentication credentials for each individual channel. The actual CMS account that the user authenticates with must be linked to the specified YouTube content owner.
+     * *Note:* This parameter is intended exclusively for YouTube content partners. The *onBehalfOfContentOwner* parameter indicates that the request's authorization credentials identify a YouTube CMS user who is acting on behalf of the content owner specified in the parameter value. This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and get access to all their video and channel data, without having to provide authentication credentials for each individual channel. The actual CMS account that the user authenticates with must be linked to the specified YouTube content owner.
      */
     onBehalfOfContentOwner?: string;
     /**
@@ -16408,9 +15395,9 @@ export namespace youtube_v3 {
     }
 
     /**
-     * youtube.videoAbuseReportReasons.list
-     * @desc Retrieves a list of resources, possibly filtered.
+     * Retrieves a list of resources, possibly filtered.
      * @example
+     * ```js
      * // Before running the sample:
      * // - Enable the API at:
      * //   https://console.developers.google.com/apis/api/youtube.googleapis.com
@@ -16439,9 +15426,7 @@ export namespace youtube_v3 {
      *   // Do the magic
      *   const res = await youtube.videoAbuseReportReasons.list({
      *     hl: 'placeholder-value',
-     *     // The <code><strong>part</strong></code> parameter specifies the
-     *     // <code>videoCategory</code> resource parts that the API response will
-     *     // include. Supported values are <code>id</code> and <code>snippet</code>.
+     *     // The *part* parameter specifies the videoCategory resource parts that the API response will include. Supported values are id and snippet.
      *     part: 'placeholder-value',
      *   });
      *   console.log(res.data);
@@ -16461,15 +15446,12 @@ export namespace youtube_v3 {
      *   throw e;
      * });
      *
-     * @alias youtube.videoAbuseReportReasons.list
-     * @memberOf! ()
+     * ```
      *
-     * @param {object} params Parameters for request
-     * @param {string=} params.hl
-     * @param {string} params.part The <code><strong>part</strong></code> parameter specifies the <code>videoCategory</code> resource parts that the API response will include. Supported values are <code>id</code> and <code>snippet</code>.
-     * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-     * @param {callback} callback The callback that handles the response.
-     * @return {object} Request object
+     * @param params - Parameters for request
+     * @param options - Optionally override request options, such as `url`, `method`, and `encoding`.
+     * @param callback - Optional callback that handles the response.
+     * @returns A promise if used with async/await, or void if used with a callback.
      */
     list(
       params: Params$Resource$Videoabusereportreasons$List,
@@ -16530,7 +15512,7 @@ export namespace youtube_v3 {
         options = {};
       }
 
-      const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+      const rootUrl = options.rootUrl || 'https://youtube.googleapis.com/';
       const parameters = {
         options: Object.assign(
           {
@@ -16550,7 +15532,7 @@ export namespace youtube_v3 {
       if (callback) {
         createAPIRequest<Schema$VideoAbuseReportReasonListResponse>(
           parameters,
-          callback as BodyResponseCallback<{} | void>
+          callback as BodyResponseCallback<unknown>
         );
       } else {
         return createAPIRequest<Schema$VideoAbuseReportReasonListResponse>(
@@ -16567,7 +15549,7 @@ export namespace youtube_v3 {
      */
     hl?: string;
     /**
-     * The <code><strong>part</strong></code> parameter specifies the <code>videoCategory</code> resource parts that the API response will include. Supported values are <code>id</code> and <code>snippet</code>.
+     * The *part* parameter specifies the videoCategory resource parts that the API response will include. Supported values are id and snippet.
      */
     part?: string[];
   }
@@ -16579,9 +15561,9 @@ export namespace youtube_v3 {
     }
 
     /**
-     * youtube.videoCategories.list
-     * @desc Retrieves a list of resources, possibly filtered.
+     * Retrieves a list of resources, possibly filtered.
      * @example
+     * ```js
      * // Before running the sample:
      * // - Enable the API at:
      * //   https://console.developers.google.com/apis/api/youtube.googleapis.com
@@ -16613,9 +15595,7 @@ export namespace youtube_v3 {
      *     hl: 'placeholder-value',
      *     // Returns the video categories with the given IDs for Stubby or Apiary.
      *     id: 'placeholder-value',
-     *     // The <code><strong>part</strong></code> parameter specifies the
-     *     // <code>videoCategory</code> resource properties that the API response will
-     *     // include. Set the parameter value to <code>snippet</code>.
+     *     // The *part* parameter specifies the videoCategory resource properties that the API response will include. Set the parameter value to snippet.
      *     part: 'placeholder-value',
      *
      *     regionCode: 'placeholder-value',
@@ -16641,17 +15621,12 @@ export namespace youtube_v3 {
      *   throw e;
      * });
      *
-     * @alias youtube.videoCategories.list
-     * @memberOf! ()
+     * ```
      *
-     * @param {object} params Parameters for request
-     * @param {string=} params.hl
-     * @param {string=} params.id Returns the video categories with the given IDs for Stubby or Apiary.
-     * @param {string} params.part The <code><strong>part</strong></code> parameter specifies the <code>videoCategory</code> resource properties that the API response will include. Set the parameter value to <code>snippet</code>.
-     * @param {string=} params.regionCode
-     * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-     * @param {callback} callback The callback that handles the response.
-     * @return {object} Request object
+     * @param params - Parameters for request
+     * @param options - Optionally override request options, such as `url`, `method`, and `encoding`.
+     * @param callback - Optional callback that handles the response.
+     * @returns A promise if used with async/await, or void if used with a callback.
      */
     list(
       params: Params$Resource$Videocategories$List,
@@ -16712,7 +15687,7 @@ export namespace youtube_v3 {
         options = {};
       }
 
-      const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+      const rootUrl = options.rootUrl || 'https://youtube.googleapis.com/';
       const parameters = {
         options: Object.assign(
           {
@@ -16732,7 +15707,7 @@ export namespace youtube_v3 {
       if (callback) {
         createAPIRequest<Schema$VideoCategoryListResponse>(
           parameters,
-          callback as BodyResponseCallback<{} | void>
+          callback as BodyResponseCallback<unknown>
         );
       } else {
         return createAPIRequest<Schema$VideoCategoryListResponse>(parameters);
@@ -16751,7 +15726,7 @@ export namespace youtube_v3 {
      */
     id?: string[];
     /**
-     * The <code><strong>part</strong></code> parameter specifies the <code>videoCategory</code> resource properties that the API response will include. Set the parameter value to <code>snippet</code>.
+     * The *part* parameter specifies the videoCategory resource properties that the API response will include. Set the parameter value to snippet.
      */
     part?: string[];
     /**
@@ -16767,9 +15742,9 @@ export namespace youtube_v3 {
     }
 
     /**
-     * youtube.videos.delete
-     * @desc Deletes a resource.
+     * Deletes a resource.
      * @example
+     * ```js
      * // Before running the sample:
      * // - Enable the API at:
      * //   https://console.developers.google.com/apis/api/youtube.googleapis.com
@@ -16798,18 +15773,7 @@ export namespace youtube_v3 {
      *   // Do the magic
      *   const res = await youtube.videos.delete({
      *     id: 'placeholder-value',
-     *     // <strong>Note:</strong> This parameter is intended exclusively for YouTube
-     *     // content partners.<br><br>The
-     *     // <code><strong>onBehalfOfContentOwner</strong></code> parameter indicates
-     *     // that the
-     *     // request's authorization credentials identify a YouTube CMS user who is
-     *     // acting on behalf of the content owner specified in the parameter value.
-     *     // This parameter is intended for YouTube content partners that own and manage
-     *     // many different YouTube channels. It allows content owners to authenticate
-     *     // once and get access to all their video and channel data, without having to
-     *     // provide authentication credentials for each individual channel. The actual
-     *     // CMS account that the user authenticates with must be linked to the
-     *     // specified YouTube content owner.
+     *     // *Note:* This parameter is intended exclusively for YouTube content partners. The *onBehalfOfContentOwner* parameter indicates that the request's authorization credentials identify a YouTube CMS user who is acting on behalf of the content owner specified in the parameter value. This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and get access to all their video and channel data, without having to provide authentication credentials for each individual channel. The actual CMS account that the user authenticates with must be linked to the specified YouTube content owner.
      *     onBehalfOfContentOwner: 'placeholder-value',
      *   });
      *   console.log(res.data);
@@ -16820,15 +15784,12 @@ export namespace youtube_v3 {
      *   throw e;
      * });
      *
-     * @alias youtube.videos.delete
-     * @memberOf! ()
+     * ```
      *
-     * @param {object} params Parameters for request
-     * @param {string} params.id
-     * @param {string=} params.onBehalfOfContentOwner <strong>Note:</strong> This parameter is intended exclusively for YouTube content partners.<br><br>The <code><strong>onBehalfOfContentOwner</strong></code> parameter indicates that the request's authorization credentials identify a YouTube CMS user who is acting on behalf of the content owner specified in the parameter value. This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and get access to all their video and channel data, without having to provide authentication credentials for each individual channel. The actual CMS account that the user authenticates with must be linked to the specified YouTube content owner.
-     * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-     * @param {callback} callback The callback that handles the response.
-     * @return {object} Request object
+     * @param params - Parameters for request
+     * @param options - Optionally override request options, such as `url`, `method`, and `encoding`.
+     * @param callback - Optional callback that handles the response.
+     * @returns A promise if used with async/await, or void if used with a callback.
      */
     delete(
       params: Params$Resource$Videos$Delete,
@@ -16879,7 +15840,7 @@ export namespace youtube_v3 {
         options = {};
       }
 
-      const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+      const rootUrl = options.rootUrl || 'https://youtube.googleapis.com/';
       const parameters = {
         options: Object.assign(
           {
@@ -16896,7 +15857,7 @@ export namespace youtube_v3 {
       if (callback) {
         createAPIRequest<void>(
           parameters,
-          callback as BodyResponseCallback<{} | void>
+          callback as BodyResponseCallback<unknown>
         );
       } else {
         return createAPIRequest<void>(parameters);
@@ -16904,9 +15865,9 @@ export namespace youtube_v3 {
     }
 
     /**
-     * youtube.videos.getRating
-     * @desc Retrieves the ratings that the authorized user gave to a list of specified videos.
+     * Retrieves the ratings that the authorized user gave to a list of specified videos.
      * @example
+     * ```js
      * // Before running the sample:
      * // - Enable the API at:
      * //   https://console.developers.google.com/apis/api/youtube.googleapis.com
@@ -16935,18 +15896,7 @@ export namespace youtube_v3 {
      *   // Do the magic
      *   const res = await youtube.videos.getRating({
      *     id: 'placeholder-value',
-     *     // <strong>Note:</strong> This parameter is intended exclusively for YouTube
-     *     // content partners.<br><br>The
-     *     // <code><strong>onBehalfOfContentOwner</strong></code> parameter indicates
-     *     // that the
-     *     // request's authorization credentials identify a YouTube CMS user who is
-     *     // acting on behalf of the content owner specified in the parameter value.
-     *     // This parameter is intended for YouTube content partners that own and manage
-     *     // many different YouTube channels. It allows content owners to authenticate
-     *     // once and get access to all their video and channel data, without having to
-     *     // provide authentication credentials for each individual channel. The CMS
-     *     // account that the user authenticates with must be linked to the specified
-     *     // YouTube content owner.
+     *     // *Note:* This parameter is intended exclusively for YouTube content partners. The *onBehalfOfContentOwner* parameter indicates that the request's authorization credentials identify a YouTube CMS user who is acting on behalf of the content owner specified in the parameter value. This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and get access to all their video and channel data, without having to provide authentication credentials for each individual channel. The CMS account that the user authenticates with must be linked to the specified YouTube content owner.
      *     onBehalfOfContentOwner: 'placeholder-value',
      *   });
      *   console.log(res.data);
@@ -16966,15 +15916,12 @@ export namespace youtube_v3 {
      *   throw e;
      * });
      *
-     * @alias youtube.videos.getRating
-     * @memberOf! ()
+     * ```
      *
-     * @param {object} params Parameters for request
-     * @param {string} params.id
-     * @param {string=} params.onBehalfOfContentOwner <strong>Note:</strong> This parameter is intended exclusively for YouTube content partners.<br><br>The <code><strong>onBehalfOfContentOwner</strong></code> parameter indicates that the request's authorization credentials identify a YouTube CMS user who is acting on behalf of the content owner specified in the parameter value. This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and get access to all their video and channel data, without having to provide authentication credentials for each individual channel. The CMS account that the user authenticates with must be linked to the specified YouTube content owner.
-     * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-     * @param {callback} callback The callback that handles the response.
-     * @return {object} Request object
+     * @param params - Parameters for request
+     * @param options - Optionally override request options, such as `url`, `method`, and `encoding`.
+     * @param callback - Optional callback that handles the response.
+     * @returns A promise if used with async/await, or void if used with a callback.
      */
     getRating(
       params: Params$Resource$Videos$Getrating,
@@ -17034,7 +15981,7 @@ export namespace youtube_v3 {
         options = {};
       }
 
-      const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+      const rootUrl = options.rootUrl || 'https://youtube.googleapis.com/';
       const parameters = {
         options: Object.assign(
           {
@@ -17054,7 +16001,7 @@ export namespace youtube_v3 {
       if (callback) {
         createAPIRequest<Schema$VideoRatingListResponse>(
           parameters,
-          callback as BodyResponseCallback<{} | void>
+          callback as BodyResponseCallback<unknown>
         );
       } else {
         return createAPIRequest<Schema$VideoRatingListResponse>(parameters);
@@ -17062,9 +16009,9 @@ export namespace youtube_v3 {
     }
 
     /**
-     * youtube.videos.insert
-     * @desc Inserts a new resource into this collection.
+     * Inserts a new resource into this collection.
      * @example
+     * ```js
      * // Before running the sample:
      * // - Enable the API at:
      * //   https://console.developers.google.com/apis/api/youtube.googleapis.com
@@ -17095,52 +16042,13 @@ export namespace youtube_v3 {
      *   const res = await youtube.videos.insert({
      *     // Should auto-levels be applied to the upload.
      *     autoLevels: 'placeholder-value',
-     *     // Notify the channel subscribers about the new video. As default, the
-     *     // notification is enabled.
+     *     // Notify the channel subscribers about the new video. As default, the notification is enabled.
      *     notifySubscribers: 'placeholder-value',
-     *     // <strong>Note:</strong> This parameter is intended exclusively for YouTube
-     *     // content partners.<br><br>The
-     *     // <code><strong>onBehalfOfContentOwner</strong></code> parameter indicates
-     *     // that the
-     *     // request's authorization credentials identify a YouTube CMS user who is
-     *     // acting on behalf of the content owner specified in the parameter value.
-     *     // This parameter is intended for YouTube content partners that own and manage
-     *     // many different YouTube channels. It allows content owners to authenticate
-     *     // once and get access to all their video and channel data, without having to
-     *     // provide authentication credentials for each individual channel. The CMS
-     *     // account that the user authenticates with must be linked to the specified
-     *     // YouTube content owner.
+     *     // *Note:* This parameter is intended exclusively for YouTube content partners. The *onBehalfOfContentOwner* parameter indicates that the request's authorization credentials identify a YouTube CMS user who is acting on behalf of the content owner specified in the parameter value. This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and get access to all their video and channel data, without having to provide authentication credentials for each individual channel. The CMS account that the user authenticates with must be linked to the specified YouTube content owner.
      *     onBehalfOfContentOwner: 'placeholder-value',
-     *     // This parameter can only be used in a properly <a
-     *     // href="/youtube/v3/guides/authentication">authorized request</a>.
-     *     // <strong>Note:</strong> This parameter is intended exclusively for YouTube
-     *     // content partners.<br><br>The
-     *     // <code><strong>onBehalfOfContentOwnerChannel</strong></code> parameter
-     *     // specifies the YouTube channel ID of the channel to which a video is being
-     *     // added. This parameter is required when a request specifies a value for the
-     *     // <code>onBehalfOfContentOwner</code> parameter, and it can only be used in
-     *     // conjunction with that parameter. In addition, the request must be
-     *     // authorized using a CMS account that is linked to the content owner that the
-     *     // <code>onBehalfOfContentOwner</code> parameter specifies. Finally, the
-     *     // channel that the <code>onBehalfOfContentOwnerChannel</code> parameter value
-     *     // specifies must be linked to the content owner that the
-     *     // <code>onBehalfOfContentOwner</code> parameter specifies.<br><br>This
-     *     // parameter is intended for YouTube content partners that own and manage many
-     *     // different YouTube channels. It allows content owners to authenticate once
-     *     // and perform actions on behalf of the channel specified in the parameter
-     *     // value, without having to provide authentication credentials for each
-     *     // separate channel.
+     *     // This parameter can only be used in a properly authorized request. *Note:* This parameter is intended exclusively for YouTube content partners. The *onBehalfOfContentOwnerChannel* parameter specifies the YouTube channel ID of the channel to which a video is being added. This parameter is required when a request specifies a value for the onBehalfOfContentOwner parameter, and it can only be used in conjunction with that parameter. In addition, the request must be authorized using a CMS account that is linked to the content owner that the onBehalfOfContentOwner parameter specifies. Finally, the channel that the onBehalfOfContentOwnerChannel parameter value specifies must be linked to the content owner that the onBehalfOfContentOwner parameter specifies. This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and perform actions on behalf of the channel specified in the parameter value, without having to provide authentication credentials for each separate channel.
      *     onBehalfOfContentOwnerChannel: 'placeholder-value',
-     *     // The <code><strong>part</strong></code> parameter serves two purposes in
-     *     // this operation. It identifies the properties that the write operation will
-     *     // set as well as the properties that the API response will
-     *     // include.<br/><br/>Note that not all parts contain properties that can be
-     *     // set when inserting or updating a video. For example, the
-     *     // <code>statistics</code> object encapsulates statistics that YouTube
-     *     // calculates for a video and does not contain values that you can set or
-     *     // modify. If the parameter value specifies a <code>part</code> that does not
-     *     // contain mutable values, that <code>part</code> will still be included in
-     *     // the API response.
+     *     // The *part* parameter serves two purposes in this operation. It identifies the properties that the write operation will set as well as the properties that the API response will include. Note that not all parts contain properties that can be set when inserting or updating a video. For example, the statistics object encapsulates statistics that YouTube calculates for a video and does not contain values that you can set or modify. If the parameter value specifies a part that does not contain mutable values, that part will still be included in the API response.
      *     part: 'placeholder-value',
      *     // Should stabilize be applied to the upload.
      *     stabilize: 'placeholder-value',
@@ -17204,23 +16112,12 @@ export namespace youtube_v3 {
      *   throw e;
      * });
      *
-     * @alias youtube.videos.insert
-     * @memberOf! ()
+     * ```
      *
-     * @param {object} params Parameters for request
-     * @param {boolean=} params.autoLevels Should auto-levels be applied to the upload.
-     * @param {boolean=} params.notifySubscribers Notify the channel subscribers about the new video. As default, the notification is enabled.
-     * @param {string=} params.onBehalfOfContentOwner <strong>Note:</strong> This parameter is intended exclusively for YouTube content partners.<br><br>The <code><strong>onBehalfOfContentOwner</strong></code> parameter indicates that the request's authorization credentials identify a YouTube CMS user who is acting on behalf of the content owner specified in the parameter value. This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and get access to all their video and channel data, without having to provide authentication credentials for each individual channel. The CMS account that the user authenticates with must be linked to the specified YouTube content owner.
-     * @param {string=} params.onBehalfOfContentOwnerChannel This parameter can only be used in a properly <a href="/youtube/v3/guides/authentication">authorized request</a>. <strong>Note:</strong> This parameter is intended exclusively for YouTube content partners.<br><br>The <code><strong>onBehalfOfContentOwnerChannel</strong></code> parameter specifies the YouTube channel ID of the channel to which a video is being added. This parameter is required when a request specifies a value for the <code>onBehalfOfContentOwner</code> parameter, and it can only be used in conjunction with that parameter. In addition, the request must be authorized using a CMS account that is linked to the content owner that the <code>onBehalfOfContentOwner</code> parameter specifies. Finally, the channel that the <code>onBehalfOfContentOwnerChannel</code> parameter value specifies must be linked to the content owner that the <code>onBehalfOfContentOwner</code> parameter specifies.<br><br>This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and perform actions on behalf of the channel specified in the parameter value, without having to provide authentication credentials for each separate channel.
-     * @param {string} params.part The <code><strong>part</strong></code> parameter serves two purposes in this operation. It identifies the properties that the write operation will set as well as the properties that the API response will include.<br/><br/>Note that not all parts contain properties that can be set when inserting or updating a video. For example, the <code>statistics</code> object encapsulates statistics that YouTube calculates for a video and does not contain values that you can set or modify. If the parameter value specifies a <code>part</code> that does not contain mutable values, that <code>part</code> will still be included in the API response.
-     * @param {boolean=} params.stabilize Should stabilize be applied to the upload.
-     * @param  {object} params.requestBody Media resource metadata
-     * @param {object} params.media Media object
-     * @param {string} params.media.mimeType Media mime-type
-     * @param {string|object} params.media.body Media body contents
-     * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-     * @param {callback} callback The callback that handles the response.
-     * @return {object} Request object
+     * @param params - Parameters for request
+     * @param options - Optionally override request options, such as `url`, `method`, and `encoding`.
+     * @param callback - Optional callback that handles the response.
+     * @returns A promise if used with async/await, or void if used with a callback.
      */
     insert(
       params: Params$Resource$Videos$Insert,
@@ -17273,7 +16170,7 @@ export namespace youtube_v3 {
         options = {};
       }
 
-      const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+      const rootUrl = options.rootUrl || 'https://youtube.googleapis.com/';
       const parameters = {
         options: Object.assign(
           {
@@ -17294,7 +16191,7 @@ export namespace youtube_v3 {
       if (callback) {
         createAPIRequest<Schema$Video>(
           parameters,
-          callback as BodyResponseCallback<{} | void>
+          callback as BodyResponseCallback<unknown>
         );
       } else {
         return createAPIRequest<Schema$Video>(parameters);
@@ -17302,9 +16199,9 @@ export namespace youtube_v3 {
     }
 
     /**
-     * youtube.videos.list
-     * @desc Retrieves a list of resources, possibly filtered.
+     * Retrieves a list of resources, possibly filtered.
      * @example
+     * ```js
      * // Before running the sample:
      * // - Enable the API at:
      * //   https://console.developers.google.com/apis/api/youtube.googleapis.com
@@ -17335,11 +16232,7 @@ export namespace youtube_v3 {
      *   const res = await youtube.videos.list({
      *     // Return the videos that are in the specified chart.
      *     chart: 'placeholder-value',
-     *     // Stands for "host language". Specifies the localization language of the
-     *     // metadata to be filled into snippet.localized. The field is filled with the
-     *     // default metadata if there is no localization in the specified language.
-     *     // The parameter value must be a language code included in the list returned
-     *     // by the i18nLanguages.list method (e.g. en_US, es_MX).
+     *     // Stands for "host language". Specifies the localization language of the metadata to be filled into snippet.localized. The field is filled with the default metadata if there is no localization in the specified language. The parameter value must be a language code included in the list returned by the i18nLanguages.list method (e.g. en_US, es_MX).
      *     hl: 'placeholder-value',
      *     // Return videos with the given ids.
      *     id: 'placeholder-value',
@@ -17347,51 +16240,17 @@ export namespace youtube_v3 {
      *     locale: 'placeholder-value',
      *
      *     maxHeight: 'placeholder-value',
-     *     // The <code><strong>maxResults</strong></code> parameter specifies the
-     *     // maximum number of items that should be returned in the result
-     *     // set.<br><br><strong>Note:</strong> This parameter is supported for use in
-     *     // conjunction with the <code><a href="#myRating">myRating</a></code> and
-     *     // <code><a href="#chart">chart</a></code> parameters, but it is not supported
-     *     // for use in conjunction with the <code><a href="#id">id</a></code>
-     *     // parameter.
+     *     // The *maxResults* parameter specifies the maximum number of items that should be returned in the result set. *Note:* This parameter is supported for use in conjunction with the myRating and chart parameters, but it is not supported for use in conjunction with the id parameter.
      *     maxResults: 'placeholder-value',
      *     // Return the player with maximum height specified in
      *     maxWidth: 'placeholder-value',
-     *     // Return videos liked/disliked by the authenticated user.
-     *     // Does not support RateType.RATED_TYPE_NONE.
+     *     // Return videos liked/disliked by the authenticated user. Does not support RateType.RATED_TYPE_NONE.
      *     myRating: 'placeholder-value',
-     *     // <strong>Note:</strong> This parameter is intended exclusively for YouTube
-     *     // content partners.<br><br>The
-     *     // <code><strong>onBehalfOfContentOwner</strong></code> parameter indicates
-     *     // that the
-     *     // request's authorization credentials identify a YouTube CMS user who is
-     *     // acting on behalf of the content owner specified in the parameter value.
-     *     // This parameter is intended for YouTube content partners that own and manage
-     *     // many different YouTube channels. It allows content owners to authenticate
-     *     // once and get access to all their video and channel data, without having to
-     *     // provide authentication credentials for each individual channel. The CMS
-     *     // account that the user authenticates with must be linked to the specified
-     *     // YouTube content owner.
+     *     // *Note:* This parameter is intended exclusively for YouTube content partners. The *onBehalfOfContentOwner* parameter indicates that the request's authorization credentials identify a YouTube CMS user who is acting on behalf of the content owner specified in the parameter value. This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and get access to all their video and channel data, without having to provide authentication credentials for each individual channel. The CMS account that the user authenticates with must be linked to the specified YouTube content owner.
      *     onBehalfOfContentOwner: 'placeholder-value',
-     *     // The <code><strong>pageToken</strong></code> parameter identifies a specific
-     *     // page in the result set that should be returned. In an API response, the
-     *     // <code>nextPageToken</code> and <code>prevPageToken</code> properties
-     *     // identify other pages that could be retrieved.<br><br><strong>Note:</strong>
-     *     // This parameter is supported for use in conjunction with the <code><a
-     *     // href="#myRating">myRating</a></code> and <code><a
-     *     // href="#chart">chart</a></code> parameters, but it is not supported for use
-     *     // in conjunction with the <code><a href="#id">id</a></code> parameter.
+     *     // The *pageToken* parameter identifies a specific page in the result set that should be returned. In an API response, the nextPageToken and prevPageToken properties identify other pages that could be retrieved. *Note:* This parameter is supported for use in conjunction with the myRating and chart parameters, but it is not supported for use in conjunction with the id parameter.
      *     pageToken: 'placeholder-value',
-     *     // The <code><strong>part</strong></code> parameter specifies a
-     *     // comma-separated list of one or more <code>video</code> resource properties
-     *     // that the API response will include.<br><br>If the parameter identifies a
-     *     // property that contains child properties, the child properties will be
-     *     // included in the response. For example, in a <code>video</code> resource,
-     *     // the <code>snippet</code> property contains the <code>channelId</code>,
-     *     // <code>title</code>, <code>description</code>, <code>tags</code>, and
-     *     // <code>categoryId</code> properties. As such, if you set
-     *     // <code><strong>part=snippet</strong></code>, the API response will contain
-     *     // all of those properties.
+     *     // The *part* parameter specifies a comma-separated list of one or more video resource properties that the API response will include. If the parameter identifies a property that contains child properties, the child properties will be included in the response. For example, in a video resource, the snippet property contains the channelId, title, description, tags, and categoryId properties. As such, if you set *part=snippet*, the API response will contain all of those properties.
      *     part: 'placeholder-value',
      *     // Use a chart that is specific to the specified region
      *     regionCode: 'placeholder-value',
@@ -17419,26 +16278,12 @@ export namespace youtube_v3 {
      *   throw e;
      * });
      *
-     * @alias youtube.videos.list
-     * @memberOf! ()
+     * ```
      *
-     * @param {object} params Parameters for request
-     * @param {string=} params.chart Return the videos that are in the specified chart.
-     * @param {string=} params.hl Stands for "host language". Specifies the localization language of the metadata to be filled into snippet.localized. The field is filled with the default metadata if there is no localization in the specified language. The parameter value must be a language code included in the list returned by the i18nLanguages.list method (e.g. en_US, es_MX).
-     * @param {string=} params.id Return videos with the given ids.
-     * @param {string=} params.locale
-     * @param {integer=} params.maxHeight
-     * @param {integer=} params.maxResults The <code><strong>maxResults</strong></code> parameter specifies the maximum number of items that should be returned in the result set.<br><br><strong>Note:</strong> This parameter is supported for use in conjunction with the <code><a href="#myRating">myRating</a></code> and <code><a href="#chart">chart</a></code> parameters, but it is not supported for use in conjunction with the <code><a href="#id">id</a></code> parameter.
-     * @param {integer=} params.maxWidth Return the player with maximum height specified in
-     * @param {string=} params.myRating Return videos liked/disliked by the authenticated user. Does not support RateType.RATED_TYPE_NONE.
-     * @param {string=} params.onBehalfOfContentOwner <strong>Note:</strong> This parameter is intended exclusively for YouTube content partners.<br><br>The <code><strong>onBehalfOfContentOwner</strong></code> parameter indicates that the request's authorization credentials identify a YouTube CMS user who is acting on behalf of the content owner specified in the parameter value. This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and get access to all their video and channel data, without having to provide authentication credentials for each individual channel. The CMS account that the user authenticates with must be linked to the specified YouTube content owner.
-     * @param {string=} params.pageToken The <code><strong>pageToken</strong></code> parameter identifies a specific page in the result set that should be returned. In an API response, the <code>nextPageToken</code> and <code>prevPageToken</code> properties identify other pages that could be retrieved.<br><br><strong>Note:</strong> This parameter is supported for use in conjunction with the <code><a href="#myRating">myRating</a></code> and <code><a href="#chart">chart</a></code> parameters, but it is not supported for use in conjunction with the <code><a href="#id">id</a></code> parameter.
-     * @param {string} params.part The <code><strong>part</strong></code> parameter specifies a comma-separated list of one or more <code>video</code> resource properties that the API response will include.<br><br>If the parameter identifies a property that contains child properties, the child properties will be included in the response. For example, in a <code>video</code> resource, the <code>snippet</code> property contains the <code>channelId</code>, <code>title</code>, <code>description</code>, <code>tags</code>, and <code>categoryId</code> properties. As such, if you set <code><strong>part=snippet</strong></code>, the API response will contain all of those properties.
-     * @param {string=} params.regionCode Use a chart that is specific to the specified region
-     * @param {string=} params.videoCategoryId Use chart that is specific to the specified video category
-     * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-     * @param {callback} callback The callback that handles the response.
-     * @return {object} Request object
+     * @param params - Parameters for request
+     * @param options - Optionally override request options, such as `url`, `method`, and `encoding`.
+     * @param callback - Optional callback that handles the response.
+     * @returns A promise if used with async/await, or void if used with a callback.
      */
     list(
       params: Params$Resource$Videos$List,
@@ -17494,7 +16339,7 @@ export namespace youtube_v3 {
         options = {};
       }
 
-      const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+      const rootUrl = options.rootUrl || 'https://youtube.googleapis.com/';
       const parameters = {
         options: Object.assign(
           {
@@ -17511,7 +16356,7 @@ export namespace youtube_v3 {
       if (callback) {
         createAPIRequest<Schema$VideoListResponse>(
           parameters,
-          callback as BodyResponseCallback<{} | void>
+          callback as BodyResponseCallback<unknown>
         );
       } else {
         return createAPIRequest<Schema$VideoListResponse>(parameters);
@@ -17519,9 +16364,9 @@ export namespace youtube_v3 {
     }
 
     /**
-     * youtube.videos.rate
-     * @desc Adds a like or dislike rating to a video or removes a rating from a video.
+     * Adds a like or dislike rating to a video or removes a rating from a video.
      * @example
+     * ```js
      * // Before running the sample:
      * // - Enable the API at:
      * //   https://console.developers.google.com/apis/api/youtube.googleapis.com
@@ -17561,15 +16406,12 @@ export namespace youtube_v3 {
      *   throw e;
      * });
      *
-     * @alias youtube.videos.rate
-     * @memberOf! ()
+     * ```
      *
-     * @param {object} params Parameters for request
-     * @param {string} params.id
-     * @param {string} params.rating
-     * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-     * @param {callback} callback The callback that handles the response.
-     * @return {object} Request object
+     * @param params - Parameters for request
+     * @param options - Optionally override request options, such as `url`, `method`, and `encoding`.
+     * @param callback - Optional callback that handles the response.
+     * @returns A promise if used with async/await, or void if used with a callback.
      */
     rate(
       params: Params$Resource$Videos$Rate,
@@ -17620,7 +16462,7 @@ export namespace youtube_v3 {
         options = {};
       }
 
-      const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+      const rootUrl = options.rootUrl || 'https://youtube.googleapis.com/';
       const parameters = {
         options: Object.assign(
           {
@@ -17640,7 +16482,7 @@ export namespace youtube_v3 {
       if (callback) {
         createAPIRequest<void>(
           parameters,
-          callback as BodyResponseCallback<{} | void>
+          callback as BodyResponseCallback<unknown>
         );
       } else {
         return createAPIRequest<void>(parameters);
@@ -17648,9 +16490,9 @@ export namespace youtube_v3 {
     }
 
     /**
-     * youtube.videos.reportAbuse
-     * @desc Report abuse for a video.
+     * Report abuse for a video.
      * @example
+     * ```js
      * // Before running the sample:
      * // - Enable the API at:
      * //   https://console.developers.google.com/apis/api/youtube.googleapis.com
@@ -17678,18 +16520,7 @@ export namespace youtube_v3 {
      *
      *   // Do the magic
      *   const res = await youtube.videos.reportAbuse({
-     *     // <strong>Note:</strong> This parameter is intended exclusively for YouTube
-     *     // content partners.<br><br>The
-     *     // <code><strong>onBehalfOfContentOwner</strong></code> parameter indicates
-     *     // that the
-     *     // request's authorization credentials identify a YouTube CMS user who is
-     *     // acting on behalf of the content owner specified in the parameter value.
-     *     // This parameter is intended for YouTube content partners that own and manage
-     *     // many different YouTube channels. It allows content owners to authenticate
-     *     // once and get access to all their video and channel data, without having to
-     *     // provide authentication credentials for each individual channel. The CMS
-     *     // account that the user authenticates with must be linked to the specified
-     *     // YouTube content owner.
+     *     // *Note:* This parameter is intended exclusively for YouTube content partners. The *onBehalfOfContentOwner* parameter indicates that the request's authorization credentials identify a YouTube CMS user who is acting on behalf of the content owner specified in the parameter value. This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and get access to all their video and channel data, without having to provide authentication credentials for each individual channel. The CMS account that the user authenticates with must be linked to the specified YouTube content owner.
      *     onBehalfOfContentOwner: 'placeholder-value',
      *
      *     // Request body metadata
@@ -17712,15 +16543,12 @@ export namespace youtube_v3 {
      *   throw e;
      * });
      *
-     * @alias youtube.videos.reportAbuse
-     * @memberOf! ()
+     * ```
      *
-     * @param {object} params Parameters for request
-     * @param {string=} params.onBehalfOfContentOwner <strong>Note:</strong> This parameter is intended exclusively for YouTube content partners.<br><br>The <code><strong>onBehalfOfContentOwner</strong></code> parameter indicates that the request's authorization credentials identify a YouTube CMS user who is acting on behalf of the content owner specified in the parameter value. This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and get access to all their video and channel data, without having to provide authentication credentials for each individual channel. The CMS account that the user authenticates with must be linked to the specified YouTube content owner.
-     * @param {().VideoAbuseReport} params.requestBody Request body data
-     * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-     * @param {callback} callback The callback that handles the response.
-     * @return {object} Request object
+     * @param params - Parameters for request
+     * @param options - Optionally override request options, such as `url`, `method`, and `encoding`.
+     * @param callback - Optional callback that handles the response.
+     * @returns A promise if used with async/await, or void if used with a callback.
      */
     reportAbuse(
       params: Params$Resource$Videos$Reportabuse,
@@ -17772,7 +16600,7 @@ export namespace youtube_v3 {
         options = {};
       }
 
-      const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+      const rootUrl = options.rootUrl || 'https://youtube.googleapis.com/';
       const parameters = {
         options: Object.assign(
           {
@@ -17792,7 +16620,7 @@ export namespace youtube_v3 {
       if (callback) {
         createAPIRequest<void>(
           parameters,
-          callback as BodyResponseCallback<{} | void>
+          callback as BodyResponseCallback<unknown>
         );
       } else {
         return createAPIRequest<void>(parameters);
@@ -17800,9 +16628,9 @@ export namespace youtube_v3 {
     }
 
     /**
-     * youtube.videos.update
-     * @desc Updates an existing resource.
+     * Updates an existing resource.
      * @example
+     * ```js
      * // Before running the sample:
      * // - Enable the API at:
      * //   https://console.developers.google.com/apis/api/youtube.googleapis.com
@@ -17830,39 +16658,9 @@ export namespace youtube_v3 {
      *
      *   // Do the magic
      *   const res = await youtube.videos.update({
-     *     // <strong>Note:</strong> This parameter is intended exclusively for YouTube
-     *     // content partners.<br><br>The
-     *     // <code><strong>onBehalfOfContentOwner</strong></code> parameter indicates
-     *     // that the
-     *     // request's authorization credentials identify a YouTube CMS user who is
-     *     // acting on behalf of the content owner specified in the parameter value.
-     *     // This parameter is intended for YouTube content partners that own and manage
-     *     // many different YouTube channels. It allows content owners to authenticate
-     *     // once and get access to all their video and channel data, without having to
-     *     // provide authentication credentials for each individual channel. The actual
-     *     // CMS account that the user authenticates with must be linked to the
-     *     // specified YouTube content owner.
+     *     // *Note:* This parameter is intended exclusively for YouTube content partners. The *onBehalfOfContentOwner* parameter indicates that the request's authorization credentials identify a YouTube CMS user who is acting on behalf of the content owner specified in the parameter value. This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and get access to all their video and channel data, without having to provide authentication credentials for each individual channel. The actual CMS account that the user authenticates with must be linked to the specified YouTube content owner.
      *     onBehalfOfContentOwner: 'placeholder-value',
-     *     // The <code><strong>part</strong></code> parameter serves two purposes in
-     *     // this operation. It identifies the properties that the write operation will
-     *     // set as well as the properties that the API response will
-     *     // include.<br/><br/>Note that this method will override the existing values
-     *     // for all of the mutable properties that are contained in any parts that the
-     *     // parameter value specifies. For example, a
-     *     // video's privacy setting is contained in the <code>status</code> part. As
-     *     // such, if your request is updating a private video, and the request's
-     *     // <code>part</code> parameter value includes the <code>status</code> part,
-     *     // the
-     *     // video's privacy setting will be updated to whatever value the request body
-     *     // specifies. If the request body does not specify a value, the existing
-     *     // privacy setting will be removed and the video will revert to the default
-     *     // privacy setting.<br/><br/>In addition, not all parts contain properties
-     *     // that can be set when inserting or updating a video. For example, the
-     *     // <code>statistics</code> object encapsulates statistics that YouTube
-     *     // calculates for a video and does not contain values that you can set or
-     *     // modify. If the parameter value specifies a <code>part</code> that does not
-     *     // contain mutable values, that <code>part</code> will still be included in
-     *     // the API response.
+     *     // The *part* parameter serves two purposes in this operation. It identifies the properties that the write operation will set as well as the properties that the API response will include. Note that this method will override the existing values for all of the mutable properties that are contained in any parts that the parameter value specifies. For example, a video's privacy setting is contained in the status part. As such, if your request is updating a private video, and the request's part parameter value includes the status part, the video's privacy setting will be updated to whatever value the request body specifies. If the request body does not specify a value, the existing privacy setting will be removed and the video will revert to the default privacy setting. In addition, not all parts contain properties that can be set when inserting or updating a video. For example, the statistics object encapsulates statistics that YouTube calculates for a video and does not contain values that you can set or modify. If the parameter value specifies a part that does not contain mutable values, that part will still be included in the API response.
      *     part: 'placeholder-value',
      *
      *     // Request body metadata
@@ -17920,16 +16718,12 @@ export namespace youtube_v3 {
      *   throw e;
      * });
      *
-     * @alias youtube.videos.update
-     * @memberOf! ()
+     * ```
      *
-     * @param {object} params Parameters for request
-     * @param {string=} params.onBehalfOfContentOwner <strong>Note:</strong> This parameter is intended exclusively for YouTube content partners.<br><br>The <code><strong>onBehalfOfContentOwner</strong></code> parameter indicates that the request's authorization credentials identify a YouTube CMS user who is acting on behalf of the content owner specified in the parameter value. This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and get access to all their video and channel data, without having to provide authentication credentials for each individual channel. The actual CMS account that the user authenticates with must be linked to the specified YouTube content owner.
-     * @param {string} params.part The <code><strong>part</strong></code> parameter serves two purposes in this operation. It identifies the properties that the write operation will set as well as the properties that the API response will include.<br/><br/>Note that this method will override the existing values for all of the mutable properties that are contained in any parts that the parameter value specifies. For example, a video's privacy setting is contained in the <code>status</code> part. As such, if your request is updating a private video, and the request's <code>part</code> parameter value includes the <code>status</code> part, the video's privacy setting will be updated to whatever value the request body specifies. If the request body does not specify a value, the existing privacy setting will be removed and the video will revert to the default privacy setting.<br/><br/>In addition, not all parts contain properties that can be set when inserting or updating a video. For example, the <code>statistics</code> object encapsulates statistics that YouTube calculates for a video and does not contain values that you can set or modify. If the parameter value specifies a <code>part</code> that does not contain mutable values, that <code>part</code> will still be included in the API response.
-     * @param {().Video} params.requestBody Request body data
-     * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-     * @param {callback} callback The callback that handles the response.
-     * @return {object} Request object
+     * @param params - Parameters for request
+     * @param options - Optionally override request options, such as `url`, `method`, and `encoding`.
+     * @param callback - Optional callback that handles the response.
+     * @returns A promise if used with async/await, or void if used with a callback.
      */
     update(
       params: Params$Resource$Videos$Update,
@@ -17982,7 +16776,7 @@ export namespace youtube_v3 {
         options = {};
       }
 
-      const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+      const rootUrl = options.rootUrl || 'https://youtube.googleapis.com/';
       const parameters = {
         options: Object.assign(
           {
@@ -17999,7 +16793,7 @@ export namespace youtube_v3 {
       if (callback) {
         createAPIRequest<Schema$Video>(
           parameters,
-          callback as BodyResponseCallback<{} | void>
+          callback as BodyResponseCallback<unknown>
         );
       } else {
         return createAPIRequest<Schema$Video>(parameters);
@@ -18013,7 +16807,7 @@ export namespace youtube_v3 {
      */
     id?: string;
     /**
-     * <strong>Note:</strong> This parameter is intended exclusively for YouTube content partners.<br><br>The <code><strong>onBehalfOfContentOwner</strong></code> parameter indicates that the request's authorization credentials identify a YouTube CMS user who is acting on behalf of the content owner specified in the parameter value. This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and get access to all their video and channel data, without having to provide authentication credentials for each individual channel. The actual CMS account that the user authenticates with must be linked to the specified YouTube content owner.
+     * *Note:* This parameter is intended exclusively for YouTube content partners. The *onBehalfOfContentOwner* parameter indicates that the request's authorization credentials identify a YouTube CMS user who is acting on behalf of the content owner specified in the parameter value. This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and get access to all their video and channel data, without having to provide authentication credentials for each individual channel. The actual CMS account that the user authenticates with must be linked to the specified YouTube content owner.
      */
     onBehalfOfContentOwner?: string;
   }
@@ -18023,7 +16817,7 @@ export namespace youtube_v3 {
      */
     id?: string[];
     /**
-     * <strong>Note:</strong> This parameter is intended exclusively for YouTube content partners.<br><br>The <code><strong>onBehalfOfContentOwner</strong></code> parameter indicates that the request's authorization credentials identify a YouTube CMS user who is acting on behalf of the content owner specified in the parameter value. This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and get access to all their video and channel data, without having to provide authentication credentials for each individual channel. The CMS account that the user authenticates with must be linked to the specified YouTube content owner.
+     * *Note:* This parameter is intended exclusively for YouTube content partners. The *onBehalfOfContentOwner* parameter indicates that the request's authorization credentials identify a YouTube CMS user who is acting on behalf of the content owner specified in the parameter value. This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and get access to all their video and channel data, without having to provide authentication credentials for each individual channel. The CMS account that the user authenticates with must be linked to the specified YouTube content owner.
      */
     onBehalfOfContentOwner?: string;
   }
@@ -18037,15 +16831,15 @@ export namespace youtube_v3 {
      */
     notifySubscribers?: boolean;
     /**
-     * <strong>Note:</strong> This parameter is intended exclusively for YouTube content partners.<br><br>The <code><strong>onBehalfOfContentOwner</strong></code> parameter indicates that the request's authorization credentials identify a YouTube CMS user who is acting on behalf of the content owner specified in the parameter value. This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and get access to all their video and channel data, without having to provide authentication credentials for each individual channel. The CMS account that the user authenticates with must be linked to the specified YouTube content owner.
+     * *Note:* This parameter is intended exclusively for YouTube content partners. The *onBehalfOfContentOwner* parameter indicates that the request's authorization credentials identify a YouTube CMS user who is acting on behalf of the content owner specified in the parameter value. This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and get access to all their video and channel data, without having to provide authentication credentials for each individual channel. The CMS account that the user authenticates with must be linked to the specified YouTube content owner.
      */
     onBehalfOfContentOwner?: string;
     /**
-     * This parameter can only be used in a properly <a href="/youtube/v3/guides/authentication">authorized request</a>. <strong>Note:</strong> This parameter is intended exclusively for YouTube content partners.<br><br>The <code><strong>onBehalfOfContentOwnerChannel</strong></code> parameter specifies the YouTube channel ID of the channel to which a video is being added. This parameter is required when a request specifies a value for the <code>onBehalfOfContentOwner</code> parameter, and it can only be used in conjunction with that parameter. In addition, the request must be authorized using a CMS account that is linked to the content owner that the <code>onBehalfOfContentOwner</code> parameter specifies. Finally, the channel that the <code>onBehalfOfContentOwnerChannel</code> parameter value specifies must be linked to the content owner that the <code>onBehalfOfContentOwner</code> parameter specifies.<br><br>This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and perform actions on behalf of the channel specified in the parameter value, without having to provide authentication credentials for each separate channel.
+     * This parameter can only be used in a properly authorized request. *Note:* This parameter is intended exclusively for YouTube content partners. The *onBehalfOfContentOwnerChannel* parameter specifies the YouTube channel ID of the channel to which a video is being added. This parameter is required when a request specifies a value for the onBehalfOfContentOwner parameter, and it can only be used in conjunction with that parameter. In addition, the request must be authorized using a CMS account that is linked to the content owner that the onBehalfOfContentOwner parameter specifies. Finally, the channel that the onBehalfOfContentOwnerChannel parameter value specifies must be linked to the content owner that the onBehalfOfContentOwner parameter specifies. This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and perform actions on behalf of the channel specified in the parameter value, without having to provide authentication credentials for each separate channel.
      */
     onBehalfOfContentOwnerChannel?: string;
     /**
-     * The <code><strong>part</strong></code> parameter serves two purposes in this operation. It identifies the properties that the write operation will set as well as the properties that the API response will include.<br/><br/>Note that not all parts contain properties that can be set when inserting or updating a video. For example, the <code>statistics</code> object encapsulates statistics that YouTube calculates for a video and does not contain values that you can set or modify. If the parameter value specifies a <code>part</code> that does not contain mutable values, that <code>part</code> will still be included in the API response.
+     * The *part* parameter serves two purposes in this operation. It identifies the properties that the write operation will set as well as the properties that the API response will include. Note that not all parts contain properties that can be set when inserting or updating a video. For example, the statistics object encapsulates statistics that YouTube calculates for a video and does not contain values that you can set or modify. If the parameter value specifies a part that does not contain mutable values, that part will still be included in the API response.
      */
     part?: string[];
     /**
@@ -18095,7 +16889,7 @@ export namespace youtube_v3 {
      */
     maxHeight?: number;
     /**
-     * The <code><strong>maxResults</strong></code> parameter specifies the maximum number of items that should be returned in the result set.<br><br><strong>Note:</strong> This parameter is supported for use in conjunction with the <code><a href="#myRating">myRating</a></code> and <code><a href="#chart">chart</a></code> parameters, but it is not supported for use in conjunction with the <code><a href="#id">id</a></code> parameter.
+     * The *maxResults* parameter specifies the maximum number of items that should be returned in the result set. *Note:* This parameter is supported for use in conjunction with the myRating and chart parameters, but it is not supported for use in conjunction with the id parameter.
      */
     maxResults?: number;
     /**
@@ -18107,15 +16901,15 @@ export namespace youtube_v3 {
      */
     myRating?: string;
     /**
-     * <strong>Note:</strong> This parameter is intended exclusively for YouTube content partners.<br><br>The <code><strong>onBehalfOfContentOwner</strong></code> parameter indicates that the request's authorization credentials identify a YouTube CMS user who is acting on behalf of the content owner specified in the parameter value. This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and get access to all their video and channel data, without having to provide authentication credentials for each individual channel. The CMS account that the user authenticates with must be linked to the specified YouTube content owner.
+     * *Note:* This parameter is intended exclusively for YouTube content partners. The *onBehalfOfContentOwner* parameter indicates that the request's authorization credentials identify a YouTube CMS user who is acting on behalf of the content owner specified in the parameter value. This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and get access to all their video and channel data, without having to provide authentication credentials for each individual channel. The CMS account that the user authenticates with must be linked to the specified YouTube content owner.
      */
     onBehalfOfContentOwner?: string;
     /**
-     * The <code><strong>pageToken</strong></code> parameter identifies a specific page in the result set that should be returned. In an API response, the <code>nextPageToken</code> and <code>prevPageToken</code> properties identify other pages that could be retrieved.<br><br><strong>Note:</strong> This parameter is supported for use in conjunction with the <code><a href="#myRating">myRating</a></code> and <code><a href="#chart">chart</a></code> parameters, but it is not supported for use in conjunction with the <code><a href="#id">id</a></code> parameter.
+     * The *pageToken* parameter identifies a specific page in the result set that should be returned. In an API response, the nextPageToken and prevPageToken properties identify other pages that could be retrieved. *Note:* This parameter is supported for use in conjunction with the myRating and chart parameters, but it is not supported for use in conjunction with the id parameter.
      */
     pageToken?: string;
     /**
-     * The <code><strong>part</strong></code> parameter specifies a comma-separated list of one or more <code>video</code> resource properties that the API response will include.<br><br>If the parameter identifies a property that contains child properties, the child properties will be included in the response. For example, in a <code>video</code> resource, the <code>snippet</code> property contains the <code>channelId</code>, <code>title</code>, <code>description</code>, <code>tags</code>, and <code>categoryId</code> properties. As such, if you set <code><strong>part=snippet</strong></code>, the API response will contain all of those properties.
+     * The *part* parameter specifies a comma-separated list of one or more video resource properties that the API response will include. If the parameter identifies a property that contains child properties, the child properties will be included in the response. For example, in a video resource, the snippet property contains the channelId, title, description, tags, and categoryId properties. As such, if you set *part=snippet*, the API response will contain all of those properties.
      */
     part?: string[];
     /**
@@ -18140,7 +16934,7 @@ export namespace youtube_v3 {
   export interface Params$Resource$Videos$Reportabuse
     extends StandardParameters {
     /**
-     * <strong>Note:</strong> This parameter is intended exclusively for YouTube content partners.<br><br>The <code><strong>onBehalfOfContentOwner</strong></code> parameter indicates that the request's authorization credentials identify a YouTube CMS user who is acting on behalf of the content owner specified in the parameter value. This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and get access to all their video and channel data, without having to provide authentication credentials for each individual channel. The CMS account that the user authenticates with must be linked to the specified YouTube content owner.
+     * *Note:* This parameter is intended exclusively for YouTube content partners. The *onBehalfOfContentOwner* parameter indicates that the request's authorization credentials identify a YouTube CMS user who is acting on behalf of the content owner specified in the parameter value. This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and get access to all their video and channel data, without having to provide authentication credentials for each individual channel. The CMS account that the user authenticates with must be linked to the specified YouTube content owner.
      */
     onBehalfOfContentOwner?: string;
 
@@ -18151,11 +16945,11 @@ export namespace youtube_v3 {
   }
   export interface Params$Resource$Videos$Update extends StandardParameters {
     /**
-     * <strong>Note:</strong> This parameter is intended exclusively for YouTube content partners.<br><br>The <code><strong>onBehalfOfContentOwner</strong></code> parameter indicates that the request's authorization credentials identify a YouTube CMS user who is acting on behalf of the content owner specified in the parameter value. This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and get access to all their video and channel data, without having to provide authentication credentials for each individual channel. The actual CMS account that the user authenticates with must be linked to the specified YouTube content owner.
+     * *Note:* This parameter is intended exclusively for YouTube content partners. The *onBehalfOfContentOwner* parameter indicates that the request's authorization credentials identify a YouTube CMS user who is acting on behalf of the content owner specified in the parameter value. This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and get access to all their video and channel data, without having to provide authentication credentials for each individual channel. The actual CMS account that the user authenticates with must be linked to the specified YouTube content owner.
      */
     onBehalfOfContentOwner?: string;
     /**
-     * The <code><strong>part</strong></code> parameter serves two purposes in this operation. It identifies the properties that the write operation will set as well as the properties that the API response will include.<br/><br/>Note that this method will override the existing values for all of the mutable properties that are contained in any parts that the parameter value specifies. For example, a video's privacy setting is contained in the <code>status</code> part. As such, if your request is updating a private video, and the request's <code>part</code> parameter value includes the <code>status</code> part, the video's privacy setting will be updated to whatever value the request body specifies. If the request body does not specify a value, the existing privacy setting will be removed and the video will revert to the default privacy setting.<br/><br/>In addition, not all parts contain properties that can be set when inserting or updating a video. For example, the <code>statistics</code> object encapsulates statistics that YouTube calculates for a video and does not contain values that you can set or modify. If the parameter value specifies a <code>part</code> that does not contain mutable values, that <code>part</code> will still be included in the API response.
+     * The *part* parameter serves two purposes in this operation. It identifies the properties that the write operation will set as well as the properties that the API response will include. Note that this method will override the existing values for all of the mutable properties that are contained in any parts that the parameter value specifies. For example, a video's privacy setting is contained in the status part. As such, if your request is updating a private video, and the request's part parameter value includes the status part, the video's privacy setting will be updated to whatever value the request body specifies. If the request body does not specify a value, the existing privacy setting will be removed and the video will revert to the default privacy setting. In addition, not all parts contain properties that can be set when inserting or updating a video. For example, the statistics object encapsulates statistics that YouTube calculates for a video and does not contain values that you can set or modify. If the parameter value specifies a part that does not contain mutable values, that part will still be included in the API response.
      */
     part?: string[];
 
@@ -18172,9 +16966,9 @@ export namespace youtube_v3 {
     }
 
     /**
-     * youtube.watermarks.set
-     * @desc Allows upload of watermark image and setting it for a channel.
+     * Allows upload of watermark image and setting it for a channel.
      * @example
+     * ```js
      * // Before running the sample:
      * // - Enable the API at:
      * //   https://console.developers.google.com/apis/api/youtube.googleapis.com
@@ -18204,18 +16998,7 @@ export namespace youtube_v3 {
      *   // Do the magic
      *   const res = await youtube.watermarks.set({
      *     channelId: 'placeholder-value',
-     *     // <strong>Note:</strong> This parameter is intended exclusively for YouTube
-     *     // content partners.<br><br>The
-     *     // <code><strong>onBehalfOfContentOwner</strong></code> parameter indicates
-     *     // that the
-     *     // request's authorization credentials identify a YouTube CMS user who is
-     *     // acting on behalf of the content owner specified in the parameter value.
-     *     // This parameter is intended for YouTube content partners that own and manage
-     *     // many different YouTube channels. It allows content owners to authenticate
-     *     // once and get access to all their video and channel data, without having to
-     *     // provide authentication credentials for each individual channel. The CMS
-     *     // account that the user authenticates with must be linked to the specified
-     *     // YouTube content owner.
+     *     // *Note:* This parameter is intended exclusively for YouTube content partners. The *onBehalfOfContentOwner* parameter indicates that the request's authorization credentials identify a YouTube CMS user who is acting on behalf of the content owner specified in the parameter value. This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and get access to all their video and channel data, without having to provide authentication credentials for each individual channel. The CMS account that the user authenticates with must be linked to the specified YouTube content owner.
      *     onBehalfOfContentOwner: 'placeholder-value',
      *
      *     // Request body metadata
@@ -18242,19 +17025,12 @@ export namespace youtube_v3 {
      *   throw e;
      * });
      *
-     * @alias youtube.watermarks.set
-     * @memberOf! ()
+     * ```
      *
-     * @param {object} params Parameters for request
-     * @param {string} params.channelId
-     * @param {string=} params.onBehalfOfContentOwner <strong>Note:</strong> This parameter is intended exclusively for YouTube content partners.<br><br>The <code><strong>onBehalfOfContentOwner</strong></code> parameter indicates that the request's authorization credentials identify a YouTube CMS user who is acting on behalf of the content owner specified in the parameter value. This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and get access to all their video and channel data, without having to provide authentication credentials for each individual channel. The CMS account that the user authenticates with must be linked to the specified YouTube content owner.
-     * @param  {object} params.requestBody Media resource metadata
-     * @param {object} params.media Media object
-     * @param {string} params.media.mimeType Media mime-type
-     * @param {string|object} params.media.body Media body contents
-     * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-     * @param {callback} callback The callback that handles the response.
-     * @return {object} Request object
+     * @param params - Parameters for request
+     * @param options - Optionally override request options, such as `url`, `method`, and `encoding`.
+     * @param callback - Optional callback that handles the response.
+     * @returns A promise if used with async/await, or void if used with a callback.
      */
     set(
       params: Params$Resource$Watermarks$Set,
@@ -18305,7 +17081,7 @@ export namespace youtube_v3 {
         options = {};
       }
 
-      const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+      const rootUrl = options.rootUrl || 'https://youtube.googleapis.com/';
       const parameters = {
         options: Object.assign(
           {
@@ -18329,7 +17105,7 @@ export namespace youtube_v3 {
       if (callback) {
         createAPIRequest<void>(
           parameters,
-          callback as BodyResponseCallback<{} | void>
+          callback as BodyResponseCallback<unknown>
         );
       } else {
         return createAPIRequest<void>(parameters);
@@ -18337,9 +17113,9 @@ export namespace youtube_v3 {
     }
 
     /**
-     * youtube.watermarks.unset
-     * @desc Allows removal of channel watermark.
+     * Allows removal of channel watermark.
      * @example
+     * ```js
      * // Before running the sample:
      * // - Enable the API at:
      * //   https://console.developers.google.com/apis/api/youtube.googleapis.com
@@ -18368,18 +17144,7 @@ export namespace youtube_v3 {
      *   // Do the magic
      *   const res = await youtube.watermarks.unset({
      *     channelId: 'placeholder-value',
-     *     // <strong>Note:</strong> This parameter is intended exclusively for YouTube
-     *     // content partners.<br><br>The
-     *     // <code><strong>onBehalfOfContentOwner</strong></code> parameter indicates
-     *     // that the
-     *     // request's authorization credentials identify a YouTube CMS user who is
-     *     // acting on behalf of the content owner specified in the parameter value.
-     *     // This parameter is intended for YouTube content partners that own and manage
-     *     // many different YouTube channels. It allows content owners to authenticate
-     *     // once and get access to all their video and channel data, without having to
-     *     // provide authentication credentials for each individual channel. The CMS
-     *     // account that the user authenticates with must be linked to the specified
-     *     // YouTube content owner.
+     *     // *Note:* This parameter is intended exclusively for YouTube content partners. The *onBehalfOfContentOwner* parameter indicates that the request's authorization credentials identify a YouTube CMS user who is acting on behalf of the content owner specified in the parameter value. This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and get access to all their video and channel data, without having to provide authentication credentials for each individual channel. The CMS account that the user authenticates with must be linked to the specified YouTube content owner.
      *     onBehalfOfContentOwner: 'placeholder-value',
      *   });
      *   console.log(res.data);
@@ -18390,15 +17155,12 @@ export namespace youtube_v3 {
      *   throw e;
      * });
      *
-     * @alias youtube.watermarks.unset
-     * @memberOf! ()
+     * ```
      *
-     * @param {object} params Parameters for request
-     * @param {string} params.channelId
-     * @param {string=} params.onBehalfOfContentOwner <strong>Note:</strong> This parameter is intended exclusively for YouTube content partners.<br><br>The <code><strong>onBehalfOfContentOwner</strong></code> parameter indicates that the request's authorization credentials identify a YouTube CMS user who is acting on behalf of the content owner specified in the parameter value. This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and get access to all their video and channel data, without having to provide authentication credentials for each individual channel. The CMS account that the user authenticates with must be linked to the specified YouTube content owner.
-     * @param {object} [options] Optionally override request options, such as `url`, `method`, and `encoding`.
-     * @param {callback} callback The callback that handles the response.
-     * @return {object} Request object
+     * @param params - Parameters for request
+     * @param options - Optionally override request options, such as `url`, `method`, and `encoding`.
+     * @param callback - Optional callback that handles the response.
+     * @returns A promise if used with async/await, or void if used with a callback.
      */
     unset(
       params: Params$Resource$Watermarks$Unset,
@@ -18449,7 +17211,7 @@ export namespace youtube_v3 {
         options = {};
       }
 
-      const rootUrl = options.rootUrl || 'https://www.googleapis.com/';
+      const rootUrl = options.rootUrl || 'https://youtube.googleapis.com/';
       const parameters = {
         options: Object.assign(
           {
@@ -18469,7 +17231,7 @@ export namespace youtube_v3 {
       if (callback) {
         createAPIRequest<void>(
           parameters,
-          callback as BodyResponseCallback<{} | void>
+          callback as BodyResponseCallback<unknown>
         );
       } else {
         return createAPIRequest<void>(parameters);
@@ -18483,7 +17245,7 @@ export namespace youtube_v3 {
      */
     channelId?: string;
     /**
-     * <strong>Note:</strong> This parameter is intended exclusively for YouTube content partners.<br><br>The <code><strong>onBehalfOfContentOwner</strong></code> parameter indicates that the request's authorization credentials identify a YouTube CMS user who is acting on behalf of the content owner specified in the parameter value. This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and get access to all their video and channel data, without having to provide authentication credentials for each individual channel. The CMS account that the user authenticates with must be linked to the specified YouTube content owner.
+     * *Note:* This parameter is intended exclusively for YouTube content partners. The *onBehalfOfContentOwner* parameter indicates that the request's authorization credentials identify a YouTube CMS user who is acting on behalf of the content owner specified in the parameter value. This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and get access to all their video and channel data, without having to provide authentication credentials for each individual channel. The CMS account that the user authenticates with must be linked to the specified YouTube content owner.
      */
     onBehalfOfContentOwner?: string;
 
@@ -18513,7 +17275,7 @@ export namespace youtube_v3 {
      */
     channelId?: string;
     /**
-     * <strong>Note:</strong> This parameter is intended exclusively for YouTube content partners.<br><br>The <code><strong>onBehalfOfContentOwner</strong></code> parameter indicates that the request's authorization credentials identify a YouTube CMS user who is acting on behalf of the content owner specified in the parameter value. This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and get access to all their video and channel data, without having to provide authentication credentials for each individual channel. The CMS account that the user authenticates with must be linked to the specified YouTube content owner.
+     * *Note:* This parameter is intended exclusively for YouTube content partners. The *onBehalfOfContentOwner* parameter indicates that the request's authorization credentials identify a YouTube CMS user who is acting on behalf of the content owner specified in the parameter value. This parameter is intended for YouTube content partners that own and manage many different YouTube channels. It allows content owners to authenticate once and get access to all their video and channel data, without having to provide authentication credentials for each individual channel. The CMS account that the user authenticates with must be linked to the specified YouTube content owner.
      */
     onBehalfOfContentOwner?: string;
   }

--- a/src/generator/generator.ts
+++ b/src/generator/generator.ts
@@ -369,15 +369,13 @@ async function main() {
   } else {
     console.log('Generating APIs...');
     await gen.generateAllAPIs(discoveryUrl || DISCOVERY_URL, useCache);
+    // Re-generates release-please manifest and config files
+    console.log(
+      'Generating .release-please-manifest.json and release-please-config.json'
+    );
+    gen.generateReleasePleaseConfig();
     console.log('Finished generating APIs!');
   }
-
-  //Re-generates release-please manifest and config files
-  console.log(
-    'Generating .release-please-manifest.json and release-please-config.json'
-  );
-  gen.generateReleasePleaseConfig();
-  console.log('Finished generating release-please config files!');
 }
 
 if (require.main === module) {

--- a/test/test.media.ts
+++ b/test/test.media.ts
@@ -106,7 +106,7 @@ describe('Media', () => {
   });
 
   it('should post progress for uploads', async () => {
-    const scope = nock(Utils.baseUrl)
+    const scope = nock('https://youtube.googleapis.com')
       .post(
         '/upload/youtube/v3/videos?part=id&part=snippet&notifySubscribers=false&uploadType=multipart'
       )
@@ -142,7 +142,7 @@ describe('Media', () => {
 
   // See: https://github.com/googleapis/google-api-nodejs-client/issues/1820
   it('should post progress for uploads, for APIs with empty requestBody', async () => {
-    const scope = nock(Utils.baseUrl)
+    const scope = nock('https://youtube.googleapis.com')
       .post(
         '/upload/youtube/v3/thumbnails/set?videoId=abc123&uploadType=multipart'
       )


### PR DESCRIPTION
Fixes #2574.

During the great OnePlatform migration of 2020, at some point the YouTube discovery bindings got very, very broken.  To unblock the pipeline, I started ignoring changes in the discovery file, and just kept on shipping the old client.  This PR turns generation for YouTube back on, and gives the API it's first update in a long time.  I can only assume there are some breaking changes in here. 