### PR TITLE
build: use GitHub Action for regeneration

### DIFF
--- a/.github/workflows/update-apis.yaml
+++ b/.github/workflows/update-apis.yaml
@@ -1,0 +1,19 @@
+on:
+  schedule:
+    - cron: "0 1 * * *"
+  workflow_dispatch:
+
+jobs:
+  update-apis:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 14
+      - run: npm install
+      - run: npm run update-disclaimers
+      - run: npm run submit-prs
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CODE_BOT_TOKEN: ${{ secrets.YOSHI_CODE_BOT_TOKEN }}

--- a/src/generator/synth.ts
+++ b/src/generator/synth.ts
@@ -47,9 +47,13 @@ export async function synth(options: SynthOptions = {}) {
   const statusFiles = status.split('\n').map(x => x.slice(3));
   const apiDir = path.resolve('./src/apis');
   const files = fs.readdirSync(apiDir);
-  const token = process.env.GITHUB_TOKEN;
-  if (!token) {
+  const githubToken = process.env.GITHUB_TOKEN;
+  if (!githubToken) {
     throw new Error('please include a GITHUB_TOKEN');
+  }
+  const codeBotToken = process.env.CODE_BOT_TOKEN;
+  if (!codeBotToken) {
+    throw new Error('please include a CODE_BOT_TOKEN');
   }
   // only set these while running in the GitHub Actions environment
   if (process.env.GITHUB_ACTIONS) {
@@ -95,10 +99,11 @@ export async function synth(options: SynthOptions = {}) {
   const prefix = getPrefix(totalSemverity);
   await execa('git', ['push', 'origin', branch, '--force']);
   try {
+    // Open the pull request with the YOSHI_CODE_BOT_TOKEN
     await gaxios.request({
       method: 'POST',
       headers: {
-        Authorization: `token ${token}`,
+        Authorization: `token ${codeBotToken}`,
       },
       url: 'https://api.github.com/repos/googleapis/google-api-nodejs-client/pulls',
       data: {

--- a/synth.py
+++ b/synth.py
@@ -30,6 +30,3 @@ s.copy(templates, excludes=[
   '.kokoro/publish.sh',
   '.kokoro/release/publish.cfg'
 ])
-subprocess.run(['npm', 'install'])
-subprocess.run(['npm', 'run', 'update-disclaimers'])
-subprocess.run(['npm', 'run', 'submit-prs'])

--- a/test/test.synth.ts
+++ b/test/test.synth.ts
@@ -26,7 +26,8 @@ describe(__filename, () => {
   before(() => {
     nock.disableNetConnect();
   });
-  const cacheToken = process.env.GITHUB_TOKEN;
+  const cacheGitHubToken = process.env.GITHUB_TOKEN;
+  const cacheCodeBotToken = process.env.CODE_BOT_TOKEN;
   let changeSets: ChangeSet[] = [];
   let stdout = '';
 
@@ -48,7 +49,8 @@ describe(__filename, () => {
     changeSets = [];
     nock.cleanAll();
     sandbox.restore();
-    process.env.GITHUB_TOKEN = cacheToken;
+    process.env.GITHUB_TOKEN = cacheGitHubToken;
+    process.env.CODE_BOT_TOKEN = cacheCodeBotToken;
   });
 
   it('should run synth', async () => {
@@ -74,6 +76,7 @@ describe(__filename, () => {
         modified:   src/apis/blogger/v1.ts
     `;
     process.env.GITHUB_TOKEN = '12345';
+    process.env.CODE_BOT_TOKEN = '12345';
     const scope = nock('https://api.github.com')
       .post('/repos/googleapis/google-api-nodejs-client/pulls')
       .reply(200);
@@ -81,9 +84,14 @@ describe(__filename, () => {
     scope.done();
   });
 
-  it('should throw if no token is provided', async () => {
+  it('should throw if no github token is provided', async () => {
     process.env.GITHUB_TOKEN = '';
     await assert.rejects(synth.synth, /please include a GITHUB_TOKEN/);
+  });
+
+  it('should throw if no code bot token is provided', async () => {
+    process.env.CODE_BOT_TOKEN = '';
+    await assert.rejects(synth.synth, /please include a CODE_BOT_TOKEN/);
   });
 
   it('should create a changelog', () => {


### PR DESCRIPTION
This change moves us from using autosynth to trigger the regeneration job over to a GitHub Action.  The biggest advantage that autosynth gave us was a single GitHub token which had write permissions to the repository.  This made it easier to push changes to a non-main branch, and open PRs with the same token.  With GitHub Actions, we now need two tokens:
- The baked in `GITHUB_TOKEN` can be used to push the changes to an upstream branch
- The `YOSHI_CODE_BOT_TOKEN` has no permissions on this repository, and can be used to open a PR

We have to take this approach because a.) the `GITHUB_TOKEN` cannot open a PR that triggers more actions (like CI), and b.) the `YOSHI_CODE_BOT_TOKEN` by design does not have push permissions to the repository.  

I _think_ this will work, but there's no real way to know until we land this change, and dispatch the action. 