### PR TITLE
build: ignore artifact registry v1beta2

### DIFF
--- a/ignore.json
+++ b/ignore.json
@@ -1,5 +1,6 @@
 {
   "ignore": [
-    "apigee:v1"
+    "apigee:v1",
+    "artifactregistry:v1beta2"
   ]
 }

--- a/test/test.auth.ts
+++ b/test/test.auth.ts
@@ -78,7 +78,7 @@ describe(__filename, () => {
   async function testNoTokens(blogger: APIEndpoint, client: OAuth2Client) {
     await assert.rejects(
       blogger.pages.get({blogId: '123', pageId: '123', auth: client}),
-      /No access, refresh token or API key is set./
+      /No access, refresh token/
     );
   }
 


### PR DESCRIPTION
Two things happening here to unblock generation:
1. artifactregistry:v1beta2 is disabled, because it has naming collisions with sub resource names and methods.  I opened #2723 to track that
2. A recent release of google-auth-library changed an error message in a way that caused a regex in a test to fail.  The unit test failure was addressed.