### PR TITLE
fix: extend test timeout from 10 to 30 seconds

### DIFF
--- a/system-test/http2.test.ts
+++ b/system-test/http2.test.ts
@@ -32,5 +32,5 @@ describe('http2', () => {
       project: projectId,
     });
     assert.ok(res.data);
-  });
+  }).timeout('30s');
 });


### PR DESCRIPTION
Fixes https://github.com/googleapis/google-api-nodejs-client/issues/2686
