### PR TITLE
chore: add api_shortname and library_type to repo metadata

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -1,9 +1,11 @@
 {
   "name": "googleapis",
   "name_pretty": "Google APIs Node.js Client",
-  "release_level": "beta",
+  "release_level": "preview",
   "language": "nodejs",
   "repo": "googleapis/google-api-nodejs-client",
   "distribution_name": "googleapis",
-  "client_documentation": "https://googleapis.dev/nodejs/googleapis/latest"
+  "client_documentation": "https://googleapis.dev/nodejs/googleapis/latest",
+  "api_shortname": "googleapis",
+  "library_type": ""
 }

--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -7,5 +7,5 @@
   "distribution_name": "googleapis",
   "client_documentation": "https://googleapis.dev/nodejs/googleapis/latest",
   "api_shortname": "googleapis",
-  "library_type": ""
+  "library_type": "REST"
 }


### PR DESCRIPTION
Update .repo-metadata.json as required by go/library-data-integrity 