### PR TITLE
Update README.md - remove suggestion to use a deprecated package

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,9 +36,6 @@
 ## Google APIs
 The full list of supported APIs can be found on the [Google APIs Explorer][apiexplorer]. The API endpoints are automatically generated, so if the API is not in the list, it is currently not supported by this API client library.
 
-### Working with Google Cloud Platform APIs?
-If you're working with [Google Cloud Platform][cloudplatform] APIs such as Datastore, Cloud Storage or Pub/Sub, consider using the [`@google-cloud`][googlecloud] client libraries: single purpose idiomatic Node.js clients for Google Cloud Platform services.
-
 ### Support and maintenance
 These client libraries are officially supported by Google. However, these libraries are considered complete and are in maintenance mode. This means that we will address critical bugs and security issues but will not add any new features. For Google Cloud Platform APIs, we recommend using [google-cloud-node](https://github.com/GoogleCloudPlatform/google-cloud-node) which is under active development.
 


### PR DESCRIPTION
Remove the suggestion of google-cloud since it's deprecated, as may be seen in their site
