### PR TITLE
fix: extend timeout for test that timed out

### DIFF
--- a/system-test/kitchen.test.ts
+++ b/system-test/kitchen.test.ts
@@ -57,7 +57,7 @@ const spawnOpts: cp.SpawnSyncOptions = {
  */
 describe('kitchen sink', async () => {
   it('should be able to use the d.ts', async function () {
-    this.timeout(160000);
+    this.timeout(320000);
     console.log(`${__filename} staging area: ${stagingPath}`);
     cp.spawnSync('npm', ['pack'], spawnOpts);
     // Sleeping here should absolutely not be necessary, but prevents a


### PR DESCRIPTION
Fixes https://github.com/googleapis/google-api-nodejs-client/issues/2925