### PR TITLE
build(release): use releasetool from Docker container

### DIFF
--- a/.kokoro/publish.sh
+++ b/.kokoro/publish.sh
@@ -25,7 +25,6 @@ fi
 export NPM_CONFIG_PREFIX=/home/node/.npm-global
 
 # Start the releasetool reporter
-python3 -m pip install gcp-releasetool
 python3 -m releasetool publish-reporter-script > /tmp/publisher-script; source /tmp/publisher-script
 
 cd $(dirname $0)/..


### PR DESCRIPTION
releasetool is now built into the base Docker container.