### PR TITLE
build: pin prettier dependency (to fix release)

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "@types/ncp": "^2.0.1",
     "@types/node": "^16.0.0",
     "@types/nunjucks": "^3.1.1",
-    "@types/prettier": "^2.0.0",
+    "@types/prettier": "2.6.0",
     "@types/proxyquire": "^1.3.28",
     "@types/qs": "^6.5.3",
     "@types/sinon": "^10.0.0",


### PR DESCRIPTION
I believe @types/prettier had a breaking change when they upgraded [TS](https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/60310).

This seems to be causing our [publication](https://fusion2.corp.google.com/invocations/32acebe9-6fc7-4338-b2f6-2fe52c3dd6a0/targets/cloud-devrel%2Fclient-libraries%2Fnodejs%2Frelease%2Fgoogleapis%2Fgoogle-api-nodejs-client%2Fpublish/log) in this library to break. 

Fixes #3085 