### PR TITLE
fix(deps): pin @types/prettier to v2.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "@types/ncp": "^2.0.1",
     "@types/node": "^16.0.0",
     "@types/nunjucks": "^3.1.1",
-    "@types/prettier": "2.7.1",
+    "@types/prettier": "2.6.0",
     "@types/proxyquire": "^1.3.28",
     "@types/qs": "^6.5.3",
     "@types/sinon": "^10.0.0",


### PR DESCRIPTION
Fixes this:

```
../../../node_modules/@types/prettier/index.d.ts:41:54 - error TS2315: Type 'IsTuple' is not generic.

41 type IndexProperties<T extends { length: number }> = IsTuple<T> extends true
                                                        ~~~~~~~~~~

../../../node_modules/@types/prettier/index.d.ts:53:6 - error TS2456: Type alias 'IsTuple' circularly references itself.

53 type IsTuple<T> = T extends [] ? true : T extends [infer First, ...infer Remain] ? IsTuple<Remain> : false;
        ~~~~~~~
```

I will close the Renovate PR when it comes to avoid it bumping this dependency again.