### PR TITLE
fix(build)!: update deps make Node 12 minimum

### DIFF
--- a/src/apis/displayvideo/package.json
+++ b/src/apis/displayvideo/package.json
@@ -18,7 +18,7 @@
     "url": "https://github.com/googleapis/google-api-nodejs-client.git"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "scripts": {
     "fix": "gts fix",
@@ -33,10 +33,10 @@
   "devDependencies": {
     "@microsoft/api-documenter": "^7.8.10",
     "@microsoft/api-extractor": "^7.8.10",
-    "gts": "^2.0.0",
+    "gts": "^3.1.1",
     "null-loader": "^4.0.0",
     "ts-loader": "^9.0.0",
-    "typescript": "~3.7.0",
+    "typescript": "^4.8.4",
     "webpack": "^5.0.0",
     "webpack-cli": "^4.0.0"
   }

--- a/src/generator/templates/package.json
+++ b/src/generator/templates/package.json
@@ -18,7 +18,7 @@
     "url": "https://github.com/googleapis/google-api-nodejs-client.git"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "scripts": {
     "fix": "gts fix",
@@ -33,10 +33,10 @@
   "devDependencies": {
     "@microsoft/api-documenter": "^7.8.10",
     "@microsoft/api-extractor": "^7.8.10",
-    "gts": "^2.0.0",
+    "gts": "^3.1.1",
     "null-loader": "^4.0.0",
     "ts-loader": "^9.0.0",
-    "typescript": "~3.7.0",
+    "typescript": "~4.8.4",
     "webpack": "^5.0.0",
     "webpack-cli": "^4.0.0"
   }


### PR DESCRIPTION
Update dependencies of sub-modules, eliminating TypeScript error.
