### PR TITLE
fix: update camel case for youtube analytics to allow publishing

### DIFF
--- a/src/apis/youtubeAnalytics/package.json
+++ b/src/apis/youtubeAnalytics/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@googleapis/youtubeAnalytics",
+  "name": "@googleapis/youtubeanalytics",
   "version": "1.0.0",
   "description": "youtubeAnalytics",
   "main": "build/index.js",


### PR DESCRIPTION
See: https://fusion2.corp.google.com/invocations/2b858743-8a3b-474c-bcc3-0795038f51be/targets/cloud-devrel%2Fclient-libraries%2Fnodejs%2Frelease%2Fgoogleapis%2Fgoogle-api-nodejs-client%2Fpublish/log