### PR TITLE
build: do not attempt to publish samples, and run npm link before compiling

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "system-test": "mocha build/system-test",
     "samples-test": "cd samples && npm install && npm link ../ && pwd && npm test",
     "lint": "gts check",
-    "precompile": "rimraf build",
+    "precompile": "rimraf build; cd samples; npm link ../; npm i",
     "compile": "cross-env NODE_OPTIONS=--max-old-space-size=8192 tsc -p tsconfig.json",
     "prebuild-test": "rimraf build",
     "build-test": "cross-env NODE_OPTIONS=--max-old-space-size=8192 tsc -p tsconfig.test.json",

--- a/samples/package.json
+++ b/samples/package.json
@@ -13,7 +13,8 @@
   ],
   "scripts": {
     "prepare": "cd typescript && tsc && cd ..",
-    "test": "mocha"
+    "test": "mocha",
+    "publish": "echo 'samples dir; do not publish'"
   },
   "dependencies": {
     "@google-cloud/local-auth": "^2.0.0",

--- a/samples/package.json
+++ b/samples/package.json
@@ -13,8 +13,7 @@
   ],
   "scripts": {
     "prepare": "cd typescript && tsc && cd ..",
-    "test": "mocha",
-    "publish": "echo 'samples dir; do not publish'"
+    "test": "mocha"
   },
   "dependencies": {
     "@google-cloud/local-auth": "^2.0.0",


### PR DESCRIPTION
Fixes #3162

```
+ googleapis@112.0.0
npm ERR! code ETARGET
npm ERR! notarget No matching version found for googleapis@^112.0.0.
npm ERR! notarget In most cases you or one of your dependencies are requesting
npm ERR! notarget a package version that doesn't exist.
npm ERR! notarget 
npm ERR! notarget It was specified as a dependency of 'samples'
npm ERR! notarget 

npm ERR! A complete log of this run can be found in:
npm ERR!     /h/.npm/_logs/2023-03-01T19_57_34_453Z-debug.log
```