### PR TITLE
build: switch to using mkdir.recursive

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,6 @@
   "devDependencies": {
     "@compodoc/compodoc": "^1.1.10",
     "@types/execa": "^0.9.0",
-    "@types/mkdirp": "^1.0.0",
     "@types/mocha": "^9.0.0",
     "@types/mv": "^2.1.0",
     "@types/ncp": "^2.0.1",
@@ -81,7 +80,6 @@
     "gts": "^3.1.0",
     "js-green-licenses": "^4.0.0",
     "linkinator": "^4.0.0",
-    "mkdirp": "^2.0.0",
     "mocha": "^9.2.2",
     "mv": "^2.1.1",
     "ncp": "^2.0.0",

--- a/src/generator/download.ts
+++ b/src/generator/download.ts
@@ -15,7 +15,7 @@
 import * as minimist from 'yargs-parser';
 import * as path from 'path';
 import * as fs from 'fs';
-import {mkdir} from 'fs/promises';
+const {mkdir} = require('fs').promises;
 import Q from 'p-queue';
 import {request, Headers} from 'gaxios';
 import * as gapi from 'googleapis-common';

--- a/src/generator/download.ts
+++ b/src/generator/download.ts
@@ -15,10 +15,10 @@
 import * as minimist from 'yargs-parser';
 import * as path from 'path';
 import * as fs from 'fs';
+import {mkdir} from 'fs/promises';
 import Q from 'p-queue';
 import {request, Headers} from 'gaxios';
 import * as gapi from 'googleapis-common';
-import * as mkdirp from 'mkdirp';
 
 export type Schema = {[index: string]: {}};
 export const DISCOVERY_URL = 'https://www.googleapis.com/discovery/v1/apis/';
@@ -41,7 +41,7 @@ export interface DownloadOptions {
 
 // exported for mocking purposes
 export const gfs = {
-  mkdir: async (dir: string) => mkdirp(dir),
+  mkdir: async (dir: string) => mkdir(dir, {recursive: true}),
   writeFile: (path: string, obj: {}) => {
     fs.writeFileSync(path, JSON.stringify(obj, null, 2));
   },

--- a/src/generator/generator.ts
+++ b/src/generator/generator.ts
@@ -13,8 +13,8 @@
 // limitations under the License.
 
 import * as fs from 'fs';
+import {mkdir} from 'fs/promises';
 import {Schema, Schemas} from 'googleapis-common';
-import * as mkdirp from 'mkdirp';
 import * as nunjucks from 'nunjucks';
 import * as path from 'path';
 import * as util from 'util';
@@ -272,7 +272,7 @@ export class Generator {
     this.logResult(apiDiscoveryUrl, 'Generating APIs...');
     const apiPath = path.join(srcPath, 'apis', schema.name);
     const exportFilename = path.join(apiPath, schema.version + '.ts');
-    await mkdirp(path.dirname(exportFilename));
+    await mkdir(path.dirname(exportFilename), {recursive: true});
     // populate the `method.fragment` property with samples
     addFragments(schema);
     // generate the API (ex: src/apis/youtube/v3.ts)

--- a/src/generator/generator.ts
+++ b/src/generator/generator.ts
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import * as fs from 'fs';
-import {mkdir} from 'fs/promises';
+const {mkdir} = require('fs').promises;
 import {Schema, Schemas} from 'googleapis-common';
 import * as nunjucks from 'nunjucks';
 import * as path from 'path';

--- a/src/generator/samplegen.ts
+++ b/src/generator/samplegen.ts
@@ -24,7 +24,7 @@ import {
 import * as nunjucks from 'nunjucks';
 import * as filters from './filters';
 import * as fs from 'fs';
-import {mkdir} from 'fs/promises';
+const {mkdir} = require('fs').promises;
 import * as util from 'util';
 
 const writeFile = util.promisify(fs.writeFile);

--- a/src/generator/samplegen.ts
+++ b/src/generator/samplegen.ts
@@ -24,6 +24,7 @@ import {
 import * as nunjucks from 'nunjucks';
 import * as filters from './filters';
 import * as fs from 'fs';
+import {mkdir} from 'fs/promises';
 import * as util from 'util';
 
 const writeFile = util.promisify(fs.writeFile);
@@ -72,7 +73,7 @@ export async function addFragments(schema: Schema) {
  */
 export async function generateSamples(apiPath: string, schema: Schema) {
   const samplesPath = path.join(apiPath, 'samples', schema.version);
-  await mkdirp(samplesPath);
+  await mkdir(samplesPath, {recursive: true});
   const methods = getAllMethods(schema);
   for (const method of methods) {
     const sampleData = getSample(schema, method);

--- a/src/generator/samplegen.ts
+++ b/src/generator/samplegen.ts
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 import * as path from 'path';
-import * as mkdirp from 'mkdirp';
 import * as prettier from 'prettier';
 import {
   Schema,


### PR DESCRIPTION
I believe we can now use the built in mkdir rather than mkdirp.