### PR TITLE
build: ignore baremetalsolutions due to duplicate identifier

### DIFF
--- a/ignore.json
+++ b/ignore.json
@@ -4,6 +4,7 @@
     "artifactregistry:v1beta2",
     "monitoring:v1",
     "identitytoolkit:v1",
-    "integrations:v1"
+    "integrations:v1",
+    "baremetalsolution:v2"
   ]
 }


### PR DESCRIPTION
```
src/apis/baremetalsolution/v2.ts:4532:16 - error TS2300: Duplicate identifier 'Resource$Projects$Locations$Nfsshares'.

45[32](https://github.com/googleapis/google-api-nodejs-client/actions/runs/4411288169/jobs/7729658584#step:7:33)   export class Resource$Projects$Locations$Nfsshares {```
