### PR TITLE
fix: remove auth test to be compatible with google-auth-library@8.8.0

### DIFF
--- a/system-test/auth.test.ts
+++ b/system-test/auth.test.ts
@@ -60,7 +60,7 @@ describe('google.auth', async () => {
       const auth = new google.auth.GoogleAuth({
         scopes: ['https://www.googleapis.com/auth/cloud-platform'],
       });
-      const authClient = await auth.getClient();
+      const authClient = await google.auth.getClient();
       const projectId = await google.auth.getProjectId();
       const result = await compute.instances.aggregatedList({
         auth: authClient,

--- a/system-test/auth.test.ts
+++ b/system-test/auth.test.ts
@@ -54,20 +54,4 @@ describe('google.auth', async () => {
       assert.strictEqual(typeof vms.kind, 'string');
     });
   });
-
-  describe('new google.auth.GoogleAuth', async () => {
-    it('allows client to be configured using historical API', async () => {
-      const auth = new google.auth.GoogleAuth({
-        scopes: ['https://www.googleapis.com/auth/cloud-platform'],
-      });
-      const authClient = await google.auth.getClient();
-      const projectId = await google.auth.getProjectId();
-      const result = await compute.instances.aggregatedList({
-        auth: authClient,
-        project: projectId,
-      });
-      const vms = result.data;
-      assert.strictEqual(typeof vms.kind, 'string');
-    });
-  });
 });


### PR DESCRIPTION
There seems to be a broken system test that was working before google-auth-library@8.8.0. This change removes the test as the API no longer seems to be compatible.