### PR TITLE
build(package): generate esm output with exports

### DIFF
--- a/generator.md
+++ b/generator.md
@@ -32,7 +32,7 @@ This repository uses [synthtool](https://github.com/googleapis/synthtool/) to re
 You can generate a single API based on a discovery URL. Replace the url and API name below to match the API you'd like to generate:
 ```
 npm run build-tools
-node build/src/generator/generator.js 'https://apigee.googleapis.com/$discovery/rest?version=v1' \
+node build/cjs/src/generator/generator.js 'https://apigee.googleapis.com/$discovery/rest?version=v1' \
   --include-private false \
   --use-cache false
 ```

--- a/package.json
+++ b/package.json
@@ -5,13 +5,33 @@
   "license": "Apache-2.0",
   "description": "Google APIs Client Library for Node.js",
   "main": "./build/cjs/src/index.js",
-  "types": "./build/cjs/src/index.d.ts",
+  "module": "./build/esm/src/index.mjs",
+  "types": "./build/esm/src/index.d.ts",
+  "exports": {
+    "./package.json": "./package.json",
+    ".": {
+      "import": {
+        "types": "./build/esm/src/index.d.ts",
+        "default": "./build/esm/src/index.mjs"
+      },
+      "require": {
+        "types": "./build/cjs/src/index.d.ts",
+        "default": "./build/cjs/src/index.js"
+      },
+      "default": {
+        "types": "./build/esm/src/index.d.ts",
+        "default": "./build/esm/src/index.mjs"
+      }
+    }
+  },
   "engines": {
     "node": ">=14.0.0"
   },
   "files": [
     "build/cjs/src",
-    "!build/cjs/src/**/*.map"
+    "!build/cjs/src/**/*.map",
+    "build/esm/src",
+    "!build/esm/src/**/*.map"
   ],
   "scripts": {
     "pretest": "npm run build-test",
@@ -28,7 +48,7 @@
     "samples-test": "cd samples && npm install && npm link ../ && pwd && npm test",
     "lint": "gts check",
     "precompile": "rimraf build",
-    "compile": "cross-env NODE_OPTIONS=--max-old-space-size=8192 tsc -p tsconfig.json",
+    "compile": "cross-env NODE_OPTIONS=--max-old-space-size=8192 tsc-multi --verbose",
     "prebuild-test": "rimraf build",
     "build-test": "cross-env NODE_OPTIONS=--max-old-space-size=8192 tsc -p tsconfig.test.json",
     "build-tools": "tsc -p tsconfig.tools.json",
@@ -93,6 +113,7 @@
     "server-destroy": "^1.0.1",
     "sinon": "^15.0.0",
     "tmp": "^0.2.0",
+    "tsc-multi": "^1.1.0",
     "typescript": "5.1.6",
     "yargs-parser": "^20.2.0"
   }

--- a/package.json
+++ b/package.json
@@ -4,27 +4,27 @@
   "repository": "googleapis/google-api-nodejs-client",
   "license": "Apache-2.0",
   "description": "Google APIs Client Library for Node.js",
-  "main": "./build/src/index.js",
-  "types": "./build/src/index.d.ts",
+  "main": "./build/cjs/src/index.js",
+  "types": "./build/cjs/src/index.d.ts",
   "engines": {
     "node": ">=14.0.0"
   },
   "files": [
-    "build/src",
-    "!build/src/**/*.map"
+    "build/cjs/src",
+    "!build/cjs/src/**/*.map"
   ],
   "scripts": {
     "pretest": "npm run build-test",
     "prepare": "npm run compile",
-    "test": "c8 mocha build/test",
+    "test": "c8 mocha build/cjs/test",
     "predocs": "npm run build-tools",
-    "docs": "node build/src/generator/docs",
+    "docs": "node build/cjs/src/generator/docs",
     "predocs2": "npm run compile",
     "docs-extract": "node --max-old-space-size=8192 ./node_modules/@microsoft/api-extractor/bin/api-extractor run --local --verbose",
-    "docs-md": "node --max-old-space-size=8192 ./node_modules/@microsoft/api-documenter/bin/api-documenter markdown --input-folder build/docs --output-folder docs",
+    "docs-md": "node --max-old-space-size=8192 ./node_modules/@microsoft/api-documenter/bin/api-documenter markdown --input-folder build/cjs/docs --output-folder docs",
     "docs2": "npm run docs-extract && npm run docs-md",
     "presystem-test": "npm run build-test",
-    "system-test": "mocha build/system-test",
+    "system-test": "mocha build/cjs/system-test",
     "samples-test": "cd samples && npm install && npm link ../ && pwd && npm test",
     "lint": "gts check",
     "precompile": "rimraf build",
@@ -35,15 +35,15 @@
     "clean": "gts clean",
     "fix": "gts fix",
     "pregenerate": "npm run build-tools",
-    "generate": "node build/src/generator/generator.js",
+    "generate": "node build/cjs/src/generator/generator.js",
     "docs-test": "echo 🙈 this was taking too long and timing out CI",
     "presubmit-prs": "npm run compile",
-    "submit-prs": "node --max-old-space-size=8192 build/src/generator/synth.js",
+    "submit-prs": "node --max-old-space-size=8192 build/cjs/src/generator/synth.js",
     "prelint": "cd samples; npm link ../; npm i",
     "predownload": "npm run build-tools",
-    "download": "node build/src/generator/download.js",
+    "download": "node build/cjs/src/generator/download.js",
     "preupdate-disclaimers": "npm run build-tools",
-    "update-disclaimers": "node build/src/generator/disclaimer.js"
+    "update-disclaimers": "node build/cjs/src/generator/disclaimer.js"
   },
   "author": "Google Inc.",
   "keywords": [

--- a/samples/test/test.samples.auth.js
+++ b/samples/test/test.samples.auth.js
@@ -37,7 +37,7 @@ describe('Auth samples', () => {
       .reply(200, {})
       .post('/oauth2/v4/token')
       .reply(200, {access_token: 'not-a-token'});
-    const fakePath = path.resolve('../test/fixtures/service.json');
+    const fakePath = path.resolve('../../test/fixtures/service.json');
     const realPath = path.resolve('jwt.keys.json');
     const exists = fs.existsSync(realPath);
     if (!exists) {

--- a/samples/test/test.samples.drive.js
+++ b/samples/test/test.samples.drive.js
@@ -42,7 +42,7 @@ for (const sample of Object.values(samples)) {
   });
 }
 
-const someFile = path.join(__dirname, '../../test/fixtures/public.pem');
+const someFile = path.join(__dirname, '../../../test/fixtures/public.pem');
 const baseUrl = 'https://www.googleapis.com';
 
 describe('Drive samples', () => {

--- a/samples/test/test.samples.youtube.js
+++ b/samples/test/test.samples.youtube.js
@@ -37,7 +37,7 @@ for (const sample of Object.values(samples)) {
   });
 }
 
-const someFile = path.join(__dirname, '../../test/fixtures/public.pem');
+const someFile = path.join(__dirname, '../../../test/fixtures/public.pem');
 
 describe('YouTube samples', () => {
   afterEach(() => {

--- a/src/generator/disclaimer.ts
+++ b/src/generator/disclaimer.ts
@@ -48,7 +48,7 @@ export const gfs = {
  * used during generation to call out improved clients in READMEs for a given
  * API.
  *
- * To use this, run `node build/src/generator/disclaimers`.
+ * To use this, run `node build/cjs/src/generator/disclaimers`.
  */
 export async function main() {
   const res = await request<LibraryMetadata[]>({url: libraryListUrl});

--- a/src/generator/docs.ts
+++ b/src/generator/docs.ts
@@ -19,10 +19,10 @@ import * as path from 'path';
 import {promisify} from 'util';
 import Q from 'p-queue';
 
-const srcPath = path.join(__dirname, '../../../src');
+const srcPath = path.join(__dirname, '../../../../src');
 const apiPath = path.join(srcPath, 'apis');
 const templatePath = path.join(srcPath, 'generator/templates/index.html.njk');
-const docsPath = path.join(__dirname, '../../../docs');
+const docsPath = path.join(__dirname, '../../../../docs');
 const indexPath = path.join(docsPath, 'index.html');
 
 export const gfs = {

--- a/src/generator/docs.ts
+++ b/src/generator/docs.ts
@@ -12,12 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import * as execa from 'execa';
 import * as fs from 'fs';
 import * as nunjucks from 'nunjucks';
 import * as path from 'path';
 import {promisify} from 'util';
 import Q from 'p-queue';
+const execa: typeof import('execa') = require('execa');
 
 const srcPath = path.join(__dirname, '../../../../src');
 const apiPath = path.join(srcPath, 'apis');

--- a/src/generator/download.ts
+++ b/src/generator/download.ts
@@ -240,6 +240,6 @@ if (require.main === module) {
   const argv = minimist(process.argv.slice(2));
   const discoveryUrl = argv['discovery-url'] || DISCOVERY_URL;
   const downloadPath =
-    argv['download-path'] || path.join(__dirname, '../../../discovery');
+    argv['download-path'] || path.join(__dirname, '../../../../discovery');
   downloadDiscoveryDocs({discoveryUrl, downloadPath});
 }

--- a/src/generator/download.ts
+++ b/src/generator/download.ts
@@ -12,13 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import * as minimist from 'yargs-parser';
 import * as path from 'path';
 import * as fs from 'fs';
 const {mkdir} = require('fs').promises;
 import Q from 'p-queue';
 import {request, Headers} from 'gaxios';
 import * as gapi from 'googleapis-common';
+
+const minimist: typeof import('yargs-parser') = require('yargs-parser');
 
 export type Schema = {[index: string]: {}};
 export const DISCOVERY_URL = 'https://www.googleapis.com/discovery/v1/apis/';

--- a/src/generator/generator.ts
+++ b/src/generator/generator.ts
@@ -20,13 +20,14 @@ import * as path from 'path';
 import * as util from 'util';
 import Q from 'p-queue';
 import * as prettier from 'prettier';
-import * as minimist from 'yargs-parser';
 import {GaxiosError, request} from 'gaxios';
 import {DISCOVERY_URL} from './download';
 import {downloadDiscoveryDocs, ChangeSet} from './download';
 import * as filters from './filters';
 import {addFragments} from './samplegen';
 import {Disclaimer} from './disclaimer';
+
+const minimist: typeof import('yargs-parser') = require('yargs-parser');
 
 const writeFile = util.promisify(fs.writeFile);
 const readDir = util.promisify(fs.readdir);

--- a/src/generator/generator.ts
+++ b/src/generator/generator.ts
@@ -33,11 +33,11 @@ const readDir = util.promisify(fs.readdir);
 const readFile = util.promisify(fs.readFile);
 const stat = util.promisify(fs.stat);
 
-const srcPath = path.join(__dirname, '../../../src');
+const srcPath = path.join(__dirname, '../../../../src');
 const TEMPLATES_DIR = path.join(srcPath, 'generator/templates');
 const API_TEMPLATE = path.join(TEMPLATES_DIR, 'api-endpoint.njk');
 // eslint-disable-next-line @typescript-eslint/no-var-requires
-const disclaimers = require('../../../disclaimers.json') as Disclaimer[];
+const disclaimers = require('../../../../disclaimers.json') as Disclaimer[];
 
 export interface GeneratorOptions {
   debug?: boolean;
@@ -103,8 +103,8 @@ export class Generator {
     discoveryUrl: string,
     useCache: boolean
   ): Promise<ChangeSet[]> {
-    const ignore = require('../../../ignore.json').ignore as string[];
-    const discoveryPath = path.join(__dirname, '../../../discovery');
+    const ignore = require('../../../../ignore.json').ignore as string[];
+    const discoveryPath = path.join(__dirname, '../../../../discovery');
     let changes = new Array<ChangeSet>();
     if (useCache) {
       console.log('Reading from cache...');
@@ -309,7 +309,7 @@ export class Generator {
     3. find the delta from 2 - 1
     4. fill out bootstrap sha
     */
-    const disclaimers = require('../../../disclaimers.json') as Array<{
+    const disclaimers = require('../../../../disclaimers.json') as Array<{
       package: string;
       api: string;
     }>;
@@ -322,7 +322,7 @@ export class Generator {
       .filter(e => e.isDirectory() && !excludedAPIs.includes(e.name))
       .map(x => x.name);
 
-    const rootPath = path.join(__dirname, '../../../');
+    const rootPath = path.join(__dirname, '../../../../');
 
     // Bootstrap sha is used the first time the releaser runs when it grabs the initial commits
     // Afterwards, it uses the most recent release as a starting point
@@ -337,12 +337,13 @@ export class Generator {
 
     for (const api of releasableAPIs) {
       releasePleaseConfig.packages[`src/apis/${api}`] = {};
-      releasePleaseManifest[`src/apis/${api}`] =
-        require(`../../../src/apis/${api}/package.json`).version;
+      releasePleaseManifest[`src/apis/${api}`] = require(
+        `../../../../src/apis/${api}/package.json`
+      ).version;
     }
 
     // Include the root library in the config:
-    releasePleaseManifest['.'] = require('../../../package.json').version;
+    releasePleaseManifest['.'] = require('../../../../package.json').version;
     releasePleaseConfig.packages['.'] = {};
 
     fs.writeFileSync(

--- a/src/generator/samplegen.ts
+++ b/src/generator/samplegen.ts
@@ -28,10 +28,10 @@ const {mkdir} = require('fs').promises;
 import * as util from 'util';
 
 const writeFile = util.promisify(fs.writeFile);
-const srcPath = path.join(__dirname, '../../../src');
+const srcPath = path.join(__dirname, '../../../../src');
 const TEMPLATES_DIR = path.join(srcPath, 'generator/templates');
 // eslint-disable-next-line @typescript-eslint/no-var-requires
-const prettierConfig: prettier.Options = require('../../../node_modules/gts/.prettierrc.json');
+const prettierConfig: prettier.Options = require('../../../../node_modules/gts/.prettierrc.json');
 prettierConfig.parser = 'babel';
 
 const env = new nunjucks.Environment(

--- a/src/generator/synth.ts
+++ b/src/generator/synth.ts
@@ -11,13 +11,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import * as execa from 'execa';
 import * as path from 'path';
 import * as fs from 'fs';
 import * as gaxios from 'gaxios';
-import * as minimist from 'yargs-parser';
 import {Generator} from './generator';
 import {DISCOVERY_URL, ChangeSet} from './download';
+const execa: typeof import('execa') = require('execa');
+const minimist: typeof import('yargs-parser') = require('yargs-parser');
 
 export enum Semverity {
   PATCH = 1,

--- a/src/generator/templates/api-index.njk
+++ b/src/generator/templates/api-index.njk
@@ -8,7 +8,7 @@ import {
   GoogleConfigurable
 } from 'googleapis-common';
 {% for versionName, version in api %}
-  import { {{ name }}_{{ version|replace('.','_') }} } from './{{ version }}';
+  import { {{ name }}_{{ version|replace('.','_') }} } from './{{ version }}.js';
 {% endfor %}
 
 export const VERSIONS = {

--- a/src/generator/templates/index.njk
+++ b/src/generator/templates/index.njk
@@ -2,10 +2,10 @@
 /*! THIS FILE IS AUTO-GENERATED */
 
 {% for apiName, api in apis %}
-  import { 
+  import {
     VERSIONS as {{apiName}}Versions,
     {{apiName}}
-  } from './{{ apiName }}';
+  } from './{{ apiName }}/index.js';
 {% endfor %}
 
 export interface APIList {

--- a/src/generator/templates/root-index.njk
+++ b/src/generator/templates/root-index.njk
@@ -1,13 +1,13 @@
 {% include "license.njk" %}
  /*! THIS FILE IS AUTO-GENERATED */
 
-import {GoogleApis} from './googleapis';
+import {GoogleApis} from './googleapis.js';
 const google = new GoogleApis();
 export {google, GoogleApis};
 export * as Common from 'googleapis-common';
 export * as Auth from 'google-auth-library';
 
 {% for apiName, api in apis %}
-  {% for versionName, version in api %}export { {{ apiName }}_{{ version|replace('.','_') }} } from './apis/{{ apiName }}/{{ version }}';
+  {% for versionName, version in api %}export { {{ apiName }}_{{ version|replace('.','_') }} } from './apis/{{ apiName }}/{{ version }}.js';
 {% endfor %}
 {% endfor %}

--- a/test/test.clients.ts
+++ b/test/test.clients.ts
@@ -220,5 +220,5 @@ describe('Clients', () => {
 
   it('should pass eslint for a given client', () => {
     execSync('npx eslint --no-ignore src/apis/youtube/*.ts');
-  });
+  }).timeout(50000);
 });

--- a/test/test.download.ts
+++ b/test/test.download.ts
@@ -134,7 +134,7 @@ describe(__filename, () => {
         });
         const indexPath = path.join(
           __dirname,
-          '../../test/fixtures/index.json'
+          '../../../test/fixtures/index.json'
         );
         fs.readFile(indexPath, (err, data) => {
           if (err) {
@@ -150,7 +150,7 @@ describe(__filename, () => {
       .listen(port);
     const downloadPath = 'build/test/temp';
     await execa('node', [
-      './build/src/generator/download',
+      './build/cjs/src/generator/download',
       '--download-path',
       downloadPath,
       '--discovery-url',

--- a/test/test.media.ts
+++ b/test/test.media.ts
@@ -27,7 +27,7 @@ async function testMultpart(drive: drive_v2.Drive) {
   const requestBody = {title: 'title', mimeType: 'text/plain'};
   const media = {body: 'hey'};
   let expectedResp = fs.readFileSync(
-    path.join(__dirname, '../../test/fixtures/media-response.txt'),
+    path.join(__dirname, '../../../test/fixtures/media-response.txt'),
     {encoding: 'utf8'}
   );
   const res = await drive.files.insert({requestBody, media});
@@ -57,7 +57,7 @@ async function testMediaBody(drive: drive_v2.Drive) {
   const requestBody = {title: 'title'};
   const media = {body: 'hey'};
   let expectedResp = fs.readFileSync(
-    path.join(__dirname, '../../test/fixtures/media-response.txt'),
+    path.join(__dirname, '../../../test/fixtures/media-response.txt'),
     {encoding: 'utf8'}
   );
   const res = await drive.files.insert({requestBody, media});
@@ -111,7 +111,10 @@ describe('Media', () => {
         '/upload/youtube/v3/videos?part=id&part=snippet&notifySubscribers=false&uploadType=multipart'
       )
       .reply(200);
-    const fileName = path.join(__dirname, '../../test/fixtures/mediabody.txt');
+    const fileName = path.join(
+      __dirname,
+      '../../../test/fixtures/mediabody.txt'
+    );
     const fileSize = fs.statSync(fileName).size;
     const google = new GoogleApis();
     const youtube = google.youtube('v3');
@@ -147,7 +150,10 @@ describe('Media', () => {
         '/upload/youtube/v3/thumbnails/set?videoId=abc123&uploadType=multipart'
       )
       .reply(200);
-    const fileName = path.join(__dirname, '../../test/fixtures/mediabody.txt');
+    const fileName = path.join(
+      __dirname,
+      '../../../test/fixtures/mediabody.txt'
+    );
     const fileSize = fs.statSync(fileName).size;
     const google = new GoogleApis();
     const youtube = google.youtube('v3');
@@ -337,10 +343,10 @@ describe('Media', () => {
         // testing purposes
       });
     let body = fs.createReadStream(
-      path.join(__dirname, '../../test/fixtures/mediabody.txt')
+      path.join(__dirname, '../../../test/fixtures/mediabody.txt')
     );
     let expectedBody = fs.readFileSync(
-      path.join(__dirname, '../../test/fixtures/mediabody.txt'),
+      path.join(__dirname, '../../../test/fixtures/mediabody.txt'),
       'utf8'
     );
     const res = await localGmail.users.drafts.create({
@@ -349,10 +355,10 @@ describe('Media', () => {
     } as gmail_v1.Params$Resource$Users$Drafts$Create);
     assert.strictEqual(res.data, expectedBody);
     body = fs.createReadStream(
-      path.join(__dirname, '../../test/fixtures/mediabody.txt')
+      path.join(__dirname, '../../../test/fixtures/mediabody.txt')
     );
     expectedBody = fs.readFileSync(
-      path.join(__dirname, '../../test/fixtures/mediabody.txt'),
+      path.join(__dirname, '../../../test/fixtures/mediabody.txt'),
       'utf8'
     );
     const res2 = await remoteGmail.users.drafts.create({
@@ -375,15 +381,15 @@ describe('Media', () => {
       message: {raw: Buffer.from('hello', 'binary').toString('base64')},
     };
     let body = fs.createReadStream(
-      path.join(__dirname, '../../test/fixtures/mediabody.txt')
+      path.join(__dirname, '../../../test/fixtures/mediabody.txt')
     );
     let bodyString = fs.readFileSync(
-      path.join(__dirname, '../../test/fixtures/mediabody.txt'),
+      path.join(__dirname, '../../../test/fixtures/mediabody.txt'),
       {encoding: 'utf8'}
     );
     let media = {mimeType: 'message/rfc822', body};
     let expectedBody = fs.readFileSync(
-      path.join(__dirname, '../../test/fixtures/media-response.txt'),
+      path.join(__dirname, '../../../test/fixtures/media-response.txt'),
       {encoding: 'utf8'}
     );
     const res = await localGmail.users.drafts.create({
@@ -407,15 +413,15 @@ describe('Media', () => {
       message: {raw: Buffer.from('hello', 'binary').toString('base64')},
     };
     body = fs.createReadStream(
-      path.join(__dirname, '../../test/fixtures/mediabody.txt')
+      path.join(__dirname, '../../../test/fixtures/mediabody.txt')
     );
     bodyString = fs.readFileSync(
-      path.join(__dirname, '../../test/fixtures/mediabody.txt'),
+      path.join(__dirname, '../../../test/fixtures/mediabody.txt'),
       {encoding: 'utf8'}
     );
     media = {mimeType: 'message/rfc822', body};
     expectedBody = fs.readFileSync(
-      path.join(__dirname, '../../test/fixtures/media-response.txt'),
+      path.join(__dirname, '../../../test/fixtures/media-response.txt'),
       {encoding: 'utf8'}
     );
     const res2 = await remoteGmail.users.drafts.create({
@@ -455,7 +461,7 @@ describe('Media', () => {
       message: {raw: Buffer.from('hello', 'binary').toString('base64')},
     };
     const body = fs.createReadStream(
-      path.join(__dirname, '../../test/fixtures/mediabody.txt')
+      path.join(__dirname, '../../../test/fixtures/mediabody.txt')
     );
     let media = {mimeType: 'message/rfc822', body};
     const res = await localGmail.users.drafts.create({
@@ -471,7 +477,7 @@ describe('Media', () => {
       message: {raw: Buffer.from('hello', 'binary').toString('base64')},
     };
     const body2 = fs.createReadStream(
-      path.join(__dirname, '../../test/fixtures/mediabody.txt')
+      path.join(__dirname, '../../../test/fixtures/mediabody.txt')
     );
     media = {mimeType: 'message/rfc822', body: body2};
     const res2 = await remoteGmail.users.drafts.create({

--- a/test/test.samplegen.ts
+++ b/test/test.samplegen.ts
@@ -17,7 +17,7 @@ import {describe, it} from 'mocha';
 import {addFragments, getAllMethods} from '../src/generator/samplegen';
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
-const schema = require('../../test/fixtures/discovery/webfonts-v1.json');
+const schema = require('../../../test/fixtures/discovery/webfonts-v1.json');
 
 describe(__filename, () => {
   it('should add fragments', async () => {

--- a/tsc-multi.json
+++ b/tsc-multi.json
@@ -1,0 +1,24 @@
+{
+  "targets": [
+    {
+      "extname": ".js",
+      "module": "commonjs",
+      "outDir": "build/cjs",
+      "tsBuildInfoFile": "build/cjs.tsbuildinfo"
+    },
+    {
+      "extname": ".mjs",
+      "module": "ES2022",
+      "outDir": "build/esm",
+      "moduleResolution": "NodeNext",
+      "tsBuildInfoFile": "build/esm.tsbuildinfo",
+      "include": [
+        "src/*.ts",
+        "src/**/*.ts"
+      ]
+    }
+  ],
+  "projects": [
+    "tsconfig.json"
+  ]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "./node_modules/gts/tsconfig-google.json",
   "compilerOptions": {
     "rootDir": ".",
-    "outDir": "build",
+    "outDir": "build/cjs",
     "incremental": true,
     "sourceMap": false
   },


### PR DESCRIPTION
Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/google-api-nodejs-client/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

Fixes #3335 

This PR attempts to address #3335. Given there are a lot of possible ways to achieve cjs/esm compatible pkg support, I can see this PR is not feasible to this repo's convention and likely can be closed without merge. That's totally fine, however would like to kickstart an initial effort.

Among various approach, this PR nearly mimics recent redux-toolkit's approach (without bundling part) and my personal experiences when I dealt with RxJS (though it's not real esm - https://github.com/ReactiveX/rxjs/blob/master/package.json). Detailed exploration can be found at https://blog.isquaredsoftware.com/2023/08/esm-modernization-lessons/, but in crux this PR does these things

- Preserve `package.json`'s `type`, so existing cjs-based scripts & assumptions (`require..`) works as-is
- Adjust existing cjs output to `build/cjs`
- Introduce another tsconfig to generate esm outputs, generates under `build/esm`. This uses `tsc-multi`(https://github.com/tommy351/tsc-multi), which is a wrapper to generate multiple target outputs with manually transforming extensions per each.
  - Using above tsc-multi, make `build/esm` uses `.mjs` extension to let node.js resolves this as esm explicitly
- Adjust `generators` template to include `.js` extension by default
- Apply conditional exports to `package.json` for `import` / `require` and lastly let default resolves to esm.

Quick local testing confirmed generated pkg can be imported in node.js with cjs / esm (`type:module`), also typescript definitions are being resolved. The caveat for type resolution is it falls back to cjs types always, but it won't be a huge concern since most of types should be equivalent between 2 build outputs. Below's manual testing from https://arethetypeswrong.github.io/ how imports are being resolved.


```
┌───────────────────┬───────────────────────────┬────────────────────────┐
│                   │ "googleapis/package.json" │ "googleapis"           │
├───────────────────┼───────────────────────────┼────────────────────────┤
│ node10            │ 🟢 (JSON)                 │ 🟢                     │
├───────────────────┼───────────────────────────┼────────────────────────┤
│ node16 (from CJS) │ 🟢 (JSON)                 │ 🟢 (CJS)               │
├───────────────────┼───────────────────────────┼────────────────────────┤
│ node16 (from ESM) │ 🟢 (JSON)                 │ 🎭 Masquerading as CJS │
├───────────────────┼───────────────────────────┼────────────────────────┤
│ bundler           │ 🟢 (JSON)                 │ 🟢                     │
└───────────────────┴───────────────────────────┴────────────────────────┘
```

One last thing to note is about conditional exports: conditional exports limits arbitaray imports (including cjs require) to subpath imports, so if anyone used subpath imports like `require('googleapi/somepath/imports')` explicitly it'll likely fail. I'm not certain this should be treated as major breaking - since the entrypoints reexports everything and individual api should be resolvable withput subpath - though.
