### PR TITLE
chore: use keystore publication token instead of github action env variable

### DIFF
--- a/.kokoro/publish.sh
+++ b/.kokoro/publish.sh
@@ -29,7 +29,7 @@ python3 -m releasetool publish-reporter-script > /tmp/publisher-script; source /
 
 cd $(dirname $0)/..
 
-NPM_TOKEN=$(cat "${KOKORO_GFILE_DIR}/secret_manager/repo_automation_bots_npm_publish_token")
+NPM_TOKEN=$(cat "${KOKORO_GFILE_DIR}/secret_manager/google-api-nodejs-client-npm-token")
 printf "//wombat-dressing-room.appspot.com/:_authToken=${NPM_TOKEN}\nregistry=https://wombat-dressing-room.appspot.com" > ~/.npmrc
 
 npx @google-cloud/mono-repo-publish --pr-url="${AUTORELEASE_PR}"

--- a/.kokoro/release/publish.cfg
+++ b/.kokoro/release/publish.cfg
@@ -1,3 +1,12 @@
+before_action {
+  fetch_keystore {
+    keystore_resource {
+      keystore_config_id: 73713
+      keyname: "google-api-nodejs-client-npm-token"
+    }
+  }
+}
+
 env_vars: {
   key: "SECRET_MANAGER_KEYS"
   value: "repo_automation_bots_npm_publish_token,releasetool-publish-reporter-app,releasetool-publish-reporter-googleapis-installation,releasetool-publish-reporter-pem"


### PR DESCRIPTION

fixes b/353320632

we should monitor to make sure publication for this library still works.