### PR TITLE
Added missing @ in npm search link

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ If you need to reduce startup times, you can alternatively install a submodule a
 $ npm install @googleapis/docs
 ```
 
-You can run [this search](https://www.npmjs.com/search?q=scope%3Agoogleapis) on `npm`, to find a list of the submodules available.
+You can run [this search](https://www.npmjs.com/search?q=scope%3A@googleapis) on `npm`, to find a list of the submodules available.
 ### Using the client library
 
 This is a very simple example. This creates a Blogger client and retrieves the details of a blog given the blog Id:


### PR DESCRIPTION
Added missing @ in npm search link. The npm scope of the submodules is `@googleapis` but the link was following to `googleapis`

[this is plain md file update, no code changes]

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/google-api-nodejs-client/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

Fixes #<issue_number_goes_here> 🦕
