### PR TITLE
ci: release-please.yml to tag pull request number

### DIFF
--- a/.github/release-please.yml
+++ b/.github/release-please.yml
@@ -1,2 +1,3 @@
 handleGHRelease: true
 manifest: true
+tagPullRequestNumber: true


### PR DESCRIPTION
This google-api-nodejs-client repository creates multiple Git tags upon one release pull request (commit). Example: https://github.com/googleapis/google-api-nodejs-client/pull/3650#issuecomment-2821424138

To adopt the new release pipeline based on Git tags, this `tagPullRequestNumber` creates an additional `release-please-<pr number>` tag to a release. We'll monitor that tag to trigger the release job. This doesn't change existing release tags.

Background: https://docs.google.com/document/d/1Y0Fv-sxLqYmjnXHry3WDq4XNPeQP1AEmsB83hNRCEY0/edit?usp=sharing&resourcekey=0-I2m8Z-mTD0-HY0TpkblOTQ

This design has been working good for google-cloud-go: https://github.com/googleapis/google-cloud-go/blob/main/.github/release-please.yml#L4

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/google-api-nodejs-client/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes #<issue_number_goes_here> 🦕
