### PR TITLE
chore: update update-apis.yaml node version

### DIFF
--- a/.github/workflows/update-apis.yaml
+++ b/.github/workflows/update-apis.yaml
@@ -9,7 +9,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v4
         with:
-          node-version: 14
+          node-version: 18
       - run: gh repo fork googleapis/google-api-nodejs-client --fork-name google-api-nodejs-client-autodisco --clone --remote
         env:
           GH_TOKEN: ${{ secrets.YOSHI_CODE_BOT_TOKEN }}


### PR DESCRIPTION
This action has been failing consistently: https://github.com/googleapis/google-api-nodejs-client/actions/workflows/update-apis.yaml

The failure is here: 

```
        this.#proxyAgent ||= (await import('https-proxy-agent')).HttpsProxyAgent;
                         ^^^

SyntaxError: Unexpected token '||='
```
Because we are running the action from node 14.