### PR TITLE
build: skip connectors for now to get the build going

### DIFF
--- a/ignore.json
+++ b/ignore.json
@@ -11,6 +11,7 @@
     "policysimulator:v1beta",
     "datalineage:v1",
     "healthcare:v1",
-    "healthcare:v1beta1"
+    "healthcare:v1beta1",
+    "connectors:v2"
   ]
 }


### PR DESCRIPTION
re: b/478880269

Currently there is a duplicate method generated for "tools". We need to investigate why, but for now, we need the generator to work.
