### PR TITLE
fix: fall back to HTTP/1.1 when global http2 option is enabled

### DIFF
--- a/src/googleapis.ts
+++ b/src/googleapis.ts
@@ -62,7 +62,29 @@ export class GoogleApis extends GeneratedAPIs {
    * @param options - Configuration options.
    */
   options(options?: GlobalOptions) {
-    this._options = options || {};
+    this._options = this.normalizeGlobalOptions(options);
+  }
+
+  private normalizeGlobalOptions(options?: GlobalOptions): GlobalOptions {
+    if (!options) {
+      return {};
+    }
+
+    if (!options.http2) {
+      return options;
+    }
+
+    process.emitWarning(
+      'google.options({http2: true}) is temporarily disabled due hanging request issues. Falling back to HTTP/1.1.',
+      {
+        code: 'GOOGLEAPIS_HTTP2_DISABLED',
+      },
+    );
+
+    return {
+      ...options,
+      http2: false,
+    };
   }
 
   /**

--- a/test/test.options.ts
+++ b/test/test.options.ts
@@ -65,6 +65,32 @@ describe('Options', () => {
     assert.deepStrictEqual(google._options.params.hello, 'world');
   });
 
+  it('should disable http2 in global options and emit a warning', () => {
+    const google = new GoogleApis();
+    const emitWarningStub = sandbox.stub(process, 'emitWarning');
+
+    google.options({http2: true, timeout: 1234});
+
+    assert.strictEqual(google._options.http2, false);
+    assert.strictEqual(google._options.timeout, 1234);
+    assert.strictEqual(emitWarningStub.callCount, 1);
+    const [message, warningOptions] = emitWarningStub.firstCall.args;
+    assert.match(String(message), /http2: true/);
+    assert.deepStrictEqual(warningOptions, {
+      code: 'GOOGLEAPIS_HTTP2_DISABLED',
+    });
+  });
+
+  it('should not emit warning when http2 is false', () => {
+    const google = new GoogleApis();
+    const emitWarningStub = sandbox.stub(process, 'emitWarning');
+
+    google.options({http2: false});
+
+    assert.strictEqual(google._options.http2, false);
+    assert.strictEqual(emitWarningStub.callCount, 0);
+  });
+
   it('should promote endpoint options over global options', async () => {
     const google = new GoogleApis();
     google.options({params: {hello: 'world'}});


### PR DESCRIPTION
## Summary
This change mitigates hanging requests reported in #3418 when `google.options({http2: true})` is used.

## Root cause
The hang occurs in the HTTP/2 request path (`googleapis-common`) where some GET requests can remain open indefinitely. Since this repo surfaces that path through global options, affected calls appear to hang forever.

## What changed
- Added normalization of global options in `GoogleApis.options()`.
- If `http2: true` is provided globally, emit a warning and force `http2: false` (HTTP/1.1 fallback).
- Preserved all other global options unchanged.
- Added tests to verify fallback behavior and warning emission.

## Tests
- `npx mocha build/test/test.options.js --grep "disable http2|not emit warning"`
- `npx mocha build/test/test.options.js`

## Notes
This is a defensive mitigation in `google-api-nodejs-client` until a full HTTP/2 transport fix is available downstream.
