### PR TITLE
chore: remove redundant --remote flag breaking update-apis

### DIFF
--- a/.github/workflows/update-apis.yaml
+++ b/.github/workflows/update-apis.yaml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: 22
-      - run: gh repo fork googleapis/google-api-nodejs-client --fork-name google-api-nodejs-client-autodisco --clone --remote
+      - run: gh repo fork googleapis/google-api-nodejs-client --fork-name google-api-nodejs-client-autodisco --clone
         env:
           GH_TOKEN: ${{ secrets.YOSHI_CODE_BOT_TOKEN }}
       - run: gh repo sync yoshi-code-bot/google-api-nodejs-client-autodisco --force

--- a/package.json
+++ b/package.json
@@ -95,9 +95,17 @@
     "proxyquire": "^2.1.3",
     "rimraf": "^5.0.0",
     "server-destroy": "^1.0.1",
-    "sinon": "^21.0.0",
+    "sinon": "21.0.3",
     "tmp": "^0.2.3",
     "typescript": "^5.8.3",
     "yargs-parser": "^21.1.1"
-  }
+  },
+    "overrides": {
+    "@sinonjs/fake-timers": "15.2.1"
+  },
+  "pnpm": {
+    "overrides": {
+      "@sinonjs/fake-timers": "15.2.1"
+    }
+  },
 }

--- a/package.json
+++ b/package.json
@@ -100,12 +100,12 @@
     "typescript": "^5.8.3",
     "yargs-parser": "^21.1.1"
   },
-    "overrides": {
+  "overrides": {
     "@sinonjs/fake-timers": "15.2.1"
   },
   "pnpm": {
     "overrides": {
       "@sinonjs/fake-timers": "15.2.1"
     }
-  },
+  }
 }


### PR DESCRIPTION
The update-apis.yaml workflow is currently broken with the following error:
```
the `--remote` flag is unsupported when a repository argument is provided
```

When you use the --clone flag, the GitHub CLI is smart enough to realize you’ll want to keep in touch with the original repository. By default, it automatically:

Sets your fork as origin.

Sets the original repository (googleapis/google-api-nodejs-client) as upstream.

Adding the --remote flag manually is redundant because gh does this for you the moment you ask it to clone.

---

Note: A bad sinon version was breaking the build (we previously faced this issue in other packages). As a result I need to pin versions to proceed.