### PR TITLE
chore: fix generator by pinning auth dep, updating samples TS version

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "client library"
   ],
   "dependencies": {
-    "google-auth-library": "^10.2.0",
+    "google-auth-library": "10.5.0",
     "googleapis-common": "^8.0.0"
   },
   "devDependencies": {

--- a/samples/package.json
+++ b/samples/package.json
@@ -29,6 +29,6 @@
     "mocha": "^9.0.0",
     "nock": "^14.0.0",
     "proxyquire": "^2.1.3",
-    "typescript": "^4.6.4"
+    "typescript": "^5.8.3"
   }
 }


### PR DESCRIPTION
## Issues addressed

### Auth library conflict
`npm install` triggered `npm run prepare` (`tsc`), which failed with 9 TypeScript compilation errors due to duplicate module resolutions of `google-auth-library`. Top-level `package.json` resolved `v10.9.1` while `googleapis-common` pinned `v10.5.0`, causing npm to create a nested copy and TypeScript to flag incompatible class type instances.

Pinning `google-auth-library` to `10.5.0` aligns root requirements with `googleapis-common`, allowing npm to deduplicate the package into top-level `node_modules` and resolving all build errors.

### Samples type breakage due to outdated TS depedency 

During tsc execution in samples/typescript:

* samples/package.json had specified an outdated TypeScript version (^4.6.4).
* tsc resolved @types/node from the root project's node_modules (version 22.15.3).
* TypeScript 4.6 is incompatible with Node 22 type declarations in @types/node/web-globals/streams.d.ts, leading to compile error:
error TS2502: 'CompressionStream' is referenced directly or indirectly in its own type annotation.