### PR TITLE
chore: fix sample generation error when schema undefined

### DIFF
--- a/src/generator/samplegen.ts
+++ b/src/generator/samplegen.ts
@@ -88,12 +88,18 @@ export async function generateSamples(apiPath: string, schema: Schema) {
 function getSample(schema: Schema, method: SchemaMethod) {
   let responseExample: undefined | {};
   if (method.response) {
-    const item = schema.schemas[method.response.$ref!];
+    const item =
+      schema.schemas && method.response.$ref
+        ? schema.schemas[method.response.$ref]
+        : undefined;
     responseExample = flattenSchema(item, schema.schemas);
   }
   let requestExample: {} | undefined;
   if (method.request) {
-    const item = schema.schemas[method.request.$ref!];
+    const item =
+      schema.schemas && method.request.$ref
+        ? schema.schemas[method.request.$ref]
+        : undefined;
     requestExample = flattenSchema(item, schema.schemas);
   }
   const sampleData: SampleData = {
@@ -137,7 +143,7 @@ export function getAllMethods(bag: MethodBag, methods?: SchemaMethod[]) {
  * Provide a flattened representation of what the structure for a
  * given request or response could look like.
  */
-function flattenSchema(item: SchemaItem | undefined, schemas: SchemaItems) {
+function flattenSchema(item?: SchemaItem, schemas?: SchemaItems) {
   // tslint:disable-next-line no-any
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const result: any = {};
@@ -153,7 +159,7 @@ function getExamplePropertyValue(
   name: string,
   details: SchemaItem,
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  schemas: SchemaItems,
+  schemas?: SchemaItems,
 ): {} {
   switch (details.type) {
     case 'string':

--- a/src/generator/samplegen.ts
+++ b/src/generator/samplegen.ts
@@ -19,7 +19,6 @@ import {
   SchemaMethods,
   SchemaResources,
   SchemaItem,
-  SchemaItems,
 } from 'googleapis-common';
 import * as nunjucks from 'nunjucks';
 import * as filters from './filters';
@@ -149,10 +148,7 @@ function flattenSchema(item?: SchemaItem) {
   return result;
 }
 
-function getExamplePropertyValue(
-  name: string,
-  details: SchemaItem,
-): {} {
+function getExamplePropertyValue(name: string, details: SchemaItem): {} {
   switch (details.type) {
     case 'string':
       return `my_${name}`;

--- a/src/generator/samplegen.ts
+++ b/src/generator/samplegen.ts
@@ -87,20 +87,14 @@ export async function generateSamples(apiPath: string, schema: Schema) {
 
 function getSample(schema: Schema, method: SchemaMethod) {
   let responseExample: undefined | {};
-  if (method.response) {
-    const item =
-      schema.schemas && method.response.$ref
-        ? schema.schemas[method.response.$ref]
-        : undefined;
-    responseExample = flattenSchema(item, schema.schemas);
+  if (method?.response?.$ref) {
+    const item = schema?.schemas?.[method.response.$ref];
+    responseExample = flattenSchema(item);
   }
   let requestExample: {} | undefined;
-  if (method.request) {
-    const item =
-      schema.schemas && method.request.$ref
-        ? schema.schemas[method.request.$ref]
-        : undefined;
-    requestExample = flattenSchema(item, schema.schemas);
+  if (method?.request?.$ref) {
+    const item = schema?.schemas?.[method.request.$ref];
+    requestExample = flattenSchema(item);
   }
   const sampleData: SampleData = {
     api: schema,
@@ -143,13 +137,13 @@ export function getAllMethods(bag: MethodBag, methods?: SchemaMethod[]) {
  * Provide a flattened representation of what the structure for a
  * given request or response could look like.
  */
-function flattenSchema(item?: SchemaItem, schemas?: SchemaItems) {
+function flattenSchema(item?: SchemaItem) {
   // tslint:disable-next-line no-any
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const result: any = {};
   if (item?.properties) {
     for (const [name, details] of Object.entries(item.properties)) {
-      result[name] = getExamplePropertyValue(name, details, schemas);
+      result[name] = getExamplePropertyValue(name, details);
     }
   }
   return result;
@@ -158,8 +152,6 @@ function flattenSchema(item?: SchemaItem, schemas?: SchemaItems) {
 function getExamplePropertyValue(
   name: string,
   details: SchemaItem,
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  schemas?: SchemaItems,
 ): {} {
   switch (details.type) {
     case 'string':

--- a/src/generator/samplegen.ts
+++ b/src/generator/samplegen.ts
@@ -137,11 +137,11 @@ export function getAllMethods(bag: MethodBag, methods?: SchemaMethod[]) {
  * Provide a flattened representation of what the structure for a
  * given request or response could look like.
  */
-function flattenSchema(item: SchemaItem, schemas: SchemaItems) {
+function flattenSchema(item: SchemaItem | undefined, schemas: SchemaItems) {
   // tslint:disable-next-line no-any
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const result: any = {};
-  if (item.properties) {
+  if (item?.properties) {
     for (const [name, details] of Object.entries(item.properties)) {
       result[name] = getExamplePropertyValue(name, details, schemas);
     }

--- a/test/test.samplegen.ts
+++ b/test/test.samplegen.ts
@@ -42,7 +42,7 @@ describe(__filename, () => {
     };
 
     await addFragments(customSchema);
-    
+
     const methods = getAllMethods(customSchema);
     assert.ok(methods.find(m => m.id === 'testMethod')?.fragment);
   });

--- a/test/test.samplegen.ts
+++ b/test/test.samplegen.ts
@@ -26,4 +26,24 @@ describe(__filename, () => {
     assert.strictEqual(methods.length, 1);
     assert.ok(methods[0].fragment);
   });
+
+  it('should handle missing schema refs gracefully', async () => {
+    const customSchema = {
+      ...schema,
+      methods: {
+        testMethod: {
+          id: 'testMethod',
+          path: 'test',
+          httpMethod: 'POST',
+          request: {$ref: 'NonExistentSchema'},
+          response: {$ref: 'AnotherMissingSchema'},
+        },
+      },
+    };
+
+    await addFragments(customSchema);
+    
+    const methods = getAllMethods(customSchema);
+    assert.ok(methods.find(m => m.id === 'testMethod')?.fragment);
+  });
 });


### PR DESCRIPTION
We got the following error in the update-api workflow. We are making some unguarded access (on undefined variables) causing this error to be thrown. 

This PR adds guarding to avoid throwing.

```
2026-07-28T01:46:00.7762143Z Failed to generate API: aiplatform:v1beta1
2026-07-28T01:46:00.7776739Z TypeError: Cannot read properties of undefined (reading 'properties')
2026-07-28T01:46:00.7778968Z     at flattenSchema (/home/runner/work/google-api-nodejs-client/google-api-nodejs-client/google-api-nodejs-client-autodisco/build/src/generator/samplegen.js:117:14)
2026-07-28T01:46:00.7782073Z     at getSample (/home/runner/work/google-api-nodejs-client/google-api-nodejs-client/google-api-nodejs-client-autodisco/build/src/generator/samplegen.js:72:27)
2026-07-28T01:46:00.7785198Z     at addFragments (/home/runner/work/google-api-nodejs-client/google-api-nodejs-client/google-api-nodejs-client-autodisco/build/src/generator/samplegen.js:43:28)
2026-07-28T01:46:00.7788770Z     at async Generator.generate (/home/runner/work/google-api-nodejs-client/google-api-nodejs-client/google-api-nodejs-client-autodisco/build/src/generator/generator.js:224:9)
2026-07-28T01:46:00.7791933Z     at async Generator.generateAPI (/home/runner/work/google-api-nodejs-client/google-api-nodejs-client/google-api-nodejs-client-autodisco/build/src/generator/generator.js:209:24)
2026-07-28T01:46:00.7794939Z     at async /home/runner/work/google-api-nodejs-client/google-api-nodejs-client/google-api-nodejs-client-autodisco/build/src/generator/generator.js:110:17
2026-07-28T01:46:00.7796390Z     at async run (/home/runner/work/google-api-nodejs-client/google-api-nodejs-client/google-api-nodejs-client-autodisco/node_modules/p-queue/dist/index.js:163:29)
2026-07-28T01:46:00.7797159Z aiplatform:v1beta1
2026-07-28T01:46:00.7797368Z -----------
2026-07-28T01:46:00.7797578Z [
2026-07-28T01:46:00.7798118Z   'Attempting first generateAPI call...',
2026-07-28T01:46:00.7798768Z   "GenerateAPI call failed with error: TypeError: Cannot read properties of undefined (reading 'properties'), moving on."
2026-07-28T01:46:00.7799561Z ]
2026-07-28T01:46:00.7799666Z 
2026-07-28T01:55:38.1811154Z Failed to generate API: poly:v1
2026-07-28T01:55:38.1833981Z [Error: ENOENT: no such file or directory, open '/home/runner/work/google-api-nodejs-client/google-api-nodejs-client/google-api-nodejs-client-autodisco/discovery/poly-v1.json'] {
2026-07-28T01:55:38.1835469Z   errno: -2,
2026-07-28T01:55:38.1835807Z   code: 'ENOENT',
2026-07-28T01:55:38.1836146Z   syscall: 'open',
2026-07-28T01:55:38.1837256Z   path: '/home/runner/work/google-api-nodejs-client/google-api-nodejs-client/google-api-nodejs-client-autodisco/discovery/poly-v1.json'
2026-07-28T01:55:38.1838749Z }
2026-07-28T01:55:38.1839077Z poly:v1
2026-07-28T01:55:38.1839367Z -----------
2026-07-28T01:55:38.1839675Z [
2026-07-28T01:55:38.1840083Z   'Attempting first generateAPI call...',
2026-07-28T01:55:38.1841957Z   "GenerateAPI call failed with error: Error: ENOENT: no such file or directory, open '/home/runner/work/google-api-nodejs-client/google-api-nodejs-client/google-api-nodejs-client-autodisco/discovery/poly-v1.json', moving on."
2026-07-28T01:55:38.1843621Z ]
```