### PR TITLE
chore: add unavailable poly:v1 library to ignore list

### DIFF
--- a/ignore.json
+++ b/ignore.json
@@ -12,6 +12,7 @@
     "datalineage:v1",
     "healthcare:v1",
     "healthcare:v1beta1",
-    "connectors:v2"
+    "connectors:v2",
+    "poly:v1"
   ]
 }


### PR DESCRIPTION
This API appears to be no longer supported. The public facing product was shut down in 2021 (https://en.wikipedia.org/wiki/Poly_(website), https://techcrunch.com/2020/12/02/google-shutting-down-poly-3d-content-platform/).  

I have added it to the ignore list to prevent it from breaking generation going forward.

```
Failed to generate API: poly:v1
[Error: ENOENT: no such file or directory, open '/home/runner/work/google-api-nodejs-client/google-api-nodejs-client/google-api-nodejs-client-autodisco/discovery/poly-v1.json'] {
  errno: -2,
poly:v1
-----------
[
  'Attempting first generateAPI call...',
  "GenerateAPI call failed with error: Error: ENOENT: no such file or directory, open '/home/runner/work/google-api-nodejs-client/google-api-nodejs-client/google-api-nodejs-client-autodisco/discovery/poly-v1.json', moving on."
]

  code: 'ENOENT',
  syscall: 'open',
  path: '/home/runner/work/google-api-nodejs-client/google-api-nodejs-client/google-api-nodejs-client-autodisco/discovery/poly-v1.json'
}
```
