### PR TITLE
chore: bump sumbit-pr's heap size to 16GB

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "generate": "node --max-old-space-size=12288 build/src/generator/generator.js",
     "docs-test": "echo 🙈 this was taking too long and timing out CI",
     "presubmit-prs": "npm run compile",
-    "submit-prs": "node --max-old-space-size=12288 build/src/generator/synth.js",
+    "submit-prs": "node --max-old-space-size=16384 build/src/generator/synth.js",
     "prelint": "cd samples; npm link ../; npm i",
     "predownload": "npm run build-tools",
     "download": "node build/src/generator/download.js",


### PR DESCRIPTION
According to https://docs.github.com/en/actions/reference/runners/github-hosted-runners our VM should have 16GB of RAM.

The update-apis.yml process is still failing with error code 143. Let's trying bumping the max heap size to 16GB to see if a little extra headroom will allow this to succeed.
