### PR TITLE
fix(generator): only commit index files if there are staged changes

### DIFF
--- a/src/generator/synth.ts
+++ b/src/generator/synth.ts
@@ -119,7 +119,10 @@ export async function synth(options: SynthOptions = {}) {
     global.gc();
   }
   await execa('git', ['add', '-A']);
-  await execa('git', ['commit', '-m', 'feat: regenerate index files']);
+  const statusAfterAdd = await execa('git', ['status', '--porcelain']);
+  if (statusAfterAdd.stdout.trim().length > 0) {
+    await execa('git', ['commit', '-m', 'feat: regenerate index files']);
+  }
   const prefix = getPrefix(totalSemverity);
   for (let attempt = 1; attempt <= 3; attempt++) {
     try {


### PR DESCRIPTION
When only existing APIs are updated (no APIs added or removed), root index files like `src/index.ts` and `src/apis/index.ts` remain unchanged.

In that scenario, `git add -A` stages zero files, causing the final unconditional `git commit -m 'feat: regenerate index files'` call in `src/generator/synth.ts` to fail with `nothing to commit, working tree clean` (as seen in run 30836757190 / job 91763690799).

Guarding the commit call by checking `git status --porcelain` prevents the generator script from crashing when root index files are unchanged.