### PR TITLE
fix(ci): pull latest upstream changes after syncing fork in update-apis workflow

### DIFF
--- a/.github/workflows/update-apis.yaml
+++ b/.github/workflows/update-apis.yaml
@@ -16,6 +16,8 @@ jobs:
       - run: gh repo sync yoshi-code-bot/google-api-nodejs-client-autodisco --force
         env:
           GH_TOKEN: ${{ secrets.YOSHI_CODE_BOT_TOKEN }}
+      - run: git pull
+        working-directory: ./google-api-nodejs-client-autodisco
       - run: npm install
         working-directory: ./google-api-nodejs-client-autodisco
       - run: npm run update-disclaimers


### PR DESCRIPTION
In `.github/workflows/update-apis.yaml`, step 1 (`gh repo fork --clone`) clones `yoshi-code-bot`'s fork onto the Actions runner disk *before* step 2 (`gh repo sync --force`) syncs it.

Since `gh repo sync` is an API call that only updates the remote repository on GitHub servers and does not touch the local working directory, the clone on disk remained 1 run behind `upstream/main` (which caused run 30851788978 to run the unpatched `synth.ts` script prior to PR #3962).

Adding a `git pull` step immediately after syncing ensures the local clone updates to the latest synced upstream commit before executing the generator.