### PR TITLE
fix(generator): respect ignore.json when downloading discovery docs and cleaning up old files

### DIFF
--- a/src/generator/download.ts
+++ b/src/generator/download.ts
@@ -75,17 +75,27 @@ export async function downloadDiscoveryDocs(
   const apis = discoveryDoc.items;
   const indexPath = path.join(options.downloadPath, 'index.json');
   gfs.writeFile(indexPath, discoveryDoc);
+  let ignore: string[] = [];
+  try {
+    ignore = require('../../../ignore.json').ignore as string[];
+  } catch {
+    // Default to empty array if ignore.json is not found
+  }
   const queue = new Q({concurrency: 25});
   console.log(`Downloading ${apis.length} APIs...`);
   const changes = await queue.addAll(
     apis.map(api => async () => {
+      const changeSet: ChangeSet = {api, changes: []};
+      if (ignore.includes(api.id)) {
+        console.log(`Skipping API ${api.id}...`);
+        return changeSet;
+      }
       console.log(`Downloading ${api.id}...`);
       const apiPath = path.join(
         options.downloadPath,
         api.id.replace(':', '-') + '.json',
       );
       const url = `${options.discoveryUrl}/${api.name}.${api.version}.json`;
-      const changeSet: ChangeSet = {api, changes: []};
       try {
         const res = await request({url});
         // The keys in the downloaded JSON come back in an arbitrary order from
@@ -109,7 +119,7 @@ export async function downloadDiscoveryDocs(
       return changeSet;
     }),
   );
-  cleanupLibrariesNotInIndexJSON(apis, options);
+  cleanupLibrariesNotInIndexJSON(apis, options, ignore);
   return changes;
 }
 
@@ -153,6 +163,7 @@ export function getApiData(fileName: string): ApiData {
 function cleanupLibrariesNotInIndexJSON(
   apis: gapi.Schema[],
   options: DownloadOptions,
+  ignore: string[] = [],
 ): void {
   const srcPath = path.join(__dirname, '../../../src', 'apis');
   const discoveryDirectory = fs.readdirSync(options.downloadPath);
@@ -161,9 +172,20 @@ function cleanupLibrariesNotInIndexJSON(
   );
   // So that we don't delete index.json
   apisReplaced.push('index.json');
-  const discoveryDocsToDelete = discoveryDirectory.filter(
-    fileName => !apisReplaced.includes(fileName),
-  );
+  const discoveryDocsToDelete = discoveryDirectory.filter(fileName => {
+    if (apisReplaced.includes(fileName)) {
+      return false;
+    }
+    try {
+      const api = getApiData(fileName);
+      if (ignore.includes(`${api.name}:${api.version}`)) {
+        return false;
+      }
+    } catch {
+      // Ignore errors parsing fileName
+    }
+    return true;
+  });
   const clientFilesToDelete = discoveryDocsToDelete.map(docFileName => {
     const api = getApiData(docFileName);
     return path.join(srcPath, api.name, `${api.version}.ts`);

--- a/src/generator/download.ts
+++ b/src/generator/download.ts
@@ -38,6 +38,7 @@ export interface DownloadOptions {
   includePrivate?: boolean;
   discoveryUrl: string;
   downloadPath: string;
+  ignore?: string[];
 }
 
 // exported for mocking purposes
@@ -75,12 +76,7 @@ export async function downloadDiscoveryDocs(
   const apis = discoveryDoc.items;
   const indexPath = path.join(options.downloadPath, 'index.json');
   gfs.writeFile(indexPath, discoveryDoc);
-  let ignore: string[] = [];
-  try {
-    ignore = require('../../../ignore.json').ignore as string[];
-  } catch {
-    // Default to empty array if ignore.json is not found
-  }
+  const ignore = options.ignore || [];
   const queue = new Q({concurrency: 25});
   console.log(`Downloading ${apis.length} APIs...`);
   const changes = await queue.addAll(

--- a/src/generator/generator.ts
+++ b/src/generator/generator.ts
@@ -113,6 +113,7 @@ export class Generator {
         includePrivate: this.options.includePrivate,
         discoveryUrl,
         downloadPath: discoveryPath,
+        ignore,
       });
     }
 

--- a/test/test.download.ts
+++ b/test/test.download.ts
@@ -153,6 +153,26 @@ describe(__filename, () => {
     scopes.forEach(s => s.done());
   });
 
+  it('should skip downloading schemas for ignored APIs', async () => {
+    const scopes = [
+      nock(
+        'https://raw.githubusercontent.com/googleapis/discovery-artifact-manager/master/discoveries',
+      )
+        .get('/index.json')
+        .reply(200, JSON.stringify(fs.readFileSync(fakeIndexPath, 'utf8')), {
+          'Content-Type': 'application/json',
+        }),
+    ];
+    const mkdirpStub = sandbox.stub(dn.gfs, 'mkdir').resolves();
+    const writeFileStub = sandbox.stub(dn.gfs, 'writeFile');
+    const downloadPath = 'build/test/temp';
+    const ignore = ['fake:v1'];
+    await dn.downloadDiscoveryDocs({discoveryUrl, downloadPath, ignore});
+    assert(mkdirpStub.calledOnce);
+    assert(writeFileStub.calledOnce); // only index.json is written
+    scopes.forEach(s => s.done());
+  });
+
   it('should clean up old files', async () => {
     const readdirSync = sandbox.stub(fs, 'readdirSync');
     const unlinkSync = sandbox.stub(fs, 'unlinkSync');


### PR DESCRIPTION
- `downloadDiscoveryDocs()` previously downloaded all Discovery JSON schemas and computed schema diffs (`getDiffs`) without checking `ignore.json`. Consequently, it generated breaking change notes and changelog entries for ignored API versions (e.g. `aiplatform:v1beta1`).
- `cleanupLibrariesNotInIndexJSON()` previously deleted local client libraries (`src/apis/<name>/<ver>.ts`) when their versions were removed from upstream `discovery-artifact-manager`'s `index.json`, without checking `ignore.json`. Consequently, it deleted `src/apis/analytics/v3.ts` even though `"analytics:v3"` was listed in `ignore.json`.
- This PR updates both functions in `src/generator/download.ts` to load `ignore.json` and skip downloading discovery schemas or deleting files for any ignored API version.