### PR TITLE
chore: ignore broken aiplatform:v1 discovery schema

### DIFF
--- a/ignore.json
+++ b/ignore.json
@@ -14,6 +14,7 @@
     "healthcare:v1beta1",
     "connectors:v2",
     "poly:v1",
+    "aiplatform:v1",
     "aiplatform:v1beta1",
     "analytics:v3"
   ]


### PR DESCRIPTION
- In the upstream Vertex AI (`aiplatform:v1`) Discovery JSON schema, under `projects.locations.publishers.v1`, the schema defines both a child resource named `responses` and an API method named `responses(...)`.
- This causes TypeScript compilation to fail with `error TS2300: Duplicate identifier 'responses'` in `src/apis/aiplatform/v1.ts` (breaking daily generator PRs like #3968).
- Adds `"aiplatform:v1"` to `ignore.json` alongside `"aiplatform:v1beta1"` until the upstream Discovery document is repaired.