### PR TITLE
fix: Add apigeeregistry to the ignore list

### DIFF
--- a/ignore.json
+++ b/ignore.json
@@ -16,6 +16,7 @@
     "poly:v1",
     "aiplatform:v1",
     "aiplatform:v1beta1",
-    "analytics:v3"
+    "analytics:v3",
+    "apigeeregistry:v1"
   ]
 }


### PR DESCRIPTION
## Description

After the generator runs there is a compiler error in apigeeregistry. We are adding apigeeregistry to the ignore file so that the generator succeeds.

## Impact

Unblocks apiary releases.
