### PR TITLE
feat!: Update apiary to minimum Node version of 22.

### DIFF
--- a/src/generator/templates/package.json
+++ b/src/generator/templates/package.json
@@ -18,7 +18,7 @@
     "url": "https://github.com/googleapis/google-api-nodejs-client.git"
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=22.0.0"
   },
   "scripts": {
     "fix": "gts fix",


### PR DESCRIPTION
## Description

Upgrade the generator to move libraries to Node v22.

## Impact

Ensures Node 22 is required to use all apiary Node client libraries.